### PR TITLE
refactor(cli): Cache PrestoParser across queries (#1173)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -82,6 +82,8 @@ std::string getLocalTimezone() {
 
 namespace axiom::sql {
 
+SqlQueryRunner::~SqlQueryRunner() = default;
+
 void SqlQueryRunner::initialize(
     const std::function<std::pair<std::string, std::string>()>&
         initializeConnectors) {
@@ -281,9 +283,14 @@ std::vector<presto::SqlStatementPtr> SqlQueryRunner::parseMultiple(
       options.defaultConnectorId.value_or(defaultConnectorId_);
   const auto& defaultSchema = options.defaultSchema.value_or(defaultSchema_);
 
-  auto prestoParser =
-      std::make_unique<presto::PrestoParser>(defaultConnectorId, defaultSchema);
-  return prestoParser->parseMultiple(sql, /*enableTracing=*/options.debugMode);
+  if (!parser_ || parserConnectorId_ != defaultConnectorId ||
+      parserSchema_ != defaultSchema) {
+    parser_ = std::make_unique<presto::PrestoParser>(
+        defaultConnectorId, defaultSchema);
+    parserConnectorId_ = defaultConnectorId;
+    parserSchema_ = defaultSchema;
+  }
+  return parser_->parseMultiple(sql, /*enableTracing=*/options.debugMode);
 }
 
 presto::SqlStatementPtr SqlQueryRunner::parseSingle(

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -19,6 +19,7 @@
 #include "axiom/optimizer/DerivedTable.h"
 #include "axiom/optimizer/ToVelox.h"
 #include "axiom/runner/LocalRunner.h"
+#include "axiom/sql/presto/PrestoParser.h"
 #include "axiom/sql/presto/SqlStatement.h"
 #include "velox/common/file/TokenProvider.h"
 
@@ -26,6 +27,8 @@ namespace axiom::sql {
 
 class SqlQueryRunner {
  public:
+  ~SqlQueryRunner();
+
   /// @param initializeConnectors Lambda to call to initialize connectors and
   /// return a pair of default {connector ID, schema}.
   void initialize(
@@ -225,6 +228,12 @@ class SqlQueryRunner {
   std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
   std::shared_ptr<folly::IOThreadPoolExecutor> spillExecutor_;
   std::unordered_map<std::string, std::string> config_;
+
+  // Cached parser, reused when connector/schema defaults don't change.
+  std::unique_ptr<presto::PrestoParser> parser_;
+  // Connector ID and schema used to construct parser_.
+  std::string parserConnectorId_;
+  std::string parserSchema_;
   std::string defaultConnectorId_;
   std::string defaultSchema_;
   std::atomic<int32_t> queryCounter_{0};


### PR DESCRIPTION
Summary:

`parseMultiple()` created a new `PrestoParser` via `make_unique` for every
parse call, even though the defaults (connector ID, schema) rarely change.
Cache the parser as a member and only recreate it when defaults change
(e.g. after a `USE` statement).

Also moves `presto_parser` to `exported_deps` in BUCK since the header now
includes PrestoParser.h, and adds an explicit destructor definition in .cpp
for the unique_ptr<PrestoParser> member (incomplete type in header).

Differential Revision: D98581193
