### PR TITLE
feat(runner): Add serial execution mode to LocalRunner and optimizer (#1294)

### DIFF
--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -19,6 +19,8 @@
 #include <iostream>
 #include "axiom/cli/Connectors.h"
 #include "axiom/cli/Console.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
 
 DEFINE_string(
     catalog,
@@ -31,6 +33,10 @@ int main(int argc, char** argv) {
 
   facebook::velox::memory::MemoryManager::initialize(
       facebook::velox::memory::MemoryManager::Options{});
+
+  facebook::velox::filesystems::registerLocalFileSystem();
+  facebook::velox::exec::ExchangeSource::registerFactory(
+      facebook::velox::exec::test::createLocalExchangeSource);
 
   facebook::axiom::Connectors connectors;
   axiom::sql::SqlQueryRunner runner;

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -36,12 +36,10 @@
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/sql/presto/PrestoParser.h"
 #include "axiom/sql/presto/ShowStatsBuilder.h"
-#include "velox/common/file/FileSystems.h"
 #include "velox/common/time/Timer.h"
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/core/QueryConfigProvider.h"
-#include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
@@ -126,10 +124,6 @@ void SqlQueryRunner::initialize(
 
     optimizer::FunctionRegistry::registerPrestoFunctions();
 
-    velox::filesystems::registerLocalFileSystem();
-
-    velox::exec::ExchangeSource::registerFactory(
-        velox::exec::test::createLocalExchangeSource);
     if (!velox::isRegisteredVectorSerde()) {
       velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
     }

--- a/axiom/cli/tests/ConsoleTest.cpp
+++ b/axiom/cli/tests/ConsoleTest.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include "axiom/connectors/tests/TestConnector.h"
 #include "velox/connectors/ConnectorRegistry.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
 
 DECLARE_string(query);
 
@@ -31,6 +32,8 @@ class ConsoleTest : public ::testing::Test {
   static void SetUpTestCase() {
     facebook::velox::memory::MemoryManager::testingSetInstance(
         facebook::velox::memory::MemoryManager::Options{});
+    facebook::velox::exec::ExchangeSource::registerFactory(
+        facebook::velox::exec::test::createLocalExchangeSource);
   }
 
   void TearDown() override {

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -27,6 +27,7 @@
 #include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/ConnectorRegistry.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -40,6 +41,8 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
   static void SetUpTestCase() {
     facebook::velox::memory::MemoryManager::testingSetInstance(
         facebook::velox::memory::MemoryManager::Options{});
+    facebook::velox::exec::ExchangeSource::registerFactory(
+        facebook::velox::exec::test::createLocalExchangeSource);
   }
 
   void SetUp() override {

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -21,6 +21,7 @@
 
 #include "axiom/common/SchemaTableName.h"
 #include "velox/common/config/ConfigProvider.h"
+#include "velox/exec/Task.h"
 
 namespace facebook::axiom::optimizer {
 
@@ -97,6 +98,11 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   /// When true, connectors skip side effects in createTable() and
   /// beginWrite(). Used for EXPLAIN queries.
   bool explain{false};
+
+  /// Execution mode for runners spawned during optimization (e.g. constant
+  /// folding). Should match the outer query's mode. Defaults to kParallel.
+  velox::exec::Task::ExecutionMode mode{
+      velox::exec::Task::ExecutionMode::kParallel};
 
   /// Constructs options from session property name-value pairs.
   /// Keys are unqualified property names (e.g., "sample_joins").

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -146,10 +146,15 @@ std::shared_ptr<velox::core::QueryCtx> constantQueryCtx(
 std::vector<velox::RowVectorPtr> runConstantPlan(
     PlanAndStats& veloxPlan,
     velox::memory::MemoryPool* pool) {
+  auto& optimization = queryCtx()->optimization();
   auto runner = std::make_shared<runner::LocalRunner>(
       veloxPlan.plan,
       std::move(veloxPlan.finishWrite),
-      constantQueryCtx(*queryCtx()->optimization()->veloxQueryCtx()));
+      constantQueryCtx(*optimization->veloxQueryCtx()),
+      std::make_shared<runner::ConnectorSplitSourceFactory>(),
+      /*outputPool=*/nullptr,
+      /*baseSpillDirectory=*/"",
+      optimization->options().mode);
 
   std::vector<velox::RowVectorPtr> results;
   while (auto rows = runner->next()) {

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -145,10 +145,15 @@ std::shared_ptr<velox::core::QueryCtx> constantQueryCtx(
 std::vector<velox::RowVectorPtr> runConstantPlan(
     PlanAndStats& veloxPlan,
     velox::memory::MemoryPool* pool) {
+  auto& optimization = queryCtx()->optimization();
   auto runner = std::make_shared<runner::LocalRunner>(
       veloxPlan.plan,
       std::move(veloxPlan.finishWrite),
-      constantQueryCtx(*queryCtx()->optimization()->veloxQueryCtx()));
+      constantQueryCtx(*optimization->veloxQueryCtx()),
+      std::make_shared<runner::ConnectorSplitSourceFactory>(),
+      /*outputPool=*/nullptr,
+      /*baseSpillDirectory=*/"",
+      optimization->options().mode);
 
   std::vector<velox::RowVectorPtr> results;
   while (auto rows = runner->next()) {

--- a/axiom/optimizer/tests/TpchDataGenerator.cpp
+++ b/axiom/optimizer/tests/TpchDataGenerator.cpp
@@ -17,6 +17,8 @@
 #include "axiom/optimizer/tests/TpchDataGenerator.h"
 #include "axiom/cli/Connectors.h"
 #include "axiom/cli/SqlQueryRunner.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
 
 using namespace facebook::velox;
 
@@ -30,6 +32,10 @@ void TpchDataGenerator::createTables(
     dwio::common::FileFormat format,
     const TableStartingCallback& onTableStarting,
     const TableCreatedCallback& onTableCreated) {
+  velox::filesystems::registerLocalFileSystem();
+  velox::exec::ExchangeSource::registerFactory(
+      velox::exec::test::createLocalExchangeSource);
+
   Connectors connectors;
   ::axiom::sql::SqlQueryRunner runner;
   runner.initialize([&]() {

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -137,6 +137,48 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
   }
 }
 
+void gatherScans(
+    const velox::core::PlanNodePtr& plan,
+    std::vector<velox::core::TableScanNodePtr>& scans) {
+  if (auto scan =
+          std::dynamic_pointer_cast<const velox::core::TableScanNode>(plan)) {
+    scans.push_back(scan);
+    return;
+  }
+  for (const auto& source : plan->sources()) {
+    gatherScans(source, scans);
+  }
+}
+
+void generateSplits(
+    SplitSourceFactory& splitSourceFactory,
+    const velox::core::PlanNodePtr& planNode,
+    const std::vector<std::shared_ptr<velox::exec::Task>>& tasks) {
+  std::vector<velox::core::TableScanNodePtr> scans;
+  gatherScans(planNode, scans);
+
+  for (const auto& scan : scans) {
+    auto source =
+        splitSourceFactory.splitSourceForScan(/*session=*/nullptr, *scan);
+    size_t taskIdx = 0;
+    for (;;) {
+      auto batch = folly::coro::blockingWait(source->co_getSplits(1));
+      for (auto& split : batch.splits) {
+        tasks[taskIdx]->addSplit(
+            scan->id(), velox::exec::Split(std::move(split)));
+        taskIdx = (taskIdx + 1) % tasks.size();
+      }
+      if (batch.noMoreSplits) {
+        break;
+      }
+    }
+
+    for (auto& task : tasks) {
+      task->noMoreSplits(scan->id());
+    }
+  }
+}
+
 void getTopologicalOrder(
     const std::vector<optimizer::ExecutableFragment>& fragments,
     int32_t index,
@@ -190,20 +232,28 @@ LocalRunner::LocalRunner(
     std::shared_ptr<velox::core::QueryCtx> queryCtx,
     std::shared_ptr<SplitSourceFactory> splitSourceFactory,
     std::shared_ptr<velox::memory::MemoryPool> outputPool,
-    std::string baseSpillDirectory)
+    std::string baseSpillDirectory,
+    velox::exec::Task::ExecutionMode mode)
     : plan_{std::move(plan)},
       fragments_{topologicalSort(plan_->fragments())},
       finishWrite_{std::move(finishWrite)},
       splitSourceFactory_{std::move(splitSourceFactory)},
+      mode_{mode},
       baseSpillDirectory_{std::move(baseSpillDirectory)} {
   params_.queryCtx = std::move(queryCtx);
   params_.outputPool = std::move(outputPool);
   if (!baseSpillDirectory_.empty()) {
     params_.spillDirectory = baseSpillDirectory_;
   }
+  params_.serialExecution =
+      (mode_ == velox::exec::Task::ExecutionMode::kSerial);
 
   VELOX_CHECK_NOT_NULL(splitSourceFactory_);
   VELOX_CHECK(!finishWrite_ || params_.outputPool != nullptr);
+  VELOX_CHECK_EQ(
+      params_.serialExecution,
+      params_.queryCtx->executor() == nullptr,
+      "Serial mode requires no executor; parallel mode requires one");
 }
 
 LocalRunner::~LocalRunner() {
@@ -217,16 +267,29 @@ velox::RowVectorPtr LocalRunner::next() {
     return nextWrite();
   }
 
-  if (!cursor_) {
-    start();
-  }
+  try {
+    if (!cursor_) {
+      start();
+    }
 
-  if (!cursor_->moveNext()) {
-    state_ = State::kFinished;
-    return nullptr;
-  }
+    if (!cursor_->moveNext()) {
+      state_ = State::kFinished;
+      return nullptr;
+    }
 
-  return cursor_->current();
+    return cursor_->current();
+  } catch (...) {
+    setErrorIfNone(std::current_exception());
+    throw;
+  }
+}
+
+void LocalRunner::setErrorIfNone(std::exception_ptr error) {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (!error_) {
+    state_ = State::kError;
+    error_ = std::move(error);
+  }
 }
 
 int64_t LocalRunner::runWrite() {
@@ -280,15 +343,28 @@ void LocalRunner::start() {
 
   params_.maxDrivers = plan_->options().numDrivers;
   params_.planNode = fragments_.back().fragment.planNode;
-  params_.serialExecution = !params_.queryCtx->isExecutorSupplied();
 
   VELOX_CHECK_LE(
       fragments_.back().width.value_or(1),
       1,
       "Last fragment must be single-task");
+  if (mode_ == velox::exec::Task::ExecutionMode::kSerial) {
+    VELOX_CHECK_EQ(
+        fragments_.size(),
+        1,
+        "Serial execution requires a single-fragment plan");
+  }
 
   auto cursor = velox::exec::TaskCursor::create(params_);
-  makeStages(cursor->task());
+
+  switch (mode_) {
+    case velox::exec::Task::ExecutionMode::kSerial:
+      generateSplits(*splitSourceFactory_, params_.planNode, {cursor->task()});
+      break;
+    case velox::exec::Task::ExecutionMode::kParallel:
+      makeStages(cursor->task());
+      break;
+  }
 
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -346,6 +422,10 @@ void LocalRunner::abort() {
 bool LocalRunner::waitForCompletion(int32_t maxWaitMicros) {
   VELOX_CHECK_NE(state_, State::kInitialized);
 
+  if (mode_ == velox::exec::Task::ExecutionMode::kSerial) {
+    return true;
+  }
+
   if (!splitScopeJoined_) {
     folly::coro::blockingWait(splitScope_.joinAsync());
     splitScopeJoined_ = true;
@@ -384,18 +464,6 @@ bool isBroadcast(const velox::core::PlanFragment& fragment) {
   return false;
 }
 
-void gatherScans(
-    const velox::core::PlanNodePtr& plan,
-    std::vector<velox::core::TableScanNodePtr>& scans) {
-  if (auto scan =
-          std::dynamic_pointer_cast<const velox::core::TableScanNode>(plan)) {
-    scans.push_back(scan);
-    return;
-  }
-  for (const auto& source : plan->sources()) {
-    gatherScans(source, scans);
-  }
-}
 } // namespace
 
 void LocalRunner::makeStages(

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -141,6 +141,50 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
   }
 }
 
+void gatherScans(
+    const velox::core::PlanNodePtr& plan,
+    std::vector<velox::core::TableScanNodePtr>& scans) {
+  if (auto scan =
+          std::dynamic_pointer_cast<const velox::core::TableScanNode>(plan)) {
+    scans.push_back(scan);
+    return;
+  }
+  for (const auto& source : plan->sources()) {
+    gatherScans(source, scans);
+  }
+}
+
+void generateSplits(
+    SplitSourceFactory& splitSourceFactory,
+    const velox::core::PlanNodePtr& planNode,
+    const std::vector<std::shared_ptr<velox::exec::Task>>& tasks) {
+  std::vector<velox::core::TableScanNodePtr> scans;
+  gatherScans(planNode, scans);
+
+  for (const auto& scan : scans) {
+    auto source =
+        splitSourceFactory.splitSourceForScan(/*session=*/nullptr, *scan);
+    size_t taskIdx = 0;
+    for (;;) {
+      auto batch = folly::coro::blockingWait(source->co_getSplits(1));
+      for (auto& split : batch.splits) {
+        tasks[taskIdx]->addSplit(
+            scan->id(), velox::exec::Split(std::move(split)));
+        taskIdx = (taskIdx + 1) % tasks.size();
+      }
+      if (batch.noMoreSplits) {
+        break;
+      }
+    }
+
+    for (auto& task : tasks) {
+      task->noMoreSplits(scan->id());
+    }
+
+    folly::coro::blockingWait(source->co_close());
+  }
+}
+
 void getTopologicalOrder(
     const std::vector<optimizer::ExecutableFragment>& fragments,
     int32_t index,
@@ -194,20 +238,28 @@ LocalRunner::LocalRunner(
     std::shared_ptr<velox::core::QueryCtx> queryCtx,
     std::shared_ptr<SplitSourceFactory> splitSourceFactory,
     std::shared_ptr<velox::memory::MemoryPool> outputPool,
-    std::string baseSpillDirectory)
+    std::string baseSpillDirectory,
+    velox::exec::Task::ExecutionMode mode)
     : plan_{std::move(plan)},
       fragments_{topologicalSort(plan_->fragments())},
       finishWrite_{std::move(finishWrite)},
       splitSourceFactory_{std::move(splitSourceFactory)},
+      mode_{mode},
       baseSpillDirectory_{std::move(baseSpillDirectory)} {
   params_.queryCtx = std::move(queryCtx);
   params_.outputPool = std::move(outputPool);
   if (!baseSpillDirectory_.empty()) {
     params_.spillDirectory = baseSpillDirectory_;
   }
+  params_.serialExecution =
+      (mode_ == velox::exec::Task::ExecutionMode::kSerial);
 
   VELOX_CHECK_NOT_NULL(splitSourceFactory_);
   VELOX_CHECK(!finishWrite_ || params_.outputPool != nullptr);
+  VELOX_CHECK_EQ(
+      params_.serialExecution,
+      params_.queryCtx->executor() == nullptr,
+      "Serial mode requires no executor; parallel mode requires one");
 }
 
 LocalRunner::~LocalRunner() {
@@ -221,16 +273,29 @@ velox::RowVectorPtr LocalRunner::next() {
     return nextWrite();
   }
 
-  if (!cursor_) {
-    start();
-  }
+  try {
+    if (!cursor_) {
+      start();
+    }
 
-  if (!cursor_->moveNext()) {
-    state_ = State::kFinished;
-    return nullptr;
-  }
+    if (!cursor_->moveNext()) {
+      state_ = State::kFinished;
+      return nullptr;
+    }
 
-  return cursor_->current();
+    return cursor_->current();
+  } catch (...) {
+    setErrorIfNone(std::current_exception());
+    throw;
+  }
+}
+
+void LocalRunner::setErrorIfNone(std::exception_ptr error) {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (!error_) {
+    state_ = State::kError;
+    error_ = std::move(error);
+  }
 }
 
 int64_t LocalRunner::runWrite() {
@@ -284,15 +349,28 @@ void LocalRunner::start() {
 
   params_.maxDrivers = plan_->options().numDrivers;
   params_.planNode = fragments_.back().fragment.planNode;
-  params_.serialExecution = !params_.queryCtx->isExecutorSupplied();
 
   VELOX_CHECK_LE(
       fragments_.back().width.value_or(1),
       1,
       "Last fragment must be single-task");
+  if (mode_ == velox::exec::Task::ExecutionMode::kSerial) {
+    VELOX_CHECK_EQ(
+        fragments_.size(),
+        1,
+        "Serial execution requires a single-fragment plan");
+  }
 
   auto cursor = velox::exec::TaskCursor::create(params_);
-  makeStages(cursor->task());
+
+  switch (mode_) {
+    case velox::exec::Task::ExecutionMode::kSerial:
+      generateSplits(*splitSourceFactory_, params_.planNode, {cursor->task()});
+      break;
+    case velox::exec::Task::ExecutionMode::kParallel:
+      makeStages(cursor->task());
+      break;
+  }
 
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -350,6 +428,10 @@ void LocalRunner::abort() {
 bool LocalRunner::waitForCompletion(int32_t maxWaitMicros) {
   VELOX_CHECK_NE(state_, State::kInitialized);
 
+  if (mode_ == velox::exec::Task::ExecutionMode::kSerial) {
+    return true;
+  }
+
   if (!splitScopeJoined_) {
     folly::coro::blockingWait(splitScope_.joinAsync());
     splitScopeJoined_ = true;
@@ -388,18 +470,6 @@ bool isBroadcast(const velox::core::PlanFragment& fragment) {
   return false;
 }
 
-void gatherScans(
-    const velox::core::PlanNodePtr& plan,
-    std::vector<velox::core::TableScanNodePtr>& scans) {
-  if (auto scan =
-          std::dynamic_pointer_cast<const velox::core::TableScanNode>(plan)) {
-    scans.push_back(scan);
-    return;
-  }
-  for (const auto& source : plan->sources()) {
-    gatherScans(source, scans);
-  }
-}
 } // namespace
 
 void LocalRunner::makeStages(

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -85,7 +85,9 @@ class LocalRunner : public Runner,
       std::shared_ptr<SplitSourceFactory> splitSourceFactory =
           std::make_shared<ConnectorSplitSourceFactory>(),
       std::shared_ptr<velox::memory::MemoryPool> outputPool = nullptr,
-      std::string baseSpillDirectory = "");
+      std::string baseSpillDirectory = "",
+      velox::exec::Task::ExecutionMode mode =
+          velox::exec::Task::ExecutionMode::kParallel);
 
   ~LocalRunner() override;
 
@@ -159,6 +161,10 @@ class LocalRunner : public Runner,
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan);
 
+  // No-op if an error was already recorded (e.g., by the parallel-mode
+  // onError callback registered in makeStages).
+  void setErrorIfNone(std::exception_ptr error);
+
   // Serializes 'cursor_' and 'error_'.
   mutable std::mutex mutex_;
 
@@ -174,6 +180,7 @@ class LocalRunner : public Runner,
   std::vector<std::vector<std::shared_ptr<velox::exec::Task>>> stages_;
   std::exception_ptr error_;
   std::shared_ptr<SplitSourceFactory> splitSourceFactory_;
+  const velox::exec::Task::ExecutionMode mode_;
   // Base directory for task spill files. Empty disables spilling.
   std::string baseSpillDirectory_;
   folly::coro::AsyncScope splitScope_{/*throwOnJoin=*/true};

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -91,7 +91,9 @@ class LocalRunner : public Runner,
       std::shared_ptr<SplitSourceFactory> splitSourceFactory =
           std::make_shared<ConnectorSplitSourceFactory>(),
       std::shared_ptr<velox::memory::MemoryPool> outputPool = nullptr,
-      std::string baseSpillDirectory = "");
+      std::string baseSpillDirectory = "",
+      velox::exec::Task::ExecutionMode mode =
+          velox::exec::Task::ExecutionMode::kParallel);
 
   ~LocalRunner() override;
 
@@ -165,6 +167,10 @@ class LocalRunner : public Runner,
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan);
 
+  // No-op if an error was already recorded (e.g., by the parallel-mode
+  // onError callback registered in makeStages).
+  void setErrorIfNone(std::exception_ptr error);
+
   // Serializes 'cursor_' and 'error_'.
   mutable std::mutex mutex_;
 
@@ -180,6 +186,7 @@ class LocalRunner : public Runner,
   std::vector<std::vector<std::shared_ptr<velox::exec::Task>>> stages_;
   std::exception_ptr error_;
   std::shared_ptr<SplitSourceFactory> splitSourceFactory_;
+  const velox::exec::Task::ExecutionMode mode_;
   // Base directory for task spill files. Empty disables spilling.
   std::string baseSpillDirectory_;
   folly::coro::AsyncScope splitScope_{/*throwOnJoin=*/true};

--- a/axiom/runner/tests/LocalRunnerTest.cpp
+++ b/axiom/runner/tests/LocalRunnerTest.cpp
@@ -141,6 +141,29 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
         std::move(plan), optimizer::FinishWrite{}, makeQueryCtx(queryId));
   }
 
+  std::shared_ptr<LocalRunner> makeSerialRunner(
+      optimizer::MultiFragmentPlanPtr plan) {
+    const auto queryId = plan->options().queryId;
+
+    auto queryCtx = velox::core::QueryCtx::create(
+        /*executor=*/nullptr,
+        velox::core::QueryConfig({}),
+        {},
+        velox::cache::AsyncDataCache::getInstance(),
+        /*pool=*/nullptr,
+        /*spillExecutor=*/nullptr,
+        queryId);
+
+    return std::make_shared<LocalRunner>(
+        std::move(plan),
+        optimizer::FinishWrite{},
+        std::move(queryCtx),
+        std::make_shared<runner::ConnectorSplitSourceFactory>(),
+        /*outputPool=*/nullptr,
+        /*baseSpillDirectory=*/"",
+        velox::exec::Task::ExecutionMode::kSerial);
+  }
+
   // Fetches all remaining data from the runner.
   static std::vector<velox::RowVectorPtr> readCursor(
       const std::shared_ptr<LocalRunner>& runner) {
@@ -277,7 +300,38 @@ TEST_F(LocalRunnerTest, spillDirectoryWiring) {
   auto results = readCursor(localRunner);
   EXPECT_EQ(1, results.size());
   EXPECT_EQ(kNumRows, extractSingleInt64(results));
+  results.clear();
   EXPECT_EQ(Runner::State::kFinished, localRunner->state());
+  ASSERT_TRUE(localRunner->waitForCompletion(kWaitTimeoutUs));
+}
+
+TEST_F(LocalRunnerTest, serialScan) {
+  auto scan = makeScanPlan(1);
+  auto localRunner = makeSerialRunner(scan);
+
+  auto results = readCursor(localRunner);
+
+  int32_t count = 0;
+  for (auto& rows : results) {
+    count += rows->size();
+  }
+  EXPECT_EQ(kNumRows, count);
+  EXPECT_EQ(Runner::State::kFinished, localRunner->state());
+  ASSERT_TRUE(localRunner->waitForCompletion(kWaitTimeoutUs));
+}
+
+TEST_F(LocalRunnerTest, serialError) {
+  optimizer::MultiFragmentPlan::Options options = {
+      .queryId = makeQueryId(), .numWorkers = 1, .numDrivers = 1};
+  test::DistributedPlanBuilder builder(options, idGenerator_, pool_.get());
+  builder.tableScan("t", rowType_)
+      .project({"if (c0 = 111, c0 / 0, c0 + 1) as c0"});
+
+  auto localRunner = makeSerialRunner(builder.build());
+
+  VELOX_ASSERT_THROW(readCursor(localRunner), "division by zero");
+  EXPECT_EQ(Runner::State::kError, localRunner->state());
+  ASSERT_TRUE(localRunner->waitForCompletion(kWaitTimeoutUs));
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

Add `ExecutionMode` parameter to `LocalRunner` so it can run in single-threaded serial mode without an executor or async split generation. In serial mode, `start()` calls synchronous `generateSplits()` instead of `makeStages()`, and `waitForCompletion()` returns immediately since there are no background tasks. Thread the mode through `OptimizerOptions` so constant-folding runners also respect it.

Differential Revision: D101037562


