### PR TITLE
feat: Change storage stats to per call instead per driver

### DIFF
--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -355,7 +355,7 @@ class TestDataSource : public velox::connector::DataSource {
     return completedRows_;
   }
 
-  std::unordered_map<std::string, velox::RuntimeCounter> runtimeStats()
+  std::unordered_map<std::string, velox::RuntimeMetric> getRuntimeStats()
       override {
     return {};
   }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/14950

Storage stats are currently [aggregated at per driver level,](https://www.internalfb.com/code/fbsource/[d5afc76c0d1efcf59e0d9eb8083dbc0d488b391c]/fbcode/velox/connectors/hive/HiveDataSource.cpp?lines=474) which makes min, max, and count values inaccurate. This diff changes
1. Return type of `runtimeStats()` of `DataSource` from `std::unordered_map<std::string, velox::RuntimeCounter>`  to `std::unordered_map<std::string, velox::RuntimeMetric>` to preserve the min, max, and count values.
2. Processing of runtime stats in `TableScan` from `addValue` to `merge`
3. The return type of any inheritors of DataSource

Differential Revision: D83120348


