### PR TITLE
feat(MV): GetMaterializedViewStatus in connectorMetadata

### DIFF
--- a/axiom/connectors/ConnectorMetadata.cpp
+++ b/axiom/connectors/ConnectorMetadata.cpp
@@ -29,9 +29,18 @@ const auto& writeKindNames() {
   return kNames;
 }
 
+const auto& viewTypeNames() {
+  static const folly::F14FastMap<ViewType, std::string_view> kNames = {
+      {ViewType::kLogicalView, "LOGICAL_VIEW"},
+      {ViewType::kMaterializedView, "MATERIALIZED_VIEW"},
+  };
+  return kNames;
+}
+
 } // namespace
 
 AXIOM_DEFINE_ENUM_NAME(WriteKind, writeKindNames);
+AXIOM_DEFINE_ENUM_NAME(ViewType, viewTypeNames);
 
 namespace {
 

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -663,20 +663,18 @@ class Table : public std::enable_shared_from_this<Table> {
     VELOX_UNSUPPORTED();
   }
 
-  /// Returns the MaterializedViewDefinition if this table represents a
-  /// materialized view, or nullptr for regular tables.
-  const std::shared_ptr<const MaterializedViewDefinition>&
-  materializedViewDefinition() const {
+  /// Returns the materialized view definition if this table is a materialized
+  /// view. Returns std::nullopt for regular tables.
+  const std::optional<MaterializedViewDefinition>& materializedViewDefinition()
+      const {
     return materializedViewDefinition_;
   }
 
+  /// Sets the materialized view definition. Called during table resolution
+  /// when the table is identified as a materialized view.
   void setMaterializedViewDefinition(
-      std::shared_ptr<const MaterializedViewDefinition> mvDef) {
-    materializedViewDefinition_ = std::move(mvDef);
-  }
-
-  bool isMaterializedView() const {
-    return materializedViewDefinition_ != nullptr;
+      MaterializedViewDefinition materializedViewDefinition) {
+    materializedViewDefinition_.emplace(std::move(materializedViewDefinition));
   }
 
   template <typename T>
@@ -691,19 +689,43 @@ class Table : public std::enable_shared_from_this<Table> {
   const std::vector<const Column*> columnPtrs_;
   const folly::F14FastMap<std::string, const Column*> columnMap_;
   const folly::F14FastMap<std::string, velox::Variant> options_;
-  std::shared_ptr<const MaterializedViewDefinition> materializedViewDefinition_;
+  std::optional<MaterializedViewDefinition> materializedViewDefinition_;
 };
 
 using TablePtr = std::shared_ptr<const Table>;
-using MaterializedViewDefinitionPtr =
-    std::shared_ptr<const MaterializedViewDefinition>;
 
-/// Specifies the type of view.
+/// State of a materialized view relative to its base table(s). Mirrors the
+/// Presto SPI enum
+/// (presto-spi/src/main/java/com/facebook/presto/spi/MaterializedViewStatus.java).
+enum class MaterializedViewState {
+  /// MV has no data at all — query must read entirely from the base table.
+  kNotMaterialized,
+  /// Too many partitions are missing — fall back to the base table.
+  kTooManyPartitionsMissing,
+  /// Some partitions are present, some are missing or stale — stitch MV + base.
+  kPartiallyMaterialized,
+  /// MV fully covers the base table — read from MV only.
+  kFullyMaterialized,
+};
+
+/// Status of a materialized view's data freshness. Returned by
+/// ConnectorMetadata::getMaterializedViewStatus() to indicate which data
+/// ranges are available in the MV and which must be read from the base table.
+/// The refresh column name is not included here — the optimizer gets it from
+/// MaterializedViewDefinition::validRefreshColumns().
+struct MaterializedViewStatus {
+  MaterializedViewState state;
+
+  /// Boundary values defining fresh ranges in the MV. Each consecutive pair
+  /// [boundaryValues[2i], boundaryValues[2i+1]] defines an inclusive range
+  /// of the refresh column where the MV has data. The optimizer reads
+  /// everything outside these ranges from the base table.
+  /// Only meaningful when state is kPartiallyMaterialized.
+  std::vector<std::string> boundaryValues;
+};
+
 enum class ViewType {
-  /// A logical view that is expanded at query time.
   kLogicalView,
-
-  /// A materialized view that stores precomputed results.
   kMaterializedView,
 };
 
@@ -742,7 +764,6 @@ class View {
     return text_;
   }
 
-  /// Returns the type of the view.
   ViewType viewType() const {
     return viewType_;
   }
@@ -758,7 +779,10 @@ class View {
 
 using ViewPtr = std::shared_ptr<const View>;
 
-/// Contains the information for an in-progress write operation. This may
+using MaterializedViewDefinitionPtr =
+    std::shared_ptr<const MaterializedViewDefinition>;
+
+/// Contains the information for an in-progress write operation.
 /// include insert, update, or delete of an existing table, or insertion into
 /// a new table. The ConnectorWriteHandle is generated when a table write
 /// operation is initiated in beginWrite and used to commit or abort any
@@ -841,14 +865,14 @@ class ConnectorMetadata {
     return nullptr;
   }
 
-  /// Return a MaterializedViewDefinitionPtr given the MV name. MV name is
-  /// provided without the connector ID / catalog prefix, but may include the
-  /// schema.
-  /// @return nullptr if MV doesn't exist.
+  /// Returns the materialized view definition for the given table name.
+  /// Returns nullptr if the table is not a materialized view.
   virtual MaterializedViewDefinitionPtr getMaterializedViewDefinition(
       std::string_view /*name*/) const {
     return nullptr;
   }
+
+  /// Returns a SplitManager
 
   /// Returns a SplitManager for split enumeration for TableLayouts accessed
   /// through 'this'.
@@ -996,6 +1020,18 @@ class ConnectorMetadata {
     VELOX_UNSUPPORTED();
   }
 
+  /// Returns the materialized view status for the given MV table. The
+  /// returned state tells the optimizer whether stitching is needed and
+  /// how to proceed:
+  ///   - kFullyMaterialized: MV covers all base data — read MV only.
+  ///   - kPartiallyMaterialized: boundaryValues define fresh ranges.
+  ///   - kNotMaterialized / kTooManyPartitionsMissing: read base table only.
+  /// Returns std::nullopt if the table is not a materialized view.
+  virtual std::optional<MaterializedViewStatus> getMaterializedViewStatus(
+      const Table& /*mvTable*/) {
+    return std::nullopt;
+  }
+
   template <typename T>
   const T* as() const {
     return dynamic_cast<const T*>(this);
@@ -1005,4 +1041,3 @@ class ConnectorMetadata {
 } // namespace facebook::axiom::connector
 
 AXIOM_ENUM_FORMATTER(facebook::axiom::connector::WriteKind);
-AXIOM_ENUM_FORMATTER(facebook::axiom::connector::ViewType);

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -663,6 +663,22 @@ class Table : public std::enable_shared_from_this<Table> {
     VELOX_UNSUPPORTED();
   }
 
+  /// Returns the MaterializedViewDefinition if this table represents a
+  /// materialized view, or nullptr for regular tables.
+  const std::shared_ptr<const MaterializedViewDefinition>&
+  materializedViewDefinition() const {
+    return materializedViewDefinition_;
+  }
+
+  void setMaterializedViewDefinition(
+      std::shared_ptr<const MaterializedViewDefinition> mvDef) {
+    materializedViewDefinition_ = std::move(mvDef);
+  }
+
+  bool isMaterializedView() const {
+    return materializedViewDefinition_ != nullptr;
+  }
+
   template <typename T>
   const T* as() const {
     return dynamic_cast<const T*>(this);
@@ -675,14 +691,35 @@ class Table : public std::enable_shared_from_this<Table> {
   const std::vector<const Column*> columnPtrs_;
   const folly::F14FastMap<std::string, const Column*> columnMap_;
   const folly::F14FastMap<std::string, velox::Variant> options_;
+  std::shared_ptr<const MaterializedViewDefinition> materializedViewDefinition_;
 };
 
 using TablePtr = std::shared_ptr<const Table>;
+using MaterializedViewDefinitionPtr =
+    std::shared_ptr<const MaterializedViewDefinition>;
+
+/// Specifies the type of view.
+enum class ViewType {
+  /// A logical view that is expanded at query time.
+  kLogicalView,
+
+  /// A materialized view that stores precomputed results.
+  kMaterializedView,
+};
+
+AXIOM_DECLARE_ENUM_NAME(ViewType);
 
 class View {
  public:
-  View(SchemaTableName name, velox::RowTypePtr type, std::string text)
-      : name_(std::move(name)), type_(std::move(type)), text_(std::move(text)) {
+  View(
+      SchemaTableName name,
+      velox::RowTypePtr type,
+      std::string text,
+      ViewType viewType = ViewType::kLogicalView)
+      : name_(std::move(name)),
+        type_(std::move(type)),
+        text_(std::move(text)),
+        viewType_(viewType) {
     VELOX_CHECK(!name_.schema.empty());
     VELOX_CHECK(!name_.table.empty());
 
@@ -705,25 +742,29 @@ class View {
     return text_;
   }
 
+  /// Returns the type of the view.
+  ViewType viewType() const {
+    return viewType_;
+  }
+
   virtual ~View() = default;
 
  private:
   const SchemaTableName name_;
   const velox::RowTypePtr type_;
   const std::string text_;
+  const ViewType viewType_;
 };
 
 using ViewPtr = std::shared_ptr<const View>;
-using MaterializedViewDefinitionPtr =
-    std::shared_ptr<const MaterializedViewDefinition>;
 
 /// Contains the information for an in-progress write operation. This may
-/// include insert, update, or delete of an existing table, or insertion into a
-/// new table. The ConnectorWriteHandle is generated when a table write
+/// include insert, update, or delete of an existing table, or insertion into
+/// a new table. The ConnectorWriteHandle is generated when a table write
 /// operation is initiated in beginWrite and used to commit or abort any
-/// completed write operations in finishWrite or abortWrite. Derived classes of
-/// the write handle must contain all the information required by the connector
-/// to finish or abort a write operation.
+/// completed write operations in finishWrite or abortWrite. Derived classes
+/// of the write handle must contain all the information required by the
+/// connector to finish or abort a write operation.
 class ConnectorWriteHandle {
  public:
   explicit ConnectorWriteHandle(
@@ -768,8 +809,8 @@ using ConnectorWriteHandlePtr = std::shared_ptr<ConnectorWriteHandle>;
 
 class ConnectorMetadata {
  public:
-  /// Temporary APIs to assist in removing dependency on ConnectorMetadata from
-  /// Velox.
+  /// Temporary APIs to assist in removing dependency on ConnectorMetadata
+  /// from Velox.
   static ConnectorMetadata* metadata(std::string_view connectorId);
   static ConnectorMetadata* FOLLY_NULLABLE
   tryMetadata(std::string_view connectorId);
@@ -783,12 +824,12 @@ class ConnectorMetadata {
 
   /// Return a TablePtr given the table name. The returned Table object is
   /// immutable. If updates to the Table object are required, the
-  /// ConnectorMetadata is required to drop its reference to the existing Table
-  /// and return a reference to a newly created Table object for subsequent
-  /// calls to findTable. The ConnectorMetadata may drop its reference to the
-  /// Table object at any time, and callers are required to retain a reference
-  /// to the Table to prevent it from being reclaimed in the case of Table
-  /// removal by the ConnectorMetadata.
+  /// ConnectorMetadata is required to drop its reference to the existing
+  /// Table and return a reference to a newly created Table object for
+  /// subsequent calls to findTable. The ConnectorMetadata may drop its
+  /// reference to the Table object at any time, and callers are required to
+  /// retain a reference to the Table to prevent it from being reclaimed in
+  /// the case of Table removal by the ConnectorMetadata.
   ///
   /// @return nullptr if table doesn't exist.
   virtual TablePtr findTable(const SchemaTableName& tableName) = 0;
@@ -818,15 +859,15 @@ class ConnectorMetadata {
   /// ConnectorSession in a connector dependent manner, then call createTable
   /// to retrieve a Table object. Any transaction semantics are
   /// connector-dependent, and the ConnectorSession may be null for connectors
-  /// which do not require it. Throws an error if the table exists. finishWrite
-  /// should be called to commit the new table and any writes even if no data
-  /// is added. To create an empty table, call createTable, then
+  /// which do not require it. Throws an error if the table exists.
+  /// finishWrite should be called to commit the new table and any writes even
+  /// if no data is added. To create an empty table, call createTable, then
   /// beginWrite/finishWrite with the generated table object. To create the
   /// table with data, call createTable to generate a Table, call beginWrite
   /// with the Table object, perform writes against the table using the
-  /// returned insert handle, then finishWrite to commit the changes. The table
-  /// is not available via the findTable interface until after finishWrite
-  /// completes.
+  /// returned insert handle, then finishWrite to commit the changes. The
+  /// table is not available via the findTable interface until after
+  /// finishWrite completes.
   ///
   /// When 'explain' is true, the connector must interpret properties and
   /// return a valid Table with correct layout metadata, but must not create
@@ -844,11 +885,11 @@ class ConnectorMetadata {
   /// Begins the process of a write operation by creating an associated write
   /// handle. This handle must contain a valid physical insert handle for use
   /// with Velox TableWriter. To perform a write operation, first make a
-  /// ConnectorSession in a connector dependent manner, then call beginWrite to
-  /// generate the write handle. Insert data using the insert handle provided by
-  /// the write handle and call finishWrite. Transaction semantics are
-  /// connector-dependent, and ConnectorSession may be null for connectors which
-  /// do not require it.
+  /// ConnectorSession in a connector dependent manner, then call beginWrite
+  /// to generate the write handle. Insert data using the insert handle
+  /// provided by the write handle and call finishWrite. Transaction semantics
+  /// are connector-dependent, and ConnectorSession may be null for connectors
+  /// which do not require it.
   ///
   /// When 'explain' is true, the connector must build and return a valid
   /// ConnectorWriteHandle for plan display, but must not allocate staging
@@ -863,6 +904,15 @@ class ConnectorMetadata {
 
   /// Finalizes the table write operation represented by the provided handle.
   /// Returns a future containing the number of rows written.
+  /// This runs once after all the table writers have finished. The result
+  /// sets from the table writer fragments are passed as 'writeResults'. Their
+  /// format and meaning is connector-specific. The type of 'writeResults'
+  /// must match ConnectorWriteHandle::resultType returned from beginWrite.
+  /// finishWrite returns a ContinueFuture which must be waited for to
+  /// finalize the commit. If the implementation is synchronous, finishWrite
+  /// should return an already-fulfilled future to the caller.
+  /// ConnectorSession may be null for connectors which do not require it. The
+  /// returned future contains the number of rows "written".
   ///
   /// @param session Connector session.
   /// @param handle Write handle returned by beginWrite.
@@ -887,13 +937,13 @@ class ConnectorMetadata {
     VELOX_UNSUPPORTED();
   }
 
-  /// Aborts an abandoned or failed write operation. Abort is not guaranteed to
-  /// run in all failure cases. After abort is triggered for the write operation
-  /// represented by ConnectorWriteHandle, this handle can no longer be used to
-  /// commit a write operation with finishWrite. If this function is not
-  /// implemented by a connector, abort will be a no-op. If the abort is a
-  /// synchronous operation, the connector should perform the abort and return
-  /// an already-fulfilled future.
+  /// Aborts an abandoned or failed write operation. Abort is not guaranteed
+  /// to run in all failure cases. After abort is triggered for the write
+  /// operation represented by ConnectorWriteHandle, this handle can no longer
+  /// be used to commit a write operation with finishWrite. If this function
+  /// is not implemented by a connector, abort will be a no-op. If the abort
+  /// is a synchronous operation, the connector should perform the abort and
+  /// return an already-fulfilled future.
   virtual velox::ContinueFuture abortWrite(
       const ConnectorSessionPtr& /*session*/,
       const ConnectorWriteHandlePtr& /*handle*/) noexcept {
@@ -955,3 +1005,4 @@ class ConnectorMetadata {
 } // namespace facebook::axiom::connector
 
 AXIOM_ENUM_FORMATTER(facebook::axiom::connector::WriteKind);
+AXIOM_ENUM_FORMATTER(facebook::axiom::connector::ViewType);

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -19,6 +19,7 @@
 #include "axiom/common/SchemaTableName.h"
 #include "axiom/connectors/ConnectorSession.h"
 #include "axiom/connectors/ConnectorSplitManager.h"
+#include "axiom/connectors/MaterializedViewDefinition.h"
 #include "folly/CppAttributes.h"
 #include "folly/coro/Task.h"
 #include "velox/common/memory/HashStringAllocator.h"
@@ -713,6 +714,8 @@ class View {
 };
 
 using ViewPtr = std::shared_ptr<const View>;
+using MaterializedViewDefinitionPtr =
+    std::shared_ptr<const MaterializedViewDefinition>;
 
 /// Contains the information for an in-progress write operation. This may
 /// include insert, update, or delete of an existing table, or insertion into a
@@ -794,6 +797,15 @@ class ConnectorMetadata {
   ///
   /// @return nullptr if view doesn't exist.
   virtual ViewPtr findView(const SchemaTableName& /*tableName*/) {
+    return nullptr;
+  }
+
+  /// Return a MaterializedViewDefinitionPtr given the MV name. MV name is
+  /// provided without the connector ID / catalog prefix, but may include the
+  /// schema.
+  /// @return nullptr if MV doesn't exist.
+  virtual MaterializedViewDefinitionPtr getMaterializedViewDefinition(
+      std::string_view /*name*/) const {
     return nullptr;
   }
 

--- a/axiom/connectors/MaterializedViewDefinition.cpp
+++ b/axiom/connectors/MaterializedViewDefinition.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/MaterializedViewDefinition.h"
+
+#include <sstream>
+
+namespace facebook::axiom::connector {
+
+std::string MaterializedViewDefinition::toString() const {
+  std::stringstream ss;
+  ss << "MaterializedViewDefinition{";
+  ss << "originalSql=" << originalSql_;
+  ss << ", schema=" << schema_;
+  ss << ", table=" << table_;
+  ss << ", baseTables=[";
+  for (size_t i = 0; i < baseTables_.size(); ++i) {
+    if (i > 0) {
+      ss << ", ";
+    }
+    ss << baseTables_[i].toString();
+  }
+  ss << "]";
+  if (owner_.has_value()) {
+    ss << ", owner=" << owner_.value();
+  }
+  if (securityMode_.has_value()) {
+    ss << ", securityMode="
+       << (securityMode_.value() == ViewSecurity::kInvoker ? "INVOKER"
+                                                           : "DEFINER");
+  }
+  ss << ", columnMappings=[" << columnMappings_.size() << " mappings]";
+  ss << ", baseTablesOnOuterJoinSide=[";
+  for (size_t i = 0; i < baseTablesOnOuterJoinSide_.size(); ++i) {
+    if (i > 0) {
+      ss << ", ";
+    }
+    ss << baseTablesOnOuterJoinSide_[i].toString();
+  }
+  ss << "]";
+  if (validRefreshColumns_.has_value()) {
+    ss << ", validRefreshColumns=[";
+    const auto& cols = validRefreshColumns_.value();
+    for (size_t i = 0; i < cols.size(); ++i) {
+      if (i > 0) {
+        ss << ", ";
+      }
+      ss << cols[i];
+    }
+    ss << "]";
+  }
+  ss << "}";
+  return ss.str();
+}
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/MaterializedViewDefinition.h
+++ b/axiom/connectors/MaterializedViewDefinition.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "axiom/common/SchemaTableName.h"
+
+namespace facebook::axiom::connector {
+
+using SchemaTableName = ::facebook::axiom::SchemaTableName;
+
+/// Security mode for views and materialized views.
+enum class ViewSecurity {
+  kInvoker, // Execute with the permissions of the current user.
+  kDefiner, // Execute with the permissions of the view owner.
+};
+
+struct TableColumn {
+  SchemaTableName tableName;
+  std::string columnName;
+  // False for columns mapped through outer joins where the mapping is indirect.
+  std::optional<bool> isDirectMapped;
+
+  bool operator==(const TableColumn& other) const {
+    return tableName == other.tableName && columnName == other.columnName &&
+        isDirectMapped == other.isDirectMapped;
+  }
+};
+
+struct ColumnMapping {
+  TableColumn viewColumn;
+  std::vector<TableColumn> baseTableColumns;
+
+  bool operator==(const ColumnMapping& other) const {
+    return viewColumn == other.viewColumn &&
+        baseTableColumns == other.baseTableColumns;
+  }
+};
+
+/// Metadata for a materialized view.
+class MaterializedViewDefinition {
+ public:
+  MaterializedViewDefinition(
+      std::string originalSql,
+      std::string schema,
+      std::string table,
+      std::vector<SchemaTableName> baseTables,
+      std::optional<std::string> owner,
+      std::optional<ViewSecurity> securityMode,
+      /// columnMappings: Maps each MV column to its source column(s) in base
+      /// tables. Used for determining MV partition status, query rewriting,
+      /// and refresh.
+      std::vector<ColumnMapping> columnMappings,
+      /// baseTablesOnOuterJoinSide : Tables on the outer side of an outer join
+      /// in the MV definition. Columns from these tables may be NULL due to
+      /// outer join semantics, which affects incremental refresh
+      /// correctness and query rewriting rules.
+      std::vector<SchemaTableName> baseTablesOnOuterJoinSide,
+      /// validRefreshColumns: Columns (typically partition columns like 'ds')
+      /// that can be used for partition-based incremental refresh. When base
+      /// table partitions change, only MV partitions matching these column
+      /// values need to be refreshed.
+      std::optional<std::vector<std::string>> validRefreshColumns)
+      : originalSql_{std::move(originalSql)},
+        schema_{std::move(schema)},
+        table_{std::move(table)},
+        baseTables_{std::move(baseTables)},
+        owner_{std::move(owner)},
+        securityMode_{std::move(securityMode)},
+        columnMappings_{std::move(columnMappings)},
+        baseTablesOnOuterJoinSide_{std::move(baseTablesOnOuterJoinSide)},
+        validRefreshColumns_{std::move(validRefreshColumns)} {}
+
+  const std::string& originalSql() const {
+    return originalSql_;
+  }
+
+  const std::string& schema() const {
+    return schema_;
+  }
+
+  const std::string& table() const {
+    return table_;
+  }
+
+  SchemaTableName schemaTableName() const {
+    return SchemaTableName{schema_, table_};
+  }
+
+  const std::vector<SchemaTableName>& baseTables() const {
+    return baseTables_;
+  }
+
+  const std::optional<std::string>& owner() const {
+    return owner_;
+  }
+
+  const std::optional<ViewSecurity>& securityMode() const {
+    return securityMode_;
+  }
+
+  const std::vector<ColumnMapping>& columnMappings() const {
+    return columnMappings_;
+  }
+
+  const std::vector<SchemaTableName>& baseTablesOnOuterJoinSide() const {
+    return baseTablesOnOuterJoinSide_;
+  }
+
+  const std::optional<std::vector<std::string>>& validRefreshColumns() const {
+    return validRefreshColumns_;
+  }
+
+  std::string toString() const;
+
+ private:
+  const std::string originalSql_;
+  const std::string schema_;
+  const std::string table_;
+  const std::vector<SchemaTableName> baseTables_;
+  const std::optional<std::string> owner_;
+  const std::optional<ViewSecurity> securityMode_;
+  const std::vector<ColumnMapping> columnMappings_;
+  const std::vector<SchemaTableName> baseTablesOnOuterJoinSide_;
+  const std::optional<std::vector<std::string>> validRefreshColumns_;
+};
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/tests/MaterializedViewDefinitionTest.cpp
+++ b/axiom/connectors/tests/MaterializedViewDefinitionTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/connectors/MaterializedViewDefinition.h"
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "axiom/connectors/tests/TestConnector.h"
 
@@ -192,12 +193,11 @@ TEST_F(MaterializedViewDefinitionTest, tableIntegration) {
   auto table =
       connector->addTable("test_table", velox::ROW({"a"}, {velox::BIGINT()}));
 
-  // A regular table is not a materialized view.
-  EXPECT_FALSE(table->isMaterializedView());
-  EXPECT_EQ(table->materializedViewDefinition(), nullptr);
+  // A regular table does not have a materialized view definition.
+  EXPECT_FALSE(table->materializedViewDefinition().has_value());
 
   // Set a MaterializedViewDefinition on the table.
-  auto mvDef = std::make_shared<MaterializedViewDefinition>(
+  MaterializedViewDefinition mvDef(
       "SELECT * FROM base",
       "schema",
       "test_table",
@@ -207,16 +207,88 @@ TEST_F(MaterializedViewDefinitionTest, tableIntegration) {
       std::vector<ColumnMapping>{},
       std::vector<SchemaTableName>{},
       std::nullopt);
-  table->setMaterializedViewDefinition(mvDef);
+  table->setMaterializedViewDefinition(std::move(mvDef));
 
-  // Now the table should be recognized as a materialized view.
-  EXPECT_TRUE(table->isMaterializedView());
-  ASSERT_NE(table->materializedViewDefinition(), nullptr);
-  EXPECT_EQ(
-      table->materializedViewDefinition()->originalSql(), "SELECT * FROM base");
-  EXPECT_EQ(table->materializedViewDefinition()->table(), "test_table");
-  EXPECT_EQ(table->materializedViewDefinition()->baseTables().size(), 1);
-  EXPECT_EQ(table->materializedViewDefinition()->baseTables()[0].table, "base");
+  // Now the table should have a materialized view definition.
+  ASSERT_TRUE(table->materializedViewDefinition().has_value());
+  const auto& def = table->materializedViewDefinition().value();
+  EXPECT_EQ(def.originalSql(), "SELECT * FROM base");
+  EXPECT_EQ(def.table(), "test_table");
+  ASSERT_EQ(def.baseTables().size(), 1);
+  EXPECT_EQ(def.baseTables()[0].table, "base");
+}
+
+TEST_F(MaterializedViewDefinitionTest, materializedViewStatusEnum) {
+  // Verify each MaterializedViewState value is distinct.
+  EXPECT_NE(
+      MaterializedViewState::kNotMaterialized,
+      MaterializedViewState::kPartiallyMaterialized);
+  EXPECT_NE(
+      MaterializedViewState::kPartiallyMaterialized,
+      MaterializedViewState::kFullyMaterialized);
+  EXPECT_NE(
+      MaterializedViewState::kTooManyPartitionsMissing,
+      MaterializedViewState::kNotMaterialized);
+}
+
+TEST_F(
+    MaterializedViewDefinitionTest,
+    materializedViewStatusPartiallyMaterialized) {
+  MaterializedViewStatus status;
+  status.state = MaterializedViewState::kPartiallyMaterialized;
+  status.boundaryValues = {"2026-01-21", "2026-01-28"};
+
+  EXPECT_EQ(status.state, MaterializedViewState::kPartiallyMaterialized);
+  EXPECT_THAT(
+      status.boundaryValues, testing::ElementsAre("2026-01-21", "2026-01-28"));
+}
+
+TEST_F(
+    MaterializedViewDefinitionTest,
+    materializedViewStatusFullyMaterialized) {
+  MaterializedViewStatus status;
+  status.state = MaterializedViewState::kFullyMaterialized;
+
+  EXPECT_EQ(status.state, MaterializedViewState::kFullyMaterialized);
+  EXPECT_THAT(status.boundaryValues, testing::IsEmpty());
+}
+
+TEST_F(MaterializedViewDefinitionTest, materializedViewStatusNotMaterialized) {
+  MaterializedViewStatus status;
+  status.state = MaterializedViewState::kNotMaterialized;
+
+  EXPECT_EQ(status.state, MaterializedViewState::kNotMaterialized);
+  EXPECT_THAT(status.boundaryValues, testing::IsEmpty());
+}
+
+TEST_F(MaterializedViewDefinitionTest, materializedViewStatusMultipleRanges) {
+  // Phase 2 scenario: non-contiguous fresh ranges due to stale partitions.
+  MaterializedViewStatus status;
+  status.state = MaterializedViewState::kPartiallyMaterialized;
+  status.boundaryValues = {
+      "2026-01-21", "2026-01-24", "2026-01-26", "2026-01-28"};
+
+  EXPECT_EQ(status.state, MaterializedViewState::kPartiallyMaterialized);
+  EXPECT_THAT(
+      status.boundaryValues,
+      testing::ElementsAre(
+          "2026-01-21", "2026-01-24", "2026-01-26", "2026-01-28"));
+}
+
+TEST_F(
+    MaterializedViewDefinitionTest,
+    connectorMetadataDefaultGetMaterializedViewStatus) {
+  velox::memory::MemoryManager::testingSetInstance(
+      velox::memory::MemoryManager::Options{});
+  auto connector = std::make_shared<TestConnector>("default_test");
+  auto metadata = ConnectorMetadata::metadata(connector->connectorId());
+
+  auto table =
+      connector->addTable("test_table", velox::ROW({"a"}, {velox::BIGINT()}));
+
+  // The default implementation returns nullopt.
+  auto result = metadata->getMaterializedViewStatus(*table);
+  EXPECT_FALSE(result.has_value());
 }
 
 } // namespace

--- a/axiom/connectors/tests/MaterializedViewDefinitionTest.cpp
+++ b/axiom/connectors/tests/MaterializedViewDefinitionTest.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/MaterializedViewDefinition.h"
+#include <gtest/gtest.h>
+#include "axiom/connectors/tests/TestConnector.h"
+
+namespace facebook::axiom::connector {
+namespace {
+
+class MaterializedViewDefinitionTest : public testing::Test {};
+
+TEST_F(MaterializedViewDefinitionTest, basic) {
+  MaterializedViewDefinition mvDef(
+      "SELECT * FROM base_table",
+      "test_schema",
+      "test_mv",
+      {SchemaTableName{"test_schema", "base_table"}},
+      "owner_user",
+      ViewSecurity::kDefiner,
+      {},
+      {},
+      std::nullopt);
+
+  EXPECT_EQ(mvDef.originalSql(), "SELECT * FROM base_table");
+  EXPECT_EQ(mvDef.schema(), "test_schema");
+  EXPECT_EQ(mvDef.table(), "test_mv");
+  EXPECT_EQ(mvDef.schemaTableName().schema, "test_schema");
+  EXPECT_EQ(mvDef.schemaTableName().table, "test_mv");
+  EXPECT_EQ(mvDef.baseTables().size(), 1);
+  EXPECT_EQ(mvDef.baseTables()[0].schema, "test_schema");
+  EXPECT_EQ(mvDef.baseTables()[0].table, "base_table");
+  EXPECT_TRUE(mvDef.owner().has_value());
+  EXPECT_EQ(mvDef.owner().value(), "owner_user");
+  EXPECT_TRUE(mvDef.securityMode().has_value());
+  EXPECT_EQ(mvDef.securityMode().value(), ViewSecurity::kDefiner);
+  EXPECT_TRUE(mvDef.columnMappings().empty());
+  EXPECT_TRUE(mvDef.baseTablesOnOuterJoinSide().empty());
+  EXPECT_FALSE(mvDef.validRefreshColumns().has_value());
+}
+
+TEST_F(MaterializedViewDefinitionTest, withColumnMappings) {
+  std::vector<ColumnMapping> columnMappings = {
+      {TableColumn{SchemaTableName{"schema", "mv"}, "col1", std::nullopt},
+       {TableColumn{SchemaTableName{"schema", "base"}, "base_col1", true}}},
+      {TableColumn{SchemaTableName{"schema", "mv"}, "col2", std::nullopt},
+       {TableColumn{SchemaTableName{"schema", "base"}, "base_col2", false}}}};
+
+  MaterializedViewDefinition mvDef(
+      "SELECT base_col1 as col1, base_col2 as col2 FROM base",
+      "schema",
+      "mv",
+      {SchemaTableName{"schema", "base"}},
+      std::nullopt,
+      ViewSecurity::kInvoker,
+      columnMappings,
+      {},
+      std::nullopt);
+
+  EXPECT_EQ(mvDef.columnMappings().size(), 2);
+  EXPECT_EQ(mvDef.columnMappings()[0].viewColumn.columnName, "col1");
+  EXPECT_EQ(
+      mvDef.columnMappings()[0].baseTableColumns[0].columnName, "base_col1");
+  EXPECT_TRUE(
+      mvDef.columnMappings()[0].baseTableColumns[0].isDirectMapped.value());
+
+  EXPECT_EQ(mvDef.columnMappings()[1].viewColumn.columnName, "col2");
+  EXPECT_FALSE(
+      mvDef.columnMappings()[1].baseTableColumns[0].isDirectMapped.value());
+
+  EXPECT_EQ(mvDef.securityMode().value(), ViewSecurity::kInvoker);
+}
+
+TEST_F(MaterializedViewDefinitionTest, withOuterJoinSideTables) {
+  std::vector<SchemaTableName> outerJoinTables = {
+      SchemaTableName{"schema", "left_table"},
+      SchemaTableName{"schema", "right_table"}};
+
+  MaterializedViewDefinition mvDef(
+      "SELECT * FROM left_table LEFT JOIN right_table ON ...",
+      "schema",
+      "mv",
+      {SchemaTableName{"schema", "left_table"},
+       SchemaTableName{"schema", "right_table"}},
+      std::nullopt,
+      std::nullopt,
+      {},
+      outerJoinTables,
+      std::nullopt);
+
+  EXPECT_EQ(mvDef.baseTablesOnOuterJoinSide().size(), 2);
+  EXPECT_EQ(mvDef.baseTablesOnOuterJoinSide()[0].table, "left_table");
+  EXPECT_EQ(mvDef.baseTablesOnOuterJoinSide()[1].table, "right_table");
+}
+
+TEST_F(MaterializedViewDefinitionTest, withValidRefreshColumns) {
+  std::vector<std::string> refreshCols = {"ds", "hr"};
+
+  MaterializedViewDefinition mvDef(
+      "SELECT * FROM base",
+      "schema",
+      "mv",
+      {SchemaTableName{"schema", "base"}},
+      std::nullopt,
+      std::nullopt,
+      {},
+      {},
+      refreshCols);
+
+  EXPECT_TRUE(mvDef.validRefreshColumns().has_value());
+  EXPECT_EQ(mvDef.validRefreshColumns().value().size(), 2);
+  EXPECT_EQ(mvDef.validRefreshColumns().value()[0], "ds");
+  EXPECT_EQ(mvDef.validRefreshColumns().value()[1], "hr");
+}
+
+TEST_F(MaterializedViewDefinitionTest, toString) {
+  MaterializedViewDefinition mvDef(
+      "SELECT * FROM base",
+      "schema",
+      "mv",
+      {SchemaTableName{"schema", "base"}},
+      "owner",
+      ViewSecurity::kDefiner,
+      {},
+      {},
+      std::vector<std::string>{"ds"});
+
+  std::string str = mvDef.toString();
+
+  EXPECT_TRUE(str.find("originalSql=SELECT * FROM base") != std::string::npos);
+  EXPECT_TRUE(str.find("schema=schema") != std::string::npos);
+  EXPECT_TRUE(str.find("table=mv") != std::string::npos);
+  EXPECT_TRUE(
+      str.find("baseTables=[\"schema\".\"base\"]") != std::string::npos);
+  EXPECT_TRUE(str.find("owner=owner") != std::string::npos);
+  EXPECT_TRUE(str.find("securityMode=DEFINER") != std::string::npos);
+  EXPECT_TRUE(str.find("validRefreshColumns=[ds]") != std::string::npos);
+}
+
+TEST_F(MaterializedViewDefinitionTest, schemaTableNameEquality) {
+  SchemaTableName stn1{"schema", "table"};
+  SchemaTableName stn2{"schema", "table"};
+  SchemaTableName stn3{"other_schema", "table"};
+  SchemaTableName stn4{"schema", "other_table"};
+
+  EXPECT_EQ(stn1, stn2);
+  EXPECT_NE(stn1, stn3);
+  EXPECT_NE(stn1, stn4);
+  EXPECT_EQ(stn1.toString(), "\"schema\".\"table\"");
+}
+
+TEST_F(MaterializedViewDefinitionTest, tableColumnEquality) {
+  TableColumn tc1{SchemaTableName{"s", "t"}, "col", true};
+  TableColumn tc2{SchemaTableName{"s", "t"}, "col", true};
+  TableColumn tc3{SchemaTableName{"s", "t"}, "col", false};
+  TableColumn tc4{SchemaTableName{"s", "t"}, "other_col", true};
+
+  EXPECT_EQ(tc1, tc2);
+  EXPECT_NE(tc1, tc3);
+  EXPECT_NE(tc1, tc4);
+}
+
+TEST_F(MaterializedViewDefinitionTest, columnMappingEquality) {
+  TableColumn viewCol{SchemaTableName{"s", "mv"}, "col", std::nullopt};
+  TableColumn baseCol{SchemaTableName{"s", "base"}, "base_col", true};
+
+  ColumnMapping cm1{viewCol, {baseCol}};
+  ColumnMapping cm2{viewCol, {baseCol}};
+  ColumnMapping cm3{viewCol, {}};
+
+  EXPECT_EQ(cm1, cm2);
+  EXPECT_NE(cm1, cm3);
+}
+
+TEST_F(MaterializedViewDefinitionTest, tableIntegration) {
+  velox::memory::MemoryManager::testingSetInstance(
+      velox::memory::MemoryManager::Options{});
+  auto connector = std::make_shared<TestConnector>("mv_test");
+  auto table =
+      connector->addTable("test_table", velox::ROW({"a"}, {velox::BIGINT()}));
+
+  // A regular table is not a materialized view.
+  EXPECT_FALSE(table->isMaterializedView());
+  EXPECT_EQ(table->materializedViewDefinition(), nullptr);
+
+  // Set a MaterializedViewDefinition on the table.
+  auto mvDef = std::make_shared<MaterializedViewDefinition>(
+      "SELECT * FROM base",
+      "schema",
+      "test_table",
+      std::vector<SchemaTableName>{SchemaTableName{"schema", "base"}},
+      std::nullopt,
+      std::nullopt,
+      std::vector<ColumnMapping>{},
+      std::vector<SchemaTableName>{},
+      std::nullopt);
+  table->setMaterializedViewDefinition(mvDef);
+
+  // Now the table should be recognized as a materialized view.
+  EXPECT_TRUE(table->isMaterializedView());
+  ASSERT_NE(table->materializedViewDefinition(), nullptr);
+  EXPECT_EQ(
+      table->materializedViewDefinition()->originalSql(), "SELECT * FROM base");
+  EXPECT_EQ(table->materializedViewDefinition()->table(), "test_table");
+  EXPECT_EQ(table->materializedViewDefinition()->baseTables().size(), 1);
+  EXPECT_EQ(table->materializedViewDefinition()->baseTables()[0].table, "base");
+}
+
+} // namespace
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -241,16 +241,23 @@ ViewPtr TestConnectorMetadata::findView(const SchemaTableName& tableName) {
   if (it == views_.end()) {
     return nullptr;
   }
-  return std::make_shared<View>(it->first, it->second.type, it->second.text);
+  return std::make_shared<View>(
+      it->first, it->second.type, it->second.text, it->second.viewType);
 }
 
 void TestConnectorMetadata::createView(
     const SchemaTableName& viewName,
     velox::RowTypePtr type,
-    std::string_view text) {
+    std::string_view text,
+    ViewType viewType) {
   auto [_, inserted] = views_.emplace(
-      viewName, ViewDefinition{std::move(type), std::string(text)});
+      viewName, ViewDefinition{type, std::string(text), viewType});
   VELOX_CHECK(inserted, "View already exists: {}", viewName.toString());
+
+  // Materialized views should also be accessible via findTable().
+  if (viewType == ViewType::kMaterializedView) {
+    connector_->addTable(viewName, std::move(type));
+  }
 }
 
 bool TestConnectorMetadata::dropView(const SchemaTableName& viewName) {
@@ -609,8 +616,9 @@ void TestConnector::addTpchTables() {
 void TestConnector::createView(
     const SchemaTableName& viewName,
     velox::RowTypePtr type,
-    std::string_view text) {
-  metadata_->createView(viewName, std::move(type), text);
+    std::string_view text,
+    ViewType viewType) {
+  metadata_->createView(viewName, std::move(type), text, viewType);
 }
 
 bool TestConnector::dropView(const SchemaTableName& viewName) {

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -363,7 +363,8 @@ class TestConnectorMetadata : public ConnectorMetadata {
   void createView(
       const SchemaTableName& viewName,
       velox::RowTypePtr type,
-      std::string_view text);
+      std::string_view text,
+      ViewType viewType = ViewType::kLogicalView);
 
   /// Remove a view by name. Returns true if the view existed.
   bool dropView(const SchemaTableName& viewName);
@@ -399,6 +400,7 @@ class TestConnectorMetadata : public ConnectorMetadata {
   struct ViewDefinition {
     velox::RowTypePtr type;
     std::string text;
+    ViewType viewType{ViewType::kLogicalView};
   };
   folly::F14FastMap<SchemaTableName, ViewDefinition, SchemaTableNameHash>
       views_;
@@ -563,7 +565,8 @@ class TestConnector : public velox::connector::Connector {
   void createView(
       const SchemaTableName& viewName,
       velox::RowTypePtr type,
-      std::string_view text);
+      std::string_view text,
+      ViewType viewType = ViewType::kLogicalView);
 
   /// Remove a view by name. Returns true if the view existed.
   bool dropView(const SchemaTableName& viewName);

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -215,23 +215,36 @@ TablePtr TpchConnectorMetadata::findTable(const SchemaTableName& tableName) {
     return nullptr;
   }
 
-  velox::tpch::Table tpchTable = velox::tpch::fromTableName(tableName.table);
-  const auto schema = tableName.schema.empty() ? kTiny : tableName.schema;
-  const auto scaleFactor = getScaleFactor(schema);
+  if (isValidTpchTableName(tableName.table)) {
+    velox::tpch::Table tpchTable = velox::tpch::fromTableName(tableName.table);
+    const auto schema = tableName.schema.empty() ? kTiny : tableName.schema;
+    const auto scaleFactor = getScaleFactor(schema);
 
-  const auto tableType = velox::tpch::getTableSchema(tpchTable);
-  const auto numRows = velox::tpch::getRowCount(tpchTable, scaleFactor);
+    const auto tableType = velox::tpch::getTableSchema(tpchTable);
+    const auto numRows = velox::tpch::getRowCount(tpchTable, scaleFactor);
 
-  auto table = std::make_shared<TpchTable>(
-      SchemaTableName{schema, tableName.table},
-      tableType,
-      tpchTable,
-      scaleFactor,
-      numRows);
+    auto table = std::make_shared<TpchTable>(
+        SchemaTableName{schema, tableName.table},
+        tableType,
+        tpchTable,
+        scaleFactor,
+        numRows);
 
-  table->makeDefaultLayout(*this);
+    table->makeDefaultLayout(*this);
 
-  return table;
+    return table;
+  }
+
+  // Check if this is a materialized view registered as a view.
+  auto view = findView(tableName);
+  if (view && view->viewType() == ViewType::kMaterializedView) {
+    auto table = std::make_shared<TpchTable>(
+        view->name(), view->type(), velox::tpch::Table::TBL_NATION, 0.01, 0);
+    table->makeDefaultLayout(*this);
+    return table;
+  }
+
+  return nullptr;
 }
 
 std::vector<std::string> TpchConnectorMetadata::listSchemaNames(
@@ -265,13 +278,15 @@ ViewPtr TpchConnectorMetadata::findView(const SchemaTableName& tableName) {
     return nullptr;
   }
 
-  return std::make_shared<View>(it->first, it->second.type, it->second.text);
+  return std::make_shared<View>(
+      it->first, it->second.type, it->second.text, it->second.viewType);
 }
 
 void TpchConnectorMetadata::createView(
     const SchemaTableName& viewName,
     velox::RowTypePtr type,
-    std::string_view text) {
+    std::string_view text,
+    ViewType viewType) {
   VELOX_USER_CHECK(!viewName.table.empty(), "View name cannot be empty");
   if (!viewName.schema.empty()) {
     VELOX_USER_CHECK(
@@ -282,7 +297,9 @@ void TpchConnectorMetadata::createView(
 
   auto ok =
       views_
-          .emplace(viewName, ViewDefinition{std::move(type), std::string(text)})
+          .emplace(
+              viewName,
+              ViewDefinition{std::move(type), std::string(text), viewType})
           .second;
   VELOX_CHECK(ok, "View already exists: {}", viewName.toString());
 }

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -190,7 +190,8 @@ class TpchConnectorMetadata : public ConnectorMetadata {
   void createView(
       const SchemaTableName& viewName,
       velox::RowTypePtr type,
-      std::string_view text);
+      std::string_view text,
+      ViewType viewType = ViewType::kLogicalView);
 
   bool dropView(const SchemaTableName& viewName);
 
@@ -206,6 +207,7 @@ class TpchConnectorMetadata : public ConnectorMetadata {
   struct ViewDefinition {
     velox::RowTypePtr type;
     std::string text;
+    ViewType viewType;
   };
 
   velox::connector::tpch::TpchConnector* tpchConnector_;

--- a/axiom/optimizer/mv-query-support.plan.md
+++ b/axiom/optimizer/mv-query-support.plan.md
@@ -1,0 +1,571 @@
+# Plan: Materialized View Query Support with Partition Stitching in Axiom
+
+## Problem Statement
+
+Currently, Axiom treats a materialized view (MV) the same as a regular table — it reads all partitions directly from the MV's data table. When querying an MV that is **partially refreshed** (has missing or stale partitions), Axiom should transparently stitch data from the MV's base table for those partitions. The result should be a **UNION ALL** of:
+- Fresh partitions read from the MV
+- Missing/stale partitions read from the base table
+
+**Example:** For `SELECT a, b FROM mv WHERE ds > '2026-01-20'`, if the MV only has fresh partitions up to `ds='2026-01-28'` (base table has data beyond that), the optimizer should rewrite this to:
+```sql
+SELECT a, b FROM mv WHERE ds > '2026-01-20' AND ds <= '2026-01-28'   -- fresh partitions from MV
+UNION ALL
+SELECT a_base, b_base FROM base_table WHERE ds > '2026-01-28'        -- missing partitions from base
+```
+
+---
+
+## Existing Foundation (Already Committed)
+
+The following are already in the current stack and can be used directly:
+
+### D92019614 — `MaterializedViewDefinition` class
+**File:** `axiom/connectors/MaterializedViewDefinition.h`
+
+Full C++ definition with:
+- `originalSql()` — the original SQL of the MV definition
+- `schema()` / `table()` — the MV's data table (where MV data is stored)
+- `baseTables()` — `vector<SchemaTableName>` of base tables the MV depends on
+- `columnMappings()` — `vector<ColumnMapping>` mapping MV columns to base table columns
+- `baseTablesOnOuterJoinSide()` — tables on outer side of outer joins
+- `validRefreshColumns()` — columns used for incremental refresh (e.g., `ds`)
+
+Supporting structs: `SchemaTableName`, `TableColumn`, `ColumnMapping`, `ViewSecurity`.
+
+### D92085304 — MV info in ConnectorMetadata
+**File:** `axiom/connectors/ConnectorMetadata.h`
+
+- `ViewType` enum: `kLogicalView`, `kMaterializedView`
+- `View` class now carries `viewType()` field
+- `MaterializedViewDefinitionPtr` typedef (`shared_ptr<const MaterializedViewDefinition>`)
+- `ConnectorMetadata::getMaterializedViewDefinition(name)` — virtual method returning `MaterializedViewDefinitionPtr`
+
+**File:** `axiom/facebook/prism/PrismConnectorMetadata.h/.cpp`
+
+- `PrismConnectorMetadata::getMaterializedViewDefinition()` — parses the JSON-encoded MV definition from metastore's `viewOriginalText` field. Already extracts `baseTables`, `columnMappings`, `owner`, `securityMode`, `baseTablesOnOuterJoinSide`, `validRefreshColumns`.
+
+### D92541143 — Parser flow for MV
+- `PrismConnectorMetadata::findTable()` now accepts MVs (only rejects logical views)
+- `PrismView` carries `ViewType` for distinguishing logical vs materialized views
+- PrestoParser updated to only expand logical views, not MVs
+- MV is treated as a table scan, but no partition stitching yet
+
+### Design Note: `MaterializedViewDefinition` stored on base `Table`, not `PrismTable`
+
+The MV definition should be stored on the base `connector::Table` class in `ConnectorMetadata.h`,
+**not** on `PrismTable`. The reason is dependency layering:
+
+```
+axiom/optimizer/  →  depends on  →  axiom/connectors/      (generic: Table, ConnectorMetadata)
+                     does NOT depend on  →  axiom/facebook/prism/  (specific: PrismTable)
+```
+
+The optimizer's `MaterializedViewRewrite` pass is the primary consumer of MV metadata.
+If the field were on `PrismTable`, the optimizer would need to `#include "axiom/facebook/prism/PrismTable.h"`
+and downcast via `connectorTable->as<PrismTable>()`, breaking the connector-agnostic abstraction.
+
+`PrismTable` already has Prism-specific fields (`parameters_`, `tableType_`, `partitionedByKeys_`),
+but those are only accessed by Prism-layer code — not by the optimizer.
+
+By placing it on `Table`, the optimizer accesses it generically:
+```cpp
+if (const auto& mvDef = baseTable->schemaTable->connectorTable->materializedViewDefinition()) {
+  // This is an MV — do partition stitching.
+}
+```
+
+And `PrismConnectorMetadata::findTable()` populates it during table resolution:
+```cpp
+auto table = updateTableCache(name, metadata);
+if (metadata->isMaterializedView()) {
+  auto mvDef = parseMaterializedViewDefinition(metadata->viewOriginalText());
+  table->setMaterializedViewDefinition(std::move(*mvDef));
+}
+return table;
+```
+
+**Note:** `getMaterializedViewDefinition(name)` on `ConnectorMetadata` is still useful for callers
+that start from a name (e.g., DDL operations like `REFRESH MATERIALIZED VIEW`), but the optimizer
+should use the `Table`-based accessor to avoid extra metastore lookups.
+
+---
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                    QUERY: SELECT a, b FROM mv WHERE ds > X          │
+└──────────────────┬───────────────────────────────────────────────────┘
+                   │
+                   ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  1. Table Resolution (already done in D92541143 + new changes)      │
+│     - MV resolved as a table via findTable()                        │
+│     - MaterializedViewDefinition populated on Table during findTable│
+└──────────────────┬───────────────────────────────────────────────────┘
+                   │
+                   ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  2. Optimizer Rewrite (NEW — MaterializedViewRewrite pass)          │
+│     a. Detect MV BaseTable via Table::materializedViewDefinition()  │
+│     b. Call ConnectorMetadata::getMaterializedViewStatus()           │
+│        → Connector computes boundaries internally (partition-agnostic│
+│        → Returns: refreshColumn + boundaryValues vector             │
+│     c. Construct UNION ALL:                                         │
+│        - Left child:  MV scan + filter (refreshCol <= boundary)     │
+│        - Right child: base table scan + filter (refreshCol > bound) │
+│        - Column mapping applied to base table scan                  │
+│     d. Replace original BaseTable with UNION ALL DerivedTable       │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Key Design: Partition-Agnostic `getMaterializedViewStatus()`
+
+The optimizer does NOT access `SplitManager` or partition lists directly. Instead,
+the connector encapsulates all partition/freshness logic behind a single call:
+
+```cpp
+// In axiom/connectors/ConnectorMetadata.h
+
+enum class MaterializedViewState {
+  kNotMaterialized,
+  kTooManyPartitionsMissing,
+  kPartiallyMaterialized,
+  kFullyMaterialized,
+};
+
+struct MaterializedViewStatus {
+  MaterializedViewState state;
+
+  /// Boundary values defining fresh ranges in the MV. Each consecutive pair
+  /// [boundaryValues[2i], boundaryValues[2i+1]] defines an inclusive range
+  /// of the refresh column where the MV has data. The optimizer reads
+  /// everything outside these ranges from the base table.
+  /// The refresh column name is not included here — the optimizer gets it
+  /// from MaterializedViewDefinition::validRefreshColumns().
+  /// Only meaningful when state is kPartiallyMaterialized.
+  ///
+  /// Phase 1 (missing only): Single pair, e.g., {"2026-01-21", "2026-01-28"}
+  ///   → MV: ds >= '2026-01-21' AND ds <= '2026-01-28'
+  ///   → Base: ds < '2026-01-21' OR ds > '2026-01-28'
+  ///
+  /// Phase 2 (missing + stale): Multiple pairs for non-contiguous fresh ranges,
+  ///   e.g., {"2026-01-21", "2026-01-24", "2026-01-26", "2026-01-28"}
+  ///   → MV: (ds >= '..21' AND ds <= '..24') OR (ds >= '..26' AND ds <= '..28')
+  ///   → Base: everything else (includes stale ds='2026-01-25')
+  std::vector<std::string> boundaryValues;
+};
+
+// On ConnectorMetadata:
+virtual std::optional<MaterializedViewStatus> getMaterializedViewStatus(
+    const Table& mvTable) = 0;
+```
+
+**Why this design:**
+- **Partition-agnostic**: The optimizer never sees partition names, handles, or
+  freshness values. It only gets a column + boundaries, and constructs predicates.
+- **Connector encapsulation**: The connector knows how to compute the boundaries:
+  - **Hive/Prism**: Compares partition sets, finds fresh MV ranges.
+  - **Iceberg (future)**: Uses snapshot metadata to determine refresh boundaries.
+  - **Any future format**: Just produces a column + boundary values.
+- **Same interface for both phases**: Phase 1 returns a single range (all existing
+  MV partitions). Phase 2 returns potentially multiple ranges (only fresh partitions).
+  The optimizer code handles both cases with the same range-building logic.
+- **Stale partitions handled transparently**: In Phase 2, the connector excludes
+  stale partitions from the boundary ranges. The optimizer treats them as missing
+  — the base table scan covers everything outside the fresh ranges.
+
+---
+
+## Phase 1: Missing Partition Detection and Stitching
+
+Phase 1 handles the case where the MV simply **doesn't have** certain partitions
+that exist in the base table. This requires no changes to the partition freshness
+pipeline — it only compares partition sets.
+
+### 1.1 Add `MaterializedViewDefinition` to `Table`
+
+**File:** `axiom/connectors/ConnectorMetadata.h/.cpp`
+
+Add an optional `MaterializedViewDefinition` field to the base `Table` class:
+
+```cpp
+class Table : public std::enable_shared_from_this<Table> {
+  // ... existing fields ...
+  std::optional<MaterializedViewDefinition> materializedViewDefinition_;
+public:
+  const std::optional<MaterializedViewDefinition>& materializedViewDefinition() const;
+  void setMaterializedViewDefinition(MaterializedViewDefinition definition);
+};
+```
+
+### 1.2 Populate `MaterializedViewDefinition` in `findTable()`
+
+**File:** `axiom/facebook/prism/PrismConnectorMetadata.cpp`
+
+In `findTable()`, after `updateTableCache()` creates the table, check if the table
+is a materialized view and populate the definition. The parsing logic already exists
+in `parseMaterializedViewDefinition()` (used by `getMaterializedViewDefinition()`).
+
+### 1.3 New Optimizer Pass: `MaterializedViewRewrite`
+
+**File:** `axiom/optimizer/MaterializedViewRewrite.h` (NEW)
+**File:** `axiom/optimizer/MaterializedViewRewrite.cpp` (NEW)
+
+```cpp
+class MaterializedViewRewrite {
+public:
+  MaterializedViewRewrite(
+      QueryGraphContext& context,
+      const connector::SchemaResolver& schemaResolver);
+
+  /// Traverses the DerivedTable tree and rewrites any MV BaseTable
+  /// into a UNION ALL of MV partitions + missing base table partitions.
+  /// Returns true if any rewrite was performed.
+  bool rewrite(DerivedTable& root);
+
+private:
+  bool rewriteBaseTable(DerivedTable& parent, BaseTable* mvTable);
+
+  /// Resolves the base table's SchemaTable.
+  const SchemaTable* resolveBaseTable(
+      const connector::SchemaTableName& baseTableName);
+
+  /// Builds column mapping: for each MV column, find the corresponding
+  /// base table column using MaterializedViewDefinition::columnMappings().
+  folly::F14FastMap<std::string, std::string> buildColumnNameMapping(
+      const connector::MaterializedViewDefinition& mvDef,
+      const connector::SchemaTableName& baseTableName);
+
+  /// Creates an IN-list filter for a set of partition values.
+  ExprCP makePartitionFilter(
+      const std::vector<std::string>& partitionValues,
+      const Column* partitionColumn);
+
+  QueryGraphContext& context_;
+  const connector::SchemaResolver& schemaResolver_;
+};
+```
+
+#### Algorithm for Phase 1 — `rewriteBaseTable()` (with `getMaterializedViewStatus` approach):
+
+```
+1. Get MV definition from Table object:
+   mvDef = baseTable->schemaTable->connectorTable->materializedViewDefinition()
+2. If mvDef has no value → not an MV, skip.
+
+3. Call ConnectorMetadata::getMaterializedViewStatus(mvTable, queryFilter):
+   → Connector internally compares MV partitions vs base table partitions.
+   → Returns: MaterializedViewStatus { refreshColumn="ds",
+       boundaryValues={"2026-01-21", "2026-01-28"} }
+   → Returns std::nullopt if MV covers everything (no stitching needed).
+
+4. If result is nullopt → MV is complete for this query, skip.
+
+5. Build column name mapping from mvDef.columnMappings().
+
+6. Construct range predicates from boundaryValues:
+   - For each pair [boundaryValues[2i], boundaryValues[2i+1]]:
+     mvRanges += (refreshCol >= val[2i] AND refreshCol <= val[2i+1])
+   - basePredicate = NOT (mvRanges)  // everything outside the fresh ranges
+
+   Phase 1 example (single pair {"2026-01-21", "2026-01-28"}):
+     MV filter:   ds >= '2026-01-21' AND ds <= '2026-01-28'
+     Base filter:  ds < '2026-01-21' OR ds > '2026-01-28'
+
+   Phase 2 example (two pairs {"2026-01-21", "2026-01-24", "2026-01-26", "2026-01-28"}):
+     MV filter:   (ds >= '..21' AND ds <= '..24') OR (ds >= '..26' AND ds <= '..28')
+     Base filter:  everything else (includes stale ds='2026-01-25')
+
+7. Construct UNION ALL DerivedTable:
+   a. mvDt (left child): DerivedTable containing original BaseTable
+      - Add mvRanges filter + existing user filters
+
+   b. baseDt (right child): DerivedTable containing new BaseTable for base table
+      - Resolve base table via SchemaResolver
+      - Create BaseTable with base table's columns
+      - Add basePredicate filter + existing user filters (translated via column mapping)
+      - Apply column mapping (base col names → MV col names) via DerivedTable.exprs
+
+   c. parentDt: DerivedTable with setOp = kUnionAll, children = [mvDt, baseDt]
+      - columns match original MV query output
+
+8. Replace original BaseTable in parent DerivedTable with parentDt.
+```
+
+**Key insight:** The optimizer never deals with partition lists. It receives
+a column + boundary vector from the connector and constructs range predicates.
+The same logic handles both Phase 1 (single range) and Phase 2 (multiple ranges
+with gaps for stale partitions).
+
+#### Alternative Algorithm — Direct `SplitManager` Approach (for reference):
+
+The alternative approach has the optimizer access partitions directly instead of
+going through `getMaterializedViewStatus()`. This is kept here for comparison.
+
+```
+1. Get MV definition from Table object (same as above).
+2. Get the MV's partition column from mvDef.validRefreshColumns() (e.g., "ds").
+3. Fetch MV partition list via SplitManager (using query's WHERE predicate).
+   → Returns: {"ds=2026-01-21", "ds=2026-01-22", ..., "ds=2026-01-28"}
+4. Fetch base table partition list via SplitManager (using same WHERE predicate).
+   → Returns: {"ds=2026-01-21", "ds=2026-01-22", ..., "ds=2026-01-30"}
+5. Compute missing partitions = base table partitions − MV partitions.
+   → Missing: {"ds=2026-01-29", "ds=2026-01-30"}
+6. If no missing partitions → skip (MV is complete for this query).
+7. Build column name mapping from mvDef.columnMappings().
+8. Construct UNION ALL DerivedTable:
+   a. mvDt: keep existing filters (missing partitions don't exist in MV)
+   b. baseDt: add partitionCol IN (missing partition values)
+   c. parentDt: setOp = kUnionAll, children = [mvDt, baseDt]
+9. Replace original BaseTable with parentDt.
+```
+
+**Tradeoffs vs `getMaterializedViewStatus()`:**
+- **Pro:** More precise — uses exact IN-list filters instead of range predicates,
+  potentially fewer partitions read from base table.
+- **Con:** Optimizer depends on SplitManager/partition concepts, not partition-agnostic.
+- **Con:** Doesn't support Iceberg or other formats without named partitions.
+- **Con:** The optimizer currently doesn't hold a `tableHandle` needed for the
+  standard `SplitManager::listPartitions()` call. Would need to use the
+  Prism-specific overload `listPartitions(layout, subfieldFilters)` which
+  breaks connector-agnostic abstraction.
+
+### 1.4 Integration Point
+
+**File:** `axiom/optimizer/Optimization.cpp`
+
+The optimization pipeline starts in the `Optimization` constructor, which builds the
+query graph and initializes plans:
+
+```cpp
+// Optimization constructor (simplified):
+root_ = toGraph_.makeQueryGraph(*logicalPlan_);
+root_->initializePlans();
+```
+
+Then `Optimization::bestPlan()` performs join planning and returns the best plan:
+
+```cpp
+PlanP Optimization::bestPlan() {
+  PlanObjectSet targetColumns;
+  targetColumns.unionObjects(root_->columns);
+  topState_.dt = root_;
+  topState_.setTargetExprsForDt(targetColumns);
+  makeJoins(topState_);
+  return topState_.plans.best();
+}
+```
+
+The MV rewrite should be inserted **after** `initializePlans()` in the constructor
+and **before** `bestPlan()` begins join planning. This ensures the UNION ALL
+DerivedTable is in place before the optimizer plans joins and selects access paths.
+
+```cpp
+// In Optimization constructor, after initializePlans():
+root_ = toGraph_.makeQueryGraph(*logicalPlan_);
+root_->initializePlans();
+
+// MV partition stitching rewrite.
+MaterializedViewRewrite mvRewrite(context_, resolver_);
+mvRewrite.rewrite(*root_);
+```
+
+### 1.5 Column Mapping Details
+
+Using the existing `MaterializedViewDefinition::columnMappings()`:
+```cpp
+struct ColumnMapping {
+  TableColumn viewColumn;                  // MV column
+  std::vector<TableColumn> baseTableColumns; // base table source columns
+};
+
+struct TableColumn {
+  SchemaTableName tableName;
+  std::string columnName;
+  std::optional<bool> isDirectMapped;
+};
+```
+
+For each column in the MV query, find the matching `ColumnMapping` where
+`viewColumn.columnName` matches. Then use `baseTableColumns[i].columnName`
+(for the matching base table) as the source column in the base table scan.
+
+When constructing `baseDt`:
+- `baseDt->exprs` = base table column references (using base column names)
+- `baseDt->columns` = shared with parent DerivedTable (using MV column names)
+
+This makes the UNION ALL seamless — both children produce columns with the same
+output names.
+
+### 1.6 Build System
+
+**File:** `axiom/optimizer/BUCK`
+
+Add `MaterializedViewRewrite.cpp` to the optimizer library target.
+
+### Phase 1 Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `axiom/connectors/ConnectorMetadata.h/.cpp` | Modify | Add `materializedViewDefinition` field and accessor to base `Table` class |
+| `axiom/facebook/prism/PrismConnectorMetadata.cpp` | Modify | Populate `MaterializedViewDefinition` on `Table` in `findTable()` |
+| `axiom/optimizer/MaterializedViewRewrite.h` | **NEW** | MV rewrite pass header |
+| `axiom/optimizer/MaterializedViewRewrite.cpp` | **NEW** | MV rewrite pass — missing partition detection and UNION ALL construction |
+| `axiom/optimizer/Optimization.cpp` | Modify | Call `MaterializedViewRewrite` in optimization pipeline |
+| `axiom/optimizer/BUCK` | Modify | Add new files to build |
+
+---
+
+## Phase 2: Stale Partition Detection via `partitionFreshness`
+
+Phase 2 extends Phase 1 to also detect **stale** partitions — partitions that exist
+in the MV but contain outdated data (base table was updated after the MV was last
+refreshed). A partition is stale when `partitionFreshness == 2` (STALE) in the
+metastore response.
+
+### Key Design: No Optimizer Changes for Phase 2
+
+With the `getMaterializedViewStatus()` approach, **no optimizer code changes are
+needed** for Phase 2. The difference is entirely inside the connector:
+
+- **Phase 1:** `getMaterializedViewStatus()` computes boundary ranges from the set of
+  existing MV partitions.
+- **Phase 2:** `getMaterializedViewStatus()` computes boundary ranges from the set of
+  **existing AND fresh** MV partitions. Stale partitions are excluded from the fresh
+  ranges, so the optimizer naturally reads them from the base table.
+
+The optimizer receives the same `MaterializedViewStatus` struct (refreshColumn +
+boundaryValues vector) and constructs the same UNION ALL — it doesn't know or care
+whether the boundaries were computed from missing partitions, stale partitions, or
+both.
+
+### 2.1 Thread `partitionFreshness` through Prism partition pipeline
+
+This is the connector-side work needed to make `getMaterializedViewStatus()` aware
+of freshness.
+
+#### 2.1.1 Extend `PartitionNameWithVersion` to include freshness
+
+**File:** `axiom/facebook/prism/PrismCatalogClient.h`
+
+```cpp
+struct PartitionNameWithVersion {
+  std::string partitionName;
+  int64_t version;
+  std::optional<int16_t> partitionFreshness; // 1=FRESH, 2=STALE
+};
+```
+
+#### 2.1.2 Extract `partitionFreshness` from thrift response
+
+**File:** `axiom/facebook/prism/metastore/client/PrismMetastoreClient.cpp`
+
+In `co_getPartitionNamesWithVersionByFilter()`, the thrift
+`PartitionNameWithVersion` response has field 6: `partitionFreshness`.
+Currently only `partitionName` and `metadataVersion` are extracted.
+Change the return type from `vector<pair<string, int64_t>>` to include
+freshness.
+
+#### 2.1.3 Use freshness in `getMaterializedViewStatus()` implementation
+
+**File:** `axiom/facebook/prism/PrismConnectorMetadata.cpp`
+
+When computing boundary ranges:
+- Phase 1: All MV partitions are considered fresh (freshness not checked).
+- Phase 2: Filter out stale partitions (freshness == 2) before computing ranges.
+  The remaining fresh partitions form the boundary ranges returned to the optimizer.
+
+### Alternative: Direct SplitManager Approach for Phase 2 (for reference)
+
+If using the direct SplitManager approach (see Phase 1 alternative algorithm), Phase 2
+would additionally require:
+
+#### Propagate freshness to `PrismPartitionHandle`
+
+**File:** `axiom/facebook/prism/PrismPartitionHandle.h/.cpp`
+
+Add `partitionFreshness` field:
+```cpp
+class PrismPartitionHandle : public connector::PartitionHandle {
+  // ... existing fields ...
+  std::optional<int16_t> partitionFreshness_;
+public:
+  std::optional<int16_t> partitionFreshness() const;
+};
+```
+
+**File:** `axiom/facebook/prism/PrismSplitManager.cpp`
+
+In `listPartitions()`, propagate `partitionFreshness` from
+`PartitionNameWithVersion` to `PrismPartitionHandle`.
+
+#### Update `MaterializedViewRewrite` to use freshness
+
+**File:** `axiom/optimizer/MaterializedViewRewrite.cpp`
+
+Extend the rewrite algorithm to also check freshness:
+
+```
+Phase 1 (existing): missing = basePartitions − mvPartitions
+Phase 2 (new):      stale   = {p ∈ mvPartitions | p.freshness == STALE}
+
+Partitions to read from base table = missing ∪ stale
+Partitions to read from MV         = mvPartitions − stale
+```
+
+When stale partitions exist, the MV scan now needs an **additional filter** to
+exclude them:
+- `partitionCol IN (fresh MV partition values)` — only read fresh partitions from MV
+- `partitionCol IN (stale + missing partition values)` — read the rest from base table
+
+**Tradeoff:** This approach requires optimizer changes for Phase 2 (filtering stale
+partitions), whereas the `getMaterializedViewStatus()` approach does not.
+
+### Phase 2 Files Changed
+
+With `getMaterializedViewStatus()` approach:
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `axiom/facebook/prism/PrismCatalogClient.h` | Modify | Add `partitionFreshness` to `PartitionNameWithVersion` |
+| `axiom/facebook/prism/metastore/client/PrismMetastoreClient.cpp` | Modify | Extract `partitionFreshness` from thrift response |
+| `axiom/facebook/prism/PrismConnectorMetadata.cpp` | Modify | Use freshness when computing boundary ranges in `getMaterializedViewStatus()` |
+
+Note: **No optimizer files changed** — the optimizer code from Phase 1 handles
+Phase 2 transparently via the boundary vector.
+
+---
+
+## Testing Strategy
+
+### Phase 1 Tests
+- MV with all partitions present → no rewrite
+- MV with some missing partitions → UNION ALL with base table for missing
+- MV with no partitions at all → full base table scan (or fall back to base)
+- Column mapping applied correctly (different column names in MV vs base)
+- Non-partition filters preserved on both sides of UNION ALL
+
+### Phase 2 Tests
+- MV with all fresh partitions → no rewrite
+- MV with some stale partitions → UNION ALL, MV side filtered to fresh only
+- MV with mix of stale + missing → UNION ALL handles both correctly
+- MV with all stale partitions → full base table scan
+
+### Integration & Regression
+- End-to-end test with mock metastore returning mixed partition states
+- Run existing optimizer tests to verify no regressions
+
+---
+
+## Open Questions / Risks
+
+1. **Multi-base-table MVs**: Initial implementation assumes a single base table. MVs defined as joins across multiple base tables would need `getMaterializedViewStatus()` to return per-base-table boundaries and the optimizer to construct a more complex rewrite. Suggest deferring to a future phase.
+2. **Non-contiguous fresh ranges**: With the boundary vector approach, scattered stale partitions produce multiple fresh ranges (e.g., ds=21–24 fresh, ds=25 stale, ds=26–28 fresh). The optimizer constructs OR'd range predicates, which may be less efficient than precise IN-list filters. Acceptable for correctness; can be optimized later.
+3. **`getMaterializedViewStatus()` latency**: The connector must fetch MV and base table partition lists to compute boundaries. This adds metastore RPCs during optimization. Consider caching partition metadata or making the call async. Also, if the MV is complete (no stitching needed), the call should be cheap — ideally a fast-path check before full partition comparison.
+4. **Boundary value type**: The current design uses `std::string` for boundary values. This works for date-string partitions (`ds='2026-01-28'`) but may need generalization for numeric or timestamp partition columns. The optimizer needs to know the column type to construct correct comparison expressions.
+5. **`queryFilter` parameter in `getMaterializedViewStatus()`**: The connector needs the query's WHERE clause to scope the partition comparison (e.g., only compare partitions where `ds > '2026-01-20'`). The expression type for this parameter needs to be defined — the optimizer works with `ExprCP`, but the connector layer doesn't understand optimizer expressions. May need a lightweight filter representation or the connector fetches all partitions and lets the optimizer intersect with the query filter.
+6. **Column mapping for partition/refresh columns**: If the MV's refresh column has a different name than the base table's partition column, the column mapping in `MaterializedViewDefinition` must handle this. The boundary's `refreshColumn` refers to the MV column name; the base table scan needs to translate it via the mapping.
+7. **Empty or fully-stale MV**: If `boundaryValues` is empty (no fresh data at all), the optimizer should eliminate the MV side entirely and read everything from the base table. Need to handle this edge case cleanly.
+8. **UNION ALL overhead**: The UNION ALL rewrite adds a set operation to every MV query, even when only a small number of partitions are missing. For queries where the MV covers 99% of partitions, this is acceptable. But if the optimizer can detect that the base table side would be empty (all partitions within the query's range are in the MV), it should skip the rewrite entirely — this is handled by `getMaterializedViewStatus()` returning `std::nullopt`.
+9. **Interaction with existing optimizer passes**: The MV rewrite inserts a UNION ALL DerivedTable into the query graph. Need to verify this doesn't interfere with subsequent optimization passes (join planning, predicate pushdown, constant folding). The rewrite runs after `initializePlans()` but before `bestPlan()`'s `makeJoins()` — verify this ordering is safe.

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "axiom/common/SchemaTableName.h"
 #include "axiom/sql/presto/PrestoParseError.h"
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -1481,6 +1482,92 @@ TEST_F(PrestoParserTest, nestedWindowFunction) {
           })
           .project({"b", "w * 2::bigint"})
           .output());
+}
+
+TEST_F(PrestoParserTest, logicalView) {
+  facebook::axiom::SchemaTableName viewName{
+      std::string(kDefaultSchema), "logical_view"};
+
+  SCOPE_EXIT {
+    connector_->dropView(viewName);
+  };
+
+  // Create a logical view explicitly.
+  connector_->createView(
+      viewName,
+      ROW({"regionkey", "cnt"}, {BIGINT(), BIGINT()}),
+      "SELECT n_regionkey as regionkey, count(*) cnt FROM nation GROUP BY 1",
+      facebook::axiom::connector::ViewType::kLogicalView);
+
+  // Verify the view type is correctly set.
+  auto* metadata =
+      facebook::axiom::connector::ConnectorMetadata::metadata(kConnectorId);
+  auto view = metadata->findView(viewName);
+  ASSERT_NE(view, nullptr);
+  ASSERT_EQ(
+      view->viewType(), facebook::axiom::connector::ViewType::kLogicalView);
+
+  // Logical views should be expanded into their underlying query.
+  // The plan should contain the aggregation from the view definition.
+  auto matcher = lp::test::LogicalPlanMatcherBuilder()
+                     .tableScan()
+                     .aggregate()
+                     .project()
+                     .output();
+  testSelect("SELECT * FROM logical_view", matcher, {"logical_view"});
+}
+
+TEST_F(PrestoParserTest, materializedView) {
+  facebook::axiom::SchemaTableName viewName{
+      std::string(kDefaultSchema), "materialized_view"};
+
+  SCOPE_EXIT {
+    connector_->dropView(viewName);
+  };
+
+  // Create a materialized view.
+  connector_->createView(
+      viewName,
+      ROW({"regionkey", "cnt"}, {BIGINT(), BIGINT()}),
+      "SELECT n_regionkey as regionkey, count(*) cnt FROM nation GROUP BY 1",
+      facebook::axiom::connector::ViewType::kMaterializedView);
+
+  // Verify the view type is correctly set.
+  auto* metadata =
+      facebook::axiom::connector::ConnectorMetadata::metadata(kConnectorId);
+  auto view = metadata->findView(viewName);
+  ASSERT_NE(view, nullptr);
+  ASSERT_EQ(
+      view->viewType(),
+      facebook::axiom::connector::ViewType::kMaterializedView);
+
+  // Materialized views should be accessed as table scans, not expanded.
+  // Since findTable() now succeeds for MVs, they take the tableScan path
+  // directly without going through findView(), so no views are recorded.
+  auto matcher = lp::test::LogicalPlanMatcherBuilder().tableScan().output();
+  testSelect("SELECT * FROM materialized_view", matcher);
+}
+
+TEST_F(PrestoParserTest, viewTypeDefault) {
+  facebook::axiom::SchemaTableName viewName{
+      std::string(kDefaultSchema), "default_view"};
+
+  SCOPE_EXIT {
+    connector_->dropView(viewName);
+  };
+
+  // Create a view without specifying type (should default to logical).
+  connector_->createView(
+      viewName,
+      ROW({"n_nationkey"}, {BIGINT()}),
+      "SELECT n_nationkey FROM nation");
+
+  auto* metadata =
+      facebook::axiom::connector::ConnectorMetadata::metadata(kConnectorId);
+  auto view = metadata->findView(viewName);
+  ASSERT_NE(view, nullptr);
+  ASSERT_EQ(
+      view->viewType(), facebook::axiom::connector::ViewType::kLogicalView);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
It will be used in the optimizer to perform UNIONs to generate the final plan for MV stitching.

Encapsulates materialized view status in connector metadata, so the optimizer doesn't need to explicitely get partitions list.

Differential Revision: D94098268


