### PR TITLE
feat(parser): Add SHOW TABLES support for TPCH connector

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -737,6 +737,13 @@ class ConnectorMetadata {
   /// @return nullptr if table doesn't exist.
   virtual TablePtr findTable(std::string_view name) = 0;
 
+  /// Returns the list of table names available in this connector,
+  /// optionally filtered by schema prefix. Returns empty by default.
+  virtual std::vector<std::string> listTables(
+      const std::optional<std::string>& /* schemaFilter */ = std::nullopt) {
+    return {};
+  }
+
   /// Return a ViewPtr given the view name. View name is provided without the
   /// connector ID / catalog prefix, but may include the schema.
   ///

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -239,6 +239,20 @@ TablePtr TpchConnectorMetadata::findTable(std::string_view name) {
   return table;
 }
 
+std::vector<std::string> TpchConnectorMetadata::listTables(
+    const std::optional<std::string>& schemaFilter) {
+  const auto schema = schemaFilter.value_or(kTiny);
+  if (!isValidTpchSchema(schema)) {
+    return {};
+  }
+
+  std::vector<std::string> result;
+  for (auto tpchTable : velox::tpch::tables) {
+    result.emplace_back(velox::tpch::toTableName(tpchTable));
+  }
+  return result;
+}
+
 std::string canonicalizeViewName(const TableNameParser& parser) {
   return fmt::format("{}.{}", parser.schema().value_or(kTiny), parser.table());
 }

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -183,6 +183,9 @@ class TpchConnectorMetadata : public ConnectorMetadata {
 
   TablePtr findTable(std::string_view name) override;
 
+  std::vector<std::string> listTables(
+      const std::optional<std::string>& schemaFilter = std::nullopt) override;
+
   ViewPtr findView(std::string_view name) override;
 
   void createView(

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -18,6 +18,8 @@
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
 
+#include <gmock/gmock.h>
+
 #include "velox/connectors/tpch/TpchConnector.h"
 #include "velox/expression/Expr.h"
 
@@ -153,6 +155,35 @@ TEST_F(TpchConnectorMetadataTest, createTableHandle) {
   EXPECT_EQ(tpchTableHandle->getTable(), tpchLayout->getTpchTable());
   EXPECT_DOUBLE_EQ(
       tpchTableHandle->getScaleFactor(), tpchLayout->getScaleFactor());
+}
+
+TEST_F(TpchConnectorMetadataTest, listTablesDefault) {
+  auto tables = metadata_->listTables();
+  EXPECT_THAT(
+      tables,
+      testing::ElementsAre(
+          "part",
+          "supplier",
+          "partsupp",
+          "customer",
+          "orders",
+          "lineitem",
+          "nation",
+          "region"));
+}
+
+TEST_F(TpchConnectorMetadataTest, listTablesWithSchema) {
+  auto tables = metadata_->listTables("sf1");
+  ASSERT_EQ(tables.size(), 8);
+  // Table names should not include schema prefix.
+  for (const auto& table : tables) {
+    EXPECT_FALSE(table.find('.') != std::string::npos) << table;
+  }
+}
+
+TEST_F(TpchConnectorMetadataTest, listTablesInvalidSchema) {
+  auto tables = metadata_->listTables("invalid");
+  EXPECT_THAT(tables, testing::IsEmpty());
 }
 
 TEST_F(TpchConnectorMetadataTest, splitGeneration) {

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1184,6 +1184,48 @@ SqlStatementPtr parseShowCatalogs(
   return std::make_shared<SelectStatement>(builder.build());
 }
 
+SqlStatementPtr parseShowTables(
+    const ShowTables& showTables,
+    const std::string& defaultConnectorId,
+    const std::optional<std::string>& defaultSchema) {
+  // Resolve connector ID and schema from the qualified name.
+  std::string connectorId = defaultConnectorId;
+  std::optional<std::string> schema = defaultSchema;
+
+  if (showTables.schemaName()) {
+    const auto& parts = showTables.schemaName()->parts();
+    if (parts.size() == 1) {
+      // SHOW TABLES FROM schema
+      schema = parts[0];
+    } else if (parts.size() == 2) {
+      // SHOW TABLES FROM catalog.schema
+      connectorId = parts[0];
+      schema = parts[1];
+    }
+  }
+
+  auto* metadata =
+      facebook::axiom::connector::ConnectorMetadata::metadata(connectorId);
+  auto tables = metadata->listTables(schema);
+
+  std::vector<Variant> data;
+  data.reserve(tables.size());
+  for (const auto& tableName : tables) {
+    data.emplace_back(Variant::row({tableName}));
+  }
+
+  lp::PlanBuilder::Context ctx(defaultConnectorId);
+  lp::PlanBuilder builder(ctx);
+  builder.values(ROW({"Table"}, VARCHAR()), std::move(data));
+
+  if (showTables.getLikePattern().has_value()) {
+    builder.filter(makeLikeExpr(
+        "Table", showTables.getLikePattern().value(), showTables.getEscape()));
+  }
+
+  return std::make_shared<SelectStatement>(builder.build());
+}
+
 SqlStatementPtr parseShowColumns(
     const ShowColumns& showColumns,
     const std::string& defaultConnectorId,
@@ -1629,6 +1671,11 @@ SqlStatementPtr doPlan(
 
   if (query->is(NodeType::kShowCatalogs)) {
     return parseShowCatalogs(*query->as<ShowCatalogs>(), defaultConnectorId);
+  }
+
+  if (query->is(NodeType::kShowTables)) {
+    return parseShowTables(
+        *query->as<ShowTables>(), defaultConnectorId, defaultSchema);
   }
 
   if (query->is(NodeType::kShowColumns)) {

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -680,7 +680,26 @@ std::any AstBuilder::visitShowCreateFunction(
 
 std::any AstBuilder::visitShowTables(PrestoSqlParser::ShowTablesContext* ctx) {
   trace("visitShowTables");
-  return visitChildren("visitShowTables", ctx);
+
+  std::shared_ptr<QualifiedName> schemaName;
+  if (ctx->qualifiedName() != nullptr) {
+    schemaName = getQualifiedName(ctx->qualifiedName());
+  }
+
+  std::optional<std::string> likePattern;
+  std::optional<std::string> escape;
+  if (ctx->LIKE() != nullptr) {
+    likePattern = visitExpression(ctx->pattern)->as<StringLiteral>()->value();
+  }
+  if (ctx->ESCAPE() != nullptr) {
+    escape = visitExpression(ctx->escape)->as<StringLiteral>()->value();
+  }
+
+  return std::static_pointer_cast<Statement>(std::make_shared<ShowTables>(
+      getLocation(ctx),
+      std::move(schemaName),
+      std::move(likePattern),
+      std::move(escape)));
 }
 
 std::any AstBuilder::visitShowSchemas(

--- a/axiom/sql/presto/ast/AstNodesAll.cpp
+++ b/axiom/sql/presto/ast/AstNodesAll.cpp
@@ -766,6 +766,10 @@ void ShowCatalogs::accept(AstVisitor* visitor) {
   visitor->visitShowCatalogs(this);
 }
 
+void ShowTables::accept(AstVisitor* visitor) {
+  visitor->visitShowTables(this);
+}
+
 void ShowColumns::accept(AstVisitor* visitor) {
   visitor->visitShowColumns(this);
 }

--- a/axiom/sql/presto/ast/AstStatements.h
+++ b/axiom/sql/presto/ast/AstStatements.h
@@ -776,6 +776,39 @@ class ShowCatalogs : public Statement {
   std::optional<std::string> escape_;
 };
 
+/// SHOW TABLES with optional schema qualifier and LIKE filter.
+class ShowTables : public Statement {
+ public:
+  ShowTables(
+      NodeLocation location,
+      std::shared_ptr<QualifiedName> schemaName,
+      std::optional<std::string> likePattern,
+      std::optional<std::string> escape)
+      : Statement(NodeType::kShowTables, location),
+        schemaName_(std::move(schemaName)),
+        likePattern_(std::move(likePattern)),
+        escape_(std::move(escape)) {}
+
+  const std::shared_ptr<QualifiedName>& schemaName() const {
+    return schemaName_;
+  }
+
+  const std::optional<std::string>& getLikePattern() const {
+    return likePattern_;
+  }
+
+  const std::optional<std::string>& getEscape() const {
+    return escape_;
+  }
+
+  void accept(AstVisitor* visitor) override;
+
+ private:
+  std::shared_ptr<QualifiedName> schemaName_;
+  std::optional<std::string> likePattern_;
+  std::optional<std::string> escape_;
+};
+
 class ShowColumns : public Statement {
  public:
   explicit ShowColumns(

--- a/axiom/sql/presto/ast/AstVisitor.h
+++ b/axiom/sql/presto/ast/AstVisitor.h
@@ -559,6 +559,10 @@ class AstVisitor {
     defaultVisit(node);
   }
 
+  virtual void visitShowTables(ShowTables* node) {
+    defaultVisit(node);
+  }
+
   virtual void visitShowColumns(ShowColumns* node) {
     defaultVisit(node);
   }

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1042,6 +1042,8 @@ TEST_F(PrestoParserTest, explainShow) {
   auto matcher = matchValues();
   testExplain("EXPLAIN SHOW CATALOGS", matcher);
 
+  testExplain("EXPLAIN SHOW TABLES", matcher);
+
   testExplain("EXPLAIN SHOW COLUMNS FROM nation", matcher);
 
   testExplain("EXPLAIN SHOW FUNCTIONS", matcher);
@@ -1088,6 +1090,28 @@ TEST_F(PrestoParserTest, showCatalogs) {
   {
     auto matcher = matchValues().filter();
     testSelect("SHOW CATALOGS LIKE 'tpch'", matcher);
+  }
+}
+
+TEST_F(PrestoParserTest, showTables) {
+  {
+    auto matcher = matchValues();
+    testSelect("SHOW TABLES", matcher);
+  }
+
+  {
+    auto matcher = matchValues();
+    testSelect("SHOW TABLES FROM tiny", matcher);
+  }
+
+  {
+    auto matcher = matchValues().filter();
+    testSelect("SHOW TABLES LIKE 'line%'", matcher);
+  }
+
+  {
+    auto matcher = matchValues().filter();
+    testSelect("SHOW TABLES FROM tiny LIKE 'nation'", matcher);
   }
 }
 


### PR DESCRIPTION
Summary:
Add `SHOW TABLES` support.

- Add `ShowTables` AST node class with schema qualifier, LIKE pattern, and escape
- Implement `visitShowTables` in AstBuilder to extract parser context
- Add `visitShowTables` virtual method to AstVisitor
- Add `listTables()` virtual method to ConnectorMetadata
- Implement `listTables()` in TpchConnectorMetadata
- Add `parseShowTables` handler in PrestoParser and wire into `doPlan`

Differential Revision: D95341637


