### PR TITLE
feat: Add subqueryAlias to LogicalPlanNode for CTE/inline subquery tracking

### DIFF
--- a/axiom/logical_plan/LogicalPlanNode.cpp
+++ b/axiom/logical_plan/LogicalPlanNode.cpp
@@ -237,6 +237,9 @@ folly::dynamic TableScanNode::serialize() const {
   obj["tableName"] = tableName_;
   obj["columnNames"] =
       serializeVector(columnNames_, [](const std::string& s) { return s; });
+  if (!alias_.empty()) {
+    obj["alias"] = alias_;
+  }
   return obj;
 }
 
@@ -244,12 +247,17 @@ folly::dynamic TableScanNode::serialize() const {
 LogicalPlanNodePtr TableScanNode::create(
     const folly::dynamic& obj,
     void* /*context*/) {
+  std::string alias;
+  if (obj.count("alias")) {
+    alias = obj["alias"].asString();
+  }
   return std::make_shared<TableScanNode>(
       obj["id"].asString(),
       deserializeOutputType(obj),
       obj["connectorId"].asString(),
       obj["tableName"].asString(),
-      deserializeStringVector(obj, "columnNames"));
+      deserializeStringVector(obj, "columnNames"),
+      std::move(alias));
 }
 
 folly::dynamic FilterNode::serialize() const {

--- a/axiom/logical_plan/LogicalPlanNode.cpp
+++ b/axiom/logical_plan/LogicalPlanNode.cpp
@@ -108,6 +108,15 @@ std::vector<std::string> deserializeStringVector(
   return result;
 }
 
+/// Restores subqueryAlias from a serialized node, if present.
+void deserializeSubqueryAlias(
+    const folly::dynamic& obj,
+    const LogicalPlanNodePtr& node) {
+  if (obj.count("subqueryAlias")) {
+    node->setSubqueryAlias(obj["subqueryAlias"].asString());
+  }
+}
+
 } // namespace
 
 AXIOM_DEFINE_ENUM_NAME(NodeKind, nodeKindNames)
@@ -124,6 +133,9 @@ folly::dynamic LogicalPlanNode::serializeBase(std::string_view name) const {
   if (!inputs_.empty()) {
     obj["inputs"] = serializeVector(
         inputs_, [](const LogicalPlanNodePtr& n) { return n->serialize(); });
+  }
+  if (subqueryAlias_.has_value()) {
+    obj["subqueryAlias"] = subqueryAlias_.value();
   }
   return obj;
 }
@@ -186,12 +198,13 @@ LogicalPlanNodePtr ValuesNode::create(
   auto outputType = deserializeOutputType(obj);
   auto dataType = obj["dataType"].asString();
 
+  LogicalPlanNodePtr node;
   if (dataType == "Variants") {
     Variants rows;
     for (const auto& v : obj["data"]) {
       rows.push_back(velox::Variant::create(v));
     }
-    return std::make_shared<ValuesNode>(
+    node = std::make_shared<ValuesNode>(
         std::move(id), outputType, std::move(rows));
   } else if (dataType == "Vectors") {
     VELOX_CHECK_NOT_NULL(
@@ -211,7 +224,7 @@ LogicalPlanNodePtr ValuesNode::create(
           velox::BaseVector::createFromVariants(outputType, variants, pool));
       vectors.push_back(std::move(vector));
     }
-    return std::make_shared<ValuesNode>(std::move(id), std::move(vectors));
+    node = std::make_shared<ValuesNode>(std::move(id), std::move(vectors));
   } else if (dataType == "Exprs") {
     const auto& data = obj["data"];
     Exprs rows;
@@ -224,11 +237,13 @@ LogicalPlanNodePtr ValuesNode::create(
       }
       rows.push_back(std::move(exprs));
     }
-    return std::make_shared<ValuesNode>(
+    node = std::make_shared<ValuesNode>(
         std::move(id), outputType, std::move(rows));
   } else {
     VELOX_FAIL("Unknown ValuesNode dataType: {}", dataType);
   }
+  deserializeSubqueryAlias(obj, node);
+  return node;
 }
 
 folly::dynamic TableScanNode::serialize() const {
@@ -251,13 +266,15 @@ LogicalPlanNodePtr TableScanNode::create(
   if (obj.count("alias")) {
     alias = obj["alias"].asString();
   }
-  return std::make_shared<TableScanNode>(
+  auto node = std::make_shared<TableScanNode>(
       obj["id"].asString(),
       deserializeOutputType(obj),
       obj["connectorId"].asString(),
       obj["tableName"].asString(),
       deserializeStringVector(obj, "columnNames"),
       std::move(alias));
+  deserializeSubqueryAlias(obj, node);
+  return node;
 }
 
 folly::dynamic FilterNode::serialize() const {
@@ -272,10 +289,12 @@ LogicalPlanNodePtr FilterNode::create(
     void* context) {
   auto inputs = deserializeNodeInputs(obj, context);
   VELOX_CHECK_EQ(inputs.size(), 1);
-  return std::make_shared<FilterNode>(
+  auto node = std::make_shared<FilterNode>(
       obj["id"].asString(),
       inputs[0],
       deserializeExpr(obj["predicate"], context));
+  deserializeSubqueryAlias(obj, node);
+  return node;
 }
 
 folly::dynamic ProjectNode::serialize() const {
@@ -293,11 +312,13 @@ LogicalPlanNodePtr ProjectNode::create(
     void* context) {
   auto inputs = deserializeNodeInputs(obj, context);
   VELOX_CHECK_EQ(inputs.size(), 1);
-  return std::make_shared<ProjectNode>(
+  auto node = std::make_shared<ProjectNode>(
       obj["id"].asString(),
       inputs[0],
       deserializeStringVector(obj, "names"),
       deserializeExprs(obj, "expressions", context));
+  deserializeSubqueryAlias(obj, node);
+  return node;
 }
 
 folly::dynamic AggregateNode::serialize() const {
@@ -349,13 +370,15 @@ LogicalPlanNodePtr AggregateNode::create(
     }
   }
 
-  return std::make_shared<AggregateNode>(
+  auto node = std::make_shared<AggregateNode>(
       obj["id"].asString(),
       inputs[0],
       std::move(groupingKeys),
       std::move(groupingSets),
       std::move(aggregates),
       deserializeStringVector(obj, "outputNames"));
+  deserializeSubqueryAlias(obj, node);
+  return node;
 }
 
 folly::dynamic JoinNode::serialize() const {
@@ -375,12 +398,14 @@ LogicalPlanNodePtr JoinNode::create(const folly::dynamic& obj, void* context) {
   if (obj.count("condition")) {
     condition = deserializeExpr(obj["condition"], context);
   }
-  return std::make_shared<JoinNode>(
+  auto node = std::make_shared<JoinNode>(
       obj["id"].asString(),
       inputs[0],
       inputs[1],
       JoinTypeName::toJoinType(obj["joinType"].asString()),
       std::move(condition));
+  deserializeSubqueryAlias(obj, node);
+  return node;
 }
 
 folly::dynamic SortNode::serialize() const {
@@ -400,8 +425,10 @@ LogicalPlanNodePtr SortNode::create(const folly::dynamic& obj, void* context) {
       ordering.push_back(SortingField::deserialize(f, context));
     }
   }
-  return std::make_shared<SortNode>(
+  auto node = std::make_shared<SortNode>(
       obj["id"].asString(), inputs[0], std::move(ordering));
+  deserializeSubqueryAlias(obj, node);
+  return node;
 }
 
 folly::dynamic LimitNode::serialize() const {
@@ -415,11 +442,13 @@ folly::dynamic LimitNode::serialize() const {
 LogicalPlanNodePtr LimitNode::create(const folly::dynamic& obj, void* context) {
   auto inputs = deserializeNodeInputs(obj, context);
   VELOX_CHECK_EQ(inputs.size(), 1);
-  return std::make_shared<LimitNode>(
+  auto node = std::make_shared<LimitNode>(
       obj["id"].asString(),
       inputs[0],
       obj["offset"].asInt(),
       obj["count"].asInt());
+  deserializeSubqueryAlias(obj, node);
+  return node;
 }
 
 folly::dynamic SetNode::serialize() const {
@@ -431,10 +460,12 @@ folly::dynamic SetNode::serialize() const {
 // static
 LogicalPlanNodePtr SetNode::create(const folly::dynamic& obj, void* context) {
   auto inputs = deserializeNodeInputs(obj, context);
-  return std::make_shared<SetNode>(
+  auto node = std::make_shared<SetNode>(
       obj["id"].asString(),
       inputs,
       SetOperationName::toSetOperation(obj["operation"].asString()));
+  deserializeSubqueryAlias(obj, node);
+  return node;
 }
 
 folly::dynamic UnnestNode::serialize() const {
@@ -479,13 +510,15 @@ LogicalPlanNodePtr UnnestNode::create(
     ordinalityName = obj["ordinalityName"].asString();
   }
 
-  return std::make_shared<UnnestNode>(
+  auto node = std::make_shared<UnnestNode>(
       obj["id"].asString(),
       inputs[0],
       deserializeExprs(obj, "unnestExpressions", context),
       std::move(unnestedNames),
       std::move(ordinalityName),
       obj["flattenArrayOfRows"].asBool());
+  deserializeSubqueryAlias(obj, node);
+  return node;
 }
 
 folly::dynamic TableWriteNode::serialize() const {
@@ -521,7 +554,7 @@ LogicalPlanNodePtr TableWriteNode::create(
     }
   }
 
-  return std::make_shared<TableWriteNode>(
+  auto node = std::make_shared<TableWriteNode>(
       obj["id"].asString(),
       inputs[0],
       obj["connectorId"].asString(),
@@ -530,6 +563,8 @@ LogicalPlanNodePtr TableWriteNode::create(
       deserializeStringVector(obj, "columnNames"),
       deserializeExprs(obj, "columnExpressions", context),
       std::move(options));
+  deserializeSubqueryAlias(obj, node);
+  return node;
 }
 
 folly::dynamic SampleNode::serialize() const {
@@ -545,11 +580,13 @@ LogicalPlanNodePtr SampleNode::create(
     void* context) {
   auto inputs = deserializeNodeInputs(obj, context);
   VELOX_CHECK_EQ(inputs.size(), 1);
-  return std::make_shared<SampleNode>(
+  auto node = std::make_shared<SampleNode>(
       obj["id"].asString(),
       inputs[0],
       deserializeExpr(obj["percentage"], context),
       SampleNode::toSampleMethod(obj["sampleMethod"].asString()));
+  deserializeSubqueryAlias(obj, node);
+  return node;
 }
 
 namespace {
@@ -1031,8 +1068,10 @@ LogicalPlanNodePtr OutputNode::create(
     }
   }
 
-  return std::make_shared<OutputNode>(
+  auto node = std::make_shared<OutputNode>(
       obj["id"].asString(), inputs[0], std::move(entries));
+  deserializeSubqueryAlias(obj, node);
+  return node;
 }
 
 } // namespace facebook::axiom::logical_plan

--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -201,11 +201,13 @@ class TableScanNode : public LogicalPlanNode {
       velox::RowTypePtr outputType,
       std::string connectorId,
       std::string tableName,
-      std::vector<std::string> columnNames)
+      std::vector<std::string> columnNames,
+      std::string alias = {})
       : LogicalPlanNode{NodeKind::kTableScan, std::move(id), {}, std::move(outputType)},
         connectorId_{std::move(connectorId)},
         tableName_{std::move(tableName)},
-        columnNames_{std::move(columnNames)} {
+        columnNames_{std::move(columnNames)},
+        alias_{std::move(alias)} {
     VELOX_USER_CHECK_EQ(outputType_->size(), columnNames_.size());
 
     const auto numColumns = outputType_->size();
@@ -227,6 +229,12 @@ class TableScanNode : public LogicalPlanNode {
     return columnNames_;
   }
 
+  /// Returns the SQL alias for this table scan (e.g., "o" in
+  /// `FROM orders AS o`). Empty if no alias was specified.
+  const std::string& alias() const {
+    return alias_;
+  }
+
   void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
       const override;
 
@@ -238,6 +246,7 @@ class TableScanNode : public LogicalPlanNode {
   const std::string connectorId_;
   const std::string tableName_;
   const std::vector<std::string> columnNames_;
+  const std::string alias_;
 };
 
 using TableScanNodePtr = std::shared_ptr<const TableScanNode>;

--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -126,6 +126,18 @@ class LogicalPlanNode : public velox::ISerializable {
       const PlanNodeVisitor& visitor,
       PlanNodeVisitorContext& context) const = 0;
 
+  /// Returns the CTE or inline subquery alias, if set.
+  const std::optional<std::string>& subqueryAlias() const {
+    return subqueryAlias_;
+  }
+
+  /// Sets the CTE or inline subquery alias. Uses mutable field because
+  /// nodes are const once constructed and this is annotation metadata
+  /// that does not affect plan shape or output types.
+  void setSubqueryAlias(std::string alias) const {
+    subqueryAlias_ = std::move(alias);
+  }
+
   /// Registers deserializers for all LogicalPlanNode subclasses.
   static void registerSerDe();
 
@@ -137,6 +149,7 @@ class LogicalPlanNode : public velox::ISerializable {
   const std::string id_;
   const std::vector<LogicalPlanNodePtr> inputs_;
   const velox::RowTypePtr outputType_;
+  mutable std::optional<std::string> subqueryAlias_;
 };
 
 /// A table whose content is embedded in the plan.

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -657,6 +657,11 @@ class PlanBuilder {
   /// "alias.column" in subsequent operations.
   PlanBuilder& as(const std::string& alias);
 
+  /// Sets the alias on the current TableScanNode. If a ProjectNode sits on
+  /// top of the scan (e.g. due to column aliases), looks through to the
+  /// underlying TableScanNode.
+  PlanBuilder& setTableScanAlias(const std::string& alias);
+
   /// Captures the current name-resolution scope into 'scope' so it can be
   /// passed to an inner PlanBuilder for correlated subqueries.
   ///

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -407,6 +407,16 @@ class RelationPlanner : public AstVisitor {
       builder_->project(renames);
     }
 
+    // Set the alias on the underlying TableScanNode when the inner relation
+    // is a table and the alias differs from the table name.
+    if (aliasedRelation.relation()->is(NodeType::kTable)) {
+      auto* innerTable = aliasedRelation.relation()->as<Table>();
+      auto tableName = canonicalizeName(innerTable->name()->suffix());
+      if (tableName != alias) {
+        builder_->setTableScanAlias(alias);
+      }
+    }
+
     builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false);
     builder_->as(alias);
   }

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -333,6 +333,7 @@ class RelationPlanner : public AstVisitor {
     if (withIt != withQueries_.end()) {
       // TODO Change WithQuery to store Query and not Statement.
       processQuery(dynamic_cast<Query*>(withIt->second->query().get()));
+      builder_->planNode()->setSubqueryAlias(tableName);
     } else {
       const auto& [connectorId, qualifiedName] = toConnectorTable(
           *table.name(), context_.defaultConnectorId, defaultSchema_);
@@ -415,6 +416,10 @@ class RelationPlanner : public AstVisitor {
       if (tableName != alias) {
         builder_->setTableScanAlias(alias);
       }
+    }
+
+    if (aliasedRelation.relation()->is(NodeType::kTableSubquery)) {
+      builder_->planNode()->setSubqueryAlias(alias);
     }
 
     builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false);


### PR DESCRIPTION
Summary:
## Problem

We need to capture the CTE names and make them available in the LogicalPlan (analogous to D94168928 for table alias). As with table alias, we need to preserve the locality.

There's no node corresponding to CTE in the logical plan. 

## Proposal

Store the CTE name as a general "subquery" alias. The idea is to have this information in nodes that are the root of the CTE queries. For example

```
WITH cte AS (SELECT 1 as x) SELECT * FROM cte
```

The  root of `(SELECT 1 as x)` will store the alias `cte`. The reason we store it on the subquery itself is to support chained CTEs like

```
WITH a AS (SELECT 1 as x), b AS (SELECT * FROM a WHERE x > 0) "
      "SELECT * FROM b
```

Here `(SELECT 1 as x)` has the subquery alias "a" and `(SELECT * FROM a WHERE x > 0)` the alias "b". 

Since the root of a subquery can be multiple node types (`kTableScan`, `kProject`) I'm proposing we store it in the base class `LogicalPlan`. Alternatively we could have an interface which only specific nodes implement.

Differential Revision: D94303813


