### PR TITLE
feat(MV): Parser flow for materialized view

### DIFF
--- a/axiom/connectors/ConnectorMetadata.cpp
+++ b/axiom/connectors/ConnectorMetadata.cpp
@@ -29,9 +29,18 @@ const auto& writeKindNames() {
   return kNames;
 }
 
+const auto& viewTypeNames() {
+  static const folly::F14FastMap<ViewType, std::string_view> kNames = {
+      {ViewType::kLogicalView, "LOGICAL_VIEW"},
+      {ViewType::kMaterializedView, "MATERIALIZED_VIEW"},
+  };
+  return kNames;
+}
+
 } // namespace
 
 AXIOM_DEFINE_ENUM_NAME(WriteKind, writeKindNames);
+AXIOM_DEFINE_ENUM_NAME(ViewType, viewTypeNames);
 
 namespace {
 

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -663,6 +663,22 @@ class Table : public std::enable_shared_from_this<Table> {
     VELOX_UNSUPPORTED();
   }
 
+  /// Returns the MaterializedViewDefinition if this table represents a
+  /// materialized view, or nullptr for regular tables.
+  const std::shared_ptr<const MaterializedViewDefinition>&
+  materializedViewDefinition() const {
+    return materializedViewDefinition_;
+  }
+
+  void setMaterializedViewDefinition(
+      std::shared_ptr<const MaterializedViewDefinition> mvDef) {
+    materializedViewDefinition_ = std::move(mvDef);
+  }
+
+  bool isMaterializedView() const {
+    return materializedViewDefinition_ != nullptr;
+  }
+
   template <typename T>
   const T* as() const {
     return dynamic_cast<const T*>(this);
@@ -675,14 +691,35 @@ class Table : public std::enable_shared_from_this<Table> {
   const std::vector<const Column*> columnPtrs_;
   const folly::F14FastMap<std::string, const Column*> columnMap_;
   const folly::F14FastMap<std::string, velox::Variant> options_;
+  std::shared_ptr<const MaterializedViewDefinition> materializedViewDefinition_;
 };
 
 using TablePtr = std::shared_ptr<const Table>;
+using MaterializedViewDefinitionPtr =
+    std::shared_ptr<const MaterializedViewDefinition>;
+
+/// Specifies the type of view.
+enum class ViewType {
+  /// A logical view that is expanded at query time.
+  kLogicalView,
+
+  /// A materialized view that stores precomputed results.
+  kMaterializedView,
+};
+
+AXIOM_DECLARE_ENUM_NAME(ViewType);
 
 class View {
  public:
-  View(SchemaTableName name, velox::RowTypePtr type, std::string text)
-      : name_(std::move(name)), type_(std::move(type)), text_(std::move(text)) {
+  View(
+      SchemaTableName name,
+      velox::RowTypePtr type,
+      std::string text,
+      ViewType viewType = ViewType::kLogicalView)
+      : name_(std::move(name)),
+        type_(std::move(type)),
+        text_(std::move(text)),
+        viewType_(viewType) {
     VELOX_CHECK(!name_.schema.empty());
     VELOX_CHECK(!name_.table.empty());
 
@@ -705,25 +742,29 @@ class View {
     return text_;
   }
 
+  /// Returns the type of the view.
+  ViewType viewType() const {
+    return viewType_;
+  }
+
   virtual ~View() = default;
 
  private:
   const SchemaTableName name_;
   const velox::RowTypePtr type_;
   const std::string text_;
+  const ViewType viewType_;
 };
 
 using ViewPtr = std::shared_ptr<const View>;
-using MaterializedViewDefinitionPtr =
-    std::shared_ptr<const MaterializedViewDefinition>;
 
 /// Contains the information for an in-progress write operation. This may
-/// include insert, update, or delete of an existing table, or insertion into a
-/// new table. The ConnectorWriteHandle is generated when a table write
+/// include insert, update, or delete of an existing table, or insertion into
+/// a new table. The ConnectorWriteHandle is generated when a table write
 /// operation is initiated in beginWrite and used to commit or abort any
-/// completed write operations in finishWrite or abortWrite. Derived classes of
-/// the write handle must contain all the information required by the connector
-/// to finish or abort a write operation.
+/// completed write operations in finishWrite or abortWrite. Derived classes
+/// of the write handle must contain all the information required by the
+/// connector to finish or abort a write operation.
 class ConnectorWriteHandle {
  public:
   explicit ConnectorWriteHandle(
@@ -768,8 +809,8 @@ using ConnectorWriteHandlePtr = std::shared_ptr<ConnectorWriteHandle>;
 
 class ConnectorMetadata {
  public:
-  /// Temporary APIs to assist in removing dependency on ConnectorMetadata from
-  /// Velox.
+  /// Temporary APIs to assist in removing dependency on ConnectorMetadata
+  /// from Velox.
   static ConnectorMetadata* metadata(std::string_view connectorId);
   static ConnectorMetadata* FOLLY_NULLABLE
   tryMetadata(std::string_view connectorId);
@@ -783,12 +824,12 @@ class ConnectorMetadata {
 
   /// Return a TablePtr given the table name. The returned Table object is
   /// immutable. If updates to the Table object are required, the
-  /// ConnectorMetadata is required to drop its reference to the existing Table
-  /// and return a reference to a newly created Table object for subsequent
-  /// calls to findTable. The ConnectorMetadata may drop its reference to the
-  /// Table object at any time, and callers are required to retain a reference
-  /// to the Table to prevent it from being reclaimed in the case of Table
-  /// removal by the ConnectorMetadata.
+  /// ConnectorMetadata is required to drop its reference to the existing
+  /// Table and return a reference to a newly created Table object for
+  /// subsequent calls to findTable. The ConnectorMetadata may drop its
+  /// reference to the Table object at any time, and callers are required to
+  /// retain a reference to the Table to prevent it from being reclaimed in
+  /// the case of Table removal by the ConnectorMetadata.
   ///
   /// @return nullptr if table doesn't exist.
   virtual TablePtr findTable(const SchemaTableName& tableName) = 0;
@@ -818,15 +859,15 @@ class ConnectorMetadata {
   /// ConnectorSession in a connector dependent manner, then call createTable
   /// to retrieve a Table object. Any transaction semantics are
   /// connector-dependent, and the ConnectorSession may be null for connectors
-  /// which do not require it. Throws an error if the table exists. finishWrite
-  /// should be called to commit the new table and any writes even if no data
-  /// is added. To create an empty table, call createTable, then
+  /// which do not require it. Throws an error if the table exists.
+  /// finishWrite should be called to commit the new table and any writes even
+  /// if no data is added. To create an empty table, call createTable, then
   /// beginWrite/finishWrite with the generated table object. To create the
   /// table with data, call createTable to generate a Table, call beginWrite
   /// with the Table object, perform writes against the table using the
-  /// returned insert handle, then finishWrite to commit the changes. The table
-  /// is not available via the findTable interface until after finishWrite
-  /// completes.
+  /// returned insert handle, then finishWrite to commit the changes. The
+  /// table is not available via the findTable interface until after
+  /// finishWrite completes.
   ///
   /// When 'explain' is true, the connector must interpret properties and
   /// return a valid Table with correct layout metadata, but must not create
@@ -844,11 +885,11 @@ class ConnectorMetadata {
   /// Begins the process of a write operation by creating an associated write
   /// handle. This handle must contain a valid physical insert handle for use
   /// with Velox TableWriter. To perform a write operation, first make a
-  /// ConnectorSession in a connector dependent manner, then call beginWrite to
-  /// generate the write handle. Insert data using the insert handle provided by
-  /// the write handle and call finishWrite. Transaction semantics are
-  /// connector-dependent, and ConnectorSession may be null for connectors which
-  /// do not require it.
+  /// ConnectorSession in a connector dependent manner, then call beginWrite
+  /// to generate the write handle. Insert data using the insert handle
+  /// provided by the write handle and call finishWrite. Transaction semantics
+  /// are connector-dependent, and ConnectorSession may be null for connectors
+  /// which do not require it.
   ///
   /// When 'explain' is true, the connector must build and return a valid
   /// ConnectorWriteHandle for plan display, but must not allocate staging
@@ -863,6 +904,15 @@ class ConnectorMetadata {
 
   /// Finalizes the table write operation represented by the provided handle.
   /// Returns a future containing the number of rows written.
+  /// This runs once after all the table writers have finished. The result
+  /// sets from the table writer fragments are passed as 'writeResults'. Their
+  /// format and meaning is connector-specific. The type of 'writeResults'
+  /// must match ConnectorWriteHandle::resultType returned from beginWrite.
+  /// finishWrite returns a ContinueFuture which must be waited for to
+  /// finalize the commit. If the implementation is synchronous, finishWrite
+  /// should return an already-fulfilled future to the caller.
+  /// ConnectorSession may be null for connectors which do not require it. The
+  /// returned future contains the number of rows "written".
   ///
   /// @param session Connector session.
   /// @param handle Write handle returned by beginWrite.
@@ -887,13 +937,13 @@ class ConnectorMetadata {
     VELOX_UNSUPPORTED();
   }
 
-  /// Aborts an abandoned or failed write operation. Abort is not guaranteed to
-  /// run in all failure cases. After abort is triggered for the write operation
-  /// represented by ConnectorWriteHandle, this handle can no longer be used to
-  /// commit a write operation with finishWrite. If this function is not
-  /// implemented by a connector, abort will be a no-op. If the abort is a
-  /// synchronous operation, the connector should perform the abort and return
-  /// an already-fulfilled future.
+  /// Aborts an abandoned or failed write operation. Abort is not guaranteed
+  /// to run in all failure cases. After abort is triggered for the write
+  /// operation represented by ConnectorWriteHandle, this handle can no longer
+  /// be used to commit a write operation with finishWrite. If this function
+  /// is not implemented by a connector, abort will be a no-op. If the abort
+  /// is a synchronous operation, the connector should perform the abort and
+  /// return an already-fulfilled future.
   virtual velox::ContinueFuture abortWrite(
       const ConnectorSessionPtr& /*session*/,
       const ConnectorWriteHandlePtr& /*handle*/) noexcept {
@@ -955,3 +1005,4 @@ class ConnectorMetadata {
 } // namespace facebook::axiom::connector
 
 AXIOM_ENUM_FORMATTER(facebook::axiom::connector::WriteKind);
+AXIOM_ENUM_FORMATTER(facebook::axiom::connector::ViewType);

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -19,6 +19,7 @@
 #include "axiom/common/SchemaTableName.h"
 #include "axiom/connectors/ConnectorSession.h"
 #include "axiom/connectors/ConnectorSplitManager.h"
+#include "axiom/connectors/MaterializedViewDefinition.h"
 #include "folly/CppAttributes.h"
 #include "folly/coro/Task.h"
 #include "velox/common/memory/HashStringAllocator.h"
@@ -713,6 +714,8 @@ class View {
 };
 
 using ViewPtr = std::shared_ptr<const View>;
+using MaterializedViewDefinitionPtr =
+    std::shared_ptr<const MaterializedViewDefinition>;
 
 /// Contains the information for an in-progress write operation. This may
 /// include insert, update, or delete of an existing table, or insertion into a
@@ -794,6 +797,15 @@ class ConnectorMetadata {
   ///
   /// @return nullptr if view doesn't exist.
   virtual ViewPtr findView(const SchemaTableName& /*tableName*/) {
+    return nullptr;
+  }
+
+  /// Return a MaterializedViewDefinitionPtr given the MV name. MV name is
+  /// provided without the connector ID / catalog prefix, but may include the
+  /// schema.
+  /// @return nullptr if MV doesn't exist.
+  virtual MaterializedViewDefinitionPtr getMaterializedViewDefinition(
+      std::string_view /*name*/) const {
     return nullptr;
   }
 

--- a/axiom/connectors/MaterializedViewDefinition.cpp
+++ b/axiom/connectors/MaterializedViewDefinition.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/MaterializedViewDefinition.h"
+
+#include <sstream>
+
+namespace facebook::axiom::connector {
+
+std::string MaterializedViewDefinition::toString() const {
+  std::stringstream ss;
+  ss << "MaterializedViewDefinition{";
+  ss << "originalSql=" << originalSql_;
+  ss << ", schema=" << schema_;
+  ss << ", table=" << table_;
+  ss << ", baseTables=[";
+  for (size_t i = 0; i < baseTables_.size(); ++i) {
+    if (i > 0) {
+      ss << ", ";
+    }
+    ss << baseTables_[i].toString();
+  }
+  ss << "]";
+  if (owner_.has_value()) {
+    ss << ", owner=" << owner_.value();
+  }
+  if (securityMode_.has_value()) {
+    ss << ", securityMode="
+       << (securityMode_.value() == ViewSecurity::kInvoker ? "INVOKER"
+                                                           : "DEFINER");
+  }
+  ss << ", columnMappings=[" << columnMappings_.size() << " mappings]";
+  ss << ", baseTablesOnOuterJoinSide=[";
+  for (size_t i = 0; i < baseTablesOnOuterJoinSide_.size(); ++i) {
+    if (i > 0) {
+      ss << ", ";
+    }
+    ss << baseTablesOnOuterJoinSide_[i].toString();
+  }
+  ss << "]";
+  if (validRefreshColumns_.has_value()) {
+    ss << ", validRefreshColumns=[";
+    const auto& cols = validRefreshColumns_.value();
+    for (size_t i = 0; i < cols.size(); ++i) {
+      if (i > 0) {
+        ss << ", ";
+      }
+      ss << cols[i];
+    }
+    ss << "]";
+  }
+  ss << "}";
+  return ss.str();
+}
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/MaterializedViewDefinition.h
+++ b/axiom/connectors/MaterializedViewDefinition.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "axiom/common/SchemaTableName.h"
+
+namespace facebook::axiom::connector {
+
+using SchemaTableName = ::facebook::axiom::SchemaTableName;
+
+/// Security mode for views and materialized views.
+enum class ViewSecurity {
+  kInvoker, // Execute with the permissions of the current user.
+  kDefiner, // Execute with the permissions of the view owner.
+};
+
+struct TableColumn {
+  SchemaTableName tableName;
+  std::string columnName;
+  // False for columns mapped through outer joins where the mapping is indirect.
+  std::optional<bool> isDirectMapped;
+
+  bool operator==(const TableColumn& other) const {
+    return tableName == other.tableName && columnName == other.columnName &&
+        isDirectMapped == other.isDirectMapped;
+  }
+};
+
+struct ColumnMapping {
+  TableColumn viewColumn;
+  std::vector<TableColumn> baseTableColumns;
+
+  bool operator==(const ColumnMapping& other) const {
+    return viewColumn == other.viewColumn &&
+        baseTableColumns == other.baseTableColumns;
+  }
+};
+
+/// Metadata for a materialized view.
+class MaterializedViewDefinition {
+ public:
+  MaterializedViewDefinition(
+      std::string originalSql,
+      std::string schema,
+      std::string table,
+      std::vector<SchemaTableName> baseTables,
+      std::optional<std::string> owner,
+      std::optional<ViewSecurity> securityMode,
+      /// columnMappings: Maps each MV column to its source column(s) in base
+      /// tables. Used for determining MV partition status, query rewriting,
+      /// and refresh.
+      std::vector<ColumnMapping> columnMappings,
+      /// baseTablesOnOuterJoinSide : Tables on the outer side of an outer join
+      /// in the MV definition. Columns from these tables may be NULL due to
+      /// outer join semantics, which affects incremental refresh
+      /// correctness and query rewriting rules.
+      std::vector<SchemaTableName> baseTablesOnOuterJoinSide,
+      /// validRefreshColumns: Columns (typically partition columns like 'ds')
+      /// that can be used for partition-based incremental refresh. When base
+      /// table partitions change, only MV partitions matching these column
+      /// values need to be refreshed.
+      std::optional<std::vector<std::string>> validRefreshColumns)
+      : originalSql_{std::move(originalSql)},
+        schema_{std::move(schema)},
+        table_{std::move(table)},
+        baseTables_{std::move(baseTables)},
+        owner_{std::move(owner)},
+        securityMode_{std::move(securityMode)},
+        columnMappings_{std::move(columnMappings)},
+        baseTablesOnOuterJoinSide_{std::move(baseTablesOnOuterJoinSide)},
+        validRefreshColumns_{std::move(validRefreshColumns)} {}
+
+  const std::string& originalSql() const {
+    return originalSql_;
+  }
+
+  const std::string& schema() const {
+    return schema_;
+  }
+
+  const std::string& table() const {
+    return table_;
+  }
+
+  SchemaTableName schemaTableName() const {
+    return SchemaTableName{schema_, table_};
+  }
+
+  const std::vector<SchemaTableName>& baseTables() const {
+    return baseTables_;
+  }
+
+  const std::optional<std::string>& owner() const {
+    return owner_;
+  }
+
+  const std::optional<ViewSecurity>& securityMode() const {
+    return securityMode_;
+  }
+
+  const std::vector<ColumnMapping>& columnMappings() const {
+    return columnMappings_;
+  }
+
+  const std::vector<SchemaTableName>& baseTablesOnOuterJoinSide() const {
+    return baseTablesOnOuterJoinSide_;
+  }
+
+  const std::optional<std::vector<std::string>>& validRefreshColumns() const {
+    return validRefreshColumns_;
+  }
+
+  std::string toString() const;
+
+ private:
+  const std::string originalSql_;
+  const std::string schema_;
+  const std::string table_;
+  const std::vector<SchemaTableName> baseTables_;
+  const std::optional<std::string> owner_;
+  const std::optional<ViewSecurity> securityMode_;
+  const std::vector<ColumnMapping> columnMappings_;
+  const std::vector<SchemaTableName> baseTablesOnOuterJoinSide_;
+  const std::optional<std::vector<std::string>> validRefreshColumns_;
+};
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/tests/MaterializedViewDefinitionTest.cpp
+++ b/axiom/connectors/tests/MaterializedViewDefinitionTest.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/MaterializedViewDefinition.h"
+#include <gtest/gtest.h>
+#include "axiom/connectors/tests/TestConnector.h"
+
+namespace facebook::axiom::connector {
+namespace {
+
+class MaterializedViewDefinitionTest : public testing::Test {};
+
+TEST_F(MaterializedViewDefinitionTest, basic) {
+  MaterializedViewDefinition mvDef(
+      "SELECT * FROM base_table",
+      "test_schema",
+      "test_mv",
+      {SchemaTableName{"test_schema", "base_table"}},
+      "owner_user",
+      ViewSecurity::kDefiner,
+      {},
+      {},
+      std::nullopt);
+
+  EXPECT_EQ(mvDef.originalSql(), "SELECT * FROM base_table");
+  EXPECT_EQ(mvDef.schema(), "test_schema");
+  EXPECT_EQ(mvDef.table(), "test_mv");
+  EXPECT_EQ(mvDef.schemaTableName().schema, "test_schema");
+  EXPECT_EQ(mvDef.schemaTableName().table, "test_mv");
+  EXPECT_EQ(mvDef.baseTables().size(), 1);
+  EXPECT_EQ(mvDef.baseTables()[0].schema, "test_schema");
+  EXPECT_EQ(mvDef.baseTables()[0].table, "base_table");
+  EXPECT_TRUE(mvDef.owner().has_value());
+  EXPECT_EQ(mvDef.owner().value(), "owner_user");
+  EXPECT_TRUE(mvDef.securityMode().has_value());
+  EXPECT_EQ(mvDef.securityMode().value(), ViewSecurity::kDefiner);
+  EXPECT_TRUE(mvDef.columnMappings().empty());
+  EXPECT_TRUE(mvDef.baseTablesOnOuterJoinSide().empty());
+  EXPECT_FALSE(mvDef.validRefreshColumns().has_value());
+}
+
+TEST_F(MaterializedViewDefinitionTest, withColumnMappings) {
+  std::vector<ColumnMapping> columnMappings = {
+      {TableColumn{SchemaTableName{"schema", "mv"}, "col1", std::nullopt},
+       {TableColumn{SchemaTableName{"schema", "base"}, "base_col1", true}}},
+      {TableColumn{SchemaTableName{"schema", "mv"}, "col2", std::nullopt},
+       {TableColumn{SchemaTableName{"schema", "base"}, "base_col2", false}}}};
+
+  MaterializedViewDefinition mvDef(
+      "SELECT base_col1 as col1, base_col2 as col2 FROM base",
+      "schema",
+      "mv",
+      {SchemaTableName{"schema", "base"}},
+      std::nullopt,
+      ViewSecurity::kInvoker,
+      columnMappings,
+      {},
+      std::nullopt);
+
+  EXPECT_EQ(mvDef.columnMappings().size(), 2);
+  EXPECT_EQ(mvDef.columnMappings()[0].viewColumn.columnName, "col1");
+  EXPECT_EQ(
+      mvDef.columnMappings()[0].baseTableColumns[0].columnName, "base_col1");
+  EXPECT_TRUE(
+      mvDef.columnMappings()[0].baseTableColumns[0].isDirectMapped.value());
+
+  EXPECT_EQ(mvDef.columnMappings()[1].viewColumn.columnName, "col2");
+  EXPECT_FALSE(
+      mvDef.columnMappings()[1].baseTableColumns[0].isDirectMapped.value());
+
+  EXPECT_EQ(mvDef.securityMode().value(), ViewSecurity::kInvoker);
+}
+
+TEST_F(MaterializedViewDefinitionTest, withOuterJoinSideTables) {
+  std::vector<SchemaTableName> outerJoinTables = {
+      SchemaTableName{"schema", "left_table"},
+      SchemaTableName{"schema", "right_table"}};
+
+  MaterializedViewDefinition mvDef(
+      "SELECT * FROM left_table LEFT JOIN right_table ON ...",
+      "schema",
+      "mv",
+      {SchemaTableName{"schema", "left_table"},
+       SchemaTableName{"schema", "right_table"}},
+      std::nullopt,
+      std::nullopt,
+      {},
+      outerJoinTables,
+      std::nullopt);
+
+  EXPECT_EQ(mvDef.baseTablesOnOuterJoinSide().size(), 2);
+  EXPECT_EQ(mvDef.baseTablesOnOuterJoinSide()[0].table, "left_table");
+  EXPECT_EQ(mvDef.baseTablesOnOuterJoinSide()[1].table, "right_table");
+}
+
+TEST_F(MaterializedViewDefinitionTest, withValidRefreshColumns) {
+  std::vector<std::string> refreshCols = {"ds", "hr"};
+
+  MaterializedViewDefinition mvDef(
+      "SELECT * FROM base",
+      "schema",
+      "mv",
+      {SchemaTableName{"schema", "base"}},
+      std::nullopt,
+      std::nullopt,
+      {},
+      {},
+      refreshCols);
+
+  EXPECT_TRUE(mvDef.validRefreshColumns().has_value());
+  EXPECT_EQ(mvDef.validRefreshColumns().value().size(), 2);
+  EXPECT_EQ(mvDef.validRefreshColumns().value()[0], "ds");
+  EXPECT_EQ(mvDef.validRefreshColumns().value()[1], "hr");
+}
+
+TEST_F(MaterializedViewDefinitionTest, toString) {
+  MaterializedViewDefinition mvDef(
+      "SELECT * FROM base",
+      "schema",
+      "mv",
+      {SchemaTableName{"schema", "base"}},
+      "owner",
+      ViewSecurity::kDefiner,
+      {},
+      {},
+      std::vector<std::string>{"ds"});
+
+  std::string str = mvDef.toString();
+
+  EXPECT_TRUE(str.find("originalSql=SELECT * FROM base") != std::string::npos);
+  EXPECT_TRUE(str.find("schema=schema") != std::string::npos);
+  EXPECT_TRUE(str.find("table=mv") != std::string::npos);
+  EXPECT_TRUE(
+      str.find("baseTables=[\"schema\".\"base\"]") != std::string::npos);
+  EXPECT_TRUE(str.find("owner=owner") != std::string::npos);
+  EXPECT_TRUE(str.find("securityMode=DEFINER") != std::string::npos);
+  EXPECT_TRUE(str.find("validRefreshColumns=[ds]") != std::string::npos);
+}
+
+TEST_F(MaterializedViewDefinitionTest, schemaTableNameEquality) {
+  SchemaTableName stn1{"schema", "table"};
+  SchemaTableName stn2{"schema", "table"};
+  SchemaTableName stn3{"other_schema", "table"};
+  SchemaTableName stn4{"schema", "other_table"};
+
+  EXPECT_EQ(stn1, stn2);
+  EXPECT_NE(stn1, stn3);
+  EXPECT_NE(stn1, stn4);
+  EXPECT_EQ(stn1.toString(), "\"schema\".\"table\"");
+}
+
+TEST_F(MaterializedViewDefinitionTest, tableColumnEquality) {
+  TableColumn tc1{SchemaTableName{"s", "t"}, "col", true};
+  TableColumn tc2{SchemaTableName{"s", "t"}, "col", true};
+  TableColumn tc3{SchemaTableName{"s", "t"}, "col", false};
+  TableColumn tc4{SchemaTableName{"s", "t"}, "other_col", true};
+
+  EXPECT_EQ(tc1, tc2);
+  EXPECT_NE(tc1, tc3);
+  EXPECT_NE(tc1, tc4);
+}
+
+TEST_F(MaterializedViewDefinitionTest, columnMappingEquality) {
+  TableColumn viewCol{SchemaTableName{"s", "mv"}, "col", std::nullopt};
+  TableColumn baseCol{SchemaTableName{"s", "base"}, "base_col", true};
+
+  ColumnMapping cm1{viewCol, {baseCol}};
+  ColumnMapping cm2{viewCol, {baseCol}};
+  ColumnMapping cm3{viewCol, {}};
+
+  EXPECT_EQ(cm1, cm2);
+  EXPECT_NE(cm1, cm3);
+}
+
+TEST_F(MaterializedViewDefinitionTest, tableIntegration) {
+  velox::memory::MemoryManager::testingSetInstance(
+      velox::memory::MemoryManager::Options{});
+  auto connector = std::make_shared<TestConnector>("mv_test");
+  auto table =
+      connector->addTable("test_table", velox::ROW({"a"}, {velox::BIGINT()}));
+
+  // A regular table is not a materialized view.
+  EXPECT_FALSE(table->isMaterializedView());
+  EXPECT_EQ(table->materializedViewDefinition(), nullptr);
+
+  // Set a MaterializedViewDefinition on the table.
+  auto mvDef = std::make_shared<MaterializedViewDefinition>(
+      "SELECT * FROM base",
+      "schema",
+      "test_table",
+      std::vector<SchemaTableName>{SchemaTableName{"schema", "base"}},
+      std::nullopt,
+      std::nullopt,
+      std::vector<ColumnMapping>{},
+      std::vector<SchemaTableName>{},
+      std::nullopt);
+  table->setMaterializedViewDefinition(mvDef);
+
+  // Now the table should be recognized as a materialized view.
+  EXPECT_TRUE(table->isMaterializedView());
+  ASSERT_NE(table->materializedViewDefinition(), nullptr);
+  EXPECT_EQ(
+      table->materializedViewDefinition()->originalSql(), "SELECT * FROM base");
+  EXPECT_EQ(table->materializedViewDefinition()->table(), "test_table");
+  EXPECT_EQ(table->materializedViewDefinition()->baseTables().size(), 1);
+  EXPECT_EQ(table->materializedViewDefinition()->baseTables()[0].table, "base");
+}
+
+} // namespace
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -241,16 +241,23 @@ ViewPtr TestConnectorMetadata::findView(const SchemaTableName& tableName) {
   if (it == views_.end()) {
     return nullptr;
   }
-  return std::make_shared<View>(it->first, it->second.type, it->second.text);
+  return std::make_shared<View>(
+      it->first, it->second.type, it->second.text, it->second.viewType);
 }
 
 void TestConnectorMetadata::createView(
     const SchemaTableName& viewName,
     velox::RowTypePtr type,
-    std::string_view text) {
+    std::string_view text,
+    ViewType viewType) {
   auto [_, inserted] = views_.emplace(
-      viewName, ViewDefinition{std::move(type), std::string(text)});
+      viewName, ViewDefinition{type, std::string(text), viewType});
   VELOX_CHECK(inserted, "View already exists: {}", viewName.toString());
+
+  // Materialized views should also be accessible via findTable().
+  if (viewType == ViewType::kMaterializedView) {
+    connector_->addTable(viewName, std::move(type));
+  }
 }
 
 bool TestConnectorMetadata::dropView(const SchemaTableName& viewName) {
@@ -609,8 +616,9 @@ void TestConnector::addTpchTables() {
 void TestConnector::createView(
     const SchemaTableName& viewName,
     velox::RowTypePtr type,
-    std::string_view text) {
-  metadata_->createView(viewName, std::move(type), text);
+    std::string_view text,
+    ViewType viewType) {
+  metadata_->createView(viewName, std::move(type), text, viewType);
 }
 
 bool TestConnector::dropView(const SchemaTableName& viewName) {

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -363,7 +363,8 @@ class TestConnectorMetadata : public ConnectorMetadata {
   void createView(
       const SchemaTableName& viewName,
       velox::RowTypePtr type,
-      std::string_view text);
+      std::string_view text,
+      ViewType viewType = ViewType::kLogicalView);
 
   /// Remove a view by name. Returns true if the view existed.
   bool dropView(const SchemaTableName& viewName);
@@ -399,6 +400,7 @@ class TestConnectorMetadata : public ConnectorMetadata {
   struct ViewDefinition {
     velox::RowTypePtr type;
     std::string text;
+    ViewType viewType{ViewType::kLogicalView};
   };
   folly::F14FastMap<SchemaTableName, ViewDefinition, SchemaTableNameHash>
       views_;
@@ -563,7 +565,8 @@ class TestConnector : public velox::connector::Connector {
   void createView(
       const SchemaTableName& viewName,
       velox::RowTypePtr type,
-      std::string_view text);
+      std::string_view text,
+      ViewType viewType = ViewType::kLogicalView);
 
   /// Remove a view by name. Returns true if the view existed.
   bool dropView(const SchemaTableName& viewName);

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -215,23 +215,36 @@ TablePtr TpchConnectorMetadata::findTable(const SchemaTableName& tableName) {
     return nullptr;
   }
 
-  velox::tpch::Table tpchTable = velox::tpch::fromTableName(tableName.table);
-  const auto schema = tableName.schema.empty() ? kTiny : tableName.schema;
-  const auto scaleFactor = getScaleFactor(schema);
+  if (isValidTpchTableName(tableName.table)) {
+    velox::tpch::Table tpchTable = velox::tpch::fromTableName(tableName.table);
+    const auto schema = tableName.schema.empty() ? kTiny : tableName.schema;
+    const auto scaleFactor = getScaleFactor(schema);
 
-  const auto tableType = velox::tpch::getTableSchema(tpchTable);
-  const auto numRows = velox::tpch::getRowCount(tpchTable, scaleFactor);
+    const auto tableType = velox::tpch::getTableSchema(tpchTable);
+    const auto numRows = velox::tpch::getRowCount(tpchTable, scaleFactor);
 
-  auto table = std::make_shared<TpchTable>(
-      SchemaTableName{schema, tableName.table},
-      tableType,
-      tpchTable,
-      scaleFactor,
-      numRows);
+    auto table = std::make_shared<TpchTable>(
+        SchemaTableName{schema, tableName.table},
+        tableType,
+        tpchTable,
+        scaleFactor,
+        numRows);
 
-  table->makeDefaultLayout(*this);
+    table->makeDefaultLayout(*this);
 
-  return table;
+    return table;
+  }
+
+  // Check if this is a materialized view registered as a view.
+  auto view = findView(tableName);
+  if (view && view->viewType() == ViewType::kMaterializedView) {
+    auto table = std::make_shared<TpchTable>(
+        view->name(), view->type(), velox::tpch::Table::TBL_NATION, 0.01, 0);
+    table->makeDefaultLayout(*this);
+    return table;
+  }
+
+  return nullptr;
 }
 
 std::vector<std::string> TpchConnectorMetadata::listSchemaNames(
@@ -265,13 +278,15 @@ ViewPtr TpchConnectorMetadata::findView(const SchemaTableName& tableName) {
     return nullptr;
   }
 
-  return std::make_shared<View>(it->first, it->second.type, it->second.text);
+  return std::make_shared<View>(
+      it->first, it->second.type, it->second.text, it->second.viewType);
 }
 
 void TpchConnectorMetadata::createView(
     const SchemaTableName& viewName,
     velox::RowTypePtr type,
-    std::string_view text) {
+    std::string_view text,
+    ViewType viewType) {
   VELOX_USER_CHECK(!viewName.table.empty(), "View name cannot be empty");
   if (!viewName.schema.empty()) {
     VELOX_USER_CHECK(
@@ -282,7 +297,9 @@ void TpchConnectorMetadata::createView(
 
   auto ok =
       views_
-          .emplace(viewName, ViewDefinition{std::move(type), std::string(text)})
+          .emplace(
+              viewName,
+              ViewDefinition{std::move(type), std::string(text), viewType})
           .second;
   VELOX_CHECK(ok, "View already exists: {}", viewName.toString());
 }

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -190,7 +190,8 @@ class TpchConnectorMetadata : public ConnectorMetadata {
   void createView(
       const SchemaTableName& viewName,
       velox::RowTypePtr type,
-      std::string_view text);
+      std::string_view text,
+      ViewType viewType = ViewType::kLogicalView);
 
   bool dropView(const SchemaTableName& viewName);
 
@@ -206,6 +207,7 @@ class TpchConnectorMetadata : public ConnectorMetadata {
   struct ViewDefinition {
     velox::RowTypePtr type;
     std::string text;
+    ViewType viewType;
   };
 
   velox::connector::tpch::TpchConnector* tpchConnector_;

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "axiom/common/SchemaTableName.h"
 #include "axiom/sql/presto/PrestoParseError.h"
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -1481,6 +1482,92 @@ TEST_F(PrestoParserTest, nestedWindowFunction) {
           })
           .project({"b", "w * 2::bigint"})
           .output());
+}
+
+TEST_F(PrestoParserTest, logicalView) {
+  facebook::axiom::SchemaTableName viewName{
+      std::string(kDefaultSchema), "logical_view"};
+
+  SCOPE_EXIT {
+    connector_->dropView(viewName);
+  };
+
+  // Create a logical view explicitly.
+  connector_->createView(
+      viewName,
+      ROW({"regionkey", "cnt"}, {BIGINT(), BIGINT()}),
+      "SELECT n_regionkey as regionkey, count(*) cnt FROM nation GROUP BY 1",
+      facebook::axiom::connector::ViewType::kLogicalView);
+
+  // Verify the view type is correctly set.
+  auto* metadata =
+      facebook::axiom::connector::ConnectorMetadata::metadata(kConnectorId);
+  auto view = metadata->findView(viewName);
+  ASSERT_NE(view, nullptr);
+  ASSERT_EQ(
+      view->viewType(), facebook::axiom::connector::ViewType::kLogicalView);
+
+  // Logical views should be expanded into their underlying query.
+  // The plan should contain the aggregation from the view definition.
+  auto matcher = lp::test::LogicalPlanMatcherBuilder()
+                     .tableScan()
+                     .aggregate()
+                     .project()
+                     .output();
+  testSelect("SELECT * FROM logical_view", matcher, {"logical_view"});
+}
+
+TEST_F(PrestoParserTest, materializedView) {
+  facebook::axiom::SchemaTableName viewName{
+      std::string(kDefaultSchema), "materialized_view"};
+
+  SCOPE_EXIT {
+    connector_->dropView(viewName);
+  };
+
+  // Create a materialized view.
+  connector_->createView(
+      viewName,
+      ROW({"regionkey", "cnt"}, {BIGINT(), BIGINT()}),
+      "SELECT n_regionkey as regionkey, count(*) cnt FROM nation GROUP BY 1",
+      facebook::axiom::connector::ViewType::kMaterializedView);
+
+  // Verify the view type is correctly set.
+  auto* metadata =
+      facebook::axiom::connector::ConnectorMetadata::metadata(kConnectorId);
+  auto view = metadata->findView(viewName);
+  ASSERT_NE(view, nullptr);
+  ASSERT_EQ(
+      view->viewType(),
+      facebook::axiom::connector::ViewType::kMaterializedView);
+
+  // Materialized views should be accessed as table scans, not expanded.
+  // Since findTable() now succeeds for MVs, they take the tableScan path
+  // directly without going through findView(), so no views are recorded.
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().output();
+  testSelect("SELECT * FROM materialized_view", matcher);
+}
+
+TEST_F(PrestoParserTest, viewTypeDefault) {
+  facebook::axiom::SchemaTableName viewName{
+      std::string(kDefaultSchema), "default_view"};
+
+  SCOPE_EXIT {
+    connector_->dropView(viewName);
+  };
+
+  // Create a view without specifying type (should default to logical).
+  connector_->createView(
+      viewName,
+      ROW({"n_nationkey"}, {BIGINT()}),
+      "SELECT n_nationkey FROM nation");
+
+  auto* metadata =
+      facebook::axiom::connector::ConnectorMetadata::metadata(kConnectorId);
+  auto view = metadata->findView(viewName);
+  ASSERT_NE(view, nullptr);
+  ASSERT_EQ(
+      view->viewType(), facebook::axiom::connector::ViewType::kLogicalView);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
In PrestoParser, if the table is a view (from findView), only expand it if it is logical view and do not expand for materialized views

Added MVDefinition in Table struct. In findTable, MV table is set with MVDefinition, so in the following milestones, the upper stream consumer like the optimizer can decide how to further resolve it (e.g. stitching) based on this info.

**Note**:
In this diff, we are not doing any UNION to stitch MV with base table, or switch base table and MV when MV lacks behind too much. This diff scans MV as it is.

Differential Revision: D92541143


