### PR TITLE
feat: Eliminate duplicate projections

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -996,9 +996,7 @@ void DerivedTable::makeInitialPlan() {
 
   auto optimization = queryCtx()->optimization();
   PlanState state(*optimization, this);
-  for (auto expr : exprs) {
-    state.targetColumns.unionColumns(expr);
-  }
+  state.targetExprs.unionObjects(exprs);
 
   optimization->makeJoins(state);
 

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -104,7 +104,7 @@ PlanP Optimization::bestPlan() {
   targetColumns.unionObjects(root_->columns);
 
   topState_.dt = root_;
-  topState_.setTargetColumnsForDt(targetColumns);
+  topState_.setTargetExprsForDt(targetColumns);
 
   makeJoins(topState_);
 
@@ -1743,9 +1743,9 @@ PlanP Optimization::makeDtPlan(
 
     PlanState inner(*this, &dt);
     if (key.firstTable->is(PlanType::kDerivedTableNode)) {
-      inner.setTargetColumnsForDt(key.columns);
+      inner.setTargetExprsForDt(key.columns);
     } else {
-      inner.targetColumns = key.columns;
+      inner.targetExprs = key.columns;
     }
 
     makeJoins(inner);

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -681,6 +681,7 @@ void Optimization::addPostprocess(
 
   if (!dt->having.empty()) {
     auto filter = make<Filter>(plan, dt->having);
+    state.placed.unionObjects(dt->having);
     state.addCost(*filter);
     plan = filter;
   }
@@ -688,17 +689,7 @@ void Optimization::addPostprocess(
   // We probably want to make this decision based on cost.
   static constexpr int64_t kMaxLimitBeforeProject = 8'192;
   if (dt->hasOrderBy()) {
-    PrecomputeProjection precompute(plan, dt);
-    auto orderKeys = precompute.toColumns(dt->orderKeys);
-
-    auto* orderBy = make<OrderBy>(
-        std::move(precompute).maybeProject(),
-        std::move(orderKeys),
-        dt->orderTypes,
-        dt->limit,
-        dt->offset);
-    state.addCost(*orderBy);
-    plan = orderBy;
+    addOrderBy(dt, plan, state);
   } else if (dt->hasLimit() && dt->limit <= kMaxLimitBeforeProject) {
     auto limit = make<Limit>(plan, dt->limit, dt->offset);
     state.addCost(*limit);
@@ -706,11 +697,9 @@ void Optimization::addPostprocess(
   }
 
   if (!dt->columns.empty()) {
+    ExprVector exprs = state.exprsToColumns(dt->exprs);
     plan = make<Project>(
-        plan,
-        dt->exprs,
-        dt->columns,
-        isRedundantProject(plan, dt->exprs, dt->columns));
+        plan, exprs, dt->columns, isRedundantProject(plan, exprs, dt->columns));
   }
 
   if (!dt->hasOrderBy() && dt->limit > kMaxLimitBeforeProject) {
@@ -793,6 +782,36 @@ void Optimization::addAggregation(
     state.addCost(*finalAgg);
     plan = finalAgg;
   }
+}
+
+void Optimization::addOrderBy(
+    DerivedTableCP dt,
+    RelationOpPtr& plan,
+    PlanState& state) const {
+  PrecomputeProjection precompute(plan, dt, /*projectAllInputs=*/false);
+  auto orderKeys = precompute.toColumns(dt->orderKeys);
+
+  for (auto i = 0; i < orderKeys.size(); ++i) {
+    state.exprToColumn[dt->orderKeys[i]] = orderKeys[i];
+  }
+
+  state.placed.unionObjects(dt->orderKeys);
+
+  const auto& downstreamColumns = state.downstreamColumns();
+  for (auto* column : plan->columns()) {
+    if (downstreamColumns.contains(column)) {
+      precompute.toColumn(column);
+    }
+  }
+
+  auto* orderBy = make<OrderBy>(
+      std::move(precompute).maybeProject(),
+      std::move(orderKeys),
+      dt->orderTypes,
+      dt->limit,
+      dt->offset);
+  state.addCost(*orderBy);
+  plan = orderBy;
 }
 
 void Optimization::joinByIndex(

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -223,6 +223,9 @@ class Optimization {
   void addAggregation(DerivedTableCP dt, RelationOpPtr& plan, PlanState& state)
       const;
 
+  void addOrderBy(DerivedTableCP dt, RelationOpPtr& plan, PlanState& state)
+      const;
+
   // Places a derived table as first table in a plan. Imports possibly reducing
   // joins into the plan if can.
   void placeDerivedTable(DerivedTableCP from, PlanState& state);

--- a/axiom/optimizer/Plan.h
+++ b/axiom/optimizer/Plan.h
@@ -205,10 +205,10 @@ struct PlanState {
   /// The columns that have a value from placed tables.
   PlanObjectSet columns;
 
-  /// The columns that need a value at the end of the plan. A dt can be
-  /// planned for just join/filter columns or all payload. Initially,
-  /// columns the selected columns of the dt depend on.
-  PlanObjectSet targetColumns;
+  /// The expressions that need a value at the end of the plan. A dt can be
+  /// planned for just join/filter columns or all payload. Initially, the
+  /// selected expressions of the dt.
+  PlanObjectSet targetExprs;
 
   /// lookup keys for an index based derived table.
   PlanObjectSet input;
@@ -242,9 +242,9 @@ struct PlanState {
   /// Adds 'added' to all hash join builds.
   void addBuilds(const HashBuildVector& added);
 
-  /// Specifies that the plan-to-make only references 'target' columns and
-  /// whatever these depend on. These refer to 'columns' of 'dt'.
-  void setTargetColumnsForDt(const PlanObjectSet& target);
+  /// Specifies that the plan-to-make only produces 'target' expressions and.
+  /// These refer to 'exprs' of 'dt'.
+  void setTargetExprsForDt(const PlanObjectSet& target);
 
   /// Returns the set of columns referenced in unplaced joins/filters union
   /// targetColumns. Gets smaller as more tables are placed.

--- a/axiom/optimizer/PlanObject.cpp
+++ b/axiom/optimizer/PlanObject.cpp
@@ -53,30 +53,7 @@ size_t PlanObject::hash() const {
 }
 
 void PlanObjectSet::unionColumns(ExprCP expr) {
-  switch (expr->type()) {
-    case PlanType::kLiteralExpr:
-      return;
-    case PlanType::kColumnExpr:
-      add(expr);
-      return;
-    case PlanType::kFieldExpr:
-      unionColumns(expr->as<Field>()->base());
-      return;
-    case PlanType::kAggregateExpr: {
-      auto condition = expr->as<Aggregate>()->condition();
-      if (condition) {
-        unionColumns(condition);
-      }
-    }
-      [[fallthrough]];
-    case PlanType::kCallExpr: {
-      auto call = reinterpret_cast<const Call*>(expr);
-      unionSet(call->columns());
-      return;
-    }
-    default:
-      VELOX_UNREACHABLE();
-  }
+  unionSet(expr->columns());
 }
 
 void PlanObjectSet::unionColumns(const ExprVector& exprs) {

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -304,6 +304,10 @@ class ProjectMatcher : public PlanMatcherImpl<ProjectNode> {
           newSymbols[expected->alias().value()] = plan.names()[i];
         }
 
+        if (!symbols.empty()) {
+          expected = rewriteInputNames(expected, symbols);
+        }
+
         EXPECT_EQ(
             plan.projections()[i]->toString(),
             expected->dropAlias()->toString());
@@ -459,7 +463,7 @@ class TopNMatcher : public PlanMatcherImpl<TopNNode> {
       EXPECT_EQ(plan.count(), count_.value());
     }
 
-    AXIOM_TEST_RETURN
+    return MatchResult::success(symbols);
   }
 
  private:
@@ -500,7 +504,7 @@ class OrderByMatcher : public PlanMatcherImpl<OrderByNode> {
       }
     }
 
-    return MatchResult::success();
+    return MatchResult::success(symbols);
   }
 
  private:


### PR DESCRIPTION
Summary: Fix  https://github.com/facebookincubator/axiom/issues/357

Extend PlanState to store pre-computed expressions as a map from expression to a column produced by PrecomputeProjection.

Populate this map when processing OrderBy and use it to eliminate expressions when generating "final" Project for a DT.

Follow-ups need to apply similar logic to all other nodes that use PrecomputeProjection.

Differential Revision: D83653189


