### PR TITLE
refactor(cli): Move filesystem/exchange registration out of SqlQueryRunner

### DIFF
--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -19,6 +19,8 @@
 #include <iostream>
 #include "axiom/cli/Connectors.h"
 #include "axiom/cli/Console.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
 
 DEFINE_string(
     catalog,
@@ -31,6 +33,10 @@ int main(int argc, char** argv) {
 
   facebook::velox::memory::MemoryManager::initialize(
       facebook::velox::memory::MemoryManager::Options{});
+
+  facebook::velox::filesystems::registerLocalFileSystem();
+  facebook::velox::exec::ExchangeSource::registerFactory(
+      facebook::velox::exec::test::createLocalExchangeSource);
 
   facebook::axiom::Connectors connectors;
   axiom::sql::SqlQueryRunner runner;

--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -22,6 +22,8 @@
 #include "axiom/cli/CatalogProperties.h"
 #include "axiom/cli/Connectors.h"
 #include "axiom/cli/Console.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
 
 DEFINE_string(
     catalog,
@@ -34,6 +36,10 @@ int main(int argc, char** argv) {
 
   facebook::velox::memory::MemoryManager::initialize(
       facebook::velox::memory::MemoryManager::Options{});
+
+  facebook::velox::filesystems::registerLocalFileSystem();
+  facebook::velox::exec::ExchangeSource::registerFactory(
+      facebook::velox::exec::test::createLocalExchangeSource);
 
   facebook::axiom::Connectors connectors;
   axiom::sql::SqlQueryRunner runner;

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -36,12 +36,10 @@
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/sql/presto/PrestoParser.h"
 #include "axiom/sql/presto/ShowStatsBuilder.h"
-#include "velox/common/file/FileSystems.h"
 #include "velox/common/time/Timer.h"
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/core/QueryConfigProvider.h"
-#include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
@@ -126,10 +124,6 @@ void SqlQueryRunner::initialize(
 
     optimizer::FunctionRegistry::registerPrestoFunctions();
 
-    velox::filesystems::registerLocalFileSystem();
-
-    velox::exec::ExchangeSource::registerFactory(
-        velox::exec::test::createLocalExchangeSource);
     if (!velox::isRegisteredVectorSerde()) {
       velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
     }

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -38,12 +38,10 @@
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/sql/presto/PrestoParser.h"
 #include "axiom/sql/presto/ShowStatsBuilder.h"
-#include "velox/common/file/FileSystems.h"
 #include "velox/common/time/Timer.h"
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/core/QueryConfigProvider.h"
-#include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/prestosql/PrestoConfigProvider.h"
 #include "velox/functions/prestosql/PrestoQueryConfig.h"
@@ -130,10 +128,6 @@ void SqlQueryRunner::initialize(
 
     optimizer::FunctionRegistry::registerPrestoFunctions();
 
-    velox::filesystems::registerLocalFileSystem();
-
-    velox::exec::ExchangeSource::registerFactory(
-        velox::exec::test::createLocalExchangeSource);
     if (!velox::isRegisteredVectorSerde()) {
       velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
     }

--- a/axiom/cli/tests/ConsoleTest.cpp
+++ b/axiom/cli/tests/ConsoleTest.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include "axiom/connectors/tests/TestConnector.h"
 #include "velox/connectors/ConnectorRegistry.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
 
 DECLARE_string(query);
 
@@ -31,6 +32,8 @@ class ConsoleTest : public ::testing::Test {
   static void SetUpTestCase() {
     facebook::velox::memory::MemoryManager::testingSetInstance(
         facebook::velox::memory::MemoryManager::Options{});
+    facebook::velox::exec::ExchangeSource::registerFactory(
+        facebook::velox::exec::test::createLocalExchangeSource);
   }
 
   void TearDown() override {

--- a/axiom/cli/tests/ConsoleTest.cpp
+++ b/axiom/cli/tests/ConsoleTest.cpp
@@ -19,6 +19,7 @@
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "velox/connectors/ConnectorRegistry.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
 
 DECLARE_string(query);
 
@@ -32,6 +33,8 @@ class ConsoleTest : public ::testing::Test {
   static void SetUpTestCase() {
     facebook::velox::memory::MemoryManager::testingSetInstance(
         facebook::velox::memory::MemoryManager::Options{});
+    facebook::velox::exec::ExchangeSource::registerFactory(
+        facebook::velox::exec::test::createLocalExchangeSource);
   }
 
   void TearDown() override {

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -27,6 +27,7 @@
 #include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/ConnectorRegistry.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -40,6 +41,8 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
   static void SetUpTestCase() {
     facebook::velox::memory::MemoryManager::testingSetInstance(
         facebook::velox::memory::MemoryManager::Options{});
+    facebook::velox::exec::ExchangeSource::registerFactory(
+        facebook::velox::exec::test::createLocalExchangeSource);
   }
 
   void SetUp() override {

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -28,6 +28,7 @@
 #include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/ConnectorRegistry.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -41,6 +42,8 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
   static void SetUpTestCase() {
     facebook::velox::memory::MemoryManager::testingSetInstance(
         facebook::velox::memory::MemoryManager::Options{});
+    facebook::velox::exec::ExchangeSource::registerFactory(
+        facebook::velox::exec::test::createLocalExchangeSource);
   }
 
   void SetUp() override {

--- a/axiom/optimizer/tests/TpchDataGenerator.cpp
+++ b/axiom/optimizer/tests/TpchDataGenerator.cpp
@@ -17,6 +17,8 @@
 #include "axiom/optimizer/tests/TpchDataGenerator.h"
 #include "axiom/cli/Connectors.h"
 #include "axiom/cli/SqlQueryRunner.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
 
 using namespace facebook::velox;
 
@@ -30,6 +32,10 @@ void TpchDataGenerator::createTables(
     dwio::common::FileFormat format,
     const TableStartingCallback& onTableStarting,
     const TableCreatedCallback& onTableCreated) {
+  velox::filesystems::registerLocalFileSystem();
+  velox::exec::ExchangeSource::registerFactory(
+      velox::exec::test::createLocalExchangeSource);
+
   Connectors connectors;
   ::axiom::sql::SqlQueryRunner runner;
   runner.initialize([&]() {


### PR DESCRIPTION
Summary:
`SqlQueryRunner::initialize()` used to unconditionally register `LocalFileSystem` and the `createLocalExchangeSource` factory. Both pull in dependencies that don't exist in WASM — the local file system relies on libc file I/O, and the local exchange source brings in a thread pool. A WASM caller needs to construct `SqlQueryRunner` without them.

Mechanism: drop the two `register*` calls from `initialize()`. Each existing caller registers them explicitly as part of its own one-time setup, which is where the rest of the per-binary initialization already lives.

Differential Revision: D101037558
