### PR TITLE
feat: Optimize INNER JOIN with constant false ON clause

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1820,7 +1820,8 @@ void ToGraph::translateJoin(
         exprSources_.pop_back();
       };
 
-      addFilter(*left, condition);
+      addFilter(
+          *left, condition, left->outputType()->unionWith(right->outputType()));
     }
     return;
   }

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -3143,7 +3143,8 @@ bool ToGraph::windowReferencesWindow(const lp::ProjectNode& project) const {
 
 void ToGraph::addFilter(
     const lp::LogicalPlanNode& input,
-    const lp::ExprPtr& predicate) {
+    const lp::ExprPtr& predicate,
+    const velox::RowTypePtr emptyValuesType) {
   exprSources_.push_back(&input);
   SCOPE_EXIT {
     exprSources_.pop_back();
@@ -3160,6 +3161,13 @@ void ToGraph::addFilter(
 
     translateConjuncts(predicate, flat);
   }
+
+  if (emptyValuesType && hasConstantFalse(flat)) {
+    currentDt_ = newDt();
+    makeEmptyValuesTable(emptyValuesType);
+    return;
+  }
+
   {
     PlanObjectSet tables = currentDt_->tableSet;
     tables.add(currentDt_);
@@ -3200,6 +3208,26 @@ void ToGraph::addLimit(const lp::LimitNode& limit) {
 void ToGraph::makeEmptyValuesTable(const lp::LogicalPlanNode& node) {
   auto* emptyData = &registerVariant(velox::Variant::array({}))->array();
   auto* valuesTable = makeValuesTable(node, emptyData);
+  currentDt_->addTable(valuesTable);
+}
+
+void ToGraph::makeEmptyValuesTable(const velox::RowTypePtr& outputType) {
+  auto* emptyData = &registerVariant(velox::Variant::array({}))->array();
+  auto* valuesTable = make<ValuesTable>(toType(outputType), emptyData);
+  valuesTable->cname = newCName("vt");
+  const auto& names = outputType->names();
+  const auto cardinality = valuesTable->cardinality();
+  for (auto i = 0; i < outputType->size(); ++i) {
+    const auto& name = names[i];
+    const auto* columnName = toName(name);
+    auto* column = make<Column>(
+        columnName,
+        valuesTable,
+        toValue(outputType->childAt(i), cardinality),
+        columnName);
+    valuesTable->columns.push_back(column);
+    renames_[name] = column;
+  }
   currentDt_->addTable(valuesTable);
 }
 
@@ -3464,7 +3492,7 @@ void ToGraph::makeFilterQueryGraph(
   if (hasNondeterministic(filter.predicate())) {
     auto* outerDt = std::exchange(currentDt_, newDt());
     makeQueryGraph(input, kAllAllowedInDt, excludeOuterJoins);
-    addFilter(input, filter.predicate());
+    addFilter(input, filter.predicate(), filter.outputType());
     finalizeDt(filter, outerDt);
     return;
   }
@@ -3479,7 +3507,7 @@ void ToGraph::makeFilterQueryGraph(
     finalizeDt(filter);
   }
 
-  addFilter(input, filter.predicate());
+  addFilter(input, filter.predicate(), filter.outputType());
 }
 
 void ToGraph::makeProjectQueryGraph(

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1846,14 +1846,14 @@ void ToGraph::translateJoin(
   }
 #endif
 
+  if (hasConstantFalse(conjuncts) &&
+      tryEliminateJoinOnConstantFalse(joinType, left, right)) {
+    return;
+  }
+
   // If non-inner, and many tables on the right they are one dt. If a single
   // table then this too is the last in 'tables'.
   auto* rightTable = currentDt_->tables.back();
-
-  if (hasConstantFalse(conjuncts) &&
-      eliminateJoinOnConstantFalse(joinType, left, right, rightTable)) {
-    return;
-  }
 
   const bool leftOptional =
       joinType == lp::JoinType::kRight || joinType == lp::JoinType::kFull;
@@ -1936,39 +1936,98 @@ void ToGraph::translateJoin(
   }
 }
 
-bool ToGraph::eliminateJoinOnConstantFalse(
+bool ToGraph::tryEliminateJoinOnConstantFalse(
     lp::JoinType joinType,
     const lp::LogicalPlanNodePtr& left,
-    const lp::LogicalPlanNodePtr& right,
-    PlanObjectCP rightTable) {
-  // TODO: For INNER/FULL joins, no rows can match at all - return empty
-  // result.
-  const lp::LogicalPlanNode* optionalSide = nullptr;
+    const lp::LogicalPlanNodePtr& right) {
+  // Helper to project NULL for each column from the given side.
+  const auto projectNulls = [&](const lp::LogicalPlanNode& side) {
+    const auto& outputType = side.outputType();
+    for (auto channel : usedChannels(side)) {
+      const auto& name = outputType->names()[channel];
+      const auto& typePtr = outputType->childAt(channel);
+      renames_[name] = make<Literal>(
+          toConstantValue(typePtr), registerVariant(toType(typePtr)->kind()));
+    }
+  };
 
-  if (joinType == lp::JoinType::kLeft) {
-    // No rows from the right can ever match.
-    currentDt_->removeLastTable(rightTable);
-    optionalSide = right.get();
-  } else if (joinType == lp::JoinType::kRight) {
-    // No rows from the left can ever match. Keep only the right table.
-    currentDt_ = newDt();
-    currentDt_->addTable(rightTable);
-    optionalSide = left.get();
-  }
+  switch (joinType) {
+    case lp::JoinType::kLeft: {
+      auto* rightTable = currentDt_->tables.back();
+      currentDt_->removeLastTable(rightTable);
+      projectNulls(*right);
+      return true;
+    }
+    case lp::JoinType::kRight: {
+      auto* rightTable = currentDt_->tables.back();
+      currentDt_ = newDt();
+      currentDt_->addTable(rightTable);
+      projectNulls(*left);
+      return true;
+    }
+    case lp::JoinType::kFull: {
+      // Full join with constant false ON clause: no rows can ever match.
+      // Return all rows from left with NULLs for right columns, UNION ALL
+      // all rows from right with NULLs for left columns.
+      auto* leftTable = currentDt_->tables.front();
+      auto* rightTable = currentDt_->tables.back();
 
-  if (!optionalSide) {
-    return false;
-  }
+      auto* unionDt = newDt();
+      unionDt->setOp = lp::SetOperation::kUnionAll;
 
-  // Project NULL for each column from the removed side.
-  const auto& outputType = optionalSide->outputType();
-  for (auto channel : usedChannels(*optionalSide)) {
-    const auto& name = outputType->names()[channel];
-    const auto& typePtr = outputType->childAt(channel);
-    renames_[name] = make<Literal>(
-        toConstantValue(typePtr), registerVariant(toType(typePtr)->kind()));
+      auto* leftChild = newDt();
+      leftChild->addTable(leftTable);
+
+      auto* rightChild = newDt();
+      rightChild->addTable(rightTable);
+
+      // Build output columns for the union DT and child expressions.
+      // Column order: left columns first, then right columns.
+      // 'isLeftSide' indicates which child gets the real column (true = left).
+      const auto addColumns = [&](const lp::LogicalPlanNode& node,
+                                  bool isLeftSide) {
+        const auto& type = node.outputType();
+        for (auto channel : usedChannels(node)) {
+          const auto& name = type->names()[channel];
+          const auto& typePtr = type->childAt(channel);
+          auto value = toConstantValue(typePtr);
+
+          Name columnName = toName(name);
+          unionDt->columns.push_back(
+              make<Column>(columnName, unionDt, value, columnName));
+
+          auto* nullLiteral =
+              make<Literal>(value, registerVariant(toType(typePtr)->kind()));
+          auto* realColumn = translateColumn(name);
+
+          leftChild->exprs.push_back(isLeftSide ? realColumn : nullLiteral);
+          rightChild->exprs.push_back(isLeftSide ? nullLiteral : realColumn);
+        }
+      };
+
+      addColumns(*left, true);
+      addColumns(*right, false);
+
+      // Left/right child DTs share the same column schema with parent Union DT.
+      // Child DTs expressions size should be equal with columns size.
+      leftChild->columns = unionDt->columns;
+      rightChild->columns = unionDt->columns;
+
+      unionDt->children.push_back(leftChild);
+      unionDt->children.push_back(rightChild);
+
+      // Update renames_ to point to the union output columns.
+      for (const auto* column : unionDt->columns) {
+        renames_[column->name()] = column;
+      }
+
+      currentDt_ = newDt();
+      currentDt_->addTable(unionDt);
+      return true;
+    }
+    default:
+      return false;
   }
-  return true;
 }
 
 DerivedTableP ToGraph::newDt() {

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -267,13 +267,18 @@ class ToGraph {
       const logical_plan::ExprPtr& condition,
       logical_plan::JoinType originalJoinType);
 
-  // Eliminates join when the ON clause contains a constant false condition.
+  // Eliminates a join when the ON clause contains a constant false conjunct.
+  // - Left join: removes right side and projects NULLs.
+  // - Right join: removes left side and projects NULLs.
+  // - Full join: creates a UNION ALL of left (with NULLs for right) and right
+  //   (with NULLs for left).
+  //
+  // Inner joins are not yet supported.
   // Returns true if the join was eliminated.
-  bool eliminateJoinOnConstantFalse(
+  bool tryEliminateJoinOnConstantFalse(
       logical_plan::JoinType joinType,
       const logical_plan::LogicalPlanNodePtr& left,
-      const logical_plan::LogicalPlanNodePtr& right,
-      PlanObjectCP rightTable);
+      const logical_plan::LogicalPlanNodePtr& right);
 
   // For LEFT JOIN with subquery conjuncts in the ON clause, processes the right
   // side inside a container DT and applies the subquery conjuncts as filters.
@@ -411,7 +416,7 @@ class ToGraph {
       const std::vector<logical_plan::SortingField>& ordering);
 
   // Process subqueries used in filter's predicate or projection expressions
-  // and populate subqueries_ map. For each IN <subquery> expression, create a
+  // and populate subqueries map. For each IN <subquery> expression, create a
   // separate DT for the subquery and add a semi-join edge. Replace the whole IN
   // predicate with a 'mark' column produced by the join. For other <subquery>
   // expressions, create a separate DT and replace the expression with the only

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -308,9 +308,14 @@ class ToGraph {
 
   void addProjection(const logical_plan::ProjectNode& project);
 
+  // Adds filter conjuncts from 'predicate' to 'currentDt_'. If
+  // 'emptyValuesType' is provided and the flattened conjuncts contain a
+  // constant false, replaces 'currentDt_' with an empty ValuesTable of the
+  // given type.
   void addFilter(
       const logical_plan::LogicalPlanNode& input,
-      const logical_plan::ExprPtr& predicate);
+      const logical_plan::ExprPtr& predicate,
+      const velox::RowTypePtr emptyValuesType = nullptr);
 
   // Returns true if any window expression in the project references another
   // window function output through renames_. Used to detect window-on-window
@@ -377,6 +382,9 @@ class ToGraph {
       ValuesTable::Data data);
 
   void makeEmptyValuesTable(const logical_plan::LogicalPlanNode& node);
+
+  // Creates an empty ValuesTable with the given output type.
+  void makeEmptyValuesTable(const velox::RowTypePtr& outputType);
 
   // Adds 'node' and descendants to query graph wrapped inside a
   // DerivedTable. Done for joins to the right of non-inner joins,

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -273,7 +273,9 @@ class ToGraph {
   // - Full join: creates a UNION ALL of left (with NULLs for right) and right
   //   (with NULLs for left).
   //
-  // Inner joins are not yet supported.
+  // Note: Inner join is handled by addFilter, which produces an empty result
+  // when there is a false conjunct.
+  //
   // Returns true if the join was eliminated.
   bool tryEliminateJoinOnConstantFalse(
       logical_plan::JoinType joinType,

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -1085,6 +1085,25 @@ TEST_F(JoinTest, leftJoinOnClausePushdown) {
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
+
+  // Constant false ON conjunct applied on FULL JOIN transforms to UNION ALL.
+  {
+    auto query = "SELECT * FROM t FULL JOIN u ON a = x AND 1 > 2";
+    SCOPED_TRACE(query);
+
+    // Full join with constant false ON clause transforms to:
+    // UNION ALL of (scan t with NULLs for u) and (scan u with NULLs for t).
+    auto matcher =
+        matchScan("t")
+            .project({"a", "b", "c", "null", "null"})
+            .localPartition(matchScan("u")
+                                .project({"null", "null", "null", "x", "y"})
+                                .build())
+            .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
 }
 
 TEST_F(JoinTest, impliedJoins) {

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -1104,6 +1104,50 @@ TEST_F(JoinTest, leftJoinOnClausePushdown) {
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
+
+  // Constant false ON conjunct applied on INNER JOIN will return an empty set.
+  {
+    auto query = "SELECT * FROM t INNER JOIN u ON a = x AND 1 > 2";
+    SCOPED_TRACE(query);
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .values(ROW({"a", "b", "c", "x", "y"}, BIGINT()))
+                       .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+
+    auto valuesNode = std::dynamic_pointer_cast<const core::ValuesNode>(plan);
+    ASSERT_NE(valuesNode, nullptr);
+    size_t numRows{0};
+    for (const auto& batch : valuesNode->values()) {
+      numRows += batch->size();
+    }
+    EXPECT_EQ(numRows, 0);
+  }
+
+  // Constant false ON conjunct on INNER JOIN when left side has aggregation.
+  {
+    auto query =
+        "SELECT * FROM (SELECT a, count(*) as cnt FROM t GROUP BY a) "
+        "INNER JOIN u ON a = x AND 1 > 2";
+    SCOPED_TRACE(query);
+
+    auto matcher = core::PlanMatcherBuilder()
+                       .values(ROW({"a", "cnt", "x", "y"}, BIGINT()))
+                       .build();
+
+    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    AXIOM_ASSERT_PLAN(plan, matcher);
+
+    auto valuesNode = std::dynamic_pointer_cast<const core::ValuesNode>(plan);
+    ASSERT_NE(valuesNode, nullptr);
+    size_t numRows{0};
+    for (const auto& batch : valuesNode->values()) {
+      numRows += batch->size();
+    }
+    EXPECT_EQ(numRows, 0);
+  }
 }
 
 TEST_F(JoinTest, impliedJoins) {

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -279,6 +279,8 @@ TEST_F(PlanTest, specialFormConstantFold) {
     std::shared_ptr<velox::core::PlanMatcher> matcher;
     if (!testCase.expectedExpression.has_value()) {
       matcher = core::PlanMatcherBuilder().tableScan().project().build();
+    } else if (testCase.expectedExpression.value() == "false") {
+      matcher = core::PlanMatcherBuilder().values().project().build();
     } else {
       matcher = core::PlanMatcherBuilder()
                     .tableScan()
@@ -357,7 +359,7 @@ TEST_F(PlanTest, inList) {
   {
     auto logicalPlan = scan().filter("4 in (1, 2, 3)").map({"a + 2"}).build();
 
-    auto matcher = scanMatcher().filter("false").project().build();
+    auto matcher = core::PlanMatcherBuilder().values().project().build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -941,6 +943,29 @@ TEST_F(PlanTest, zeroLimit) {
                                  core::PlanMatcherBuilder{}.tableScan().build(),
                                  core::JoinType::kInner)
                              .build();
+    AXIOM_ASSERT_PLAN(planSql(query), matcher);
+  }
+}
+
+TEST_F(PlanTest, constantFalseFilter) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+
+  const auto planSql = [&](const std::string& sql) {
+    return toSingleNodePlan(parseSelect(sql, kTestConnectorId));
+  };
+
+  const auto matcher =
+      core::PlanMatcherBuilder{}.values(ROW({"a", "b"}, BIGINT())).build();
+
+  {
+    const auto query = "SELECT * FROM t WHERE false";
+    SCOPED_TRACE(query);
+    AXIOM_ASSERT_PLAN(planSql(query), matcher);
+  }
+
+  {
+    const auto query = "SELECT * FROM t WHERE 1 > 2";
+    SCOPED_TRACE(query);
     AXIOM_ASSERT_PLAN(planSql(query), matcher);
   }
 }


### PR DESCRIPTION
Summary:
Optimizes INNER JOIN with constant false ON clause (e.g., `ON a = x AND 1 > 2`)
by replacing the join with an empty ValuesTable. Adds a two-input `makeEmptyValuesTable`
overload that combines the output schemas of both join sides. Also passes the
`JoinNode` to `addFilter` in `translateJoin` to enable constant-false detection.

Differential Revision: D95403359


