### PR TITLE
fix(optimizer): Add descriptive error message to correlated aggregation check

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -3174,7 +3174,9 @@ AggregationPlanCP ToGraph::processCorrelatedAggregation(
     return nullptr;
   }
 
-  VELOX_CHECK(agg->groupingKeys().empty());
+  VELOX_CHECK(
+      agg->groupingKeys().empty(),
+      "Correlated aggregation with grouping keys is not supported");
 
   // Check if all conjuncts are equalities. If any are non-equi, we'll
   // handle decorrelation at the outer level using AssignUniqueId.


### PR DESCRIPTION
Summary:
The `VELOX_CHECK` in `processCorrelatedAggregation` had no error message. When this check fails (correlated aggregation with non-empty grouping keys), the resulting `VeloxRuntimeError` carries only the raw expression string (`agg->groupingKeys().empty()`) as its message.

Callers that catch `VeloxException` and propagate the message to end users or logging systems (e.g., the Presto-compatible HTTP server in fb_axel) surface this as an empty or generic error. Query monitoring dashboards (Scuba) then record null `failure_message`, making it impossible to triage these failures without digging into server-side stack traces.

Add a human-readable message: `Correlated aggregation with grouping keys is not supported`.

Before: empty or expression-only error → invisible in monitoring
After: clear error message → filterable and triageable in Scuba

Differential Revision: D106329739


