### PR TITLE
fix: Use outputName() instead of name() in PrecomputeProjection

### DIFF
--- a/axiom/optimizer/PrecomputeProjection.cpp
+++ b/axiom/optimizer/PrecomputeProjection.cpp
@@ -56,7 +56,7 @@ ExprCP PrecomputeProjection::toColumn(
       toName(fmt::format("__p{}", expr->id())),
       dt_,
       expr->value(),
-      alias != nullptr ? alias->name() : nullptr);
+      alias != nullptr ? toName(alias->outputName()) : nullptr);
 
   addToProject(expr, column);
   needsProject_ = true;

--- a/axiom/optimizer/tests/PrecomputeProjectionTest.cpp
+++ b/axiom/optimizer/tests/PrecomputeProjectionTest.cpp
@@ -192,6 +192,23 @@ TEST_F(PrecomputeProjectionTest, basic) {
     {
       PrecomputeProjection precompute(input, dt, /*projectAllInputs=*/false);
 
+      const auto* aliasName = toName("aaa");
+      auto* outputColumn =
+          make<Column>(aliasName, dt, Value(toType(INTEGER()), 1), aliasName);
+
+      auto* column = precompute.toColumn(agg->groupingKeys()[0], outputColumn);
+      ASSERT_NE(column, agg->groupingKeys()[0]);
+
+      auto project = std::move(precompute).maybeProject();
+      ASSERT_NE(project.get(), input.get());
+      ASSERT_EQ(project->columns().size(), 1);
+      ASSERT_EQ(project->as<Project>()->columns().back()->alias(), aliasName);
+    }
+
+    // Output name as alias column.
+    {
+      PrecomputeProjection precompute(input, dt, /*projectAllInputs=*/false);
+
       auto* outputColumn =
           make<Column>(toName("aaa"), dt, Value(toType(INTEGER()), 1));
 
@@ -202,7 +219,7 @@ TEST_F(PrecomputeProjectionTest, basic) {
       ASSERT_NE(project.get(), input.get());
       ASSERT_EQ(project->columns().size(), 1);
       ASSERT_EQ(
-          project->as<Project>()->columns().back()->alias(), toName("aaa"));
+          project->as<Project>()->columns().back()->outputName(), "dt1.aaa");
     }
   });
 }


### PR DESCRIPTION
Current code is inconsistent, because
1. when we decide rename or not input column we compare `outputName()`
https://github.com/facebookincubator/axiom/blob/31180a5f45443e3c799b30000d64f03203c73916/axiom/optimizer/PrecomputeProjection.cpp#L50
3. when we actually create new column we're using `name()`
https://github.com/facebookincubator/axiom/blob/31180a5f45443e3c799b30000d64f03203c73916/axiom/optimizer/PrecomputeProjection.cpp#L59

So I make it consistent and update unit tests.
I don't think this affects non-unittest behavior, because I think when we use this in optimizer `name()` is always equal to `outputName()`

