### PR TITLE
feat(optimizer/v2): Plan and lower WITH RECURSIVE queries. (#1571)

### DIFF
--- a/axiom/logical_plan/LogicalPlanNode.cpp
+++ b/axiom/logical_plan/LogicalPlanNode.cpp
@@ -1323,11 +1323,6 @@ FixedPointNode::FixedPointNode(
     : LogicalPlanNode{NodeKind::kFixedPoint, std::move(id), {anchor, step}, anchor->outputType()},
       name_{std::move(name)} {
   VELOX_USER_CHECK(!name_.empty(), "FixedPointNode name must be non-empty");
-  // Equivalence (types only), not strict name equality. Anchor and step
-  // schemas may carry different canonical column ids -- e.g. when the step's
-  // final projection allocates fresh names from the shared NameAllocator --
-  // so tightening this to name-equality would break valid recursive plans
-  // whose anchor and step differ only by id.
   VELOX_USER_CHECK(
       anchor->outputType()->equivalent(*step->outputType()),
       "Anchor and step branches of FixedPointNode must have equivalent output schemas: {} vs. {}",
@@ -1335,7 +1330,7 @@ FixedPointNode::FixedPointNode(
       step->outputType()->toString());
 
   rejectAnchorRecursiveReference(anchor, name_);
-  bool found = false;
+  bool found{false};
   checkRecursiveReferences(step, name_, anchor->outputType(), &found);
   VELOX_USER_CHECK(
       found,

--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -1069,10 +1069,11 @@ using OutputNodePtr = std::shared_ptr<const OutputNode>;
 ///
 class FixedPointNode : public LogicalPlanNode {
  public:
-  /// 'name' is the recursive relation's name and must be non-empty. The
-  /// step must contain at least one RecursiveReferenceNode with this name.
-  /// 'anchor' and 'step' must produce equivalent output schemas; that schema
-  /// is the node's output type.
+  /// Requires:
+  /// - `name` is non-empty.
+  /// - `anchor` does not reference its enclosing fixed-point state.
+  /// - `step` contains at least one RecursiveReferenceNode named `name`.
+  /// - `anchor` and `step` produce equivalent output schemas.
   FixedPointNode(
       std::string id,
       std::string name,

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -2231,8 +2231,6 @@ PlanBuilder& PlanBuilder::fixedPoint(
       node_, "Anchor plan must be set before calling fixedPoint");
   VELOX_USER_CHECK_NOT_NULL(step);
   node_ = std::make_shared<FixedPointNode>(nextId(), name, node_, step);
-  // FixedPointNode's constructor enforces that anchor and step output schemas
-  // are equivalent, so outputMapping_ (built from the anchor) stays valid.
   return *this;
 }
 
@@ -2244,9 +2242,9 @@ PlanBuilder& PlanBuilder::recursiveRef(
       anchor.node_, "Anchor plan must be set before calling recursiveRef");
   const auto& anchorType = anchor.node_->outputType();
   const auto& anchorMapping = *anchor.outputMapping_;
-  // Rebuild the anchor's mappings under fresh ids so each recursive reference
-  // site has distinct column ids -- two refs joined side by side
-  // (e.g. `r r1 JOIN r r2`) must not collide on shared anchor ids.
+  // Rebuilds the anchor's mappings under fresh ids so each recursive reference
+  // site has distinct column ids. Two references joined side by side must not
+  // collide on shared anchor ids.
   outputMapping_ = std::make_shared<NameMappings>();
   const auto numColumns = anchorType->size();
   std::vector<std::string> outputNames;

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -820,19 +820,17 @@ class PlanBuilder {
   }
 
   /// Wraps the current plan (treated as the anchor) and the provided step
-  /// plan in a FixedPointNode named `name`. The step must contain at least
-  /// one RecursiveReferenceNode named `name`, and anchor and step must
-  /// produce equivalent schemas.
+  /// plan in a FixedPointNode named `name`. The step must contain at least one
+  /// RecursiveReferenceNode named `name`, and anchor and step must produce
+  /// equivalent schemas.
   PlanBuilder& fixedPoint(
       const std::string& name,
       const LogicalPlanNodePtr& step);
 
   /// Creates a RecursiveReferenceNode leaf referencing the enclosing
-  /// FixedPointNode named `name`. Schema and name resolution mirror
-  /// `anchor` -- step-body lookups like `r.x` resolve through a clone of
-  /// the anchor's NameMappings, with each column id reallocated so
-  /// multiple references within a step body compare as distinct. Must be
-  /// the first call on a fresh builder.
+  /// FixedPointNode named `name`. Schema and name resolution mirror `anchor`,
+  /// with each column id reallocated so multiple references within a step body
+  /// compare as distinct. Must be the first call on a fresh builder.
   PlanBuilder& recursiveRef(const std::string& name, const PlanBuilder& anchor);
 
   /// Builds the plan using user-specified names for output columns.

--- a/axiom/optimizer/OptimizerOptions.cpp
+++ b/axiom/optimizer/OptimizerOptions.cpp
@@ -111,6 +111,12 @@ std::vector<ConfigProperty> buildProperties(
           "time on dense join graphs. 0 means unlimited.",
       },
       {
+          std::string(OptimizerOptions::kFixedPointMaxIterations),
+          ConfigPropertyType::kInteger,
+          std::to_string(OptimizerOptions::kFixedPointMaxIterationsDefault),
+          "Safety bound on iterations for a recursive CTE FixedPoint. Must be >= 1.",
+      },
+      {
           std::string(OptimizerOptions::kTraceFlags),
           ConfigPropertyType::kInteger,
           std::to_string(OptimizerOptions::kTraceFlagsDefault),
@@ -162,6 +168,10 @@ std::string OptimizerOptions::normalize(
     // Throws if 'value' is not a valid capacity string (e.g. "100MB").
     velox::config::toCapacity(
         std::string(value), velox::config::CapacityUnit::BYTE);
+  } else if (name == kFixedPointMaxIterations) {
+    auto iterations = std::stoi(std::string(value));
+    VELOX_USER_CHECK_GE(
+        iterations, 1, "fixed_point_max_iterations must be >= 1: {}", value);
   }
   return std::string(value);
 }
@@ -203,6 +213,7 @@ OptimizerOptions OptimizerOptions::from(
   setInt(kGreedyJoinThreshold, options.greedyJoinThreshold);
   setCapacity(kBroadcastSizeLimit, options.broadcastSizeLimit);
   setInt(kDphypEnumerationBudget, options.dphypEnumerationBudget);
+  setInt(kFixedPointMaxIterations, options.fixedPointMaxIterations);
 
   auto setUint = [&](std::string_view key, uint32_t& field) {
     auto it = properties.find(key);

--- a/axiom/optimizer/OptimizerOptions.cpp
+++ b/axiom/optimizer/OptimizerOptions.cpp
@@ -16,6 +16,7 @@
 #include "axiom/optimizer/OptimizerOptions.h"
 
 #include <fmt/format.h>
+#include <folly/Conv.h>
 #include <glog/logging.h>
 
 #include "velox/common/base/Exceptions.h"
@@ -27,6 +28,18 @@ using velox::config::ConfigProperty;
 using velox::config::ConfigPropertyType;
 
 namespace {
+
+int32_t parseRecursionLimit(std::string_view value) {
+  int32_t iterations;
+  try {
+    iterations = folly::to<int32_t>(value);
+  } catch (const folly::ConversionError&) {
+    VELOX_USER_FAIL(
+        "recursion_limit must be a valid 32-bit integer: {}", value);
+  }
+  VELOX_USER_CHECK_GE(iterations, 1, "recursion_limit must be >= 1: {}", value);
+  return iterations;
+}
 
 std::vector<ConfigProperty> buildProperties(
     const std::unordered_map<std::string, std::string>& configOverrides) {
@@ -126,6 +139,12 @@ std::vector<ConfigProperty> buildProperties(
           "time on dense join graphs. 0 means unlimited.",
       },
       {
+          std::string(OptimizerOptions::kRecursionLimit),
+          ConfigPropertyType::kInteger,
+          std::to_string(OptimizerOptions::kRecursionLimitDefault),
+          "Maximum iterations for a recursion that has no bound of its own. Must be >= 1.",
+      },
+      {
           std::string(OptimizerOptions::kTraceFlags),
           ConfigPropertyType::kInteger,
           std::to_string(OptimizerOptions::kTraceFlagsDefault),
@@ -185,6 +204,8 @@ std::string OptimizerOptions::normalize(
     // Throws if 'value' is not a valid capacity string (e.g. "100MB").
     velox::config::toCapacity(
         std::string(value), velox::config::CapacityUnit::BYTE);
+  } else if (name == kRecursionLimit) {
+    parseRecursionLimit(value);
   }
   return std::string(value);
 }
@@ -235,6 +256,9 @@ OptimizerOptions OptimizerOptions::from(
   setInt(kGreedyJoinThreshold, options.greedyJoinThreshold);
   setCapacity(kBroadcastSizeLimit, options.broadcastSizeLimit);
   setInt(kDphypEnumerationBudget, options.dphypEnumerationBudget);
+  if (auto it = properties.find(kRecursionLimit); it != properties.end()) {
+    options.recursionLimit = parseRecursionLimit(it->second);
+  }
 
   auto setUint = [&](std::string_view key, uint32_t& field) {
     auto it = properties.find(key);

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -53,6 +53,8 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
       "broadcast_size_limit";
   static constexpr std::string_view kDphypEnumerationBudget =
       "dphyp_enumeration_budget";
+  static constexpr std::string_view kFixedPointMaxIterations =
+      "fixed_point_max_iterations";
   static constexpr std::string_view kTraceFlags = "trace_flags";
 
   // Default values — single source of truth for field initializers
@@ -64,6 +66,7 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   static constexpr std::string_view kBroadcastSizeLimitDefault = "100MB";
   static constexpr int64_t kBroadcastSizeLimitDefaultBytes = 100LL << 20;
   static constexpr int32_t kDphypEnumerationBudgetDefault = 100'000;
+  static constexpr int32_t kFixedPointMaxIterationsDefault = 1'000;
   static constexpr bool kPushdownSubfieldsDefault = false;
   static constexpr bool kAllMapsAsStructDefault = false;
   static constexpr bool kSampleJoinsDefault = false;
@@ -137,6 +140,12 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   /// which equality-transitivity closure turns into cliques). 0 means
   /// unlimited.
   int32_t dphypEnumerationBudget{kDphypEnumerationBudgetDefault};
+
+  /// Maximum iterations before a FixedPoint loop errors out as a safety
+  /// bound. Must be >= 1. Matches Presto/Trino/MySQL WITH RECURSIVE
+  /// semantics: exceeding the cap raises rather than silently truncating.
+  /// Forwarded to `velox::core::ConvergenceConfig::maxIterations`.
+  int32_t fixedPointMaxIterations{kFixedPointMaxIterationsDefault};
 
   /// Disable cost-based decision re: whether to split an aggregation into
   /// partial + final or not.

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -57,6 +57,7 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
       "small_query_max_scan_rows";
   static constexpr std::string_view kSmallQueryNumWorkers =
       "small_query_num_workers";
+  static constexpr std::string_view kRecursionLimit = "recursion_limit";
   static constexpr std::string_view kTraceFlags = "trace_flags";
 
   // Default values — single source of truth for field initializers
@@ -70,6 +71,7 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   static constexpr std::string_view kBroadcastSizeLimitDefault = "100MB";
   static constexpr int64_t kBroadcastSizeLimitDefaultBytes = 100LL << 20;
   static constexpr int32_t kDphypEnumerationBudgetDefault = 100'000;
+  static constexpr int32_t kRecursionLimitDefault = 1'000;
   static constexpr bool kPushdownSubfieldsDefault = false;
   static constexpr bool kAllMapsAsStructDefault = false;
   static constexpr bool kSampleJoinsDefault = false;
@@ -153,6 +155,12 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   /// which equality-transitivity closure turns into cliques). 0 means
   /// unlimited.
   int32_t dphypEnumerationBudget{kDphypEnumerationBudgetDefault};
+
+  /// Bounds a recursion that has no bound of its own, such as a SQL recursive
+  /// CTE. The query fails if the recursion has not converged within this many
+  /// iterations. Shapes that carry their own bound set it per node instead.
+  /// Must be at least 1.
+  int32_t recursionLimit{kRecursionLimitDefault};
 
   /// Disable cost-based decision re: whether to split an aggregation into
   /// partial + final or not.

--- a/axiom/optimizer/tests/FixedPointTest.cpp
+++ b/axiom/optimizer/tests/FixedPointTest.cpp
@@ -16,34 +16,118 @@
 
 #include <gtest/gtest.h>
 #include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
-
-using namespace facebook::velox;
 
 namespace facebook::axiom::optimizer {
 namespace {
 
-class FixedPointTest : public test::QueryTestBase {};
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
 
-// Attempting to execute a recursive plan must fail with a clear NYI error.
-TEST_F(FixedPointTest, withRecursiveThrowsNyi) {
-  auto rowType = ROW("n", BIGINT());
-  logical_plan::PlanBuilder::Context context;
+class FixedPointTest : public test::QueryTestBase {
+ protected:
+  FixedPointTest() {
+    useV2_ = true;
+  }
 
-  auto anchor = logical_plan::PlanBuilder(context).values(
-      rowType, std::vector<Variant>{Variant::row({0LL})});
+  lp::PlanBuilder anchor() {
+    return lp::PlanBuilder(context_).values(
+        ROW({"n"}, {BIGINT()}),
+        std::vector<Variant>{Variant::row({int64_t{1}})});
+  }
 
-  auto step = logical_plan::PlanBuilder(context)
-                  .recursiveRef("counter", anchor)
-                  .project({"n + 1 as n"})
-                  .planNode();
+  lp::PlanBuilder::Context context_;
+};
 
-  auto plan = anchor.fixedPoint("counter", step).build();
+TEST_F(FixedPointTest, planShape) {
+  auto logicalPlan = parseSelect(
+      "WITH RECURSIVE counter(n) AS ("
+      "VALUES 1 UNION ALL SELECT n + 1 FROM counter WHERE n < 10) "
+      "SELECT * FROM counter",
+      kTestConnectorId);
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  core::FixedPointDetails details;
+  details.name = "counter";
+  details.anchor = matchValues().build();
+  details.step = core::PlanMatcherBuilder()
+                     .workingTableScan({.name = "counter"})
+                     .filter("n < 10")
+                     .project()
+                     .build();
+
+  auto matcher =
+      core::PlanMatcherBuilder().fixedPoint(details).project().build();
+  EXPECT_TRUE(matcher->match(plan));
+}
+
+TEST_F(FixedPointTest, multipleWorkersUseSingleFragment) {
+  auto logicalPlan = parseSelect(
+      "WITH RECURSIVE counter(n) AS ("
+      "VALUES 1 UNION ALL SELECT n + 1 FROM counter WHERE n < 10) "
+      "SELECT * FROM counter",
+      kTestConnectorId);
+
+  auto plan = planVelox(logicalPlan, {.numWorkers = 2, .numDrivers = 1}).plan;
+  ASSERT_EQ(plan->fragments().size(), 1);
+  EXPECT_EQ(plan->fragments().front().type, FragmentType::kSingle);
+}
+
+// The outer filter stays on the fixed-point output and is not copied into the
+// anchor.
+TEST_F(FixedPointTest, outerFilterNotPushedIntoAnchor) {
+  auto logicalPlan = parseSelect(
+      "WITH RECURSIVE counter(n) AS ("
+      "VALUES 1 UNION ALL SELECT n + 1 FROM counter WHERE n < 20) "
+      "SELECT n FROM counter WHERE n > 15",
+      kTestConnectorId);
+
+  core::FixedPointDetails details;
+  details.name = "counter";
+  details.anchor = matchValues().build();
+  details.step = core::PlanMatcherBuilder()
+                     .workingTableScan({.name = "counter"})
+                     .filter("n < 20")
+                     .project()
+                     .build();
+
+  auto matcher = core::PlanMatcherBuilder()
+                     .fixedPoint(details)
+                     .filter("n > 15")
+                     .project()
+                     .build();
+  EXPECT_TRUE(matcher->match(toSingleNodePlan(logicalPlan)));
+}
+
+TEST_F(FixedPointTest, recursiveRefWithoutFixedPointFails) {
+  auto seed = anchor();
+  auto orphan = lp::PlanBuilder(context_).recursiveRef("counter", seed).build();
+
+  VELOX_ASSERT_THROW(
+      toSingleNodePlan(orphan),
+      "RecursiveReferenceNode outside any enclosing FixedPoint");
+}
+
+TEST_F(FixedPointTest, nestedFixedPointNyi) {
+  auto innerSeed = anchor();
+  auto innerBody = lp::PlanBuilder(context_)
+                       .recursiveRef("inner", innerSeed)
+                       .project({"n + 1 as n"})
+                       .planNode();
+  innerSeed.fixedPoint("inner", innerBody);
+
+  auto outerSeed = anchor();
+  auto outerBody = lp::PlanBuilder(context_)
+                       .recursiveRef("outer", outerSeed)
+                       .unionAll(innerSeed)
+                       .planNode();
+  auto plan = outerSeed.fixedPoint("outer", outerBody).build();
 
   VELOX_ASSERT_THROW(
       toSingleNodePlan(plan),
-      "Fixed-point (recursive) plan execution is not yet implemented");
+      "Nested FixedPoint translation is not yet implemented");
 }
 
 } // namespace

--- a/axiom/optimizer/tests/FixedPointTest.cpp
+++ b/axiom/optimizer/tests/FixedPointTest.cpp
@@ -16,34 +16,307 @@
 
 #include <gtest/gtest.h>
 #include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
-
-using namespace facebook::velox;
 
 namespace facebook::axiom::optimizer {
 namespace {
 
-class FixedPointTest : public test::QueryTestBase {};
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
 
-// Attempting to execute a recursive plan must fail with a clear NYI error.
-TEST_F(FixedPointTest, withRecursiveThrowsNyi) {
-  auto rowType = ROW("n", BIGINT());
-  logical_plan::PlanBuilder::Context context;
+core::FixedPointMatch matchFixedPoint(const std::string& name) {
+  return core::FixedPointMatch(name);
+}
 
-  auto anchor = logical_plan::PlanBuilder(context).values(
-      rowType, std::vector<Variant>{Variant::row({0LL})});
+core::PlanMatcherBuilder matchDelta(
+    const std::string& name,
+    const std::vector<std::optional<std::string>>& columns) {
+  return core::PlanMatcherBuilder()
+      .stateSource(name, /*delta=*/true)
+      .aliases(columns);
+}
 
-  auto step = logical_plan::PlanBuilder(context)
-                  .recursiveRef("counter", anchor)
-                  .project({"n + 1 as n"})
-                  .planNode();
+class FixedPointTest : public test::QueryTestBase {
+ protected:
+  FixedPointTest() {
+    useV2_ = true;
+  }
 
-  auto plan = anchor.fixedPoint("counter", step).build();
+  lp::PlanBuilder singleRow(const std::string& name, int64_t value) {
+    return lp::PlanBuilder(context_).values(
+        ROW(name, BIGINT()), std::vector<Variant>{Variant::row({value})});
+  }
+
+  lp::PlanBuilder::Context context_;
+};
+
+TEST_F(FixedPointTest, recursiveCte) {
+  static constexpr int32_t kRecursionLimit = 37;
+  optimizerOptions_.recursionLimit = kRecursionLimit;
+
+  auto logicalPlan = parseSelect(
+      "WITH RECURSIVE counter(n) AS ("
+      "VALUES 1 UNION ALL SELECT n + 1 FROM counter WHERE n < 10) "
+      "SELECT * FROM counter",
+      kTestConnectorId);
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher =
+      core::PlanMatcherBuilder()
+          .fixedPoint(matchFixedPoint("counter")
+                          .outputState(/*append=*/true, matchValues())
+                          .plan(matchDelta("counter", {"n"})
+                                    .filter("n < 10")
+                                    .project({"n + 1"}))
+                          .convergeOnEmpty({.maxIterations = kRecursionLimit}))
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_F(FixedPointTest, singleDriverStep) {
+  auto counter = singleRow("n", 1);
+  auto recursiveStep = lp::PlanBuilder(context_)
+                           .recursiveRef("counter", counter)
+                           .filter("n < 10")
+                           .aggregate({}, {"count(*) as n"})
+                           .planNode();
+  auto logicalPlan = counter.fixedPoint("counter", recursiveStep)
+                         .aggregate({}, {"count(*)"})
+                         .build();
+
+  auto matcher =
+      core::PlanMatcherBuilder()
+          .fixedPoint(matchFixedPoint("counter")
+                          .outputState(/*append=*/true, matchValues())
+                          .plan(matchDelta("counter", {"n"})
+                                    .filter("n < 10")
+                                    .singleAggregation({}, {"count(*)"}))
+                          .convergeOnEmpty())
+          .localAggregation({}, {"count(*)"})
+          .build();
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan, /*numDrivers=*/4), matcher);
+}
+
+TEST_F(FixedPointTest, outerLimit) {
+  auto logicalPlan = parseSelect(
+      "WITH RECURSIVE counter(n) AS ("
+      "VALUES 1 UNION ALL SELECT n + 1 FROM counter WHERE n < 20) "
+      "SELECT n FROM counter LIMIT 5",
+      kTestConnectorId);
+
+  auto matcher = core::PlanMatcherBuilder()
+                     .fixedPoint()
+                     .finalLimit(0, 5)
+                     .project()
+                     .build();
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+}
+
+TEST_F(FixedPointTest, multipleWorkersRejected) {
+  auto logicalPlan = parseSelect(
+      "WITH RECURSIVE counter(n) AS ("
+      "VALUES 1 UNION ALL SELECT n + 1 FROM counter WHERE n < 10) "
+      "SELECT * FROM counter",
+      kTestConnectorId);
+
+  VELOX_ASSERT_THROW(
+      planVelox(logicalPlan, {.numWorkers = 2, .numDrivers = 1}),
+      "Distributed FixedPoint execution is not yet implemented");
+}
+
+TEST_F(FixedPointTest, outerJoinInAnchor) {
+  // The anchor outer join remains outer when the step maps NULL to non-NULL.
+  auto logicalPlan = parseSelect(
+      "WITH RECURSIVE t(n) AS ("
+      "  SELECT r.n FROM (VALUES 1) l(k) "
+      "  LEFT JOIN (VALUES (2, 2)) r(k, n) ON l.k = r.k "
+      "  UNION ALL "
+      "  SELECT coalesce(n, 1) FROM t WHERE n IS NULL) "
+      "SELECT t.n FROM t JOIN (VALUES 1) e(n) ON t.n = e.n",
+      kTestConnectorId);
+
+  auto matcher =
+      core::PlanMatcherBuilder()
+          .fixedPoint(matchFixedPoint("t")
+                          .outputState(
+                              /*append=*/true,
+                              matchValues().hashJoinRight(matchValues()))
+                          .plan(matchDelta("t", {"n"})
+                                    .filter("n IS NULL")
+                                    .project({"coalesce(n, 1)"})))
+          .hashJoinInner(matchValues())
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+}
+
+TEST_F(FixedPointTest, outerFilter) {
+  auto logicalPlan = parseSelect(
+      "WITH RECURSIVE counter(n) AS ("
+      "VALUES 1 UNION ALL SELECT n + 1 FROM counter WHERE n < 20) "
+      "SELECT n FROM counter WHERE n > 15",
+      kTestConnectorId);
+
+  auto matcher =
+      core::PlanMatcherBuilder()
+          .fixedPoint(matchFixedPoint("counter")
+                          .outputState(/*append=*/true, matchValues())
+                          .plan(matchDelta("counter", {"n"})
+                                    .filter("n < 20")
+                                    .project({"n + 1"})))
+          .aliases({"n"})
+          .filter("n > 15")
+          .project()
+          .build();
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+}
+
+TEST_F(FixedPointTest, outerSelectsOneColumn) {
+  // The recursive state keeps every column the step writes, even when the
+  // outer query reads only one of them.
+  auto logicalPlan = parseSelect(
+      "WITH RECURSIVE counter(n, carried) AS ("
+      "VALUES (1, 7) UNION ALL "
+      "SELECT n + 1, carried FROM counter WHERE n < 10) "
+      "SELECT n FROM counter",
+      kTestConnectorId);
+
+  auto matcher =
+      core::PlanMatcherBuilder()
+          .fixedPoint(
+              matchFixedPoint("counter")
+                  .outputState(/*append=*/true, matchValues())
+                  .plan(matchDelta("counter", {"n", "carried"})
+                            .filter("n < 10")
+                            .project({"n + 1", "carried"}))
+                  .convergeOnEmpty({.stateColumns = {{"n", "carried"}}}))
+          .project({"c0 as n"})
+          .build();
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+}
+
+TEST_F(FixedPointTest, orphanRecursiveReference) {
+  auto counter = singleRow("n", 1);
+  auto orphan =
+      lp::PlanBuilder(context_).recursiveRef("counter", counter).build();
+
+  VELOX_ASSERT_THROW(
+      toSingleNodePlan(orphan),
+      "RecursiveReferenceNode outside any enclosing FixedPoint");
+}
+
+TEST_F(FixedPointTest, siblingRecursions) {
+  auto logicalPlan = parseSelect(
+      "WITH RECURSIVE "
+      "r1(a) AS (VALUES 0 UNION ALL SELECT a + 1 FROM r1 WHERE a < 3), "
+      "r2(b) AS (SELECT a FROM r1 UNION ALL "
+      "SELECT b + 10 FROM r2 WHERE b < 30) "
+      "SELECT b FROM r2",
+      kTestConnectorId);
+
+  auto matcher =
+      core::PlanMatcherBuilder()
+          .fixedPoint(
+              matchFixedPoint("r2")
+                  .outputState(
+                      /*append=*/true,
+                      core::PlanMatcherBuilder().fixedPoint(
+                          matchFixedPoint("r1")
+                              .outputState(/*append=*/true, matchValues())
+                              .plan(matchDelta("r1", {"a"})
+                                        .filter("a < 3")
+                                        .project({"a + 1"}))))
+                  .plan(matchDelta("r2", {"b"})
+                            .filter("b < 30")
+                            .project({"b + 10"})))
+          .project()
+          .build();
+
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+}
+
+TEST_F(FixedPointTest, twoRecursiveReferencesRejected) {
+  auto logicalPlan = parseSelect(
+      "WITH RECURSIVE reach(src, dst) AS ("
+      "VALUES (1, 2) UNION ALL "
+      "SELECT a.src, b.dst FROM reach a JOIN reach b ON a.dst = b.src) "
+      "SELECT src, dst FROM reach",
+      kTestConnectorId);
+
+  VELOX_ASSERT_THROW(
+      toSingleNodePlan(logicalPlan),
+      "Optimizer v2 supports exactly one RecursiveReferenceNode per FixedPoint step");
+}
+
+TEST_F(FixedPointTest, twoRecursionsInUnionRejected) {
+  auto logicalPlan = parseSelect(
+      "WITH RECURSIVE r(n) AS ("
+      "VALUES 1 UNION ALL SELECT n + 1 FROM r WHERE n < 10) "
+      "SELECT n FROM r UNION ALL SELECT n FROM r",
+      kTestConnectorId);
+
+  VELOX_ASSERT_THROW(
+      toSingleNodePlan(logicalPlan),
+      "Multiple FixedPoint nodes in one execution fragment are not yet supported");
+}
+
+TEST_F(FixedPointTest, twoRecursionsInJoinRejected) {
+  auto logicalPlan = parseSelect(
+      "WITH RECURSIVE r(n) AS ("
+      "VALUES 1 UNION ALL SELECT n + 1 FROM r WHERE n < 10) "
+      "SELECT l.n FROM r l JOIN r r2 ON l.n = r2.n",
+      kTestConnectorId);
+
+  VELOX_ASSERT_THROW(
+      toSingleNodePlan(logicalPlan),
+      "Multiple FixedPoint nodes in one execution fragment are not yet supported");
+}
+
+TEST_F(FixedPointTest, outerJoinAndFilter) {
+  auto logicalPlan = parseSelect(
+      "WITH RECURSIVE r(n) AS ("
+      "VALUES 1 UNION ALL SELECT n + 1 FROM r WHERE n < 10) "
+      "SELECT r.n + 1 FROM r JOIN (VALUES 2) v(n) ON r.n = v.n "
+      "WHERE r.n > 0",
+      kTestConnectorId);
+
+  auto matcher =
+      core::PlanMatcherBuilder()
+          .fixedPoint(matchFixedPoint("r")
+                          .outputState(/*append=*/true, matchValues())
+                          .plan(matchDelta("r", {"n"})
+                                    .filter("n < 10")
+                                    .project({"n + 1"})))
+          .aliases({"n"})
+          .filter("n > 0")
+          .hashJoinInner(matchValues().aliases({"n"}).filter("n > 0"))
+          .project()
+          .build();
+
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+}
+
+TEST_F(FixedPointTest, nestedRecursionRejected) {
+  auto inner = singleRow("n", 1);
+  auto innerBody = lp::PlanBuilder(context_)
+                       .recursiveRef("inner", inner)
+                       .project({"n + 1 as n"})
+                       .planNode();
+  inner.fixedPoint("inner", innerBody);
+
+  auto outer = singleRow("n", 1);
+  auto outerBody = lp::PlanBuilder(context_)
+                       .recursiveRef("outer", outer)
+                       .unionAll(inner)
+                       .planNode();
+  auto plan = outer.fixedPoint("outer", outerBody).build();
 
   VELOX_ASSERT_THROW(
       toSingleNodePlan(plan),
-      "Fixed-point (recursive) plan execution is not yet implemented");
+      "Nested FixedPoint translation is not yet implemented");
 }
 
 } // namespace

--- a/axiom/optimizer/tests/OptimizerOptionsTest.cpp
+++ b/axiom/optimizer/tests/OptimizerOptionsTest.cpp
@@ -96,6 +96,9 @@ TEST(OptimizerOptionsTest, normalizeRejectsInvalidValues) {
   VELOX_ASSERT_THROW(
       options.normalize(OptimizerOptions::kBroadcastSizeLimit, "100"),
       "Invalid capacity string");
+  VELOX_ASSERT_THROW(
+      options.normalize(OptimizerOptions::kFixedPointMaxIterations, "0"),
+      "fixed_point_max_iterations must be >= 1");
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/OptimizerOptionsTest.cpp
+++ b/axiom/optimizer/tests/OptimizerOptionsTest.cpp
@@ -111,4 +111,26 @@ TEST(OptimizerOptionsTest, normalizeRejectsInvalidValues) {
       "small_query_num_workers must be >= 1");
 }
 
+TEST(OptimizerOptionsTest, recursionLimit) {
+  OptimizerOptions options;
+  EXPECT_EQ(options.normalize(OptimizerOptions::kRecursionLimit, "17"), "17");
+  EXPECT_EQ(
+      OptimizerOptions::from(
+          {{std::string(OptimizerOptions::kRecursionLimit), "17"}})
+          .recursionLimit,
+      17);
+  VELOX_ASSERT_THROW(
+      options.normalize(OptimizerOptions::kRecursionLimit, "invalid"),
+      "recursion_limit must be a valid 32-bit integer");
+  VELOX_ASSERT_THROW(
+      options.normalize(OptimizerOptions::kRecursionLimit, "2147483648"),
+      "recursion_limit must be a valid 32-bit integer");
+  VELOX_ASSERT_THROW(
+      options.normalize(OptimizerOptions::kRecursionLimit, "0"),
+      "recursion_limit must be >= 1");
+  VELOX_ASSERT_THROW(
+      options.normalize(OptimizerOptions::kRecursionLimit, "-1"),
+      "recursion_limit must be >= 1");
+}
+
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -20,6 +20,7 @@
 #include "axiom/optimizer/MultiFragmentPlan.h"
 #include "axiom/optimizer/tests/ExprMatcher.h"
 #include "velox/connectors/hive/TableHandle.h"
+#include "velox/core/FixedPointPlanNodes.h"
 #include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/exec/HashPartitionFunction.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
@@ -331,6 +332,70 @@ class ValuesMatcher : public PlanMatcherImpl<ValuesNode> {
 
  private:
   const RowTypePtr outputType_;
+};
+
+class WorkingTableScanMatcher : public PlanMatcherImpl<StateSourceNode> {
+ public:
+  WorkingTableScanMatcher() = default;
+
+  explicit WorkingTableScanMatcher(WorkingTableScanDetails details)
+      : PlanMatcherImpl<StateSourceNode>{}, details_{std::move(details)} {}
+
+  MatchResult matchDetails(
+      const StateSourceNode& plan,
+      const std::unordered_map<std::string, std::string>& /*symbols*/)
+      const override {
+    SCOPED_TRACE(plan.toString(true, false));
+    if (details_.name.has_value()) {
+      EXPECT_EQ(plan.stateName(), *details_.name);
+    }
+    AXIOM_TEST_RETURN
+  }
+
+ private:
+  const WorkingTableScanDetails details_;
+};
+
+class FixedPointMatcher : public PlanMatcherImpl<FixedPointNode> {
+ public:
+  FixedPointMatcher() = default;
+
+  explicit FixedPointMatcher(FixedPointDetails details)
+      : PlanMatcherImpl<FixedPointNode>{}, details_{std::move(details)} {}
+
+  MatchResult matchDetails(
+      const FixedPointNode& plan,
+      const std::unordered_map<std::string, std::string>& symbols)
+      const override {
+    SCOPED_TRACE(plan.toString(true, false));
+    if (details_.name.has_value()) {
+      EXPECT_EQ(plan.outputStateEntry(), *details_.name);
+    }
+    if (details_.anchor != nullptr) {
+      EXPECT_FALSE(plan.stateDeclarations().empty());
+      AXIOM_TEST_RETURN_IF_FAILURE
+      auto result = details_.anchor->match(
+          plan.stateDeclarations()[0]->initialPlan(),
+          symbols,
+          /*context=*/nullptr);
+      if (!result.match) {
+        return MatchResult::failure();
+      }
+    }
+    if (details_.step != nullptr) {
+      EXPECT_EQ(plan.plans().size(), 1);
+      AXIOM_TEST_RETURN_IF_FAILURE
+      auto result =
+          details_.step->match(plan.plans()[0], symbols, /*context=*/nullptr);
+      if (!result.match) {
+        return MatchResult::failure();
+      }
+    }
+    AXIOM_TEST_RETURN
+  }
+
+ private:
+  const FixedPointDetails details_;
 };
 
 class FilterMatcher : public PlanMatcherImpl<FilterNode> {
@@ -1945,6 +2010,32 @@ PlanMatcherBuilder& PlanMatcherBuilder::values(
   });
 
   matcher_->setAliases(toAliases(expected.front()->rowType()));
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::workingTableScan() {
+  VELOX_USER_CHECK_NULL(matcher_);
+  matcher_ = std::make_shared<WorkingTableScanMatcher>();
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::workingTableScan(
+    const WorkingTableScanDetails& details) {
+  VELOX_USER_CHECK_NULL(matcher_);
+  matcher_ = std::make_shared<WorkingTableScanMatcher>(details);
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::fixedPoint() {
+  VELOX_USER_CHECK_NULL(matcher_);
+  matcher_ = std::make_shared<FixedPointMatcher>();
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::fixedPoint(
+    const FixedPointDetails& details) {
+  VELOX_USER_CHECK_NULL(matcher_);
+  matcher_ = std::make_shared<FixedPointMatcher>(details);
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -20,6 +20,7 @@
 #include "axiom/optimizer/MultiFragmentPlan.h"
 #include "axiom/optimizer/tests/ExprMatcher.h"
 #include "velox/connectors/hive/TableHandle.h"
+#include "velox/core/FixedPointPlanNodes.h"
 #include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/exec/HashPartitionFunction.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
@@ -314,6 +315,139 @@ class ValuesMatcher : public PlanMatcherImpl<ValuesNode> {
 
  private:
   const RowTypePtr outputType_;
+};
+
+class StateSourceMatcher : public PlanMatcherImpl<StateSourceNode> {
+ public:
+  StateSourceMatcher(std::string stateName, bool delta)
+      : PlanMatcherImpl<StateSourceNode>{},
+        stateName_{std::move(stateName)},
+        delta_{delta} {}
+
+  MatchResult matchDetails(
+      const StateSourceNode& plan,
+      const std::unordered_map<std::string, std::string>& symbols)
+      const override {
+    SCOPED_TRACE(plan.toString(true, false));
+    EXPECT_EQ(plan.stateName(), stateName_);
+    EXPECT_EQ(plan.delta(), delta_);
+    AXIOM_TEST_RETURN_IF_FAILURE
+    return MatchResult::success(symbols);
+  }
+
+ private:
+  const std::string stateName_;
+  const bool delta_;
+};
+
+class FixedPointMatcher : public PlanMatcherImpl<FixedPointNode> {
+ public:
+  FixedPointMatcher() = default;
+
+  explicit FixedPointMatcher(FixedPointMatch match)
+      : PlanMatcherImpl<FixedPointNode>{}, match_{std::move(match)} {}
+
+  MatchResult matchDetails(
+      const FixedPointNode& plan,
+      const std::unordered_map<std::string, std::string>& symbols)
+      const override {
+    SCOPED_TRACE(plan.toString(true, false));
+    if (!match_.has_value()) {
+      return MatchResult::success(symbols);
+    }
+
+    EXPECT_EQ(plan.outputStateEntry(), match_->outputStateEntry());
+    AXIOM_TEST_RETURN_IF_FAILURE
+
+    const auto& states = match_->states();
+    if (!states.empty()) {
+      EXPECT_EQ(plan.stateDeclarations().size(), states.size());
+      AXIOM_TEST_RETURN_IF_FAILURE
+    }
+    for (const auto& state : states) {
+      if (!matchState(plan, state, symbols)) {
+        return MatchResult::failure();
+      }
+    }
+
+    const auto& plans = match_->plans();
+    if (!plans.empty()) {
+      EXPECT_EQ(plan.plans().size(), plans.size());
+      AXIOM_TEST_RETURN_IF_FAILURE
+      for (size_t i = 0; i < plans.size(); ++i) {
+        if (!plans[i]
+                 ->match(plan.plans()[i], symbols, /*context=*/nullptr)
+                 .match) {
+          return MatchResult::failure();
+        }
+      }
+    }
+
+    if (const auto& convergence = match_->convergencePlan()) {
+      EXPECT_NE(plan.convergenceConfig().plan, nullptr);
+      AXIOM_TEST_RETURN_IF_FAILURE
+      if (!convergence
+               ->match(
+                   plan.convergenceConfig().plan, symbols, /*context=*/nullptr)
+               .match) {
+        return MatchResult::failure();
+      }
+    }
+
+    if (match_->maxIterations().has_value()) {
+      EXPECT_EQ(plan.maxIterations(), *match_->maxIterations());
+    }
+    if (match_->errorWhenMaxIterationReached().has_value()) {
+      EXPECT_EQ(
+          plan.convergenceConfig().errorWhenMaxIterationReached,
+          *match_->errorWhenMaxIterationReached());
+    }
+    AXIOM_TEST_RETURN
+  }
+
+ private:
+  bool matchState(
+      const FixedPointNode& plan,
+      const FixedPointMatch::State& expected,
+      const std::unordered_map<std::string, std::string>& symbols) const {
+    const StateDeclaration* declaration = nullptr;
+    for (const auto& candidate : plan.stateDeclarations()) {
+      if (candidate->name() == expected.name) {
+        declaration = candidate.get();
+        break;
+      }
+    }
+    EXPECT_NE(declaration, nullptr)
+        << "No state declaration named " << expected.name;
+    if (declaration == nullptr) {
+      return false;
+    }
+
+    const auto* vector =
+        dynamic_cast<const VectorStateDeclaration*>(declaration);
+    EXPECT_NE(vector, nullptr) << expected.name << " is not a vector state";
+    if (vector == nullptr) {
+      return false;
+    }
+    EXPECT_EQ(vector->append(), expected.append);
+    if (::testing::Test::HasFailure()) {
+      return false;
+    }
+
+    if (expected.initialPlan != nullptr) {
+      EXPECT_NE(declaration->initialPlan(), nullptr)
+          << expected.name << " has no initial plan";
+      if (declaration->initialPlan() == nullptr) {
+        return false;
+      }
+      return expected.initialPlan
+          ->match(declaration->initialPlan(), symbols, /*context=*/nullptr)
+          .match;
+    }
+    return true;
+  }
+
+  const std::optional<FixedPointMatch> match_;
 };
 
 class FilterMatcher : public PlanMatcherImpl<FilterNode> {
@@ -1966,6 +2100,67 @@ PlanMatcherBuilder& PlanMatcherBuilder::values(
   return *this;
 }
 
+PlanMatcherBuilder& PlanMatcherBuilder::stateSource(
+    const std::string& stateName,
+    bool delta) {
+  VELOX_USER_CHECK_NULL(matcher_);
+  matcher_ = std::make_shared<StateSourceMatcher>(stateName, delta);
+  return *this;
+}
+
+FixedPointMatch& FixedPointMatch::outputState(
+    bool append,
+    PlanMatcherBuilder initialPlan) {
+  states_.push_back(
+      {.name = outputStateEntry_,
+       .append = append,
+       .initialPlan = initialPlan.build()});
+  return *this;
+}
+
+FixedPointMatch& FixedPointMatch::plan(PlanMatcherBuilder body) {
+  plans_.push_back(body.build());
+  return *this;
+}
+
+namespace {
+// The plan a stop-when-empty loop uses today: count the rows the last
+// iteration wrote and compare to zero. 'stateColumns', when set, pins the
+// columns the delta read presents.
+PlanMatcherBuilder emptyDeltaConvergence(
+    const std::string& stateName,
+    const std::optional<std::vector<std::optional<std::string>>>&
+        stateColumns) {
+  PlanMatcherBuilder builder;
+  builder.stateSource(stateName, /*delta=*/true);
+  if (stateColumns.has_value()) {
+    builder.aliases(*stateColumns);
+  }
+  return builder.singleAggregation({}, {"count(*) as convergence_count"})
+      .project({"convergence_count = 0"});
+}
+} // namespace
+
+FixedPointMatch& FixedPointMatch::convergeOnEmpty(Convergence assertions) {
+  convergence_ =
+      emptyDeltaConvergence(outputStateEntry_, assertions.stateColumns).build();
+  errorWhenMaxIterationReached_ = true;
+  maxIterations_ = assertions.maxIterations;
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::fixedPoint() {
+  VELOX_USER_CHECK_NULL(matcher_);
+  matcher_ = std::make_shared<FixedPointMatcher>();
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::fixedPoint(FixedPointMatch match) {
+  VELOX_USER_CHECK_NULL(matcher_);
+  matcher_ = std::make_shared<FixedPointMatcher>(std::move(match));
+  return *this;
+}
+
 PlanMatcherBuilder& PlanMatcherBuilder::filter() {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<FilterMatcher>(matcher_);
@@ -2461,6 +2656,18 @@ PlanMatcherBuilder& PlanMatcherBuilder::distributedMarkDistinct(
 PlanMatcherBuilder& PlanMatcherBuilder::multiThreaded(bool enabled) {
   localExchanges_ = enabled;
   return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::localAggregation(
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::string>& aggregates) {
+  partialAggregation(groupingKeys, aggregates);
+  if (groupingKeys.empty()) {
+    localGather();
+  } else {
+    localPartition(groupingKeys);
+  }
+  return finalAggregation();
 }
 
 PlanMatcherBuilder& PlanMatcherBuilder::distributedAggregation(

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -160,6 +160,27 @@ class PlanMatcher {
   const parse::ParseOptions options_;
 };
 
+/// Match details for a FixedPoint node.
+struct FixedPointDetails {
+  /// When set, asserts `FixedPointNode::outputStateEntry()` — the working
+  /// table's state entry name (mirrors `lp::FixedPointNode::name()`).
+  std::optional<std::string> name;
+
+  /// When set, matches the anchor's lowered initial plan — the plan on the
+  /// first vector state declaration.
+  std::shared_ptr<PlanMatcher> anchor;
+
+  /// When set, matches the step's lowered plan — the first entry in
+  /// `plans()`.
+  std::shared_ptr<PlanMatcher> step;
+};
+
+/// Match details for a WorkingTableScan. Lowers to `StateSourceNode`.
+struct WorkingTableScanDetails {
+  /// When set, asserts the working table's name.
+  std::optional<std::string> name;
+};
+
 /// Match details for a HashJoin node beyond join type. Each field is
 /// optional: leave as nullopt to skip the check, set a value to assert it.
 struct HashJoinDetails {
@@ -233,6 +254,20 @@ class PlanMatcherBuilder {
   /// names. The names in 'expected's row type are registered as aliases (by
   /// position) so downstream matchers can reference the columns by those names.
   PlanMatcherBuilder& values(const std::vector<RowVectorPtr>& expected);
+
+  /// Matches any WorkingTableScan node regardless of state name.
+  PlanMatcherBuilder& workingTableScan();
+
+  /// Matches a WorkingTableScan node with the specified details.
+  PlanMatcherBuilder& workingTableScan(const WorkingTableScanDetails& details);
+
+  /// Matches any FixedPoint node regardless of state declarations, plans, or
+  /// convergence config.
+  PlanMatcherBuilder& fixedPoint();
+
+  /// Matches a FixedPoint node with the specified details. See
+  /// FixedPointDetails for per-field semantics.
+  PlanMatcherBuilder& fixedPoint(const FixedPointDetails& details);
 
   /// Matches any Filter node regardless of predicate.
   PlanMatcherBuilder& filter();

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -182,6 +182,92 @@ struct HashJoinDetails {
   std::optional<std::vector<std::string>> outputColumnNames;
 };
 
+class PlanMatcherBuilder;
+
+/// Describes the parts of a FixedPointNode to assert, for
+/// `PlanMatcherBuilder::fixedPoint`. A part that is not named is not checked,
+/// but naming the output state or any body plan also asserts how many the node
+/// has, so a test notices one that appears later.
+///
+///   PlanMatcherBuilder().fixedPoint(
+///       FixedPointMatch("counter")
+///           .outputState(/*append=*/true, matchValues())
+///           .plan(PlanMatcherBuilder()
+///                     .stateSource("counter", /*delta=*/true)
+///                     .aliases({"n"})
+///                     .filter("n < 10")
+///                     .project({"n + 1"}))
+///           .convergeOnEmpty({.maxIterations = 1000}));
+class FixedPointMatch {
+ public:
+  /// One expected VectorStateDeclaration.
+  struct State {
+    std::string name;
+    bool append{false};
+    std::shared_ptr<PlanMatcher> initialPlan;
+  };
+
+  /// 'outputStateEntry' is the state entry the fixed point emits.
+  explicit FixedPointMatch(std::string outputStateEntry)
+      : outputStateEntry_{std::move(outputStateEntry)} {}
+
+  /// Matches the VectorStateDeclaration the fixed point outputs — the entry
+  /// named at construction — with the given append mode, and its initial plan.
+  FixedPointMatch& outputState(bool append, PlanMatcherBuilder initialPlan);
+
+  /// Matches the next per-iteration plan — for a recursive CTE, the step — in
+  /// call order.
+  FixedPointMatch& plan(PlanMatcherBuilder body);
+
+  /// Assertions the convergence plan can carry beyond its shape. Each is
+  /// checked only when set.
+  struct Convergence {
+    /// The fixed point's iteration bound.
+    std::optional<int32_t> maxIterations;
+
+    /// The state columns the convergence plan reads, in order. A `nullopt`
+    /// element leaves that position unchecked. Set this where a rewrite above
+    /// the fixed point must not narrow the recursive state.
+    std::optional<std::vector<std::optional<std::string>>> stateColumns;
+  };
+
+  /// Asserts the loop stops once an iteration produces no rows, and that
+  /// reaching the iteration bound before converging fails the query.
+  FixedPointMatch& convergeOnEmpty(Convergence assertions = {});
+
+  const std::string& outputStateEntry() const {
+    return outputStateEntry_;
+  }
+
+  const std::vector<State>& states() const {
+    return states_;
+  }
+
+  const std::vector<std::shared_ptr<PlanMatcher>>& plans() const {
+    return plans_;
+  }
+
+  const std::shared_ptr<PlanMatcher>& convergencePlan() const {
+    return convergence_;
+  }
+
+  const std::optional<int32_t>& maxIterations() const {
+    return maxIterations_;
+  }
+
+  const std::optional<bool>& errorWhenMaxIterationReached() const {
+    return errorWhenMaxIterationReached_;
+  }
+
+ private:
+  std::string outputStateEntry_;
+  std::vector<State> states_;
+  std::vector<std::shared_ptr<PlanMatcher>> plans_;
+  std::shared_ptr<PlanMatcher> convergence_;
+  std::optional<int32_t> maxIterations_;
+  std::optional<bool> errorWhenMaxIterationReached_;
+};
+
 class PlanMatcherBuilder {
  public:
   /// Callback invoked with the matched node on a successful match.
@@ -233,6 +319,17 @@ class PlanMatcherBuilder {
   /// names. The names in 'expected's row type are registered as aliases (by
   /// position) so downstream matchers can reference the columns by those names.
   PlanMatcherBuilder& values(const std::vector<RowVectorPtr>& expected);
+
+  /// Matches a StateSourceNode reading fixed-point state 'stateName'. 'delta'
+  /// selects which read: true is the rows the previous iteration produced,
+  /// false the entry's full accumulation.
+  PlanMatcherBuilder& stateSource(const std::string& stateName, bool delta);
+
+  /// Matches any FixedPointNode.
+  PlanMatcherBuilder& fixedPoint();
+
+  /// Matches the FixedPointNode described by 'match'.
+  PlanMatcherBuilder& fixedPoint(FixedPointMatch match);
 
   /// Matches any Filter node regardless of predicate.
   PlanMatcherBuilder& filter();
@@ -747,6 +844,15 @@ class PlanMatcherBuilder {
   /// localPartition/localGather before a final aggregation and a partial sort +
   /// LocalMerge before a merge boundary. Pass false for a single-driver plan.
   PlanMatcherBuilder& multiThreaded(bool enabled);
+
+  /// Matches the single-node split aggregation pattern:
+  /// partialAggregation(groupingKeys, aggregates) →
+  /// localPartition(groupingKeys) → finalAggregation, with localGather in place
+  /// of localPartition when there are no grouping keys. This is the shape
+  /// intra-node parallelism produces when the input is already on one node.
+  PlanMatcherBuilder& localAggregation(
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates);
 
   /// Matches the distributed (split) aggregation pattern:
   /// partialAggregation(groupingKeys, aggregates) → shuffle →

--- a/axiom/optimizer/v2/Builder.h
+++ b/axiom/optimizer/v2/Builder.h
@@ -202,6 +202,10 @@ class Builder {
       return exchanges_;
     } else if constexpr (std::is_same_v<T, TableWrite>) {
       return tableWrites_;
+    } else if constexpr (std::is_same_v<T, WorkingTable>) {
+      return workingTables_;
+    } else if constexpr (std::is_same_v<T, FixedPoint>) {
+      return fixedPoints_;
     } else {
       static_assert(sizeof(T) == 0, "No dedup map for this node type");
     }
@@ -241,6 +245,8 @@ class Builder {
   DedupSet<EnforceDistinct> enforceDistincts_;
   DedupSet<Exchange> exchanges_;
   DedupSet<TableWrite> tableWrites_;
+  DedupSet<WorkingTable> workingTables_;
+  DedupSet<FixedPoint> fixedPoints_;
 
   // Expr leaves, interned via `makeLiteral` / `makeCall` / `makeAggregate`.
   DedupSet<Literal> literals_;

--- a/axiom/optimizer/v2/Builder.h
+++ b/axiom/optimizer/v2/Builder.h
@@ -73,6 +73,9 @@ class Builder {
       addEquivalences(key);
     }
     const T* node = optimizer::make<T>(std::move(key));
+    // After construction, so `inputs()` is available and the set allocates in
+    // this node's `QueryGraphContext`.
+    node->primeRequiredStates();
     dedup.insert(node);
     return node;
   }
@@ -244,6 +247,10 @@ class Builder {
       return exchanges_;
     } else if constexpr (std::is_same_v<T, TableWrite>) {
       return tableWrites_;
+    } else if constexpr (std::is_same_v<T, WorkingTable>) {
+      return workingTables_;
+    } else if constexpr (std::is_same_v<T, FixedPoint>) {
+      return fixedPoints_;
     } else {
       static_assert(sizeof(T) == 0, "No dedup map for this node type");
     }
@@ -284,6 +291,8 @@ class Builder {
   DedupSet<EnforceDistinct> enforceDistincts_;
   DedupSet<Exchange> exchanges_;
   DedupSet<TableWrite> tableWrites_;
+  DedupSet<WorkingTable> workingTables_;
+  DedupSet<FixedPoint> fixedPoints_;
 
   // Expr leaves, interned via `makeLiteral` / `makeCall` / `makeAggregate`.
   DedupSet<Literal> literals_;

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -26,6 +26,7 @@
 #include "axiom/optimizer/WriteStatsBuilder.h"
 #include "axiom/optimizer/v2/ExprEmitter.h"
 #include "axiom/optimizer/v2/PhysicalProperties.h"
+#include "velox/core/FixedPointPlanNodes.h"
 #include "velox/core/PlanConsistencyChecker.h"
 #include "velox/core/TableWriteTraits.h"
 #include "velox/exec/HashPartitionFunction.h"
@@ -209,6 +210,34 @@ bool isSingleThreadedPipeline(const velox::core::PlanNodePtr& node) {
   }
 }
 
+struct AggregationParams {
+  velox::core::AggregationNode::Step step;
+  std::vector<velox::core::FieldAccessTypedExprPtr> groupingKeys;
+  std::vector<velox::core::FieldAccessTypedExprPtr> preGroupedKeys;
+  std::vector<std::string> names;
+  std::vector<velox::core::AggregationNode::Aggregate> aggregates;
+  std::vector<velox::vector_size_t> globalGroupingSets;
+  std::optional<velox::core::FieldAccessTypedExprPtr> groupId;
+  velox::core::PlanNodePtr input;
+};
+
+// Extracts `globalGroupingSets` + `groupId` from an IR `Aggregate` for
+// `AggregationParams`. Synthesized aggregates that carry no IR node
+// (e.g., the empty-delta convergence sub-plan) leave those fields empty.
+std::pair<
+    std::vector<velox::vector_size_t>,
+    std::optional<velox::core::FieldAccessTypedExprPtr>>
+groupingSetInfo(const Aggregate& aggregate) {
+  std::vector<velox::vector_size_t> globalGroupingSets(
+      aggregate.globalGroupingSets().begin(),
+      aggregate.globalGroupingSets().end());
+  std::optional<velox::core::FieldAccessTypedExprPtr> groupId;
+  if (aggregate.groupId() != nullptr) {
+    groupId = toFieldAccess(aggregate.groupId());
+  }
+  return {std::move(globalGroupingSets), std::move(groupId)};
+}
+
 class Emitter {
  public:
   Emitter(
@@ -266,6 +295,10 @@ class Emitter {
         return emitTableWrite(*node->as<TableWrite>());
       case NodeType::kExchange:
         return emitExchange(*node->as<Exchange>());
+      case NodeType::kFixedPoint:
+        return emitFixedPoint(*node->as<FixedPoint>());
+      case NodeType::kWorkingTable:
+        return emitWorkingTable(*node->as<WorkingTable>());
     }
     VELOX_UNREACHABLE();
   }
@@ -331,16 +364,7 @@ class Emitter {
   velox::core::PlanNodePtr emitSingleAggregation(const Aggregate& aggregate);
   velox::core::PlanNodePtr emitPartialAggregation(const Aggregate& aggregate);
   velox::core::PlanNodePtr emitFinalAggregation(const Aggregate& aggregate);
-  // Builds an AggregationNode, carrying the grouping-set default-row info
-  // (`globalGroupingSets`/`groupId`) from `aggregate` when present.
-  velox::core::PlanNodePtr makeAggregationNode(
-      velox::core::AggregationNode::Step step,
-      const Aggregate& aggregate,
-      std::vector<velox::core::FieldAccessTypedExprPtr> groupingKeys,
-      std::vector<velox::core::FieldAccessTypedExprPtr> preGroupedKeys,
-      std::vector<std::string> names,
-      std::vector<velox::core::AggregationNode::Aggregate> aggregates,
-      velox::core::PlanNodePtr input);
+  velox::core::PlanNodePtr makeAggregationNode(AggregationParams params);
   velox::core::PlanNodePtr emitGroupId(const GroupId& groupId);
   velox::core::PlanNodePtr emitMarkDistinct(const MarkDistinct& markDistinct);
   velox::core::PlanNodePtr emitJoin(const Join& join);
@@ -377,6 +401,15 @@ class Emitter {
   // current fragment, wiring the `InputStage` between them.
   velox::core::PlanNodePtr emitExchange(const Exchange& exchange);
   velox::core::PlanNodePtr emitTableWrite(const TableWrite& tableWrite);
+  velox::core::PlanNodePtr emitFixedPoint(const FixedPoint& fixedPoint);
+  velox::core::PlanNodePtr emitWorkingTable(const WorkingTable& workingTable);
+
+  // Convergence sub-plan: StateSource(delta=true) -> count() ->
+  // ProjectNode("converged" = count == 0). An iteration that appends no
+  // rows produces an empty delta, count=0, and marks convergence.
+  velox::core::PlanNodePtr makeFixpointCheck(
+      const std::string& stateName,
+      const velox::RowTypePtr& schema);
 
   // Builds the producer-side `PartitionedOutput` capping 'sourcePlan' for
   // 'partitioning'. A connector-bucketed partitioning that scales to a single
@@ -961,32 +994,19 @@ velox::core::PlanNodePtr Emitter::emitAggregation(const Aggregate& aggregate) {
 }
 
 velox::core::PlanNodePtr Emitter::makeAggregationNode(
-    velox::core::AggregationNode::Step step,
-    const Aggregate& aggregate,
-    std::vector<velox::core::FieldAccessTypedExprPtr> groupingKeys,
-    std::vector<velox::core::FieldAccessTypedExprPtr> preGroupedKeys,
-    std::vector<std::string> names,
-    std::vector<velox::core::AggregationNode::Aggregate> aggregates,
-    velox::core::PlanNodePtr input) {
-  std::vector<velox::vector_size_t> globalGroupingSets(
-      aggregate.globalGroupingSets().begin(),
-      aggregate.globalGroupingSets().end());
-  std::optional<velox::core::FieldAccessTypedExprPtr> groupId;
-  if (aggregate.groupId() != nullptr) {
-    groupId = toFieldAccess(aggregate.groupId());
-  }
+    AggregationParams params) {
   return std::make_shared<velox::core::AggregationNode>(
       nextId(),
-      step,
-      std::move(groupingKeys),
-      std::move(preGroupedKeys),
-      std::move(names),
-      std::move(aggregates),
-      std::move(globalGroupingSets),
-      std::move(groupId),
+      params.step,
+      std::move(params.groupingKeys),
+      std::move(params.preGroupedKeys),
+      std::move(params.names),
+      std::move(params.aggregates),
+      std::move(params.globalGroupingSets),
+      std::move(params.groupId),
       /*ignoreNullKeys=*/false,
       /*noGroupsSpanBatches=*/false,
-      std::move(input));
+      std::move(params.input));
 }
 
 velox::core::PlanNodePtr Emitter::emitSingleAggregation(
@@ -1018,14 +1038,17 @@ velox::core::PlanNodePtr Emitter::emitSingleAggregation(
         *aggregateExpr, toTypePtr(aggregateExpr->value().type), exprEmitter_);
   });
 
-  return makeAggregationNode(
-      velox::core::AggregationNode::Step::kSingle,
-      aggregate,
-      std::move(groupingKeys),
-      std::move(preGroupedKeys),
-      std::move(names),
-      std::move(aggregates),
-      std::move(input));
+  auto [globalGroupingSets, groupId] = groupingSetInfo(aggregate);
+  return makeAggregationNode({
+      .step = velox::core::AggregationNode::Step::kSingle,
+      .groupingKeys = std::move(groupingKeys),
+      .preGroupedKeys = std::move(preGroupedKeys),
+      .names = std::move(names),
+      .aggregates = std::move(aggregates),
+      .globalGroupingSets = std::move(globalGroupingSets),
+      .groupId = std::move(groupId),
+      .input = std::move(input),
+  });
 }
 
 velox::core::PlanNodePtr Emitter::emitPartialAggregation(
@@ -1043,14 +1066,17 @@ velox::core::PlanNodePtr Emitter::emitPartialAggregation(
         exprEmitter_);
   });
 
-  return makeAggregationNode(
-      velox::core::AggregationNode::Step::kPartial,
-      aggregate,
-      std::move(groupingKeys),
-      /*preGroupedKeys=*/{},
-      std::move(names),
-      std::move(aggregates),
-      std::move(input));
+  auto [globalGroupingSets, groupId] = groupingSetInfo(aggregate);
+  return makeAggregationNode({
+      .step = velox::core::AggregationNode::Step::kPartial,
+      .groupingKeys = std::move(groupingKeys),
+      .preGroupedKeys = {},
+      .names = std::move(names),
+      .aggregates = std::move(aggregates),
+      .globalGroupingSets = std::move(globalGroupingSets),
+      .groupId = std::move(groupId),
+      .input = std::move(input),
+  });
 }
 
 velox::core::PlanNodePtr Emitter::emitFinalAggregation(
@@ -1079,14 +1105,17 @@ velox::core::PlanNodePtr Emitter::emitFinalAggregation(
         exprEmitter_);
   });
 
-  return makeAggregationNode(
-      velox::core::AggregationNode::Step::kFinal,
-      aggregate,
-      std::move(groupingKeys),
-      /*preGroupedKeys=*/{},
-      std::move(names),
-      std::move(aggregates),
-      std::move(input));
+  auto [globalGroupingSets, groupId] = groupingSetInfo(aggregate);
+  return makeAggregationNode({
+      .step = velox::core::AggregationNode::Step::kFinal,
+      .groupingKeys = std::move(groupingKeys),
+      .preGroupedKeys = {},
+      .names = std::move(names),
+      .aggregates = std::move(aggregates),
+      .globalGroupingSets = std::move(globalGroupingSets),
+      .groupId = std::move(groupId),
+      .input = std::move(input),
+  });
 }
 
 velox::core::PlanNodePtr Emitter::emitGroupId(const GroupId& groupId) {
@@ -1657,6 +1686,7 @@ std::optional<FragmentType> fragmentTypeContribution(NodeCP node) {
     case NodeType::kScan:
       return FragmentType::kSource;
     case NodeType::kValues:
+    case NodeType::kFixedPoint:
       return FragmentType::kSingle;
     default: {
       std::optional<FragmentType> result;
@@ -2035,6 +2065,91 @@ velox::core::PlanNodePtr Emitter::emitTableWrite(const TableWrite& tableWrite) {
       std::move(finalMergeOutputType),
       std::move(finalMergeSpec),
       std::move(gather));
+}
+
+velox::core::PlanNodePtr Emitter::makeFixpointCheck(
+    const std::string& stateName,
+    const velox::RowTypePtr& schema) {
+  static constexpr std::string_view kConvergedCountName = "__converged_count";
+  static constexpr std::string_view kConvergedColumnName = "converged";
+
+  const auto& functionNames = queryCtx()->functionNames();
+
+  auto source = std::make_shared<velox::core::StateSourceNode>(
+      nextId(), stateName, schema, /*delta=*/true);
+
+  auto countCall = std::make_shared<velox::core::CallTypedExpr>(
+      velox::BIGINT(),
+      std::vector<velox::core::TypedExprPtr>{},
+      std::string{functionNames.count});
+  velox::core::AggregationNode::Aggregate countAggregate{
+      .call = std::move(countCall),
+      .rawInputTypes = {},
+      .mask = nullptr,
+      .sortingKeys = {},
+      .sortingOrders = {},
+      .distinct = false,
+  };
+  std::vector<velox::core::AggregationNode::Aggregate> aggregates;
+  aggregates.push_back(std::move(countAggregate));
+  auto aggregation = makeAggregationNode({
+      .step = velox::core::AggregationNode::Step::kSingle,
+      .groupingKeys = {},
+      .preGroupedKeys = {},
+      .names = std::vector<std::string>{std::string{kConvergedCountName}},
+      .aggregates = std::move(aggregates),
+      .globalGroupingSets = {},
+      .groupId = std::nullopt,
+      .input = std::move(source),
+  });
+
+  auto countRef = std::make_shared<velox::core::FieldAccessTypedExpr>(
+      velox::BIGINT(), std::string{kConvergedCountName});
+  auto zeroConst = std::make_shared<velox::core::ConstantTypedExpr>(
+      velox::BIGINT(), velox::Variant(int64_t{0}));
+  auto eqExpr = std::make_shared<velox::core::CallTypedExpr>(
+      velox::BOOLEAN(),
+      std::vector<velox::core::TypedExprPtr>{
+          std::move(countRef), std::move(zeroConst)},
+      std::string{functionNames.equality});
+  return std::make_shared<velox::core::ProjectNode>(
+      nextId(),
+      std::vector<std::string>{std::string{kConvergedColumnName}},
+      std::vector<velox::core::TypedExprPtr>{std::move(eqExpr)},
+      std::move(aggregation));
+}
+
+velox::core::PlanNodePtr Emitter::emitFixedPoint(const FixedPoint& fixedPoint) {
+  auto anchorPlan = emit(fixedPoint.anchor());
+  auto stepPlan = emit(fixedPoint.step());
+
+  auto schema = makeRowType(fixedPoint.outputColumns());
+  const std::string stateName{fixedPoint.name()};
+
+  velox::core::ConvergenceConfig convergence;
+  convergence.plan = makeFixpointCheck(stateName, schema);
+  convergence.maxIterations = session_.options().fixedPointMaxIterations;
+
+  std::vector<velox::core::StateDeclarationPtr> stateDeclarations;
+  stateDeclarations.push_back(
+      std::make_shared<velox::core::VectorStateDeclaration>(
+          stateName, schema, std::move(anchorPlan), /*append=*/true));
+  std::vector<velox::core::PlanNodePtr> plans;
+  plans.push_back(std::move(stepPlan));
+
+  return std::make_shared<velox::core::FixedPointNode>(
+      nextId(),
+      std::move(stateDeclarations),
+      std::move(plans),
+      std::move(convergence),
+      stateName);
+}
+
+velox::core::PlanNodePtr Emitter::emitWorkingTable(
+    const WorkingTable& workingTable) {
+  auto schema = makeRowType(workingTable.outputColumns());
+  return std::make_shared<velox::core::StateSourceNode>(
+      nextId(), std::string{workingTable.name()}, schema, /*delta=*/true);
 }
 
 std::vector<ExecutableFragment> Emitter::emitFragments(

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -28,6 +28,7 @@
 #include "axiom/optimizer/v2/EstimateProvider.h"
 #include "axiom/optimizer/v2/ExprEmitter.h"
 #include "axiom/optimizer/v2/PhysicalProperties.h"
+#include "velox/core/FixedPointPlanNodes.h"
 #include "velox/core/PlanConsistencyChecker.h"
 #include "velox/core/TableWriteTraits.h"
 #include "velox/exec/HashPartitionFunction.h"
@@ -284,6 +285,10 @@ class Emitter {
         return emitTableWrite(*node->as<TableWrite>());
       case NodeType::kExchange:
         return emitExchange(*node->as<Exchange>());
+      case NodeType::kFixedPoint:
+        return emitFixedPoint(*node->as<FixedPoint>());
+      case NodeType::kWorkingTable:
+        return emitWorkingTable(*node->as<WorkingTable>());
     }
     VELOX_UNREACHABLE();
   }
@@ -417,6 +422,8 @@ class Emitter {
   // current fragment, wiring the `InputStage` between them.
   velox::core::PlanNodePtr emitExchange(const Exchange& exchange);
   velox::core::PlanNodePtr emitTableWrite(const TableWrite& tableWrite);
+  velox::core::PlanNodePtr emitFixedPoint(const FixedPoint& fixedPoint);
+  velox::core::PlanNodePtr emitWorkingTable(const WorkingTable& workingTable);
 
   // Returns the handle of the scan whose rows 'tableWrite' deletes. Fails if
   // that scan's handle does not describe exactly the rows to remove.
@@ -492,7 +499,9 @@ class Emitter {
   const OptimizerSession& session_;
   velox::core::ExpressionEvaluator& evaluator_;
   ExprEmitter exprEmitter_;
-  const MultiFragmentPlan::Options& options_;
+  // A copy, not a reference: emitting a fixed point lowers `numDrivers` for the
+  // recursive subtree and restores it afterwards.
+  MultiFragmentPlan::Options options_;
   int32_t nextNodeId_{0};
 
   // The exchange serialization format for remote
@@ -1660,6 +1669,7 @@ std::optional<FragmentType> fragmentTypeContribution(NodeCP node) {
           ? FragmentType::kCoordinator
           : FragmentType::kSource;
     case NodeType::kValues:
+    case NodeType::kFixedPoint:
       return FragmentType::kSingle;
     default: {
       std::optional<FragmentType> result;
@@ -2017,13 +2027,13 @@ velox::core::PlanNodePtr Emitter::emitTableWrite(const TableWrite& tableWrite) {
   // A single-fragment write over a single-threaded pipeline (e.g. a Values
   // source) has one writer producing all rows, so the per-driver stats need no
   // merge. Reporting one driver keeps the plan a bare TableWrite.
-  const int32_t numDrivers =
+  const int32_t writerNumDrivers =
       !distributed && isSingleThreadedPipeline(input) ? 1 : options_.numDrivers;
   WriteStatsBuilder statsBuilder(
       table,
       inputType,
       *handle,
-      numDrivers,
+      writerNumDrivers,
       distributed ? options_.numWorkers : 1);
   std::optional<velox::core::ColumnStatsSpec> writeStatsSpec;
   if (statsBuilder.hasStats()) {
@@ -2101,6 +2111,78 @@ velox::core::PlanNodePtr Emitter::emitTableWrite(const TableWrite& tableWrite) {
       std::move(finalMergeSpec),
       std::move(gather));
 }
+
+velox::core::PlanNodePtr Emitter::emitFixedPoint(const FixedPoint& fixedPoint) {
+  if (options_.numWorkers > 1) {
+    VELOX_NYI("Distributed FixedPoint execution is not yet implemented");
+  }
+
+  auto anchorPlan = emit(fixedPoint.anchor());
+
+  VELOX_CHECK_EQ(
+      fixedPoint.recursiveNumDrivers().value_or(0),
+      1,
+      "FixedPoint must be physically planned for one recursive driver before emission");
+  const int32_t previousNumDrivers =
+      std::exchange(options_.numDrivers, *fixedPoint.recursiveNumDrivers());
+  SCOPE_EXIT {
+    options_.numDrivers = previousNumDrivers;
+  };
+  auto stepPlan = emit(fixedPoint.step());
+
+  auto schema = makeRowType(fixedPoint.outputColumns());
+  const std::string stateName{fixedPoint.name()};
+
+  auto convergence = velox::core::ConvergenceConfig::converging(
+      emit(fixedPoint.convergence()), fixedPoint.maxIterations());
+
+  std::vector<velox::core::StateDeclarationPtr> stateDeclarations;
+  stateDeclarations.push_back(
+      std::make_shared<velox::core::VectorStateDeclaration>(
+          stateName, schema, std::move(anchorPlan), /*append=*/true));
+  std::vector<velox::core::PlanNodePtr> plans;
+  plans.push_back(std::move(stepPlan));
+
+  return std::make_shared<velox::core::FixedPointNode>(
+      nextId(),
+      std::move(stateDeclarations),
+      std::move(plans),
+      std::move(convergence),
+      stateName);
+}
+
+velox::core::PlanNodePtr Emitter::emitWorkingTable(
+    const WorkingTable& workingTable) {
+  auto schema = makeRowType(workingTable.outputColumns());
+  const bool delta =
+      workingTable.readMode() == WorkingTableReadMode::kLatestDelta;
+  return std::make_shared<velox::core::StateSourceNode>(
+      nextId(), std::string{workingTable.name()}, schema, delta);
+}
+
+namespace {
+
+// Rejects fragments that would require one task to orchestrate multiple
+// independent fixed points. Fixed points isolated in separate fragments remain
+// valid.
+void validateFixedPointLeaves(const ExecutableFragment& fragment) {
+  const auto& root = fragment.fragment.planNode;
+  int32_t numFixedPoints{0};
+  for (const auto& leafId : root->leafPlanNodeIds()) {
+    const auto* leaf = velox::core::PlanNode::findNodeById(root.get(), leafId);
+    VELOX_CHECK_NOT_NULL(leaf);
+    if (dynamic_cast<const velox::core::FixedPointNode*>(leaf) != nullptr) {
+      ++numFixedPoints;
+    }
+  }
+  if (numFixedPoints > 1) {
+    VELOX_NYI(
+        "Multiple FixedPoint nodes in one execution fragment are not yet supported: {}",
+        numFixedPoints);
+  }
+}
+
+} // namespace
 
 std::vector<ExecutableFragment> Emitter::emitFragments(
     NodeCP root,
@@ -2184,8 +2266,10 @@ std::vector<ExecutableFragment> Emitter::emitFragments(
   }
 
   for (const auto& fragment : stages_) {
+    validateFixedPointLeaves(fragment);
     velox::core::PlanConsistencyChecker::check(fragment.fragment.planNode);
   }
+  validateFixedPointLeaves(top);
   velox::core::PlanConsistencyChecker::check(outputProjection);
 
   stages_.push_back(std::move(top));

--- a/axiom/optimizer/v2/EstimateProvider.cpp
+++ b/axiom/optimizer/v2/EstimateProvider.cpp
@@ -268,6 +268,23 @@ Estimate EstimateProvider::compute(NodeCP node) {
       return result;
     }
 
+    case NodeType::kFixedPoint: {
+      // Convergence depth is workload-dependent; single-pass sum would
+      // understate it and skew join placement. Propagate unknown rather
+      // than fabricate a fallback.
+      Estimate result;
+      result.cardinality = std::nullopt;
+      return result;
+    }
+
+    case NodeType::kWorkingTable: {
+      // Per-iteration frontier size is workload-dependent. Propagate
+      // unknown rather than fabricate a fallback.
+      Estimate result;
+      result.cardinality = std::nullopt;
+      return result;
+    }
+
     // Cardinality-neutral operators: pass the input's estimate through.
     case NodeType::kProject:
     case NodeType::kSort:

--- a/axiom/optimizer/v2/EstimateProvider.cpp
+++ b/axiom/optimizer/v2/EstimateProvider.cpp
@@ -312,6 +312,23 @@ Estimate EstimateProvider::compute(NodeCP node) {
       return result;
     }
 
+    case NodeType::kFixedPoint: {
+      // Convergence depth is workload-dependent; single-pass sum would
+      // understate it and skew join placement. Keep cardinality unknown so a
+      // join cluster that depends on this estimate is uncostable and falls
+      // back to its written join shape at that boundary.
+      Estimate result;
+      result.cardinality = std::nullopt;
+      return result;
+    }
+
+    case NodeType::kWorkingTable: {
+      // Per-iteration frontier size is workload-dependent.
+      Estimate result;
+      result.cardinality = std::nullopt;
+      return result;
+    }
+
     // Cardinality-neutral operators: pass the input's estimate through.
     case NodeType::kProject:
     case NodeType::kSort:

--- a/axiom/optimizer/v2/LimitAndOrderPass.cpp
+++ b/axiom/optimizer/v2/LimitAndOrderPass.cpp
@@ -245,6 +245,8 @@ class LimitAndOrderRewriter : public NodeRewriter<LimitContext> {
   LIMIT_BARRIER(EnforceDistinct, rewriteEnforceDistinct, false)
   LIMIT_BARRIER(TopNRowNumber, rewriteTopNRowNumber, false)
   LIMIT_BARRIER(Exchange, rewriteExchange, false)
+  LIMIT_BARRIER(WorkingTable, rewriteWorkingTable, true)
+  LIMIT_BARRIER(FixedPoint, rewriteFixedPoint, false)
 
 #undef LIMIT_BARRIER
 

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -48,6 +48,8 @@ const auto& nodeTypeNames() {
       {NodeType::kEnforceDistinct, "EnforceDistinct"},
       {NodeType::kExchange, "Exchange"},
       {NodeType::kTableWrite, "TableWrite"},
+      {NodeType::kFixedPoint, "FixedPoint"},
+      {NodeType::kWorkingTable, "WorkingTable"},
   };
   return kNames;
 }
@@ -1981,6 +1983,95 @@ bool TableWrite::KeyEq::operator()(const TableWrite* node, const Key& key)
   return (*this)(key, node);
 }
 
+WorkingTable::WorkingTable(Key key)
+    : Node(NodeType::kWorkingTable, ColumnVector{key.outputColumns}, {}),
+      name_(key.name) {
+  VELOX_CHECK_NOT_NULL(name_);
+}
+
+size_t WorkingTable::KeyHash::operator()(const WorkingTable* node) const {
+  return hashOf(node->name(), node->outputColumns());
+}
+
+size_t WorkingTable::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.name, key.outputColumns);
+}
+
+bool WorkingTable::KeyEq::operator()(
+    const WorkingTable* left,
+    const WorkingTable* right) const {
+  return left->name() == right->name() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool WorkingTable::KeyEq::operator()(const Key& key, const WorkingTable* node)
+    const {
+  return key.name == node->name() && key.outputColumns == node->outputColumns();
+}
+
+bool WorkingTable::KeyEq::operator()(const WorkingTable* node, const Key& key)
+    const {
+  return (*this)(key, node);
+}
+
+FixedPoint::FixedPoint(Key key)
+    : Node(NodeType::kFixedPoint, ColumnVector{key.outputColumns}, {}),
+      inputs_{key.anchor, key.step},
+      name_(key.name) {
+  VELOX_CHECK_NOT_NULL(inputs_[0]);
+  VELOX_CHECK_NOT_NULL(inputs_[1]);
+  VELOX_CHECK_NOT_NULL(name_);
+  VELOX_CHECK(
+      std::ranges::equal(outputColumns(), inputs_[0]->outputColumns()),
+      "FixedPoint output columns must match anchor by pointer identity");
+
+  // Step must produce a schema compatible with the anchor at every
+  // iteration. Anchor Column*s are reused where possible, but the step's
+  // Project mints fresh Column*s so pointer identity is not required.
+  const auto& anchorCols = inputs_[0]->outputColumns();
+  const auto& stepCols = inputs_[1]->outputColumns();
+  VELOX_CHECK_EQ(
+      stepCols.size(),
+      anchorCols.size(),
+      "FixedPoint step must produce the same column count as anchor");
+  for (size_t i = 0; i < stepCols.size(); ++i) {
+    VELOX_CHECK(
+        stepCols[i]->value().type->equivalent(*anchorCols[i]->value().type),
+        "FixedPoint step output column {} type does not match anchor: step={}, anchor={}",
+        i,
+        stepCols[i]->value().type->toString(),
+        anchorCols[i]->value().type->toString());
+  }
+}
+
+size_t FixedPoint::KeyHash::operator()(const FixedPoint* node) const {
+  return hashOf(
+      node->anchor(), node->step(), node->name(), node->outputColumns());
+}
+
+size_t FixedPoint::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.anchor, key.step, key.name, key.outputColumns);
+}
+
+bool FixedPoint::KeyEq::operator()(
+    const FixedPoint* left,
+    const FixedPoint* right) const {
+  return left->anchor() == right->anchor() && left->step() == right->step() &&
+      left->name() == right->name() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool FixedPoint::KeyEq::operator()(const Key& key, const FixedPoint* node)
+    const {
+  return key.anchor == node->anchor() && key.step == node->step() &&
+      key.name == node->name() && key.outputColumns == node->outputColumns();
+}
+
+bool FixedPoint::KeyEq::operator()(const FixedPoint* node, const Key& key)
+    const {
+  return (*this)(key, node);
+}
+
 #define V2_DEFINE_ACCEPT(NodeT)                                               \
   void NodeT::accept(const NodeVisitor& visitor, NodeVisitorContext& context) \
       const {                                                                 \
@@ -2008,6 +2099,8 @@ V2_DEFINE_ACCEPT(AssignUniqueId)
 V2_DEFINE_ACCEPT(EnforceDistinct)
 V2_DEFINE_ACCEPT(Exchange)
 V2_DEFINE_ACCEPT(TableWrite)
+V2_DEFINE_ACCEPT(WorkingTable)
+V2_DEFINE_ACCEPT(FixedPoint)
 
 #undef V2_DEFINE_ACCEPT
 

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -49,15 +49,41 @@ const auto& nodeTypeNames() {
       {NodeType::kEnforceDistinct, "EnforceDistinct"},
       {NodeType::kExchange, "Exchange"},
       {NodeType::kTableWrite, "TableWrite"},
+      {NodeType::kFixedPoint, "FixedPoint"},
+      {NodeType::kWorkingTable, "WorkingTable"},
   };
+  return kNames;
+}
+
+const auto& workingTableReadModeNames() {
+  static const folly::F14FastMap<WorkingTableReadMode, std::string_view>
+      kNames = {
+          {WorkingTableReadMode::kLatestDelta, "latestDelta"},
+          {WorkingTableReadMode::kAccumulated, "accumulated"},
+      };
   return kNames;
 }
 } // namespace
 
 AXIOM_DEFINE_ENUM_NAME(NodeType, nodeTypeNames);
+AXIOM_DEFINE_ENUM_NAME(WorkingTableReadMode, workingTableReadModeNames);
 
 std::string Node::toString() const {
   return NodePrinter::toText(this);
+}
+
+RequiredStates Node::deriveRequiredStates() const {
+  RequiredStates states;
+  for (NodeCP input : inputs()) {
+    for (const auto& [name, columns] : input->requiredStates()) {
+      auto [it, inserted] = states.emplace(name, columns);
+      VELOX_CHECK(
+          inserted || it->second == columns,
+          "WorkingTable reads of state {} disagree on columns",
+          name);
+    }
+  }
+  return states;
 }
 
 namespace {
@@ -2187,6 +2213,180 @@ bool TableWrite::KeyEq::operator()(const TableWrite* node, const Key& key)
   return (*this)(key, node);
 }
 
+WorkingTable::WorkingTable(const Key& key)
+    : Node(NodeType::kWorkingTable, ColumnVector{key.outputColumns}, {}),
+      name_(key.name),
+      readMode_(key.readMode) {
+  VELOX_CHECK_NOT_NULL(name_);
+}
+
+RequiredStates WorkingTable::deriveRequiredStates() const {
+  return {{name_, outputColumns()}};
+}
+
+size_t WorkingTable::KeyHash::operator()(const WorkingTable* node) const {
+  return hashOf(node->name(), node->outputColumns(), node->readMode());
+}
+
+size_t WorkingTable::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.name, key.outputColumns, key.readMode);
+}
+
+bool WorkingTable::KeyEq::operator()(
+    const WorkingTable* left,
+    const WorkingTable* right) const {
+  return left->name() == right->name() &&
+      left->outputColumns() == right->outputColumns() &&
+      left->readMode() == right->readMode();
+}
+
+bool WorkingTable::KeyEq::operator()(const Key& key, const WorkingTable* node)
+    const {
+  return key.name == node->name() &&
+      key.outputColumns == node->outputColumns() &&
+      key.readMode == node->readMode();
+}
+
+bool WorkingTable::KeyEq::operator()(const WorkingTable* node, const Key& key)
+    const {
+  return (*this)(key, node);
+}
+
+namespace {
+
+// The branch reads the fixed point's state, presents the columns the fixed
+// point outputs, and reads no other state.
+void checkBranchReadsState(
+    NodeCP branch,
+    Name name,
+    const ColumnVector& stateColumns,
+    std::string_view branchName) {
+  const auto& states = branch->requiredStates();
+  auto it = states.find(name);
+  VELOX_CHECK(
+      it != states.end(),
+      "FixedPoint {} must read its working table",
+      branchName);
+  VELOX_CHECK(
+      it->second == stateColumns,
+      "FixedPoint {} WorkingTable columns must match the fixed-point output by pointer identity",
+      branchName);
+  VELOX_CHECK_EQ(
+      states.size(),
+      1,
+      "FixedPoint {} must read only the state this fixed point binds, but reads {} states",
+      branchName,
+      states.size());
+}
+
+} // namespace
+
+FixedPoint::FixedPoint(const Key& key)
+    : Node(NodeType::kFixedPoint, ColumnVector{key.outputColumns}, {}),
+      inputs_{key.anchor, key.step, key.convergence},
+      name_(key.name),
+      maxIterations_(key.maxIterations),
+      recursiveNumDrivers_(key.recursiveNumDrivers) {
+  VELOX_CHECK_NOT_NULL(inputs_[0]);
+  VELOX_CHECK_NOT_NULL(inputs_[1]);
+  VELOX_CHECK_NOT_NULL(inputs_[2]);
+  VELOX_CHECK_NOT_NULL(name_);
+  VELOX_CHECK_GE(
+      maxIterations_, 1, "FixedPoint maxIterations must be at least one");
+  VELOX_CHECK(
+      !recursiveNumDrivers_.has_value() || *recursiveNumDrivers_ == 1,
+      "FixedPoint recursiveNumDrivers must be one when set");
+  VELOX_CHECK(
+      std::ranges::equal(outputColumns(), inputs_[0]->outputColumns()),
+      "FixedPoint output columns must match anchor by pointer identity");
+
+  const auto& anchorCols = inputs_[0]->outputColumns();
+  const auto& stepCols = inputs_[1]->outputColumns();
+  VELOX_CHECK_EQ(
+      stepCols.size(),
+      anchorCols.size(),
+      "FixedPoint step must produce the same column count as anchor");
+  for (size_t i = 0; i < stepCols.size(); ++i) {
+    VELOX_CHECK(
+        stepCols[i]->value().type->equivalent(*anchorCols[i]->value().type),
+        "FixedPoint step output column {} type does not match anchor: step={}, anchor={}",
+        i,
+        stepCols[i]->value().type->toString(),
+        anchorCols[i]->value().type->toString());
+  }
+
+  const auto& convergenceCols = inputs_[2]->outputColumns();
+  VELOX_CHECK_EQ(
+      convergenceCols.size(),
+      1,
+      "FixedPoint convergence must produce exactly one column");
+  VELOX_CHECK_EQ(
+      convergenceCols[0]->value().type->kind(),
+      velox::TypeKind::BOOLEAN,
+      "FixedPoint convergence output must be BOOLEAN");
+
+  VELOX_CHECK(
+      inputs_[0]->requiredStates().empty(),
+      "FixedPoint anchor must not read its working table");
+  checkBranchReadsState(inputs_[1], name_, outputColumns(), "step");
+  checkBranchReadsState(inputs_[2], name_, outputColumns(), "convergence");
+}
+
+RequiredStates FixedPoint::deriveRequiredStates() const {
+  RequiredStates states = Node::deriveRequiredStates();
+  states.erase(name_);
+  return states;
+}
+
+size_t FixedPoint::KeyHash::operator()(const FixedPoint* node) const {
+  return hashOf(
+      node->anchor(),
+      node->step(),
+      node->convergence(),
+      node->name(),
+      node->outputColumns(),
+      node->maxIterations(),
+      node->recursiveNumDrivers().has_value(),
+      node->recursiveNumDrivers().value_or(0));
+}
+
+size_t FixedPoint::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.anchor,
+      key.step,
+      key.convergence,
+      key.name,
+      key.outputColumns,
+      key.maxIterations,
+      key.recursiveNumDrivers.has_value(),
+      key.recursiveNumDrivers.value_or(0));
+}
+
+bool FixedPoint::KeyEq::operator()(
+    const FixedPoint* left,
+    const FixedPoint* right) const {
+  return left->anchor() == right->anchor() && left->step() == right->step() &&
+      left->convergence() == right->convergence() &&
+      left->name() == right->name() &&
+      left->outputColumns() == right->outputColumns() &&
+      left->maxIterations() == right->maxIterations() &&
+      left->recursiveNumDrivers() == right->recursiveNumDrivers();
+}
+
+bool FixedPoint::KeyEq::operator()(const Key& key, const FixedPoint* node)
+    const {
+  return key.anchor == node->anchor() && key.step == node->step() &&
+      key.convergence == node->convergence() && key.name == node->name() &&
+      key.outputColumns == node->outputColumns() &&
+      key.maxIterations == node->maxIterations() &&
+      key.recursiveNumDrivers == node->recursiveNumDrivers();
+}
+
+bool FixedPoint::KeyEq::operator()(const FixedPoint* node, const Key& key)
+    const {
+  return (*this)(key, node);
+}
+
 #define V2_DEFINE_ACCEPT(NodeT)                                               \
   void NodeT::accept(const NodeVisitor& visitor, NodeVisitorContext& context) \
       const {                                                                 \
@@ -2215,6 +2415,8 @@ V2_DEFINE_ACCEPT(AssignUniqueId)
 V2_DEFINE_ACCEPT(EnforceDistinct)
 V2_DEFINE_ACCEPT(Exchange)
 V2_DEFINE_ACCEPT(TableWrite)
+V2_DEFINE_ACCEPT(WorkingTable)
+V2_DEFINE_ACCEPT(FixedPoint)
 
 #undef V2_DEFINE_ACCEPT
 

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -53,6 +53,8 @@ enum class NodeType : uint8_t {
   kEnforceDistinct,
   kExchange,
   kTableWrite,
+  kFixedPoint,
+  kWorkingTable,
 };
 
 AXIOM_DECLARE_ENUM_NAME(NodeType);
@@ -1820,6 +1822,111 @@ class TableWrite : public Node {
 };
 
 using TableWriteCP = const TableWrite*;
+
+/// Leaf placeholder for the working table of an enclosing `FixedPoint`.
+/// `outputColumns` share `Column*` identity with the enclosing FP's
+/// `outputColumns`, so the step body binds through pointer identity.
+class WorkingTable : public Node {
+ public:
+  struct Key {
+    /// Name of the enclosing `FixedPoint` (matches its `name()`).
+    Name name;
+    /// Output schema -- same `Column*`s as the enclosing `FixedPoint`.
+    ColumnVector outputColumns;
+  };
+
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const WorkingTable* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const WorkingTable* left, const WorkingTable* right) const;
+    bool operator()(const Key& key, const WorkingTable* node) const;
+    bool operator()(const WorkingTable* node, const Key& key) const;
+  };
+
+  explicit WorkingTable(Key key);
+
+  Name name() const {
+    return name_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const Name name_;
+};
+
+using WorkingTableCP = const WorkingTable*;
+
+/// Iterates `step` over a working table seeded by `anchor` until convergence
+/// or a max-iteration bound. `outputColumns` equal `anchor->outputColumns()`
+/// by pointer identity.
+///
+/// Invariants (enforced by the ctor):
+///   - `anchor`, `step`, and `name` are non-null.
+///   - `outputColumns` equal `anchor->outputColumns()` by pointer identity.
+class FixedPoint : public Node {
+ public:
+  struct Key {
+    /// Anchor sub-plan; runs once, seeds the working table.
+    NodeCP anchor;
+    /// Step sub-plan; iterates over the working table.
+    NodeCP step;
+    /// Name of this `FixedPoint` (matches `lp::FixedPointNode::name()`).
+    Name name;
+    /// Output schema -- same `Column*`s as `anchor->outputColumns()`.
+    ColumnVector outputColumns;
+  };
+
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const FixedPoint* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const FixedPoint* left, const FixedPoint* right) const;
+    bool operator()(const Key& key, const FixedPoint* node) const;
+    bool operator()(const FixedPoint* node, const Key& key) const;
+  };
+
+  explicit FixedPoint(Key key);
+
+  NodeCP anchor() const {
+    return inputs_[0];
+  }
+
+  NodeCP step() const {
+    return inputs_[1];
+  }
+
+  Name name() const {
+    return name_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return inputs_;
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const std::array<NodeCP, 2> inputs_;
+  const Name name_;
+};
+
+using FixedPointCP = const FixedPoint*;
 
 } // namespace facebook::axiom::optimizer::v2
 

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <array>
+#include <optional>
 #include <span>
 
 #include "axiom/logical_plan/LogicalPlanNode.h"
@@ -56,6 +57,8 @@ enum class NodeType : uint8_t {
   kEnforceDistinct,
   kExchange,
   kTableWrite,
+  kFixedPoint,
+  kWorkingTable,
 };
 
 AXIOM_DECLARE_ENUM_NAME(NodeType);
@@ -66,8 +69,18 @@ class NodeVisitorContext;
 using NodeCP = const Node*;
 using NodeVector = QGVector<NodeCP>;
 
-/// Base class for tree-IR operator nodes. Immutable. All members are const
-/// and initialized via the constructor. Abstract — instantiate via a subclass.
+/// The recursive states a subtree reads, as carried by
+/// `Node::requiredStates()`: state name to the columns the reads present. Names
+/// are interned, so hashing the pointer is equivalent to hashing the text. In a
+/// valid plan this holds at most one entry; a branch that accumulates more is
+/// rejected by the enclosing `FixedPoint`.
+using RequiredStates = QGF14FastMap<Name, ColumnVector>;
+
+/// Base class for tree-IR operator nodes. Immutable: every member describing
+/// the node is const and initialized via the constructor. The one exception is
+/// `requiredStates()`, a pure function of those members that `Builder::make`
+/// fills in once construction is complete.
+/// Abstract — instantiate via a subclass.
 ///
 /// Cross-node references — predicates, join/grouping/sort keys, expression
 /// operands, per-leg layouts — bind by pointer identity, and keys may be
@@ -141,6 +154,23 @@ class Node : public PlanObject {
   virtual void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const = 0;
 
+  /// Recursive states this subtree needs an enclosing `FixedPoint` to provide,
+  /// each mapped to the columns its reads present. Empty for a self-contained
+  /// subtree, so for every node outside a recursive query. Lets a `FixedPoint`
+  /// check both that a branch reads its state and that the read agrees with the
+  /// state schema, with one lookup rather than a subtree search. Primed by
+  /// `Builder::make`, which is the only way to construct a node.
+  const RequiredStates& requiredStates() const {
+    return *requiredStates_;
+  }
+
+  /// Computes and caches `requiredStates()`. Called by `Builder::make` once the
+  /// node is fully constructed, so the set allocates in the same
+  /// `QueryGraphContext` as the rest of the node.
+  void primeRequiredStates() const {
+    requiredStates_ = deriveRequiredStates();
+  }
+
   std::string toString() const override;
 
  protected:
@@ -156,10 +186,20 @@ class Node : public PlanObject {
         PlanObjectSet::fromObjects(outputColumns_));
   }
 
+  // Unions the inputs' entries, rejecting two reads of one state that disagree
+  // on columns. `WorkingTable` requires the state it reads and `FixedPoint`
+  // satisfies the one it binds.
+  virtual RequiredStates deriveRequiredStates() const;
+
  private:
   const NodeType nodeType_;
   const ColumnVector outputColumns_;
   const PhysicalProperties physicalProperties_;
+  // Set by `primeRequiredStates()`. Mutable because that runs after
+  // construction, from `Builder::make` on an already-const node; safe under the
+  // single-threaded planning assumption (see `QueryGraphContext`). A pure
+  // function of the node's structure, so interning cannot make it stale.
+  mutable std::optional<RequiredStates> requiredStates_;
 };
 
 /// Reads rows from a connector-backed table (`BaseTable`).
@@ -1958,6 +1998,193 @@ class TableWrite : public Node {
 
 using TableWriteCP = const TableWrite*;
 
+/// Selects which rows a `WorkingTable` reads from recursive state.
+enum class WorkingTableReadMode : uint8_t {
+  /// Rows produced by the immediately preceding anchor or step evaluation.
+  kLatestDelta,
+  /// All rows accumulated since the anchor initialized the state.
+  kAccumulated,
+};
+
+AXIOM_DECLARE_ENUM_NAME(WorkingTableReadMode);
+
+/// Reads recursive state inside a `FixedPoint` branch.
+///
+/// A latest-delta read returns the rows produced by the immediately preceding
+/// anchor or step evaluation, not every row accumulated so far. An accumulated
+/// read returns the full recursive result produced through that iteration.
+/// `name` identifies which enclosing fixed-point state to read.
+///
+/// Requires:
+/// - `name` is non-null and identifies the enclosing fixed-point state.
+/// - `outputColumns` share pointer identity with the fixed-point output.
+class WorkingTable : public Node {
+ public:
+  struct Key {
+    /// Identifies the enclosing fixed-point state.
+    Name name;
+    /// Shares `Column*` identity with the enclosing `FixedPoint` output.
+    ColumnVector outputColumns;
+    /// Selects the latest iteration's rows or all accumulated rows.
+    WorkingTableReadMode readMode;
+  };
+
+  /// Transparent hasher for interning `WorkingTable`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const WorkingTable* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `WorkingTable`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const WorkingTable* left, const WorkingTable* right) const;
+    bool operator()(const Key& key, const WorkingTable* node) const;
+    bool operator()(const WorkingTable* node, const Key& key) const;
+  };
+
+  explicit WorkingTable(const Key& key);
+
+  Name name() const {
+    return name_;
+  }
+
+  WorkingTableReadMode readMode() const {
+    return readMode_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ protected:
+  RequiredStates deriveRequiredStates() const override;
+
+ private:
+  const Name name_;
+  const WorkingTableReadMode readMode_;
+};
+
+using WorkingTableCP = const WorkingTable*;
+
+/// Represents a loop whose `anchor` seeds recursive state and whose `step`
+/// produces one new delta per iteration. For append-only state, the loop is:
+///
+///   delta = anchor(); result = delta;
+///   for (iteration = 0; iteration < maxIterations; ++iteration) {
+///     delta = step(delta);
+///     result += delta;
+///     if (convergence(delta)) break;
+///   }
+///
+/// For example:
+///
+///   WITH RECURSIVE counter(n) AS (
+///     VALUES 1
+///     UNION ALL
+///     SELECT n + 1 FROM counter WHERE n < 10)
+///
+/// translates to `VALUES 1` as the anchor, `n + 1 WHERE n < 10` over a
+/// latest-delta `WorkingTable[counter]` as the step, and `count(*) = 0` over
+/// another latest-delta read as convergence. The fixed point outputs all rows
+/// accumulated from the anchor and successive step deltas.
+///
+/// Requires:
+/// - `anchor`, `step`, `convergence`, and `name` are non-null.
+/// - `outputColumns` equal `anchor->outputColumns()` by pointer identity.
+/// - `step` output is type-compatible with `anchor` output.
+/// - `anchor->requiredStates()` is empty: the anchor reads no recursive state.
+/// - `step` and `convergence` each require exactly `name`, with columns
+///   pointer-identical to `outputColumns`.
+/// - `convergence` produces exactly one BOOLEAN column.
+/// - `maxIterations` is at least one.
+/// - `recursiveNumDrivers`, when set by physical planning, is one.
+class FixedPoint : public Node {
+ public:
+  struct Key {
+    /// Runs once to seed the working table.
+    NodeCP anchor;
+    /// Runs iteratively over the working table.
+    NodeCP step;
+    /// Produces a single Boolean indicating whether iteration should stop.
+    NodeCP convergence;
+    /// Identifies the recursive state represented by this fixed point.
+    Name name;
+    /// Shares `Column*` identity with the anchor output.
+    ColumnVector outputColumns;
+    /// Maximum number of recursive iterations.
+    int32_t maxIterations;
+    /// Driver width chosen by physical planning for step and convergence.
+    /// Unset in logical IR; currently only one is valid, and emission requires
+    /// the physically planned value.
+    std::optional<int32_t> recursiveNumDrivers;
+  };
+
+  /// Transparent hasher for interning `FixedPoint`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const FixedPoint* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `FixedPoint`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const FixedPoint* left, const FixedPoint* right) const;
+    bool operator()(const Key& key, const FixedPoint* node) const;
+    bool operator()(const FixedPoint* node, const Key& key) const;
+  };
+
+  explicit FixedPoint(const Key& key);
+
+  NodeCP anchor() const {
+    return inputs_[0];
+  }
+
+  NodeCP step() const {
+    return inputs_[1];
+  }
+
+  NodeCP convergence() const {
+    return inputs_[2];
+  }
+
+  Name name() const {
+    return name_;
+  }
+
+  int32_t maxIterations() const {
+    return maxIterations_;
+  }
+
+  std::optional<int32_t> recursiveNumDrivers() const {
+    return recursiveNumDrivers_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return inputs_;
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ protected:
+  RequiredStates deriveRequiredStates() const override;
+
+ private:
+  const std::array<NodeCP, 3> inputs_;
+  const Name name_;
+  const int32_t maxIterations_;
+  const std::optional<int32_t> recursiveNumDrivers_;
+};
+
+using FixedPointCP = const FixedPoint*;
+
 } // namespace facebook::axiom::optimizer::v2
 
 AXIOM_ENUM_FORMATTER(facebook::axiom::optimizer::v2::NodeType);
+AXIOM_ENUM_FORMATTER(facebook::axiom::optimizer::v2::WorkingTableReadMode);

--- a/axiom/optimizer/v2/NodeExpressions.h
+++ b/axiom/optimizer/v2/NodeExpressions.h
@@ -202,6 +202,8 @@ void forEachExpressionInNode(NodeCP node, Visit&& visit) {
     case NodeType::kLimit:
     case NodeType::kEnforceSingleRow:
     case NodeType::kAssignUniqueId:
+    case NodeType::kFixedPoint:
+    case NodeType::kWorkingTable:
       // No expressions on these nodes.
       break;
   }

--- a/axiom/optimizer/v2/NodeExpressions.h
+++ b/axiom/optimizer/v2/NodeExpressions.h
@@ -208,6 +208,8 @@ void forEachExpressionInNode(NodeCP node, Visit&& visit) {
     case NodeType::kLimit:
     case NodeType::kEnforceSingleRow:
     case NodeType::kAssignUniqueId:
+    case NodeType::kFixedPoint:
+    case NodeType::kWorkingTable:
       // No expressions on these nodes.
       break;
   }

--- a/axiom/optimizer/v2/NodePrinter.cpp
+++ b/axiom/optimizer/v2/NodePrinter.cpp
@@ -339,6 +339,24 @@ class Printer : public NodeVisitor {
     visitInputs(node, ctx);
   }
 
+  void visit(const WorkingTable& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node, fmt::format("[name={}]", node.name()));
+    visitInputs(node, ctx);
+  }
+
+  void visit(const FixedPoint& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node, fmt::format("[name={}]", node.name()));
+    IndentGuard guard(ctx);
+    ctx.out << spaces(ctx.indent) << "anchor:\n";
+    node.anchor()->accept(*this, ctx);
+    ctx.out << spaces(ctx.indent) << "step:\n";
+    node.step()->accept(*this, ctx);
+  }
+
  private:
   void header(Context& ctx, const Node& node, std::string_view extra = {})
       const {

--- a/axiom/optimizer/v2/NodePrinter.cpp
+++ b/axiom/optimizer/v2/NodePrinter.cpp
@@ -355,6 +355,38 @@ class Printer : public NodeVisitor {
     visitInputs(node, ctx);
   }
 
+  void visit(const WorkingTable& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(
+        ctx,
+        node,
+        fmt::format("[name={}, readMode={}]", node.name(), node.readMode()));
+    visitInputs(node, ctx);
+  }
+
+  void visit(const FixedPoint& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(
+        ctx,
+        node,
+        fmt::format(
+            "[name={}, maxIterations={}, recursiveNumDrivers={}]",
+            node.name(),
+            node.maxIterations(),
+            node.recursiveNumDrivers().has_value()
+                ? fmt::to_string(*node.recursiveNumDrivers())
+                : "unplanned"));
+    IndentGuard guard(ctx);
+    ctx.out << spaces(ctx.indent) << "anchor:\n";
+    node.anchor()->accept(*this, ctx);
+    ctx.out << spaces(ctx.indent) << "step:\n";
+    node.step()->accept(*this, ctx);
+    ctx.out << spaces(ctx.indent) << "convergence:\n";
+    node.convergence()->accept(*this, ctx);
+  }
+
  private:
   void header(Context& ctx, const Node& node, std::string_view extra = {})
       const {

--- a/axiom/optimizer/v2/NodeRewriter.h
+++ b/axiom/optimizer/v2/NodeRewriter.h
@@ -84,6 +84,10 @@ class NodeRewriter {
         return rewriteExchange(node->as<Exchange>(), context);
       case NodeType::kTableWrite:
         return rewriteTableWrite(node->as<TableWrite>(), context);
+      case NodeType::kWorkingTable:
+        return rewriteWorkingTable(node->as<WorkingTable>(), context);
+      case NodeType::kFixedPoint:
+        return rewriteFixedPoint(node->as<FixedPoint>(), context);
     }
     VELOX_UNREACHABLE();
   }
@@ -348,6 +352,22 @@ class NodeRewriter {
     }
     return builder_.template make<TableWrite>(
         {newInput, node->table(), node->kind(), node->columnExprs()});
+  }
+
+  virtual NodeCP rewriteWorkingTable(
+      const WorkingTable* node,
+      TContext& /*context*/) {
+    return node;
+  }
+
+  virtual NodeCP rewriteFixedPoint(const FixedPoint* node, TContext& context) {
+    NodeCP newAnchor = rewrite(node->anchor(), context);
+    NodeCP newStep = rewrite(node->step(), context);
+    if (newAnchor == node->anchor() && newStep == node->step()) {
+      return node;
+    }
+    return builder_.template make<FixedPoint>(
+        {newAnchor, newStep, node->name(), node->outputColumns()});
   }
 
   Builder& builder() {

--- a/axiom/optimizer/v2/NodeRewriter.h
+++ b/axiom/optimizer/v2/NodeRewriter.h
@@ -97,6 +97,10 @@ class NodeRewriter {
         return rewriteExchange(node->as<Exchange>(), context);
       case NodeType::kTableWrite:
         return rewriteTableWrite(node->as<TableWrite>(), context);
+      case NodeType::kWorkingTable:
+        return rewriteWorkingTable(node->as<WorkingTable>(), context);
+      case NodeType::kFixedPoint:
+        return rewriteFixedPoint(node->as<FixedPoint>(), context);
     }
     VELOX_UNREACHABLE();
   }
@@ -374,6 +378,31 @@ class NodeRewriter {
     }
     return builder_.template make<TableWrite>(
         {newInput, node->table(), node->kind(), node->columnExprs()});
+  }
+
+  virtual NodeCP rewriteWorkingTable(
+      const WorkingTable* node,
+      TContext& /*context*/) {
+    return node;
+  }
+
+  virtual NodeCP rewriteFixedPoint(const FixedPoint* node, TContext& context) {
+    NodeCP newAnchor = rewrite(node->anchor(), context);
+    NodeCP newStep = rewrite(node->step(), context);
+    NodeCP newConvergence = rewrite(node->convergence(), context);
+    if (newAnchor == node->anchor() && newStep == node->step() &&
+        newConvergence == node->convergence()) {
+      return node;
+    }
+    return builder_.template make<FixedPoint>(FixedPoint::Key{
+        .anchor = newAnchor,
+        .step = newStep,
+        .convergence = newConvergence,
+        .name = node->name(),
+        .outputColumns = node->outputColumns(),
+        .maxIterations = node->maxIterations(),
+        .recursiveNumDrivers = node->recursiveNumDrivers(),
+    });
   }
 
   Builder& builder() {

--- a/axiom/optimizer/v2/NodeVisitor.h
+++ b/axiom/optimizer/v2/NodeVisitor.h
@@ -63,6 +63,10 @@ class NodeVisitor {
       const = 0;
   virtual void visit(const TableWrite& node, NodeVisitorContext& context)
       const = 0;
+  virtual void visit(const WorkingTable& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const FixedPoint& node, NodeVisitorContext& context)
+      const = 0;
 
  protected:
   void visitInputs(const Node& node, NodeVisitorContext& context) const {

--- a/axiom/optimizer/v2/NodeVisitor.h
+++ b/axiom/optimizer/v2/NodeVisitor.h
@@ -65,6 +65,10 @@ class NodeVisitor {
       const = 0;
   virtual void visit(const TableWrite& node, NodeVisitorContext& context)
       const = 0;
+  virtual void visit(const WorkingTable& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const FixedPoint& node, NodeVisitorContext& context)
+      const = 0;
 
  protected:
   void visitInputs(const Node& node, NodeVisitorContext& context) const {

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -295,6 +295,34 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
   }
 
  protected:
+  NodeCP rewriteFixedPoint(const FixedPoint* node, NoContext& context)
+      override {
+    NodeCP anchor = rewrite(node->anchor(), context);
+
+    static constexpr int32_t kRecursiveNumDrivers = 1;
+    PhysicalPlanRewriter singleThreaded{
+        builder(),
+        options_,
+        /*numWorkers=*/1,
+        /*numDrivers=*/kRecursiveNumDrivers};
+    NodeCP step = singleThreaded.rewrite(node->step());
+    NodeCP convergence = singleThreaded.rewrite(node->convergence());
+    if (anchor == node->anchor() && step == node->step() &&
+        convergence == node->convergence() &&
+        node->recursiveNumDrivers() == kRecursiveNumDrivers) {
+      return node;
+    }
+    return builder().make<FixedPoint>(FixedPoint::Key{
+        .anchor = anchor,
+        .step = step,
+        .convergence = convergence,
+        .name = node->name(),
+        .outputColumns = node->outputColumns(),
+        .maxIterations = node->maxIterations(),
+        .recursiveNumDrivers = kRecursiveNumDrivers,
+    });
+  }
+
   // Rebuilds a join that DPhyp does not plan (non-clusterable cross / theta /
   // decorrelated-subquery joins, and the syntactic-order / uncostable
   // fallbacks) with its children rewritten, giving it a valid distributed input

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
@@ -348,6 +348,8 @@ class Rewriter : public NodeRewriter<> {
   NodeCP rewriteUnnest(const Unnest* unnest, NoContext& context) override;
   NodeCP rewriteJoin(const Join* join, NoContext& context) override;
   NodeCP rewriteUnionAll(const UnionAll* unionAll, NoContext& context) override;
+  NodeCP rewriteFixedPoint(const FixedPoint* fixedPoint, NoContext& context)
+      override;
   NodeCP rewriteApply(const Apply* /*apply*/, NoContext& /*context*/) override {
     VELOX_UNREACHABLE(
         "Apply must be removed by decorrelate before PrecomputeProjections");
@@ -684,6 +686,40 @@ NodeCP Rewriter::rewriteUnnest(const Unnest* unnest, NoContext& context) {
        unnest->unnestColumns(),
        unnest->ordinalityColumn(),
        unnest->outputColumns()});
+}
+
+NodeCP Rewriter::rewriteFixedPoint(
+    const FixedPoint* fixedPoint,
+    NoContext& context) {
+  auto restoreSchema = [&](NodeCP branch, const ColumnVector& columns) {
+    if (branch->outputColumns() == columns) {
+      return branch;
+    }
+    return makeProject(
+        branch, ExprVector{columns.begin(), columns.end()}, columns, builder());
+  };
+
+  NodeCP anchor = restoreSchema(
+      rewrite(fixedPoint->anchor(), context), fixedPoint->outputColumns());
+  NodeCP step = restoreSchema(
+      rewrite(fixedPoint->step(), context),
+      fixedPoint->step()->outputColumns());
+  NodeCP convergence = restoreSchema(
+      rewrite(fixedPoint->convergence(), context),
+      fixedPoint->convergence()->outputColumns());
+  if (anchor == fixedPoint->anchor() && step == fixedPoint->step() &&
+      convergence == fixedPoint->convergence()) {
+    return fixedPoint;
+  }
+  return builder().make<FixedPoint>(FixedPoint::Key{
+      .anchor = anchor,
+      .step = step,
+      .convergence = convergence,
+      .name = fixedPoint->name(),
+      .outputColumns = fixedPoint->outputColumns(),
+      .maxIterations = fixedPoint->maxIterations(),
+      .recursiveNumDrivers = fixedPoint->recursiveNumDrivers(),
+  });
 }
 
 NodeCP Rewriter::rewriteUnionAll(const UnionAll* unionAll, NoContext& context) {

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -1379,6 +1379,43 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     return NodeRewriter::rewriteTableWrite(node, child);
   }
 
+  // FixedPoint: keep the pending predicate above the FP. Do not push into
+  // the anchor (unsound without iteration-invariance proof) or the step
+  // (would change what accumulates each iteration).
+  // TODO: Push iteration-invariant predicates into the anchor and step.
+  NodeCP rewriteFixedPoint(const FixedPoint* node, PushdownContext& context)
+      override {
+    // Filtering seed rows requires `p(step(x)) ⇒ p(x)`; without that,
+    // dropping a row that fails `p` silently drops descendants that
+    // satisfy `p`. E.g. `p = (n > 15)` with `step = n+1` drops seed row 1
+    // whose descendants 16..20 would have matched.
+    PushdownContext anchorContext;
+    anchorContext.required.unionObjects(node->outputColumns());
+    anchorContext.requiredAbove = anchorContext.required;
+    NodeCP newAnchor = rewrite(node->anchor(), anchorContext);
+
+    // Key `required` on the step's own outputs: its Project mints fresh
+    // Column*s, so filtering by anchor names would prune everything.
+    // `nonNullColumns` stays empty: the step reads through a `WorkingTable`
+    // leaf that carries no outer null guarantees.
+    PushdownContext stepContext;
+    stepContext.required.unionObjects(node->step()->outputColumns());
+    stepContext.requiredAbove = stepContext.required;
+    NodeCP newStep = rewrite(node->step(), stepContext);
+
+    NodeCP fp = node;
+    if (newAnchor != node->anchor() || newStep != node->step()) {
+      fp = builder().make<FixedPoint>(
+          {newAnchor, newStep, node->name(), node->outputColumns()});
+    }
+    return maybeWrapFilter(fp, std::move(context.pending));
+  }
+
+  NodeCP rewriteWorkingTable(const WorkingTable* node, PushdownContext& context)
+      override {
+    return maybeWrapFilter(node, std::move(context.pending));
+  }
+
  private:
   // Builds a child `PushdownContext` whose required column set is
   // `parent.required` plus the columns referenced by any conjunct in

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -1769,6 +1769,59 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     return NodeRewriter::rewriteTableWrite(node, child);
   }
 
+  // Pending predicates must remain above the fixed point because pushing them
+  // into either branch can change the rows accumulated across iterations.
+  // TODO: Push iteration-invariant predicates into the anchor and step.
+  NodeCP rewriteFixedPoint(const FixedPoint* node, PushdownContext& context)
+      override {
+    // Filtering seed rows is sound only when `p(step(x))` implies `p(x)`;
+    // otherwise, a rejected seed can still produce matching descendants.
+    PushdownContext anchorContext;
+    anchorContext.required.unionObjects(node->outputColumns());
+    anchorContext.requiredAbove = anchorContext.required;
+    NodeCP newAnchor = rewrite(node->anchor(), anchorContext);
+    VELOX_CHECK(
+        std::ranges::equal(newAnchor->outputColumns(), node->outputColumns()),
+        "FixedPoint anchor output columns must retain pointer identity after pushdown");
+
+    // Required columns use step output identities because they may differ from
+    // anchor output identities. The working table carries no outer null
+    // guarantees, so `nonNullColumns` remains empty.
+    PushdownContext stepContext;
+    stepContext.required.unionObjects(node->step()->outputColumns());
+    stepContext.requiredAbove = stepContext.required;
+    NodeCP newStep = rewrite(node->step(), stepContext);
+
+    // Convergence is an independent Boolean subplan. Seed only its root output;
+    // each operator adds its expression dependencies while WorkingTable keeps
+    // the complete recursive-state schema.
+    PushdownContext convergenceContext;
+    convergenceContext.required.unionObjects(
+        node->convergence()->outputColumns());
+    convergenceContext.requiredAbove = convergenceContext.required;
+    NodeCP newConvergence = rewrite(node->convergence(), convergenceContext);
+
+    NodeCP fixedPoint = node;
+    if (newAnchor != node->anchor() || newStep != node->step() ||
+        newConvergence != node->convergence()) {
+      fixedPoint = builder().make<FixedPoint>(FixedPoint::Key{
+          .anchor = newAnchor,
+          .step = newStep,
+          .convergence = newConvergence,
+          .name = node->name(),
+          .outputColumns = node->outputColumns(),
+          .maxIterations = node->maxIterations(),
+          .recursiveNumDrivers = node->recursiveNumDrivers(),
+      });
+    }
+    return maybeWrapFilter(fixedPoint, std::move(context.pending));
+  }
+
+  NodeCP rewriteWorkingTable(const WorkingTable* node, PushdownContext& context)
+      override {
+    return maybeWrapFilter(node, std::move(context.pending));
+  }
+
  private:
   // Builds a child `PushdownContext` whose required column set is
   // `parent.required` plus the columns referenced by any conjunct in

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "axiom/optimizer/v2/TranslatePass.h"
-
+#include <folly/ScopeGuard.h>
 #include <folly/container/F14Map.h>
 #include "axiom/optimizer/EstimateMath.h"
 #include "axiom/optimizer/Filters.h"
@@ -447,6 +447,12 @@ class Translator {
   Translated translateTableWrite(
       const lp::TableWriteNode& tableWrite,
       const LpNameSet& required);
+  Translated translateFixedPoint(
+      const lp::FixedPointNode& fixedPoint,
+      const LpNameSet& required);
+  Translated translateRecursiveRef(
+      const lp::RecursiveReferenceNode& ref,
+      const LpNameSet& required);
   NodeCP maybeWrapInWindow(
       NodeCP input,
       const Scope& inputScope,
@@ -573,6 +579,17 @@ class Translator {
   // target's output, so a reference in an unrelated scope re-lifts.
   folly::F14FastMap<const lp::LogicalPlanNode*, ColumnCP>
       scalarSubqueryColumns_;
+
+  // Present only while translating a `FixedPoint`; `optional`, not a
+  // stack, because nested `FixedPoint`s are NYI. `anchorColumns` is
+  // populated after the anchor is translated; the scope is emplaced
+  // earlier so nested FPs inside the anchor also trip the NYI check in
+  // `translateFixedPoint`.
+  struct FixedPointScope {
+    Name name;
+    ColumnVector anchorColumns;
+  };
+  std::optional<FixedPointScope> fixedPointScope_;
 };
 
 Translated Translator::translateTableWrite(
@@ -644,6 +661,105 @@ Translated Translator::translateTableWrite(
   return {writeNode, std::move(scope)};
 }
 
+Translated Translator::translateFixedPoint(
+    const lp::FixedPointNode& fixedPoint,
+    const LpNameSet& /*required*/) {
+  VELOX_USER_CHECK(
+      !fixedPointScope_.has_value(),
+      "Nested FixedPoint translation is not yet implemented");
+
+  const auto* recursionName = toName(fixedPoint.name());
+
+  // Set the scope before translating the anchor so a nested `FixedPoint`
+  // inside the anchor sub-tree also trips the NYI check above, not only
+  // one inside the step sub-tree. `anchorColumns` is filled in after the
+  // anchor is translated; a `RecursiveReferenceNode` in the anchor would
+  // fail the size check in `translateRecursiveRef` (empty vs. its schema).
+  fixedPointScope_.emplace(FixedPointScope{.name = recursionName});
+  SCOPE_EXIT {
+    fixedPointScope_.reset();
+  };
+
+  // MVP: request all of anchor + step; pruning either would break
+  // WorkingTable <-> anchor Column identity.
+  // TODO: Prune FP outputs when both sides can be pruned to the same subset.
+  const auto& anchorType = fixedPoint.anchor()->outputType();
+  Translated anchor =
+      translateNode(*fixedPoint.anchor(), allNames(*anchorType));
+
+  ColumnVector anchorColumns;
+  Scope anchorScope;
+  anchorColumns.reserve(anchorType->size());
+  for (size_t i = 0; i < anchorType->size(); ++i) {
+    const auto& name = anchorType->nameOf(static_cast<uint32_t>(i));
+    auto it = anchor.scope.find(name);
+    VELOX_CHECK(
+        it != anchor.scope.end(),
+        "FixedPoint anchor scope missing column: {}",
+        name);
+    ColumnCP column = it->second;
+    anchorColumns.push_back(column);
+    anchorScope[name] = column;
+  }
+
+  fixedPointScope_->anchorColumns = anchorColumns;
+
+  // For `PlanBuilder(...).recursiveRef("counter", anchor)`, the ref's
+  // schema renames anchor's `n` to `n_0` (or similar). Request all of
+  // step's own outputs — filtering by anchor's names prunes everything.
+  Translated step = translateNode(
+      *fixedPoint.step(), allNames(*fixedPoint.step()->outputType()));
+
+  return {
+      builder_.make<FixedPoint>(
+          {anchor.node, step.node, recursionName, std::move(anchorColumns)}),
+      std::move(anchorScope)};
+}
+
+Translated Translator::translateRecursiveRef(
+    const lp::RecursiveReferenceNode& ref,
+    const LpNameSet& /*required*/) {
+  const auto* recursionName = toName(ref.name());
+  VELOX_USER_CHECK(
+      fixedPointScope_.has_value(),
+      "RecursiveReferenceNode outside any enclosing FixedPoint: {}",
+      ref.name());
+  const auto& enclosing = *fixedPointScope_;
+  VELOX_USER_CHECK_EQ(
+      enclosing.name,
+      recursionName,
+      "RecursiveReferenceNode name does not match enclosing FixedPoint");
+
+  const auto& schema = ref.outputType();
+  VELOX_CHECK_EQ(
+      schema->size(),
+      enclosing.anchorColumns.size(),
+      "RecursiveReference schema size mismatches enclosing FixedPoint anchor");
+
+  // For `SELECT * FROM r r1 JOIN r r2 ON r1.k = r2.k`, both refs share
+  // anchor's Column* but LP renames their names to (`k_1`, `k_2`) so they
+  // stay distinct in scope. Keep the renamed names as scope keys; bind
+  // them to the anchor's original Column*s.
+  Scope newScope;
+  ColumnVector outputs;
+  outputs.reserve(schema->size());
+  for (size_t i = 0; i < schema->size(); ++i) {
+    ColumnCP column = enclosing.anchorColumns[i];
+    VELOX_USER_CHECK(
+        schema->childAt(i)->equivalent(*column->value().type),
+        "RecursiveReference column {} type does not match enclosing FixedPoint anchor: ref={}, anchor={}",
+        i,
+        schema->childAt(i)->toString(),
+        column->value().type->toString());
+    outputs.push_back(column);
+    newScope[schema->nameOf(static_cast<uint32_t>(i))] = column;
+  }
+
+  return {
+      builder_.make<WorkingTable>({recursionName, std::move(outputs)}),
+      std::move(newScope)};
+}
+
 Translated Translator::translateNode(
     const lp::LogicalPlanNode& node,
     const LpNameSet& required) {
@@ -676,6 +792,11 @@ Translated Translator::translateNode(
       return translateTableWrite(*node.as<lp::TableWriteNode>(), required);
     case lp::NodeKind::kOutput:
       VELOX_UNREACHABLE();
+    case lp::NodeKind::kFixedPoint:
+      return translateFixedPoint(*node.as<lp::FixedPointNode>(), required);
+    case lp::NodeKind::kRecursiveReference:
+      return translateRecursiveRef(
+          *node.as<lp::RecursiveReferenceNode>(), required);
     default:
       VELOX_NYI(
           "Unsupported logical plan node kind: {}",

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -16,6 +16,9 @@
 
 #include "axiom/optimizer/v2/TranslatePass.h"
 
+#include <utility>
+
+#include <folly/ScopeGuard.h>
 #include <folly/container/F14Map.h>
 #include "axiom/optimizer/ConstantFold.h"
 #include "axiom/optimizer/EstimateMath.h"
@@ -505,6 +508,17 @@ class Translator {
   Translated translateTableWrite(
       const lp::TableWriteNode& tableWrite,
       const LpNameSet& required);
+  Translated translateFixedPoint(
+      const lp::FixedPointNode& fixedPoint,
+      const LpNameSet& required);
+  // Reads the enclosing fixed point's state. Takes the columns from
+  // `activeFixedPoint_` rather than from the caller, so every read of one state
+  // presents the same `Column*`s by construction.
+  NodeCP makeWorkingTable();
+  NodeCP makeEmptyDeltaConvergence();
+  Translated translateRecursiveRef(
+      const lp::RecursiveReferenceNode& ref,
+      const LpNameSet& required);
   NodeCP maybeWrapInWindow(
       NodeCP input,
       const Scope& inputScope,
@@ -643,6 +657,13 @@ class Translator {
   // target's output, so a reference in an unrelated scope re-lifts; a folded
   // constant (Literal) is always in scope and always reused.
   folly::F14FastMap<const lp::LogicalPlanNode*, ExprCP> scalarSubqueryColumns_;
+
+  struct ActiveFixedPoint {
+    Name stateName;
+    ColumnVector stateColumns;
+    int32_t numReferences{0};
+  };
+  std::optional<ActiveFixedPoint> activeFixedPoint_;
 };
 
 Translated Translator::translateTableWrite(
@@ -717,6 +738,158 @@ Translated Translator::translateTableWrite(
   return {writeNode, std::move(scope)};
 }
 
+NodeCP Translator::makeWorkingTable() {
+  VELOX_CHECK(
+      activeFixedPoint_.has_value(),
+      "WorkingTable requires an enclosing FixedPoint");
+  const auto& enclosing = *activeFixedPoint_;
+  return builder_.make<WorkingTable>(WorkingTable::Key{
+      .name = enclosing.stateName,
+      .outputColumns = enclosing.stateColumns,
+      .readMode = WorkingTableReadMode::kLatestDelta,
+  });
+}
+
+NodeCP Translator::makeEmptyDeltaConvergence() {
+  NodeCP workingTable = makeWorkingTable();
+  const auto* count = builder_.makeAggregate(
+      builder_.functionNames().count,
+      Value(toType(velox::BIGINT())),
+      {},
+      FunctionSet{},
+      /*isDistinct=*/false,
+      /*condition=*/nullptr,
+      toType(velox::BIGINT()),
+      {},
+      {});
+  ColumnCP countColumn =
+      Column::create("__converged_count", Value(toType(velox::BIGINT())));
+  NodeCP aggregation = builder_.make<Aggregate>(Aggregate::Key{
+      .input = workingTable,
+      .groupingKeys = {},
+      .aggregates = {count},
+      .outputColumns = {countColumn},
+      .step = AggregateStep::kSingle,
+  });
+  ExprCP zero =
+      builder_.makeLiteral(velox::Variant(int64_t{0}), toType(velox::BIGINT()));
+  ExprCP convergedExpr = exprFactory_.makeEq(countColumn, zero);
+  ColumnCP convergedColumn =
+      Column::create("converged", Value(toType(velox::BOOLEAN())));
+  return builder_.make<Project>(Project::Key{
+      .input = aggregation,
+      .exprs = {convergedExpr},
+      .outputColumns = {convergedColumn},
+  });
+}
+
+Translated Translator::translateFixedPoint(
+    const lp::FixedPointNode& fixedPoint,
+    const LpNameSet& /*required*/) {
+  VELOX_USER_CHECK(
+      !activeFixedPoint_.has_value(),
+      "Nested FixedPoint translation is not yet implemented");
+
+  // Every recursive state read shares the anchor's Column* identities. Pruning
+  // must therefore choose one ordered subset and rewrite the fixed-point
+  // output, anchor, step, convergence, and every WorkingTable consistently.
+  // TODO: Implement this coordinated FixedPoint state-schema pruning.
+  const auto& anchorType = fixedPoint.anchor()->outputType();
+  Translated anchor =
+      translateNode(*fixedPoint.anchor(), allNames(*anchorType));
+
+  ColumnVector anchorColumns;
+  Scope anchorScope;
+  anchorColumns.reserve(anchorType->size());
+  for (size_t i = 0; i < anchorType->size(); ++i) {
+    const auto& name = anchorType->nameOf(static_cast<uint32_t>(i));
+    auto it = anchor.scope.find(name);
+    VELOX_CHECK(
+        it != anchor.scope.end(),
+        "FixedPoint anchor scope missing column: {}",
+        name);
+    ColumnCP column = it->second;
+    anchorColumns.push_back(column);
+    anchorScope[name] = column;
+  }
+
+  const auto* recursionName = toName(fixedPoint.name());
+  auto previousFixedPoint = std::exchange(
+      activeFixedPoint_,
+      ActiveFixedPoint{
+          .stateName = recursionName,
+          .stateColumns = anchorColumns,
+      });
+  SCOPE_EXIT {
+    activeFixedPoint_ = std::move(previousFixedPoint);
+  };
+
+  // Recursive-reference field names may differ from anchor field names.
+  Translated step = translateNode(
+      *fixedPoint.step(), allNames(*fixedPoint.step()->outputType()));
+  // Each recursive reference currently maps back to the same anchor Column*s.
+  // Two references would therefore collapse into one relation identity instead
+  // of representing independently aliased inputs to a self-join.
+  VELOX_USER_CHECK_EQ(
+      activeFixedPoint_->numReferences,
+      1,
+      "Optimizer v2 supports exactly one RecursiveReferenceNode per FixedPoint step: found {}",
+      activeFixedPoint_->numReferences);
+
+  NodeCP convergence = makeEmptyDeltaConvergence();
+
+  return {
+      builder_.make<FixedPoint>(FixedPoint::Key{
+          .anchor = anchor.node,
+          .step = step.node,
+          .convergence = convergence,
+          .name = recursionName,
+          .outputColumns = std::move(anchorColumns),
+          .maxIterations = session_.options().recursionLimit,
+          .recursiveNumDrivers = std::nullopt,
+      }),
+      std::move(anchorScope)};
+}
+
+Translated Translator::translateRecursiveRef(
+    const lp::RecursiveReferenceNode& ref,
+    const LpNameSet& /*required*/) {
+  const auto* recursionName = toName(ref.name());
+  VELOX_USER_CHECK(
+      activeFixedPoint_.has_value(),
+      "RecursiveReferenceNode outside any enclosing FixedPoint: {}",
+      ref.name());
+  auto& enclosing = *activeFixedPoint_;
+  VELOX_USER_CHECK_EQ(
+      enclosing.stateName,
+      recursionName,
+      "RecursiveReferenceNode name does not match enclosing FixedPoint");
+  ++enclosing.numReferences;
+
+  const auto& schema = ref.outputType();
+  VELOX_CHECK_EQ(
+      schema->size(),
+      enclosing.stateColumns.size(),
+      "RecursiveReference schema size mismatches enclosing FixedPoint anchor");
+
+  // Scope names come from the reference schema, while the working table's
+  // columns come from the enclosing state.
+  Scope newScope;
+  for (size_t i = 0; i < schema->size(); ++i) {
+    ColumnCP column = enclosing.stateColumns[i];
+    const auto& refType = schema->childAt(static_cast<uint32_t>(i));
+    VELOX_USER_CHECK(
+        refType->equivalent(*column->value().type),
+        "RecursiveReference column {} type does not match enclosing FixedPoint anchor: ref={}, anchor={}",
+        i,
+        refType->toString(),
+        column->value().type->toString());
+    newScope[schema->nameOf(static_cast<uint32_t>(i))] = column;
+  }
+
+  return {makeWorkingTable(), std::move(newScope)};
+}
+
 Translated Translator::translateNode(
     const lp::LogicalPlanNode& node,
     const LpNameSet& required) {
@@ -749,6 +922,11 @@ Translated Translator::translateNode(
       return translateTableWrite(*node.as<lp::TableWriteNode>(), required);
     case lp::NodeKind::kOutput:
       VELOX_UNREACHABLE();
+    case lp::NodeKind::kFixedPoint:
+      return translateFixedPoint(*node.as<lp::FixedPointNode>(), required);
+    case lp::NodeKind::kRecursiveReference:
+      return translateRecursiveRef(
+          *node.as<lp::RecursiveReferenceNode>(), required);
     default:
       VELOX_NYI(
           "Unsupported logical plan node kind: {}",

--- a/axiom/optimizer/v2/docs/FixedPoint.md
+++ b/axiom/optimizer/v2/docs/FixedPoint.md
@@ -1,0 +1,293 @@
+# Fixed Point
+
+*How a recursive query becomes a Velox plan: the `FixedPoint` / `WorkingTable`
+IR nodes, the invariants each pass must preserve, and what is deliberately
+rejected.*
+
+**Status: planning and lowering only.** This machinery produces a Velox plan for
+a recursive query; it does not run one yet. Distributed recursion, nested
+recursion, multiple recursive references per step, and multiple fixed points per
+execution fragment are rejected — see [Boundaries](#boundaries).
+
+## Introduction
+
+Most SQL queries have linear logical chains: data flows from input sources to
+output results. Iterative and recursive logic is historically uncommon, but
+matters for newer workloads like graph and vector search.
+
+A **fixed point** operator is a customizable for-loop:
+
+```
+delta = anchor();
+result = delta;
+while (!convergence(delta)) {
+  delta = step(delta);
+  result += delta;
+}
+```
+
+Reaching `maxIterations` without `convergence` holding is an error, not a
+partial answer — see invariant 6.
+
+Three components describe it:
+
+- **`anchor()`** — initializes the set.
+- **`step(delta)`** — the loop body.
+- **`convergence(delta)`** — decides when to terminate.
+
+In practice a **recursion limit** bounds the loop, and further simplifying
+assumptions apply — notably **append-only results**. Several are expandable;
+see [Invariants](#invariants).
+
+The problems this shape solves:
+
+| Surface syntax | Underlying computation |
+| --- | --- |
+| SQL `WITH RECURSIVE` | anchor + step, converge on empty delta |
+| Cypher `-[:R*1..n]->` / SQL/PGQ `MATCH` | fixed point over the edge relation, bounded iterations |
+| Reachability / transitive closure | fixed point, UNION ALL step |
+| Shortest path, connected components, PageRank | *general* fixed point (aggregation-in-step, custom convergence) |
+
+Only the first row is supported today. Recursive CTEs are the narrow SQL entry
+point; `LogicalPlan` is the dialect-agnostic input, so a fixed point is also
+constructible directly through `PlanBuilder::fixedPoint`. Cypher is the intended
+next surface: variable-length patterns are currently planned by inline-expanding
+UNIONs for a fixed hop count (see
+[UnionAllPlanning.md](../../docs/UnionAllPlanning.md)), and a fixed point
+replaces that unrolling.
+
+## End-to-end mapping
+
+A counter query:
+
+```sql
+WITH RECURSIVE counter(n) AS (
+  SELECT 1                                -- anchor
+  UNION ALL
+  SELECT n + 1 FROM counter WHERE n < 10  -- step
+)
+SELECT * FROM counter;
+```
+
+It maps directly onto the loop above: the anchor is `SELECT 1`, the step is
+`SELECT n + 1 WHERE n < 10`, convergence is `count(*) == 0` over the latest
+delta, and the result is `{1, 2, … 10}`.
+
+### 1. Logical plan
+
+The self-reference is a `RecursiveReferenceNode`. There is no convergence branch
+and no working table yet — Translate introduces both.
+
+```
+- Project                                  (SELECT *)   -> n:INTEGER
+  - FixedPoint[name=counter]                             -> n:INTEGER
+    anchor:
+    - Values (1)                                         -> n:INTEGER
+    step:
+    - Project n + 1
+      - Filter n < 10
+        - RecursiveReference[counter]                    -> n:INTEGER
+```
+
+### 2. Optimizer v2 IR
+
+The IR tracks internal details that change over time. The default empty-delta
+convergence is expanded into a real subtree so it is optimized like any other
+plan.
+
+```
+- FixedPoint[name=counter, maxIterations=1000, recursiveNumDrivers=unplanned] -> c01:INTEGER
+  anchor:
+  - Values -> c01:INTEGER
+  step:
+  - Project -> expr2:INTEGER
+    expr2 := plus(c01, 1)
+    - Filter -> c01:INTEGER
+      predicate: lt(c01, 10)
+      - WorkingTable[name=counter, readMode=latestDelta] -> c01:INTEGER
+  convergence:
+  - Project -> converged4:BOOLEAN
+    converged4 := eq(__converged_count3, 0)
+    - Aggregate -> __converged_count3:BIGINT
+      aggregates: count()
+      - WorkingTable[name=counter, readMode=latestDelta] -> c01:INTEGER
+```
+
+### 3. Velox plan
+
+The delta / working-table representation becomes a state that outlives
+iterations and is seeded from the anchor.
+
+```
+- ProjectNode                                        (SELECT *)
+  - FixedPointNode[state=counter, maxIterations=1000]
+      stateDeclarations:
+        VectorStateDeclaration[counter, append=true]:
+          - ValuesNode                               (VALUES 1)   <- seeds state
+      plans (step):
+        - ProjectNode  n + 1
+          - FilterNode  n < 10
+            - StateSourceNode[counter, delta=true]                <- latest delta
+      convergence (ConvergenceConfig):
+        - ProjectNode  eq(count, 0) -> converged
+          - AggregationNode  count()
+            - StateSourceNode[counter, delta=true]                <- latest delta
+```
+
+### Cross-layer correspondence
+
+| Logical plan | Optimizer v2 IR | Velox plan |
+| --- | --- | --- |
+| `RecursiveReferenceNode[counter]` | `WorkingTable[counter, latestDelta]` | `StateSourceNode(counter, delta=true)` |
+| anchor branch | anchor branch | `VectorStateDeclaration(counter, append=true)` |
+| — (synthesized in Translate) | `convergence:` `Aggregate count()` -> `Project eq(count, 0)` | `ConvergenceConfig.plan`: `AggregationNode(count)` -> `ProjectNode(count == 0)` |
+
+`WorkingTableReadMode` also has an `kAccumulated` mode, which emits
+`delta=false` — a read of the whole state rather than the last iteration's
+output. Translate never produces it today; it exists for step shapes that need
+the full result set.
+
+## Invariants
+
+Each item below is one `VELOX_CHECK` in the `FixedPoint` or `WorkingTable`
+constructor. Stated up front so they can be checked against rather than
+inferred. Policies that other passes impose, rather than the constructor, are
+listed separately after the list.
+
+1. **Named state.** A `FixedPoint`'s name is non-null, and a `WorkingTable`
+   references its fixed point by that name: the constructor rejects a branch that
+   reads any state other than the one this fixed point binds. An orphan recursive
+   reference with no enclosing fixed point is rejected in Translate.
+
+2. **Each branch reads the state it should, with the state's own columns.** The
+   anchor must read no recursive state at all; the step and convergence must each
+   read exactly this fixed point's state, with columns pointer-identical to the
+   fixed-point output. `Node::requiredStates()` carries, per node, the recursive
+   states that subtree needs an enclosing `FixedPoint` to provide, each mapped to
+   the columns its reads present: the union of its inputs' entries, where a
+   `WorkingTable` requires the state it reads and a `FixedPoint` satisfies the
+   one it binds. The map is empty for a self-contained subtree, and the
+   constructor checks presence *and* column identity with one lookup per branch
+   instead of searching three subtrees. Two reads of one state that disagree on
+   columns are rejected where they meet. `Builder::make` primes the map once per
+   node, so a shared subplan is walked once.
+
+3. **Schema equivalence, not name equality.** Anchor and step output types must
+   be equivalent in types and positions, not identical column ids. The step's
+   final projection may allocate fresh canonical ids from the shared
+   `NameAllocator`, so an identity check would spuriously fail.
+
+4. **Column-pointer identity is shared.** The anchor, the working table, and the
+   fixed-point output refer to the same `Column*` objects for the recursive
+   state, which invariant 2 enforces. It is also why output pruning is deferred:
+   dropping or renaming a fixed-point output column would break the identity the
+   step relies on. Pruning the state is possible, but only as one coordinated
+   rewrite of the output, all three branches, and every `WorkingTable` — see the
+   TODO in `TranslatePass::translateFixedPoint`.
+
+5. **One BOOLEAN convergence column.** The convergence plan must produce exactly
+   one BOOLEAN column. Any single-column BOOLEAN subtree that reads the state is
+   accepted; the constructor does not check how that boolean is computed.
+
+6. **Bounded.** `maxIterations >= 1`. A SQL recursive CTE carries no depth hint of
+   its own, so it inherits the session `recursion_limit` (default 1000) as a
+   safety cap; a shape with its own bound — a `1..5` hop pattern — sets
+   `maxIterations` per node instead. Emit builds the `ConvergenceConfig` with
+   `ConvergenceConfig::converging`, which sets
+   `errorWhenMaxIterationReached`, so a query that has not converged within the
+   bound fails rather than returning a partial answer.
+
+### Policies the passes impose
+
+These hold for every plan the optimizer produces today, but no constructor check
+enforces them — a hand-built node may violate them.
+
+- **Append-only state.** The loop only adds rows; Emit declares the state
+  `append`.
+- **Convergence is an empty delta.** Translate synthesizes `count(*) == 0` over
+  the latest delta as the convergence plan. Invariant 5 admits any one-column
+  BOOLEAN shape, so a future step could supply its own predicate.
+
+## Per-pass changes
+
+- **Translate** — lowers a recursive CTE into `FixedPoint(anchor, step,
+  convergence)` and synthesizes the convergence plan.
+  `translateRecursiveRef` binds each `RecursiveReferenceNode` to the anchor's
+  `Column*`s and emits a latest-delta `WorkingTable`.
+
+- **PrecomputeProjections** — `rewriteFixedPoint` restores each branch's schema
+  after projection precompute, so the anchor and step keep presenting equivalent
+  output (invariant 3).
+
+- **PushdownAndPrune** — an outer filter is not pushed into the anchor, and the
+  anchor and step keep `nonNullColumns` empty; otherwise `demoteOuterToInner`
+  could drop null-padded seed rows whose step descendants become non-null via
+  `coalesce`. Output pruning is deferred to preserve column identity
+  (invariant 4).
+
+- **LimitAndOrder** — `FixedPoint` and `WorkingTable` are limit barriers. An
+  outer `LIMIT` or ordering cannot be pushed across the loop boundary.
+
+- **EstimateLeafStats** — `FixedPoint` and `WorkingTable` report unknown
+  cardinality. Convergence depth and per-iteration frontier size are
+  workload-dependent, and a single-pass sum would understate them and skew join
+  placement, so a dependent join cluster is left uncostable and falls back to its
+  written join shape at that boundary.
+
+- **PlanPhysical** — plans the step and convergence with a nested rewriter
+  pinned to one worker and one driver, and records the result as
+  `recursiveNumDrivers`.
+
+- **Emit** — transcribes the convergence branch already present in the IR into a
+  Velox `ConvergenceConfig`; nothing about *when* to stop is decided at emit. The
+  step and convergence are emitted single-driver by swapping `numDrivers` in the
+  emitter's options copy for the duration of the recursive subtree, so the
+  surrounding query keeps its own parallelism. Restoring parallelism *inside* the
+  loop is intended but not shipped.
+
+## Boundaries
+
+Each of these is rejected with a specific error rather than mis-planned.
+
+- **Multiple recursive references per step (non-linear recursion).** A step with
+  two references would compute `delta ⋈ delta`. The SQL standard and PostgreSQL
+  reject a recursive reference appearing more than once; DuckDB evaluates
+  `(delta, delta)`. Semi-naive evaluation assumes a single linear reference, so
+  both the semantics and the delta-iteration strategy are undecided. Because v2
+  consumes a logical plan directly rather than only SQL, a two-reference step is
+  constructible via `PlanBuilder`, so the rejection lives in the translator, not
+  only in the SQL parser.
+
+- **Distributed recursion (`numWorkers > 1`).** The working-table state is shared
+  and mutated across iterations, and the step and convergence run single-driver.
+  Distributing needs coordinated cross-worker state and a distributed
+  convergence test. Emit raises `VELOX_NYI` for any query containing a fixed
+  point at `numWorkers > 1`.
+
+- **Nested recursion and multiple fixed points per fragment.** Two enforcement
+  points, not a missing capability: Translate rejects a nested fixed point
+  because `activeFixedPoint_` tracks a single enclosing loop, and Emit's
+  `validateFixedPointLeaves` raises `VELOX_NYI` when more than one
+  `FixedPointNode` appears in *leaf position* within one fragment. Per-loop
+  identity is not the blocker — the interned state `Name` already distinguishes
+  loops end to end, through `WorkingTable`, `FixedPoint`, `RequiredStates`, and
+  the emitted `StateSourceNode` and `VectorStateDeclaration`. Sibling fixed
+  points that are not both fragment leaves already plan today, as
+  `FixedPointTest.siblingRecursions` shows.
+
+## Tests
+
+- `optimizer/tests/FixedPointTest.cpp` — SQL-level and `PlanBuilder`-level plan
+  assertions via `PlanMatcher`, including every rejection above.
+  `FixedPointMatch` describes the parts of a `FixedPointNode` to check: the
+  output state and its initial plan, each per-iteration plan, and the
+  convergence shape and iteration bound.
+- `optimizer/v2/tests/NodePrinterTest.cpp` — the IR printer's rendering of a
+  fixed point, built directly through `Builder`.
+
+## References
+
+- D111499361 — [Axiom] feat(optimizer/v2): Plan and lower WITH RECURSIVE queries
+- Workplace post: [*Velox and Axiom for graph queries: a primer*](https://fb.workplace.com/groups/1588734491493342/permalink/2823843241315788/) — motivates the
+  CQL roadmap and introduces recursive CTEs, variable-length patterns, and
+  fixpoint operators.

--- a/axiom/optimizer/v2/tests/CMakeLists.txt
+++ b/axiom/optimizer/v2/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   axiom_optimizer_v2_test
   AlgebraicPropertiesTest.cpp
   JoinHypergraphTest.cpp
+  NodePrinterTest.cpp
   RelationSetTest.cpp
   TpchPlanTest.cpp
   TpchResultTest.cpp

--- a/axiom/optimizer/v2/tests/CMakeLists.txt
+++ b/axiom/optimizer/v2/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   axiom_optimizer_v2_test
   AlgebraicPropertiesTest.cpp
   JoinHypergraphTest.cpp
+  NodePrinterTest.cpp
   RelationSetTest.cpp
   TpchPlanTest.cpp
 )
@@ -34,5 +35,6 @@ target_link_libraries(
   axiom_optimizer_tests_plan_matcher
   axiom_optimizer_tests_tpch_queries
   velox_exec_test_lib
+  GTest::gmock
   GTest::gtest
 )

--- a/axiom/optimizer/v2/tests/NodePrinterTest.cpp
+++ b/axiom/optimizer/v2/tests/NodePrinterTest.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "axiom/optimizer/v2/Node.h"
+#include "axiom/optimizer/v2/tests/UnitTestBase.h"
+
+namespace facebook::axiom::optimizer::v2::test {
+namespace {
+
+using ::testing::HasSubstr;
+
+class NodePrinterTest : public UnitTestBase {};
+
+// WorkingTable prints its `name` and outputs but has no inputs.
+TEST_F(NodePrinterTest, workingTable) {
+  optimizer::ColumnVector cols{makeColumn("n", velox::BIGINT())};
+  NodeCP wt = builder_->make<WorkingTable>({toName("counter"), cols});
+
+  const std::string out = wt->toString();
+  EXPECT_THAT(out, HasSubstr("- WorkingTable[name=counter]"));
+  EXPECT_THAT(out, HasSubstr(":BIGINT"));
+}
+
+// FixedPoint prints its `name`, anchor sub-plan, and step sub-plan.
+TEST_F(NodePrinterTest, fixedPoint) {
+  optimizer::ColumnVector cols{makeColumn("n", velox::BIGINT())};
+  NodeCP anchor = builder_->makeEmptyValues(cols);
+  NodeCP step = builder_->make<WorkingTable>({toName("counter"), cols});
+  NodeCP fp = builder_->make<FixedPoint>(
+      {anchor, step, toName("counter"), std::move(cols)});
+
+  const std::string out = fp->toString();
+  EXPECT_THAT(out, HasSubstr("- FixedPoint[name=counter]"));
+  EXPECT_THAT(out, HasSubstr("anchor:"));
+  EXPECT_THAT(out, HasSubstr("- Values"));
+  EXPECT_THAT(out, HasSubstr("step:"));
+  EXPECT_THAT(out, HasSubstr("- WorkingTable[name=counter]"));
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer::v2::test

--- a/axiom/optimizer/v2/tests/NodePrinterTest.cpp
+++ b/axiom/optimizer/v2/tests/NodePrinterTest.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/String.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/SchemaResolver.h"
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/ConstantFold.h"
+#include "axiom/optimizer/FunctionRegistry.h"
+#include "axiom/optimizer/OptimizerSession.h"
+#include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/Node.h"
+#include "axiom/optimizer/v2/TranslatePass.h"
+#include "axiom/optimizer/v2/tests/UnitTestBase.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/expression/Expr.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+namespace facebook::axiom::optimizer::v2::test {
+namespace {
+
+namespace lp = facebook::axiom::logical_plan;
+
+using testing::ElementsAre;
+using testing::Eq;
+using testing::HasSubstr;
+using testing::StartsWith;
+
+class NodePrinterTest : public UnitTestBase {
+ protected:
+  static constexpr int32_t kMaxIterations = 10;
+
+  static void SetUpTestCase() {
+    velox::functions::prestosql::registerAllScalarFunctions();
+    optimizer::FunctionRegistry::registerPrestoFunctions();
+  }
+
+  void SetUp() override {
+    UnitTestBase::SetUp();
+    veloxQueryCtx_ = velox::core::QueryCtx::create();
+    evaluator_ = std::make_unique<velox::exec::SimpleExpressionEvaluator>(
+        veloxQueryCtx_.get(), pool_.get());
+    optimizer::OptimizerOptions options;
+    options.recursionLimit = kMaxIterations;
+    session_ = std::make_shared<optimizer::OptimizerSession>(
+        veloxQueryCtx_->queryId(),
+        "test",
+        options,
+        connector::ConnectorProperties{});
+    schemaResolver_ = std::make_unique<connector::SchemaResolver>(
+        connector::ConnectorMetadataRegistry::global());
+    schema_ = std::make_unique<optimizer::Schema>(*schemaResolver_);
+  }
+
+  NodeCP translate(const lp::LogicalPlanNodePtr& plan) {
+    optimizer::ConstantPlanRunner constantPlanRunner{veloxQueryCtx_};
+    return TranslatePass::run(
+               *plan,
+               *schema_,
+               *evaluator_,
+               *builder_,
+               *session_,
+               constantPlanRunner)
+        .root;
+  }
+
+  std::vector<std::string> toLines(NodeCP node) {
+    std::vector<std::string> lines;
+    folly::split('\n', node->toString(), lines);
+    return lines;
+  }
+
+  lp::PlanBuilder singleRow(const std::string& name, int64_t value) {
+    return lp::PlanBuilder(context_).values(
+        ROW(name, velox::BIGINT()),
+        std::vector<velox::Variant>{velox::Variant::row({value})});
+  }
+
+  lp::PlanBuilder::Context context_;
+  std::shared_ptr<velox::core::QueryCtx> veloxQueryCtx_;
+  std::unique_ptr<velox::exec::SimpleExpressionEvaluator> evaluator_;
+  std::shared_ptr<optimizer::OptimizerSession> session_;
+  std::unique_ptr<connector::SchemaResolver> schemaResolver_;
+  std::unique_ptr<optimizer::Schema> schema_;
+};
+
+TEST_F(NodePrinterTest, fixedPoint) {
+  auto anchor = singleRow("n", 1);
+  auto step = lp::PlanBuilder(context_)
+                  .recursiveRef("counter", anchor)
+                  .filter("n < 10")
+                  .project({"n + 1"})
+                  .planNode();
+  auto plan = anchor.fixedPoint("counter", step).build();
+
+  // Names carry NameAllocator ids, so assert structure and drop the tail.
+  EXPECT_THAT(
+      toLines(translate(plan)),
+      ElementsAre(
+          StartsWith(
+              "- FixedPoint[name=counter, maxIterations=10, recursiveNumDrivers=unplanned] ->"),
+          Eq("  anchor:"),
+          StartsWith("  - Values ->"),
+          Eq("  step:"),
+          StartsWith("  - Project ->"),
+          HasSubstr(":= plus("),
+          StartsWith("    - Filter ->"),
+          StartsWith("      predicate: lt("),
+          StartsWith(
+              "      - WorkingTable[name=counter, readMode=latestDelta] ->"),
+          Eq("  convergence:"),
+          StartsWith("  - Project ->"),
+          HasSubstr(":= eq("),
+          StartsWith("    - Aggregate ->"),
+          Eq("      aggregates: count()"),
+          StartsWith(
+              "      - WorkingTable[name=counter, readMode=latestDelta] ->"),
+          Eq("")));
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer::v2::test


### PR DESCRIPTION
Summary:

Optimizer v2 can now plan recursive CTEs such as:

```
WITH RECURSIVE counter(n) AS (
  VALUES 1
  UNION ALL
  SELECT n + 1 FROM counter WHERE n < 10
)
SELECT * FROM counter;
```

This adds `FixedPoint` and `WorkingTable` IR nodes. Translation lowers a recursive CTE into anchor and step branches plus an empty-delta convergence plan represented as ordinary `Aggregate` and `Project` IR. Keeping convergence in IR lets optimizer passes preserve and inspect it instead of synthesizing a hidden plan during emission. Each fixed point carries its own iteration bound; SQL recursive CTEs use the session `recursion_limit` as a safety cap.

Physical planning and emission keep the recursive step and convergence single-worker and single-driver, then restore the surrounding query's parallelism. The change supports planning and lowering only; recursive execution is not ready. Distributed recursion, nested recursion, multiple recursive references per step, and multiple fixed points per execution fragment remain unsupported. Fixed-point output pruning is deferred to preserve recursive-state column identity.

Reviewed By: mbasmanova

Differential Revision: D111499361


