### PR TITLE
feat: Support =ANY/=SOME/<>ALL quantified comparison

### DIFF
--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -300,6 +300,26 @@ SELECT t.a NOT IN (SELECT t2.a FROM t t2 WHERE t.b = t2.b) FROM t
 SELECT a FROM (VALUES (1), (CAST(NULL AS INTEGER)), (5)) AS l(a)
 WHERE a NOT IN (SELECT b FROM (VALUES (1), (3)) AS r(b))
 ----
+-- `= ANY` is equivalent to IN.
+SELECT a FROM t WHERE a = ANY (SELECT a FROM v)
+----
+-- `<> ALL` is equivalent to NOT IN.
+SELECT a FROM t WHERE a <> ALL (SELECT a FROM v)
+----
+-- `= SOME` (synonym for `= ANY`) in the SELECT list returns a boolean.
+SELECT a = SOME (SELECT a FROM v) FROM t
+----
+-- `<> ALL` with a NULL left key follows NOT IN three-valued logic.
+SELECT a FROM (VALUES (1), (CAST(NULL AS INTEGER)), (5)) AS l(a) WHERE a <> ALL (SELECT a FROM v)
+----
+-- `<> ALL` with a NULL in the subquery yields NULL for every non-matching
+-- row, so no rows qualify.
+SELECT a FROM (VALUES (1), (2)) AS l(a) WHERE a <> ALL (SELECT b FROM (VALUES (2), (CAST(NULL AS INTEGER))) AS r(b))
+----
+-- `= ANY` with a NULL in the subquery matches only non-NULL elements; a
+-- non-match against NULL is unknown, not false.
+SELECT a FROM (VALUES (1), (2)) AS l(a) WHERE a = ANY (SELECT b FROM (VALUES (2), (CAST(NULL AS INTEGER))) AS r(b))
+----
 -- Uncorrelated `WHERE NOT EXISTS` over an empty subquery returns every
 -- outer row.
 SELECT a FROM t WHERE NOT EXISTS (SELECT 1 FROM v WHERE false)

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -889,6 +889,33 @@ lp::ExprApi ExpressionPlanner::toExpr(
           exists->subquery()->as<SubqueryExpression>(), /*scalar=*/false));
     }
 
+    case NodeType::kQuantifiedComparisonExpression: {
+      auto* quantified = node->as<QuantifiedComparisonExpression>();
+      using Quantifier = QuantifiedComparisonExpression::Quantifier;
+      const auto op = quantified->op();
+      const auto quantifier = quantified->quantifier();
+
+      const bool isEqualAny = op == ComparisonExpression::Operator::kEqual &&
+          (quantifier == Quantifier::kAny || quantifier == Quantifier::kSome);
+      const bool isNotEqualAll =
+          op == ComparisonExpression::Operator::kNotEqual &&
+          quantifier == Quantifier::kAll;
+      AXIOM_PRESTO_SEMANTIC_CHECK(
+          isEqualAny || isNotEqualAll,
+          quantified->location(),
+          std::nullopt,
+          "Quantified comparison is only supported for = ANY, = SOME, and <> ALL");
+
+      auto value = toExpr(quantified->value(), options);
+      auto subquery = toExpr(quantified->subquery(), options);
+
+      // = ANY/SOME is definitionally equivalent to IN; <> ALL to NOT IN.
+      if (isEqualAny) {
+        return lp::Call("in", value, subquery);
+      }
+      return lp::Call("not", lp::Call("in", value, subquery));
+    }
+
     case NodeType::kCast: {
       auto* cast = node->as<Cast>();
       const auto type = resolveType(cast->toType());

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1837,6 +1837,20 @@ ComparisonExpression::Operator toComparisonOperator(size_t tokenType) {
   }
 }
 
+QuantifiedComparisonExpression::Quantifier toQuantifier(
+    PrestoSqlParser::ComparisonQuantifierContext* ctx) {
+  if (ctx->ALL() != nullptr) {
+    return QuantifiedComparisonExpression::Quantifier::kAll;
+  }
+  if (ctx->ANY() != nullptr) {
+    return QuantifiedComparisonExpression::Quantifier::kAny;
+  }
+  if (ctx->SOME() != nullptr) {
+    return QuantifiedComparisonExpression::Quantifier::kSome;
+  }
+  VELOX_UNREACHABLE();
+}
+
 } // anonymous namespace
 
 std::any AstBuilder::visitComparison(PrestoSqlParser::ComparisonContext* ctx) {
@@ -1857,7 +1871,21 @@ std::any AstBuilder::visitComparison(PrestoSqlParser::ComparisonContext* ctx) {
 std::any AstBuilder::visitQuantifiedComparison(
     PrestoSqlParser::QuantifiedComparisonContext* ctx) {
   trace("visitQuantifiedComparison");
-  return visitChildren("visitQuantifiedComparison", ctx);
+
+  auto value = visitExpression(ctx->value);
+
+  auto operatorToken = ctx->comparisonOperator()->children[0];
+  auto terminalNode = dynamic_cast<antlr4::tree::TerminalNode*>(operatorToken);
+  auto op = toComparisonOperator(terminalNode->getSymbol()->getType());
+
+  auto quantifier = toQuantifier(ctx->comparisonQuantifier());
+
+  auto subquery = std::make_shared<SubqueryExpression>(
+      getLocation(ctx), visitTyped<Statement>(ctx->query()));
+
+  return std::static_pointer_cast<Expression>(
+      std::make_shared<QuantifiedComparisonExpression>(
+          getLocation(ctx), op, quantifier, value, subquery));
 }
 
 namespace {

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -829,6 +829,25 @@ TEST_F(PrestoParserTest, exists) {
   }
 }
 
+// Only `= ANY`/`= SOME` and `<> ALL` are supported; other operator and
+// quantifier combinations are not supported yet.
+TEST_F(PrestoParserTest, quantifiedComparisonUnsupported) {
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql(
+          "SELECT * FROM nation WHERE n_regionkey > ALL (SELECT r_regionkey FROM region)"),
+      "Quantified comparison is only supported for");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql(
+          "SELECT * FROM nation WHERE n_regionkey = ALL (SELECT r_regionkey FROM region)"),
+      "Quantified comparison is only supported for");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql(
+          "SELECT * FROM nation WHERE n_regionkey <> ANY (SELECT r_regionkey FROM region)"),
+      "Quantified comparison is only supported for");
+}
+
 // JOIN ON in a correlated subquery body resolves outer-scope columns
 // the same way WHERE does.
 TEST_F(PrestoParserTest, correlatedSubqueryWithOuterReferenceInJoinOn) {


### PR DESCRIPTION
Summary:
Quantified comparison over a subquery — x <op> {ALL | ANY | SOME} (subquery) — now parses and executes for the equality forms. `x = ANY (sq)` and `x = SOME (sq)` behave as `x IN (sq)`; `x <> ALL (sq)` behaves as `x NOT IN (sq)`. For example:

    SELECT a FROM t WHERE a = ANY (SELECT a FROM v)

now runs. Previously any quantified comparison failed to parse with an internal error:

    visitChildren called with more than one child: 5 (visitQuantifiedComparison)

The parser builds a QuantifiedComparisonExpression AST node, and ExpressionPlanner rewrites it to the existing `in`/`not in` calls, reusing the semi-join lowering. Ordered comparisons (<, <=, >, >=) and = ALL / <> ANY / <> SOME are not supported yet and fail with a clear message.

Differential Revision: D110353151


