### PR TITLE
feat(optimizer): Merge correlated scalar subqueries into single JOIN

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -2265,9 +2265,7 @@ void ToGraph::addProjection(const lp::ProjectNode& project) {
     }
   });
 
-  for (auto i : channels) {
-    processSubqueries(input, exprs[i], /*filter=*/false);
-  }
+  processProjectionSubqueries(input, exprs, channels);
 
   QGVector<WindowFunctionCP> windowFunctions;
   ColumnVector windowColumns;
@@ -2347,6 +2345,28 @@ void extractSubqueries(const lp::ExprPtr& expr, Subqueries& subqueries) {
 }
 } // namespace
 
+void ToGraph::processProjectionSubqueries(
+    const lp::LogicalPlanNode& input,
+    const std::vector<lp::ExprPtr>& exprs,
+    const std::vector<int32_t>& channels) {
+  Subqueries allSubqueries;
+  for (auto i : channels) {
+    extractSubqueries(exprs[i], allSubqueries);
+  }
+
+  if (allSubqueries.empty()) {
+    return;
+  }
+
+  if (currentDt_->hasAggregation() || currentDt_->hasUnnestTable()) {
+    finalizeDt(input);
+  }
+
+  processScalarSubqueries(input, allSubqueries.scalars);
+  processInPredicates(allSubqueries.inPredicates);
+  processExistsSubqueries(allSubqueries.exists);
+}
+
 DerivedTableP ToGraph::translateSubquery(
     const logical_plan::LogicalPlanNode& node,
     bool finalize) {
@@ -2385,7 +2405,98 @@ ColumnCP ToGraph::addMarkColumn() {
   return markColumn;
 }
 
+// Holds a translated scalar subquery along with its correlation state.
+// Used by processScalarSubqueries() to group mergeable subqueries.
+struct TranslatedSubquery {
+  lp::SubqueryExprPtr subqueryExpr;
+  DerivedTableP subqueryDt;
+  ExprVector correlatedConjuncts;
+};
+
 namespace {
+// Replaces column references in 'expr'. For each column in 'from',
+// replaces it with the corresponding entry in 'to'. Used to remap aggregate
+// expressions from one BaseTable's columns to another's.
+ExprCP
+remapColumns(ExprCP expr, const ColumnVector& from, const ColumnVector& to) {
+  if (!expr) {
+    return nullptr;
+  }
+
+  switch (expr->type()) {
+    case PlanType::kColumnExpr: {
+      for (size_t i = 0; i < from.size(); ++i) {
+        if (from[i] == expr) {
+          return to[i];
+        }
+      }
+      return expr;
+    }
+    case PlanType::kLiteralExpr:
+      return expr;
+    case PlanType::kCallExpr:
+    case PlanType::kAggregateExpr: {
+      auto children = expr->children();
+      ExprVector newChildren(children.size());
+      FunctionSet functions;
+      bool anyChange = false;
+      for (size_t i = 0; i < children.size(); ++i) {
+        newChildren[i] = remapColumns(children[i]->as<Expr>(), from, to);
+        anyChange |= newChildren[i] != children[i];
+        if (newChildren[i]->isFunction()) {
+          functions = functions | newChildren[i]->as<Call>()->functions();
+        }
+      }
+
+      if (expr->type() == PlanType::kAggregateExpr) {
+        const auto* aggregate = expr->as<Aggregate>();
+        auto* newCondition = remapColumns(aggregate->condition(), from, to);
+
+        ExprVector newOrderKeys;
+        newOrderKeys.reserve(aggregate->orderKeys().size());
+        for (const auto* orderKey : aggregate->orderKeys()) {
+          newOrderKeys.push_back(remapColumns(orderKey, from, to));
+        }
+
+        anyChange |= newCondition != aggregate->condition();
+        anyChange |= newOrderKeys != aggregate->orderKeys();
+
+        if (!anyChange) {
+          return expr;
+        }
+
+        return make<Aggregate>(
+            aggregate->name(),
+            aggregate->value(),
+            std::move(newChildren),
+            functions,
+            aggregate->isDistinct(),
+            newCondition,
+            aggregate->intermediateType(),
+            std::move(newOrderKeys),
+            aggregate->orderTypes());
+      }
+
+      if (!anyChange) {
+        return expr;
+      }
+
+      const auto* call = expr->as<Call>();
+      return make<Call>(
+          call->name(), call->value(), std::move(newChildren), functions);
+    }
+    case PlanType::kFieldExpr: {
+      auto* field = expr->as<Field>();
+      auto* newBase = remapColumns(field->base(), from, to);
+      if (newBase == field->base()) {
+        return expr;
+      }
+      return make<Field>(field->value().type, newBase, field->field());
+    }
+    default:
+      return expr;
+  }
+}
 
 // Holds the extracted join keys and filters from correlated conjuncts.
 // Used when decorrelating subqueries.
@@ -2474,7 +2585,167 @@ CorrelationKeys extractCorrelationKeys(
   return result;
 }
 
+// Extracts correlation keys if the subquery is eligible for merging, or
+// returns std::nullopt otherwise. A merge candidate must be: correlated with
+// equi-only correlation, have exactly one aggregate function, and scan a
+// single base table with no extra filters.
+std::optional<CorrelationKeys> tryExtractMergeKeys(
+    const FunctionNames& funcs,
+    const TranslatedSubquery& subquery) {
+  // Uncorrelated subqueries cannot be merged via the correlation-based path.
+  if (subquery.correlatedConjuncts.empty()) {
+    return std::nullopt;
+  }
+
+  auto* subqueryDt = subquery.subqueryDt;
+  // Reject subqueries that are too complex to merge: no aggregation, multiple
+  // tables, non-base-table scans, WHERE filters, HAVING clauses, or multiple
+  // aggregates (multi-aggregate merging would require N:N column mapping).
+  if (!subqueryDt->hasAggregation() || subqueryDt->tables.size() != 1 ||
+      !subqueryDt->tables[0]->is(PlanType::kTableNode) ||
+      !subqueryDt->conjuncts.empty() || !subqueryDt->having.empty() ||
+      subqueryDt->aggregation->aggregates().size() != 1) {
+    return std::nullopt;
+  }
+
+  // Extract correlation keys (left/right key pairs from equi-conjuncts).
+  // Reject if any non-equi conjuncts exist (can't use hash join) or if the
+  // outer table couldn't be identified.
+  auto keys = extractCorrelationKeys(
+      funcs, subquery.correlatedConjuncts, subquery.subqueryDt);
+  if (!keys.nonEquiConjuncts.empty() || !keys.leftTable) {
+    return std::nullopt;
+  }
+
+  // Reject if the base table has pushed-down column filters or table filter.
+  // These would produce different scan results per subquery, preventing merge.
+  auto* baseTable = subqueryDt->tables[0]->as<BaseTable>();
+  if (!baseTable->columnFilters.empty() || !baseTable->filter.empty()) {
+    return std::nullopt;
+  }
+
+  return keys;
+}
+
+// Returns true if two merge candidates can be combined into a single
+// aggregation. They must correlate with the same outer table using the same
+// outer keys, scan the same physical table, and group by the same columns.
+bool areMergeable(
+    const TranslatedSubquery& lhs,
+    const CorrelationKeys& keysLhs,
+    const TranslatedSubquery& rhs,
+    const CorrelationKeys& keysRhs) {
+  // Must correlate with the same outer table and same number of keys.
+  if (keysLhs.leftTable != keysRhs.leftTable ||
+      keysLhs.leftKeys.size() != keysRhs.leftKeys.size()) {
+    return false;
+  }
+
+  // Must scan the same physical table (same SchemaTable catalog entry).
+  auto* baseTableLhs = lhs.subqueryDt->tables[0]->as<BaseTable>();
+  auto* baseTableRhs = rhs.subqueryDt->tables[0]->as<BaseTable>();
+  if (baseTableLhs->schemaTable != baseTableRhs->schemaTable) {
+    return false;
+  }
+
+  // Outer (left) keys must be identical — same column pointers since they
+  // reference the same outer table.
+  for (size_t i = 0; i < keysLhs.leftKeys.size(); ++i) {
+    if (keysLhs.leftKeys[i] != keysRhs.leftKeys[i]) {
+      return false;
+    }
+  }
+
+  // Inner (right) correlation keys become GROUP BY keys. Compare by column
+  // name rather than pointer since they come from different DerivedTables.
+  auto* aggLhs = lhs.subqueryDt->aggregation;
+  auto* aggRhs = rhs.subqueryDt->aggregation;
+  if (aggLhs->groupingKeys().size() != aggRhs->groupingKeys().size()) {
+    return false;
+  }
+  for (size_t i = 0; i < aggLhs->groupingKeys().size(); ++i) {
+    auto* groupKeyLhs = aggLhs->groupingKeys()[i];
+    auto* groupKeyRhs = aggRhs->groupingKeys()[i];
+    if (!groupKeyLhs->is(PlanType::kColumnExpr) ||
+        !groupKeyRhs->is(PlanType::kColumnExpr) ||
+        groupKeyLhs->as<Column>()->name() !=
+            groupKeyRhs->as<Column>()->name()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 } // namespace
+
+void ToGraph::mergeAggregateIntoPrimary(
+    BaseTable* primaryBt,
+    DerivedTableP primaryDt,
+    const DerivedTable* secondaryDt,
+    AggregateVector& aggregates,
+    ColumnVector& columns,
+    ColumnVector& intermediateColumns) {
+  auto* secondaryBt = secondaryDt->tables[0]->as<BaseTable>();
+
+  // Build a column mapping from secondary BaseTable columns to primary
+  // BaseTable columns. Both BaseTables reference the same physical table but
+  // have separate Column objects. The mapping lets us rewrite aggregate
+  // expressions to reference the primary's columns.
+  ColumnVector sourceColumns;
+  ColumnVector targetColumns;
+  for (auto* secondaryColumn : secondaryBt->columns) {
+    sourceColumns.push_back(secondaryColumn);
+
+    // Find the matching column in the primary BaseTable by name.
+    ColumnCP match = nullptr;
+    for (auto* primaryColumn : primaryBt->columns) {
+      if (primaryColumn->name() == secondaryColumn->name()) {
+        match = primaryColumn;
+        break;
+      }
+    }
+
+    // If the primary doesn't read this column yet, add it. This happens when
+    // the secondary's aggregate uses a column the primary didn't need
+    // (e.g., primary has count(*), secondary has max(n_nationkey)).
+    if (!match) {
+      auto* newColumn = make<Column>(
+          secondaryColumn->name(), primaryBt, secondaryColumn->value());
+      primaryBt->columns.push_back(newColumn);
+      match = newColumn;
+    }
+
+    targetColumns.push_back(match);
+  }
+
+  // Remap each aggregate from the secondary to reference primary's columns,
+  // then create matching output and intermediate columns for it.
+  auto* secondaryAgg = secondaryDt->aggregation;
+  for (auto* agg : secondaryAgg->aggregates()) {
+    // Replace column references: e.g., max(secondary.n_nationkey) becomes
+    // max(primary.n_nationkey).
+    auto* remappedAgg =
+        remapColumns(agg, sourceColumns, targetColumns)->as<Aggregate>();
+    aggregates.push_back(remappedAgg);
+
+    // Use the same name for both output and intermediate columns. The
+    // distributed plan splitter pairs them by position and expects
+    // consistent names between partial and final aggregation stages.
+    auto* name = newCName("__agg");
+
+    // Output column: the final aggregate result type (e.g., BIGINT for count).
+    auto* aggColumn = make<Column>(name, primaryDt, remappedAgg->value());
+    columns.push_back(aggColumn);
+
+    // Intermediate column: the partial accumulator type (e.g., ROW<BIGINT>
+    // for count). Used as output during partial aggregation.
+    auto intermediateValue = remappedAgg->value();
+    intermediateValue.type = remappedAgg->intermediateType();
+    auto* intermediateColumn = make<Column>(name, primaryDt, intermediateValue);
+    intermediateColumns.push_back(intermediateColumn);
+  }
+}
 
 void ToGraph::appendArbitraryAggregates(
     const lp::LogicalPlanNode& input,
@@ -2626,17 +2897,92 @@ void ToGraph::processSubqueries(
 void ToGraph::processScalarSubqueries(
     const lp::LogicalPlanNode& input,
     const std::vector<lp::SubqueryExprPtr>& scalars) {
-  for (const auto& subquery : scalars) {
-    auto subqueryDt = translateSubquery(*subquery->subquery());
-
-    ExprCP column;
-    if (correlatedConjuncts_.empty()) {
-      column = processUncorrelatedScalarSubquery(subqueryDt);
-    } else {
-      column = processCorrelatedScalarSubquery(input, subqueryDt);
+  // Fast path: with 0-1 subqueries, merging is impossible. Process directly.
+  if (scalars.size() <= 1) {
+    for (const auto& subquery : scalars) {
+      auto subqueryDt = translateSubquery(*subquery->subquery());
+      resolveScalarSubquery(input, subquery, subqueryDt);
     }
-    subqueries_.emplace(subquery, column);
+    return;
   }
+
+  // Phase 1: Translate all subqueries upfront without adding to currentDt_.
+  // We pass finalize=false so the subquery DTs are not yet integrated into
+  // the outer query — we need to inspect them first to decide which can merge.
+  // Save each subquery's correlation conjuncts since translateSubquery sets
+  // correlatedConjuncts_ as a side effect.
+  std::vector<TranslatedSubquery> translated;
+  translated.reserve(scalars.size());
+  for (const auto& subquery : scalars) {
+    auto subqueryDt =
+        translateSubquery(*subquery->subquery(), /*finalize=*/false);
+    translated.push_back(
+        TranslatedSubquery{subquery, subqueryDt, correlatedConjuncts_});
+    correlatedConjuncts_.clear();
+  }
+
+  // Phase 2: Group mergeable subqueries and process each group.
+  // For each unprocessed subquery, check if it's a merge candidate. If so,
+  // scan remaining subqueries for compatible partners. Groups of 2+ get
+  // merged; singletons fall through to the normal path.
+  std::vector<bool> processed(translated.size(), false);
+  for (size_t i = 0; i < translated.size(); ++i) {
+    if (processed[i]) {
+      continue;
+    }
+
+    auto& candidate = translated[i];
+    auto candidateKeys = tryExtractMergeKeys(functionNames_, candidate);
+
+    if (candidateKeys) {
+      // Start a group with this candidate and find compatible partners.
+      std::vector<TranslatedSubquery> group;
+      group.push_back(std::move(candidate));
+
+      for (size_t j = i + 1; j < translated.size(); ++j) {
+        if (processed[j]) {
+          continue;
+        }
+        auto partnerKeys = tryExtractMergeKeys(functionNames_, translated[j]);
+        if (partnerKeys &&
+            areMergeable(
+                group[0], *candidateKeys, translated[j], *partnerKeys)) {
+          group.push_back(std::move(translated[j]));
+          processed[j] = true;
+        }
+      }
+
+      processed[i] = true;
+
+      if (group.size() > 1) {
+        mergeCorrelatedScalarSubqueries(input, group);
+        continue;
+      }
+
+      // Singleton merge candidate: move back and process via normal path.
+      candidate = std::move(group[0]);
+    }
+
+    // Normal path: process as a single subquery (uncorrelated or correlated).
+    processed[i] = true;
+
+    currentDt_->addTable(candidate.subqueryDt);
+    correlatedConjuncts_ = candidate.correlatedConjuncts;
+    resolveScalarSubquery(input, candidate.subqueryExpr, candidate.subqueryDt);
+  }
+}
+
+void ToGraph::resolveScalarSubquery(
+    const lp::LogicalPlanNode& input,
+    const lp::SubqueryExprPtr& subqueryExpr,
+    DerivedTableP subqueryDt) {
+  ExprCP column;
+  if (correlatedConjuncts_.empty()) {
+    column = processUncorrelatedScalarSubquery(subqueryDt);
+  } else {
+    column = processCorrelatedScalarSubquery(input, subqueryDt);
+  }
+  subqueries_.emplace(subqueryExpr, column);
 }
 
 ExprCP ToGraph::processUncorrelatedScalarSubquery(DerivedTableP subqueryDt) {
@@ -2807,6 +3153,114 @@ ExprCP ToGraph::processCorrelatedScalarSubquery(
       ExprVector{rowNumberColumn}, allAggregates, allColumns, allColumns);
 
   return aggResultColumn;
+}
+
+void ToGraph::addCorrelationJoin(
+    const ExprVector& conjuncts,
+    DerivedTableP subqueryDt) {
+  auto correlation =
+      extractCorrelationKeys(functionNames_, conjuncts, subqueryDt);
+
+  // Merged candidates are pre-validated as equi-only by tryExtractMergeKeys.
+  VELOX_CHECK(correlation.nonEquiConjuncts.empty());
+
+  // Create a LEFT JOIN (rightOptional = true) from the outer table to the
+  // subquery DT. The LEFT JOIN preserves all outer rows, producing NULL for
+  // the aggregate columns when there is no matching inner row.
+  auto* join = make<JoinEdge>(
+      correlation.leftTable, subqueryDt, JoinEdge::Spec{.rightOptional = true});
+  for (size_t i = 0; i < correlation.leftKeys.size(); ++i) {
+    join->addEquality(correlation.leftKeys[i], correlation.rightKeys[i]);
+  }
+  currentDt_->joins.push_back(join);
+}
+
+void ToGraph::mapSubqueriesToResults(
+    const std::vector<TranslatedSubquery>& group,
+    const ColumnVector& columns,
+    const AggregateVector& aggregates,
+    size_t numGroupingKeys) {
+  // Columns are laid out as [groupingKeys..., agg0, agg1, ...].
+  // Skip grouping keys to iterate over aggregate result columns.
+  size_t aggIdx = numGroupingKeys;
+  for (const auto& subquery : group) {
+    auto* aggResultColumn = columns[aggIdx];
+    auto* agg = aggregates[aggIdx - numGroupingKeys];
+
+    // For count-like aggregates, wrap with COALESCE(result, 0). When the
+    // LEFT JOIN produces no match, the aggregate column is NULL, but
+    // count should return 0 (not NULL) for unmatched outer rows.
+    ExprCP result = aggResultColumn;
+    if (auto* literal = tryMakeLiteralForEmptyInput(agg)) {
+      result = make<Call>(
+          SpecialFormCallNames::kCoalesce,
+          aggResultColumn->value(),
+          ExprVector{aggResultColumn, literal},
+          FunctionSet());
+    }
+
+    // Map the original subquery expression to its aggregate result so that
+    // the outer query's projection can reference it.
+    subqueries_.emplace(subquery.subqueryExpr, result);
+    ++aggIdx;
+  }
+}
+
+void ToGraph::mergeCorrelatedScalarSubqueries(
+    const lp::LogicalPlanNode& /*input*/,
+    std::vector<TranslatedSubquery>& group) {
+  // Use the first subquery as the primary — its DerivedTable survives in the
+  // plan. All others are secondaries whose aggregates get folded in.
+  VELOX_CHECK_GE(group.size(), 2);
+  auto* primaryDt = group[0].subqueryDt;
+  currentDt_->addTable(primaryDt);
+
+  auto* primaryBt =
+      const_cast<BaseTable*>(primaryDt->tables[0]->as<BaseTable>());
+  auto* primaryAgg = primaryDt->aggregation;
+  VELOX_CHECK_NOT_NULL(primaryAgg);
+
+  // Start with the primary's aggregation components. We'll append secondaries.
+  ExprVector groupingKeys = primaryAgg->groupingKeys();
+  AggregateVector aggregates = primaryAgg->aggregates();
+  ColumnVector columns(
+      primaryAgg->columns().begin(), primaryAgg->columns().end());
+  ColumnVector intermediateColumns(
+      primaryAgg->intermediateColumns().begin(),
+      primaryAgg->intermediateColumns().end());
+
+  // Merge each secondary subquery's aggregate into primary.
+  for (size_t i = 1; i < group.size(); ++i) {
+    mergeAggregateIntoPrimary(
+        primaryBt,
+        primaryDt,
+        group[i].subqueryDt,
+        aggregates,
+        columns,
+        intermediateColumns);
+  }
+
+  // Replace the primary's aggregation with the combined one (original
+  // grouping keys + all aggregates from primary and secondaries).
+  primaryDt->aggregation = make<AggregationPlan>(
+      groupingKeys, aggregates, columns, intermediateColumns);
+
+  // Expose the new aggregate columns in the primary DT's output so
+  // downstream operators can reference them. The primary's original
+  // columns are already there; only add the newly merged ones.
+  for (size_t i = primaryAgg->columns().size(); i < columns.size(); ++i) {
+    primaryDt->columns.push_back(columns[i]);
+    primaryDt->exprs.push_back(columns[i]);
+    renames_[columns[i]->name()] = columns[i];
+  }
+
+  // Create one LEFT JOIN from the outer table to the primary DT using
+  // the correlation keys. All subqueries share the same correlation.
+  addCorrelationJoin(group[0].correlatedConjuncts, primaryDt);
+
+  // Map each subquery's expression to its corresponding aggregate result
+  // column, wrapping count-like aggregates with COALESCE.
+  mapSubqueriesToResults(group, columns, aggregates, groupingKeys.size());
 }
 
 void ToGraph::processInPredicates(

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -96,6 +96,8 @@ struct SubfieldProjections {
   folly::F14FastMap<PathCP, ExprCP> pathToExpr;
 };
 
+struct TranslatedSubquery;
+
 class ToGraph {
  public:
   ToGraph(
@@ -425,11 +427,26 @@ class ToGraph {
       const logical_plan::ExprPtr& expr,
       bool filter);
 
+  // Extracts all subqueries from a set of projection expressions and processes
+  // them in a single batch. Enables merging of correlated scalar subqueries
+  // that reference the same table with the same correlation keys.
+  void processProjectionSubqueries(
+      const logical_plan::LogicalPlanNode& input,
+      const std::vector<logical_plan::ExprPtr>& exprs,
+      const std::vector<int32_t>& channels);
+
   // Processes scalar subqueries, creating DTs and joins for each.
   // Populates subqueries_ with mappings from subquery expressions to columns.
   void processScalarSubqueries(
       const logical_plan::LogicalPlanNode& input,
       const std::vector<logical_plan::SubqueryExprPtr>& scalars);
+
+  // Resolves a scalar subquery to its output expression via the uncorrelated
+  // or correlated path. Stores the result in subqueries_.
+  void resolveScalarSubquery(
+      const logical_plan::LogicalPlanNode& input,
+      const logical_plan::SubqueryExprPtr& subqueryExpr,
+      DerivedTableP subqueryDt);
 
   // Processes an uncorrelated scalar subquery. Attempts constant folding,
   // otherwise ensures single row. Returns the expression to map to the
@@ -442,6 +459,36 @@ class ToGraph {
   ExprCP processCorrelatedScalarSubquery(
       const logical_plan::LogicalPlanNode& input,
       DerivedTableP subqueryDt);
+
+  // Merges a group of correlated scalar subqueries that reference the same
+  // table with the same correlation keys. Combines their aggregations into a
+  // single DerivedTable and creates one LEFT JOIN instead of N separate ones.
+  void mergeCorrelatedScalarSubqueries(
+      const logical_plan::LogicalPlanNode& input,
+      std::vector<TranslatedSubquery>& group);
+
+  // Creates a LEFT JOIN edge from equi-only correlation conjuncts.
+  void addCorrelationJoin(
+      const ExprVector& conjuncts,
+      DerivedTableP subqueryDt);
+
+  // Remaps a secondary subquery's aggregate to reference primaryBt's columns
+  // and appends it to the combined aggregation vectors.
+  void mergeAggregateIntoPrimary(
+      BaseTable* primaryBt,
+      DerivedTableP primaryDt,
+      const DerivedTable* secondaryDt,
+      AggregateVector& aggregates,
+      ColumnVector& columns,
+      ColumnVector& intermediateColumns);
+
+  // Maps each merged subquery to its aggregate result column, wrapping
+  // count-like aggregates with COALESCE.
+  void mapSubqueriesToResults(
+      const std::vector<TranslatedSubquery>& group,
+      const ColumnVector& columns,
+      const AggregateVector& aggregates,
+      size_t numGroupingKeys);
 
   // Processes IN <subquery> predicates, creating semi-joins with mark columns.
   // Populates subqueries_ with mappings from IN predicates to mark columns.

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -643,7 +643,8 @@ TEST_F(SubqueryTest, correlatedProject) {
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
-  // Multiple scalar subqueries in projection.
+  // Multiple scalar subqueries in projection with same correlation are merged
+  // into a single join with combined aggregation.
   {
     auto query =
         "SELECT r_name, "
@@ -651,13 +652,18 @@ TEST_F(SubqueryTest, correlatedProject) {
         "   (SELECT max(n_nationkey) FROM nation WHERE n_regionkey = r_regionkey) AS max_key "
         "FROM region";
 
-    // Each subquery produces a separate LEFT JOIN.
-    auto matcher = matchHiveScan("region")
-                       // TODO Optimize to combine the two LEFT JOINs into one.
-                       .hashJoin(matchAggNation(), velox::core::JoinType::kLeft)
-                       .hashJoin(matchAggNation(), velox::core::JoinType::kLeft)
-                       .project()
-                       .build();
+    // The two correlated scalar subqueries reference the same table (nation)
+    // with the same correlation key (n_regionkey = r_regionkey), so they are
+    // merged into a single join with combined aggregation (count + max).
+    // The optimizer may flip join sides, producing a RIGHT join.
+    auto matcher =
+        matchHiveScan("nation")
+            .singleAggregation()
+            .project()
+            .hashJoin(
+                matchHiveScan("region").build(), velox::core::JoinType::kRight)
+            .project()
+            .build();
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
@@ -727,6 +733,342 @@ TEST_F(SubqueryTest, correlatedProject) {
                 true)
             .project()
             .build();
+
+    SCOPED_TRACE(query);
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
+TEST_F(SubqueryTest, mergedCorrelatedScalarSubqueries) {
+  auto matchAggNation = [&]() {
+    return matchHiveScan("nation").singleAggregation().project().build();
+  };
+
+  // Three scalar subqueries on the same table with same correlation produce
+  // one join with combined aggregation (count + max + min).
+  // The optimizer may flip join sides, producing a RIGHT join.
+  {
+    auto query =
+        "SELECT r_name, "
+        "   (SELECT count(*) FROM nation WHERE n_regionkey = r_regionkey) AS cnt, "
+        "   (SELECT max(n_nationkey) FROM nation WHERE n_regionkey = r_regionkey) AS max_key, "
+        "   (SELECT min(n_nationkey) FROM nation WHERE n_regionkey = r_regionkey) AS min_key "
+        "FROM region";
+
+    auto matcher =
+        matchHiveScan("nation")
+            .singleAggregation()
+            .project()
+            .hashJoin(
+                matchHiveScan("region").build(), velox::core::JoinType::kRight)
+            .project()
+            .build();
+
+    SCOPED_TRACE(query);
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Subqueries with different source tables are not merged.
+  {
+    auto query =
+        "SELECT n_name, "
+        "   (SELECT count(*) FROM region WHERE r_regionkey = n_regionkey) AS cnt, "
+        "   (SELECT max(s_acctbal) FROM supplier WHERE s_nationkey = n_nationkey) AS max_bal "
+        "FROM nation";
+
+    auto matchAggRegion = [&]() {
+      return matchHiveScan("region").singleAggregation().project().build();
+    };
+    auto matchAggSupplier = [&]() {
+      return matchHiveScan("supplier").singleAggregation().project().build();
+    };
+
+    auto matcher =
+        matchHiveScan("nation")
+            .hashJoin(matchAggRegion(), velox::core::JoinType::kLeft)
+            .hashJoin(matchAggSupplier(), velox::core::JoinType::kLeft)
+            .project()
+            .build();
+
+    SCOPED_TRACE(query);
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Subqueries with different correlation keys are not merged.
+  {
+    auto query =
+        "SELECT s_name, "
+        "   (SELECT count(*) FROM nation WHERE n_nationkey = s_nationkey) AS cnt, "
+        "   (SELECT max(n_regionkey) FROM nation WHERE n_regionkey = s_nationkey) AS max_rk "
+        "FROM supplier";
+
+    auto matcher = matchHiveScan("supplier")
+                       .hashJoin(matchAggNation(), velox::core::JoinType::kLeft)
+                       .hashJoin(matchAggNation(), velox::core::JoinType::kLeft)
+                       .project()
+                       .build();
+
+    SCOPED_TRACE(query);
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Single correlated subquery still works.
+  {
+    auto query =
+        "SELECT r_name, "
+        "   (SELECT count(*) FROM nation WHERE n_regionkey = r_regionkey) AS cnt "
+        "FROM region";
+
+    auto matcher = matchHiveScan("region")
+                       .hashJoin(matchAggNation(), velox::core::JoinType::kLeft)
+                       .project()
+                       .build();
+
+    SCOPED_TRACE(query);
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Mix of mergeable and non-mergeable subqueries.
+  {
+    auto query =
+        "SELECT r_name, "
+        "   (SELECT count(*) FROM nation WHERE n_regionkey = r_regionkey) AS cnt, "
+        "   (SELECT max(n_nationkey) FROM nation WHERE n_regionkey = r_regionkey) AS max_key, "
+        "   r_regionkey IN (SELECT n_regionkey FROM nation) AS has_nations "
+        "FROM region";
+
+    // Two correlated scalar subqueries are merged into one join.
+    // The IN subquery gets its own separate semi-join.
+    // The optimizer processes the IN subquery first (bottom of the plan tree)
+    // and places the merged scalar subquery join on top.
+    auto matcher = matchHiveScan("nation")
+                       .project()
+                       .hashJoin(
+                           matchHiveScan("region").build(),
+                           velox::core::JoinType::kRightSemiProject,
+                           true)
+                       .hashJoin(matchAggNation(), velox::core::JoinType::kLeft)
+                       .project()
+                       .build();
+
+    SCOPED_TRACE(query);
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
+TEST_F(SubqueryTest, mergedCorrelatedScalarSubqueriesEdgeCases) {
+  auto matchAggNation = [&]() {
+    return matchHiveScan("nation").singleAggregation().project().build();
+  };
+
+  auto matchMergedNation = [&]() {
+    return matchHiveScan("nation")
+        .singleAggregation()
+        .project()
+        .hashJoin(
+            matchHiveScan("region").build(), velox::core::JoinType::kRight)
+        .project()
+        .build();
+  };
+
+  // WHERE filter on one subquery prevents merging for that subquery.
+  // Two merge, one with filter stays separate -> 2 joins total.
+  {
+    auto query =
+        "SELECT r_name, "
+        "   (SELECT count(*) FROM nation WHERE n_regionkey = r_regionkey) AS cnt, "
+        "   (SELECT max(n_nationkey) FROM nation WHERE n_regionkey = r_regionkey) AS max_key, "
+        "   (SELECT min(n_nationkey) FROM nation WHERE n_regionkey = r_regionkey AND n_nationkey < 5) AS min_filtered "
+        "FROM region";
+
+    auto matcher =
+        matchHiveScan("nation")
+            .singleAggregation()
+            .project()
+            .hashJoin(
+                matchHiveScan("region").build(), velox::core::JoinType::kRight)
+            .hashJoin(matchAggNation(), velox::core::JoinType::kLeft)
+            .project()
+            .build();
+
+    SCOPED_TRACE(query);
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // HAVING clause prevents merging. Each gets its own LEFT JOIN.
+  {
+    auto query =
+        "SELECT r_name, "
+        "   (SELECT count(*) FROM nation WHERE n_regionkey = r_regionkey) AS cnt1, "
+        "   (SELECT count(*) FROM nation WHERE n_regionkey = r_regionkey HAVING count(*) > 2) AS cnt2 "
+        "FROM region";
+
+    auto matcher = matchHiveScan("region")
+                       .hashJoin(matchAggNation(), velox::core::JoinType::kLeft)
+                       .hashJoin(
+                           matchHiveScan("nation")
+                               .singleAggregation()
+                               .filter()
+                               .project()
+                               .build(),
+                           velox::core::JoinType::kLeft)
+                       .project()
+                       .build();
+
+    SCOPED_TRACE(query);
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Singleton merge candidate with uncorrelated subquery. The correlated one
+  // falls through to normal path since it has no merge partner.
+  {
+    auto query =
+        "SELECT r_name, "
+        "   (SELECT count(*) FROM nation WHERE n_regionkey = r_regionkey) AS cnt, "
+        "   (SELECT count(*) FROM supplier) AS total_suppliers "
+        "FROM region";
+
+    auto matcher =
+        matchHiveScan("region")
+            .hashJoin(matchAggNation(), velox::core::JoinType::kLeft)
+            .nestedLoopJoin(
+                matchHiveScan("supplier").singleAggregation().build(),
+                velox::core::JoinType::kInner)
+            .project()
+            .build();
+
+    SCOPED_TRACE(query);
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Multiple correlation keys: both subqueries have the same 2 keys.
+  {
+    auto query =
+        "SELECT n_name, "
+        "   (SELECT count(*) FROM supplier WHERE s_nationkey = n_nationkey AND s_suppkey = n_regionkey) AS cnt, "
+        "   (SELECT max(s_acctbal) FROM supplier WHERE s_nationkey = n_nationkey AND s_suppkey = n_regionkey) AS max_bal "
+        "FROM nation";
+
+    auto matcher =
+        matchHiveScan("supplier")
+            .singleAggregation()
+            .project()
+            .hashJoin(
+                matchHiveScan("nation").build(), velox::core::JoinType::kRight)
+            .project()
+            .build();
+
+    SCOPED_TRACE(query);
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Different number of correlation keys (1 vs 2) -> not merged.
+  {
+    auto query =
+        "SELECT n_name, "
+        "   (SELECT count(*) FROM supplier WHERE s_nationkey = n_nationkey) AS cnt, "
+        "   (SELECT max(s_acctbal) FROM supplier WHERE s_nationkey = n_nationkey AND s_suppkey = n_regionkey) AS max_bal "
+        "FROM nation";
+
+    auto matcher =
+        matchHiveScan("supplier")
+            .singleAggregation()
+            .project()
+            .hashJoin(
+                matchHiveScan("nation").build(), velox::core::JoinType::kRight)
+            .hashJoin(
+                matchHiveScan("supplier").singleAggregation().project().build(),
+                velox::core::JoinType::kLeft)
+            .project()
+            .build();
+
+    SCOPED_TRACE(query);
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // Two independent merge groups: 2 scan nation + 2 scan customer -> 2 joins.
+  {
+    auto query =
+        "SELECT o_orderkey, "
+        "   (SELECT count(*) FROM nation WHERE n_nationkey = o_custkey) AS cnt_n, "
+        "   (SELECT max(n_regionkey) FROM nation WHERE n_nationkey = o_custkey) AS max_rk, "
+        "   (SELECT count(*) FROM customer WHERE c_custkey = o_custkey) AS cnt_c, "
+        "   (SELECT sum(c_acctbal) FROM customer WHERE c_custkey = o_custkey) AS sum_bal "
+        "FROM orders";
+
+    auto matcher =
+        matchHiveScan("orders")
+            .hashJoin(
+                matchHiveScan("nation").singleAggregation().project().build(),
+                velox::core::JoinType::kLeft)
+            .hashJoin(
+                matchHiveScan("customer").singleAggregation().project().build(),
+                velox::core::JoinType::kLeft)
+            .project()
+            .build();
+
+    SCOPED_TRACE(query);
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // count(DISTINCT) and count(*) merge together.
+  {
+    auto query =
+        "SELECT r_name, "
+        "   (SELECT count(DISTINCT n_nationkey) FROM nation WHERE n_regionkey = r_regionkey) AS cnt_d, "
+        "   (SELECT count(*) FROM nation WHERE n_regionkey = r_regionkey) AS cnt "
+        "FROM region";
+
+    SCOPED_TRACE(query);
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matchMergedNation());
+  }
+
+  // Identical aggregates (redundant but valid) still merge.
+  {
+    auto query =
+        "SELECT r_name, "
+        "   (SELECT count(*) FROM nation WHERE n_regionkey = r_regionkey) AS cnt1, "
+        "   (SELECT count(*) FROM nation WHERE n_regionkey = r_regionkey) AS cnt2 "
+        "FROM region";
+
+    SCOPED_TRACE(query);
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matchMergedNation());
+  }
+
+  // Subquery with ORDER BY/LIMIT inside prevents merging.
+  {
+    auto query =
+        "SELECT r_name, "
+        "   (SELECT count(*) FROM nation WHERE n_regionkey = r_regionkey) AS cnt, "
+        "   (SELECT max(n_nationkey) FROM (SELECT * FROM nation ORDER BY n_name LIMIT 10) WHERE n_regionkey = r_regionkey) AS max_key "
+        "FROM region";
+
+    auto matcher = matchHiveScan("region")
+                       .hashJoin(matchAggNation(), velox::core::JoinType::kLeft)
+                       .hashJoin(
+                           matchHiveScan("nation")
+                               .topN()
+                               .project()
+                               .singleAggregation()
+                               .project()
+                               .build(),
+                           velox::core::JoinType::kLeft)
+                       .project()
+                       .build();
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);


### PR DESCRIPTION
Summary:
When N correlated scalar subqueries in a SELECT projection scan the same table with the same correlation keys, merge them into a single aggregation + single LEFT JOIN instead of N separate ones.

Before: `Scan(region) → LEFT JOIN(agg nation [count]) → LEFT JOIN(agg nation [max])`
After:  `Scan(region) → LEFT JOIN(agg nation [count, max])`

Two-phase approach: translate all subqueries upfront, group mergeable ones by same outer/inner table and correlation keys, merge groups of 2+ into a single DerivedTable. Singletons and ineligible subqueries fall back to the existing path unchanged.

Conservative eligibility — only merges equi-correlated subqueries with a single aggregate, single base table, and no extra filters/HAVING.

Fixes https://github.com/facebookincubator/axiom/issues/852

Differential Revision: D96260326


