### PR TITLE
feat: Add alias field to TableScanNode

### DIFF
--- a/axiom/logical_plan/LogicalPlanNode.cpp
+++ b/axiom/logical_plan/LogicalPlanNode.cpp
@@ -237,6 +237,9 @@ folly::dynamic TableScanNode::serialize() const {
   obj["tableName"] = tableName_;
   obj["columnNames"] =
       serializeVector(columnNames_, [](const std::string& s) { return s; });
+  if (!alias_.empty()) {
+    obj["alias"] = alias_;
+  }
   return obj;
 }
 
@@ -244,12 +247,17 @@ folly::dynamic TableScanNode::serialize() const {
 LogicalPlanNodePtr TableScanNode::create(
     const folly::dynamic& obj,
     void* /*context*/) {
+  std::string alias;
+  if (obj.count("alias")) {
+    alias = obj["alias"].asString();
+  }
   return std::make_shared<TableScanNode>(
       obj["id"].asString(),
       deserializeOutputType(obj),
       obj["connectorId"].asString(),
       obj["tableName"].asString(),
-      deserializeStringVector(obj, "columnNames"));
+      deserializeStringVector(obj, "columnNames"),
+      std::move(alias));
 }
 
 folly::dynamic FilterNode::serialize() const {

--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -201,11 +201,13 @@ class TableScanNode : public LogicalPlanNode {
       velox::RowTypePtr outputType,
       std::string connectorId,
       std::string tableName,
-      std::vector<std::string> columnNames)
+      std::vector<std::string> columnNames,
+      std::string alias = {})
       : LogicalPlanNode{NodeKind::kTableScan, std::move(id), {}, std::move(outputType)},
         connectorId_{std::move(connectorId)},
         tableName_{std::move(tableName)},
-        columnNames_{std::move(columnNames)} {
+        columnNames_{std::move(columnNames)},
+        alias_{std::move(alias)} {
     VELOX_USER_CHECK_EQ(outputType_->size(), columnNames_.size());
 
     const auto numColumns = outputType_->size();
@@ -227,6 +229,12 @@ class TableScanNode : public LogicalPlanNode {
     return columnNames_;
   }
 
+  /// Returns the SQL alias for this table scan (e.g., "o" in
+  /// `FROM orders AS o`). Empty if no alias was specified.
+  const std::string& alias() const {
+    return alias_;
+  }
+
   void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
       const override;
 
@@ -238,6 +246,7 @@ class TableScanNode : public LogicalPlanNode {
   const std::string connectorId_;
   const std::string tableName_;
   const std::vector<std::string> columnNames_;
+  const std::string alias_;
 };
 
 using TableScanNodePtr = std::shared_ptr<const TableScanNode>;

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -657,6 +657,11 @@ class PlanBuilder {
   /// "alias.column" in subsequent operations.
   PlanBuilder& as(const std::string& alias);
 
+  /// Sets the alias on the current TableScanNode. If a ProjectNode sits on
+  /// top of the scan (e.g. due to column aliases), looks through to the
+  /// underlying TableScanNode.
+  PlanBuilder& setTableScanAlias(const std::string& alias);
+
   /// Captures the current name-resolution scope into 'scope' so it can be
   /// passed to an inner PlanBuilder for correlated subqueries.
   ///

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -407,6 +407,16 @@ class RelationPlanner : public AstVisitor {
       builder_->project(renames);
     }
 
+    // Set the alias on the underlying TableScanNode when the inner relation
+    // is a table and the alias differs from the table name.
+    if (aliasedRelation.relation()->is(NodeType::kTable)) {
+      auto* innerTable = aliasedRelation.relation()->as<Table>();
+      auto tableName = canonicalizeName(innerTable->name()->suffix());
+      if (tableName != alias) {
+        builder_->setTableScanAlias(alias);
+      }
+    }
+
     builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false);
     builder_->as(alias);
   }


### PR DESCRIPTION
Summary:
This makes the table alias available in Axiom's logical plan. For example, for the query

```sql
SELECT x FROM t AS src
```

we want to access the alias `src`. This information will be stored in the logical plan node `TableScanNode`. Example:

```cpp
auto statement = parseSql("SELECT x FROM t AS src");
auto plan = statement->as<SelectStatement>()->plan();
auto* scan = plan->onlyInput()->as<lp::TableScanNode>();
EXPECT_EQ(scan->alias(), "src");
```

The reason we need to store this info in the `TableScanNode` as opposed to a plan-level property is that subqueries may have the same aliases and query the same tables, for example:

```sql
SELECT
  o1.o_orderkey,
  o2.o_totalprice
FROM
  (SELECT o_orderkey, o_custkey FROM orders AS o1) AS o1
JOIN
  (SELECT o_totalprice, o_custkey FROM orders AS o2) AS o2
ON o1.o_custkey = o2.o_custkey
```

Differential Revision: D94168928


