### PR TITLE
fix: Make cmake self consistent

### DIFF
--- a/axiom/connectors/tests/CMakeLists.txt
+++ b/axiom/connectors/tests/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-velox_add_library(axiom_test_connector TestConnector.cpp)
+velox_add_library(axiom_test_connector OBJECT TestConnector.cpp)
 
 velox_link_libraries(
   axiom_test_connector

--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -16,17 +16,16 @@ if(AXIOM_BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 
-add_library(axiom_model Model.cpp)
+velox_add_library(axiom_model Model.cpp)
 
-target_link_libraries(
-  axiom_model velox_exception)
+velox_link_libraries(axiom_model velox_exception)
 
-add_library(axiom_schema_resolver SchemaResolver.cpp SchemaUtils.cpp)
+velox_add_library(axiom_schema_resolver SchemaResolver.cpp SchemaUtils.cpp)
 
-target_link_libraries(
-  axiom_schema_resolver axiom_connector_metadata velox_exception velox_vector)
+velox_link_libraries(axiom_schema_resolver axiom_connector_metadata
+                     velox_exception velox_vector)
 
-add_library(
+velox_add_library(
   axiom_optimizer
   DerivedTable.cpp
   DerivedTablePrinter.cpp
@@ -49,9 +48,7 @@ add_library(
   VeloxHistory.cpp
   JoinSample.cpp)
 
-add_dependencies(axiom_optimizer velox_hive_connector)
-
-target_link_libraries(
+velox_link_libraries(
   axiom_optimizer
   velox_core
   axiom_connector_metadata

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-velox_add_library(axiom_optimizer_tests_parquet_tpch ParquetTpchTest.cpp)
+add_library(axiom_optimizer_tests_parquet_tpch ParquetTpchTest.cpp)
 
-velox_link_libraries(
+target_link_libraries(
   axiom_optimizer_tests_parquet_tpch
   axiom_logical_plan_builder
   axiom_optimizer
@@ -29,9 +29,9 @@ velox_link_libraries(
   gtest
   gtest_main)
 
-velox_add_library(axiom_optimizer_tests_query_test_base QueryTestBase.cpp)
+add_library(axiom_optimizer_tests_query_test_base QueryTestBase.cpp)
 
-velox_link_libraries(
+target_link_libraries(
   axiom_optimizer_tests_query_test_base
   axiom_optimizer
   axiom_schema_resolver
@@ -44,16 +44,21 @@ velox_link_libraries(
   gtest
   gtest_main)
 
-velox_add_library(axiom_optimizer_tests_presto_parser PrestoParser.cpp)
+add_library(axiom_optimizer_tests_presto_parser PrestoParser.cpp)
 
-velox_link_libraries(
+target_link_libraries(
   axiom_optimizer_tests_presto_parser axiom_logical_plan_builder
   axiom_sql_presto_ast antlr4_shared)
 
-velox_add_library(axiom_optimizer_tests_plan_matcher PlanMatcher.cpp
-                  LogicalPlanMatcher.cpp)
+velox_add_library(axiom_optimizer_tests_duck_parser DuckParser.cpp)
 
-velox_link_libraries(
+velox_link_libraries(axiom_optimizer_tests_duck_parser
+                     axiom_logical_plan_builder velox_parse_parser velox_vector)
+
+add_library(axiom_optimizer_tests_plan_matcher PlanMatcher.cpp
+                                               LogicalPlanMatcher.cpp)
+
+target_link_libraries(
   axiom_optimizer_tests_plan_matcher
   velox_hive_connector
   velox_parse_parser
@@ -62,10 +67,10 @@ velox_link_libraries(
   GTest::gtest
   GTest::gtest_main)
 
-velox_add_library(axiom_optimizer_tests_hive_queries_test_base
-                  HiveQueriesTestBase.cpp)
+add_library(axiom_optimizer_tests_hive_queries_test_base
+            HiveQueriesTestBase.cpp)
 
-velox_link_libraries(
+target_link_libraries(
   axiom_optimizer_tests_hive_queries_test_base
   axiom_optimizer_tests_parquet_tpch
   axiom_optimizer_tests_plan_matcher
@@ -98,7 +103,6 @@ add_executable(
   PlanTest.cpp
   UnnestTest.cpp
   ParquetTpchTest.cpp
-  QueryTestBase.cpp
   SubfieldTest.cpp
   FeatureGen.cpp
   Genies.cpp

--- a/axiom/sql/presto/grammar/CMakeLists.txt
+++ b/axiom/sql/presto/grammar/CMakeLists.txt
@@ -16,7 +16,7 @@ if(AXIOM_BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 
-add_library(
+velox_add_library(
   axiom_sql_presto_grammar
   PrestoSqlBaseListener.cpp
   PrestoSqlBaseVisitor.cpp
@@ -25,5 +25,4 @@ add_library(
   PrestoSqlParser.cpp
   PrestoSqlVisitor.cpp)
 
-target_link_libraries(
-  axiom_sql_presto_grammar antlr4_shared)
+velox_link_libraries(axiom_sql_presto_grammar antlr4_shared)


### PR DESCRIPTION
* Use velox_add_library (will be replaced with axiom_add_library) for all public libraries
* Use object library for connector (same as for other connectors)
* Remove unnecessary `add_dependencies`

