### PR TITLE
refactor(optimizer): Isolate optimizer sub-runner runtime stats

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -49,12 +49,15 @@
 #include "axiom/optimizer/DerivedTablePrinter.h"
 #include "axiom/optimizer/ExplainIo.h"
 #include "axiom/optimizer/Optimization.h"
+#include "axiom/optimizer/OptimizerMetrics.h"
 #include "axiom/optimizer/OptimizerOptions.h"
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/RelationOpPrinter.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/optimizer/v2/Optimize.h"
 #include "axiom/runner/ProgressReporter.h"
+#include "axiom/runner/RunnerMetrics.h"
+#include "axiom/sql/presto/ParserMetrics.h"
 #include "axiom/sql/presto/PrestoParser.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/ShowStatsBuilder.h"
@@ -80,17 +83,16 @@ using connector::ConnectorMetadataRegistry;
 
 namespace {
 
-// Times a phase: writes wall-clock micros to 'wallMicros', and if
-// 'runtimeStats' is non-null, also records wall and CPU durations under the
-// given keys.
+// Times a phase: writes wall-clock micros to 'wallMicros' and records wall and
+// CPU durations into 'sink' under the given keys.
 class PhaseTimer {
  public:
   PhaseTimer(
       uint64_t& wallMicros,
-      QueryRuntimeStats* runtimeStats,
+      RuntimeStatsSink sink,
       std::string_view wallKey,
       std::string_view cpuKey)
-      : runtimeStats_(runtimeStats),
+      : sink_(std::move(sink)),
         wallKey_(wallKey),
         cpuKey_(cpuKey),
         wallMicros_(wallMicros),
@@ -101,12 +103,9 @@ class PhaseTimer {
     // Destroy the wall timer first so wallMicros_ is finalized before we
     // read it below.
     timer_.reset();
-    if (runtimeStats_ != nullptr) {
-      const auto cpuNanos = velox::process::threadCpuNanos() - cpuStartNanos_;
-      runtimeStats_->recordTiming(
-          wallKey_, std::chrono::microseconds(wallMicros_));
-      runtimeStats_->recordTiming(cpuKey_, std::chrono::nanoseconds(cpuNanos));
-    }
+    const auto cpuNanos = velox::process::threadCpuNanos() - cpuStartNanos_;
+    sink_.recordTiming(wallKey_, std::chrono::microseconds(wallMicros_));
+    sink_.recordTiming(cpuKey_, std::chrono::nanoseconds(cpuNanos));
   }
 
   PhaseTimer(const PhaseTimer&) = delete;
@@ -115,7 +114,7 @@ class PhaseTimer {
   PhaseTimer& operator=(PhaseTimer&&) = delete;
 
  private:
-  QueryRuntimeStats* const runtimeStats_;
+  RuntimeStatsSink sink_;
   const std::string_view wallKey_;
   const std::string_view cpuKey_;
   uint64_t& wallMicros_;
@@ -366,6 +365,7 @@ void onComplete(
 connector::TablePtr SqlQueryRunner::createTable(
     std::string_view queryId,
     const presto::CreateTableStatement& statement,
+    const std::shared_ptr<QueryRuntimeStats>& runtimeStats,
     bool explain) {
   auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
 
@@ -375,7 +375,8 @@ connector::TablePtr SqlQueryRunner::createTable(
         optimizer::ConstantExprEvaluator::evaluateConstantExpr(*value);
   }
 
-  auto session = makeConnectorSession(queryId, statement.connectorId());
+  auto session =
+      makeConnectorSession(queryId, statement.connectorId(), runtimeStats);
   auto table = metadata->createTable(
       session,
       statement.tableName(),
@@ -421,6 +422,7 @@ connector::TablePtr SqlQueryRunner::createTable(
 connector::TablePtr SqlQueryRunner::createTable(
     std::string_view queryId,
     const presto::CreateTableAsSelectStatement& statement,
+    const std::shared_ptr<QueryRuntimeStats>& runtimeStats,
     bool explain) {
   auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
 
@@ -431,7 +433,7 @@ connector::TablePtr SqlQueryRunner::createTable(
   }
 
   auto table = metadata->createTable(
-      makeConnectorSession(queryId, statement.connectorId()),
+      makeConnectorSession(queryId, statement.connectorId(), runtimeStats),
       statement.tableName(),
       statement.tableSchema(),
       options,
@@ -443,13 +445,14 @@ connector::TablePtr SqlQueryRunner::createTable(
 
 std::string SqlQueryRunner::dropTable(
     std::string_view queryId,
-    const presto::DropTableStatement& statement) {
+    const presto::DropTableStatement& statement,
+    const std::shared_ptr<QueryRuntimeStats>& runtimeStats) {
   auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
 
   const auto& tableName = statement.tableName();
 
   const bool dropped = metadata->dropTable(
-      makeConnectorSession(queryId, statement.connectorId()),
+      makeConnectorSession(queryId, statement.connectorId(), runtimeStats),
       statement.tableName(),
       statement.ifExists(),
       /*explain=*/false);
@@ -463,7 +466,8 @@ std::string SqlQueryRunner::dropTable(
 
 folly::coro::Task<std::string> SqlQueryRunner::co_call(
     std::string_view queryId,
-    const presto::CallStatement& statement) {
+    const presto::CallStatement& statement,
+    const std::shared_ptr<QueryRuntimeStats>& runtimeStats) {
   // Fold each bound argument expression to a value.
   std::vector<velox::Variant> boundArguments;
   boundArguments.reserve(statement.arguments().size());
@@ -477,7 +481,8 @@ folly::coro::Task<std::string> SqlQueryRunner::co_call(
   // outlive the awaited task; hold them in named locals rather than awaiting a
   // temporary.
   auto procedure = statement.procedure();
-  auto session = makeConnectorSession(queryId, statement.connectorId());
+  auto session =
+      makeConnectorSession(queryId, statement.connectorId(), runtimeStats);
   auto task = procedure->execute(session, boundArguments);
   co_await std::move(task);
   co_return "CALL";
@@ -486,11 +491,12 @@ folly::coro::Task<std::string> SqlQueryRunner::co_call(
 std::string SqlQueryRunner::addColumn(
     std::string_view queryId,
     const presto::AddColumnStatement& statement,
+    const std::shared_ptr<QueryRuntimeStats>& runtimeStats,
     bool explain) {
   auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
 
   auto result = metadata->addColumn(
-      makeConnectorSession(queryId, statement.connectorId()),
+      makeConnectorSession(queryId, statement.connectorId(), runtimeStats),
       statement.tableName(),
       statement.columnName(),
       statement.columnType(),
@@ -516,7 +522,8 @@ std::string SqlQueryRunner::addColumn(
 
 std::string SqlQueryRunner::createSchema(
     std::string_view queryId,
-    const presto::CreateSchemaStatement& statement) {
+    const presto::CreateSchemaStatement& statement,
+    const std::shared_ptr<QueryRuntimeStats>& runtimeStats) {
   auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
 
   folly::F14FastMap<std::string, velox::Variant> properties;
@@ -526,7 +533,7 @@ std::string SqlQueryRunner::createSchema(
   }
 
   metadata->createSchema(
-      makeConnectorSession(queryId, statement.connectorId()),
+      makeConnectorSession(queryId, statement.connectorId(), runtimeStats),
       statement.schemaName(),
       statement.ifNotExists(),
       properties);
@@ -535,10 +542,11 @@ std::string SqlQueryRunner::createSchema(
 
 std::string SqlQueryRunner::dropSchema(
     std::string_view queryId,
-    const presto::DropSchemaStatement& statement) {
+    const presto::DropSchemaStatement& statement,
+    const std::shared_ptr<QueryRuntimeStats>& runtimeStats) {
   auto metadata = ConnectorMetadataRegistry::get(statement.connectorId());
   metadata->dropSchema(
-      makeConnectorSession(queryId, statement.connectorId()),
+      makeConnectorSession(queryId, statement.connectorId(), runtimeStats),
       statement.schemaName(),
       statement.ifExists());
   return fmt::format("Dropped schema: {}", statement.schemaName());
@@ -617,18 +625,22 @@ SqlQueryRunner::co_run(std::string sql, RunOptions options) {
     {
       auto cpuStart = velox::process::threadCpuNanos();
       velox::MicrosecondTimer parseTimer(&completionInfo.timing.parse);
-      statement = parseSingle(sql, runOptions);
+      statement = parseSingle(sql, runOptions, completionInfo.runtimeStats);
       parseCpuNanos = velox::process::threadCpuNanos() - cpuStart;
     }
     completionInfo.startInfo.queryType = statement->kind();
     completionInfo.referencedTables = statement->referencedTables();
-    completionInfo.runtimeStats->recordTiming(
-        QueryRuntimeStats::kParseWallNanos,
+    auto parseSink = completionInfo.runtimeStats->sinkFor(
+        ::axiom::sql::presto::kStatsComponent);
+    parseSink.recordTiming(
+        ::axiom::sql::presto::kParseWallNanos,
         std::chrono::microseconds(completionInfo.timing.parse));
-    completionInfo.runtimeStats->recordTiming(
-        QueryRuntimeStats::kParseCpuNanos,
+    parseSink.recordTiming(
+        ::axiom::sql::presto::kParseCpuNanos,
         std::chrono::nanoseconds(parseCpuNanos));
 
+    auto runnerSink = completionInfo.runtimeStats->sinkFor(
+        facebook::axiom::runner::kStatsComponent);
     {
       auto permissionCpuStart = velox::process::threadCpuNanos();
       runOptions.tokenProvider = checkPermission(
@@ -636,13 +648,13 @@ SqlQueryRunner::co_run(std::string sql, RunOptions options) {
           completionInfo,
           statement->views(),
           statement->referencedTables());
-      completionInfo.runtimeStats->recordTiming(
-          QueryRuntimeStats::kPermissionCheckCpuNanos,
+      runnerSink.recordTiming(
+          facebook::axiom::runner::kPermissionCheckCpuNanos,
           std::chrono::nanoseconds(
               velox::process::threadCpuNanos() - permissionCpuStart));
     }
-    completionInfo.runtimeStats->recordTiming(
-        QueryRuntimeStats::kPermissionCheckWallNanos,
+    runnerSink.recordTiming(
+        facebook::axiom::runner::kPermissionCheckWallNanos,
         std::chrono::microseconds(completionInfo.timing.checkPermission));
 
     auto generator = co_runUnchecked(
@@ -699,12 +711,20 @@ std::string SqlQueryRunner::toQueryGraphDot(std::string_view sql) {
 
   std::string dotOutput;
   RunOptions options;
-  optimize(logicalPlan, newQuery(options), options, [&](const auto& dt) {
-    std::ostringstream out;
-    graphviz::DerivedTableDotPrinter::print(dt, out);
-    dotOutput = out.str();
-    return false; // Stop optimization.
-  });
+  optimize(
+      logicalPlan,
+      newQuery(options),
+      options,
+      [&](const auto& dt) {
+        std::ostringstream out;
+        graphviz::DerivedTableDotPrinter::print(dt, out);
+        dotOutput = out.str();
+        return false; // Stop optimization.
+      },
+      /*checkBestPlan=*/nullptr,
+      /*schemaResolver=*/nullptr,
+      /*explain=*/false,
+      std::make_shared<QueryRuntimeStats>());
   return dotOutput;
 }
 
@@ -726,7 +746,15 @@ std::string SqlQueryRunner::toMultiFragmentPlanDot(
   options.numWorkers = numWorkers;
   options.numDrivers = numDrivers;
   auto queryCtx = newQuery(options);
-  auto planAndStats = optimize(logicalPlan, queryCtx, options);
+  auto planAndStats = optimize(
+      logicalPlan,
+      queryCtx,
+      options,
+      /*checkDerivedTable=*/nullptr,
+      /*checkBestPlan=*/nullptr,
+      /*schemaResolver=*/nullptr,
+      /*explain=*/false,
+      std::make_shared<QueryRuntimeStats>());
   VELOX_CHECK_NOT_NULL(planAndStats.plan);
 
   std::ostringstream out;
@@ -738,7 +766,9 @@ std::string SqlQueryRunner::toMultiFragmentPlanDot(
 logical_plan::LogicalPlanNodePtr SqlQueryRunner::toLogicalPlan(
     std::string_view sql) {
   RunOptions options;
-  auto statements = parseMultiple(sql, options);
+  // Plan-printing tooling discards connector-metadata metrics.
+  auto statements =
+      parseMultiple(sql, options, std::make_shared<QueryRuntimeStats>());
   VELOX_CHECK_EQ(statements.size(), 1, "Expected a single SELECT statement.");
 
   auto statement = statements[0];
@@ -761,7 +791,8 @@ std::vector<std::string_view> SqlQueryRunner::splitStatements(
 
 std::vector<presto::SqlStatementPtr> SqlQueryRunner::parseMultiple(
     std::string_view sql,
-    const RunOptions& options) {
+    const RunOptions& options,
+    const std::shared_ptr<QueryRuntimeStats>& runtimeStats) {
   const std::string& defaultConnectorId =
       options.defaultConnectorId.value_or(defaultConnectorId_);
   const auto& defaultSchema = options.defaultSchema.value_or(defaultSchema_);
@@ -771,7 +802,8 @@ std::vector<presto::SqlStatementPtr> SqlQueryRunner::parseMultiple(
       user_,
       presto::ParserOptions::from(
           sessionConfig_->effectiveValues(kParserPrefix)),
-      collectConnectorProperties(*sessionConfig_));
+      collectConnectorProperties(*sessionConfig_),
+      runtimeStats);
   auto prestoParser = std::make_unique<presto::PrestoParser>(
       defaultConnectorId, defaultSchema, std::move(parserSession));
   return prestoParser->parseMultiple(sql, /*enableTracing=*/options.debugMode);
@@ -779,8 +811,10 @@ std::vector<presto::SqlStatementPtr> SqlQueryRunner::parseMultiple(
 
 presto::SqlStatementPtr SqlQueryRunner::parseSingle(
     std::string_view sql,
-    const RunOptions& options) {
-  std::vector<presto::SqlStatementPtr> statements = parseMultiple(sql, options);
+    const RunOptions& options,
+    const std::shared_ptr<QueryRuntimeStats>& runtimeStats) {
+  std::vector<presto::SqlStatementPtr> statements =
+      parseMultiple(sql, options, runtimeStats);
   VELOX_USER_CHECK_EQ(
       statements.size(),
       1,
@@ -794,11 +828,16 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
     const RunOptions& options) {
   QueryTiming timing;
   std::string planString;
+  // No completion info to carry the metrics; discard them into a throwaway.
   return folly::coro::blockingWait(
       folly::coro::co_invoke([&]() -> folly::coro::Task<SqlResult> {
         SqlResult result;
-        auto generator =
-            co_runUnchecked(sqlStatement, options, timing, planString);
+        auto generator = co_runUnchecked(
+            sqlStatement,
+            options,
+            timing,
+            planString,
+            std::make_shared<QueryRuntimeStats>());
         while (auto chunk = co_await generator.next()) {
           if (chunk->message.has_value()) {
             result.message = std::move(chunk->message);
@@ -818,6 +857,7 @@ SqlQueryRunner::co_runUnchecked(
     QueryTiming& timing,
     std::string& planString,
     std::shared_ptr<QueryRuntimeStats> runtimeStats) {
+  VELOX_CHECK_NOT_NULL(runtimeStats);
   const std::string queryId = options.queryId.value_or(queryIdGenerator_());
   if (sqlStatement.isExplain()) {
     const auto* explain = sqlStatement.as<presto::ExplainStatement>();
@@ -837,15 +877,15 @@ SqlQueryRunner::co_runUnchecked(
 
       // EXPLAIN ANALYZE runs the query for real, so createTable must not
       // be in explain mode. Regular EXPLAIN must be side-effect-free.
-      auto table =
-          createTable(queryId, *ctas, /*explain=*/!explain->isAnalyze());
+      auto table = createTable(
+          queryId, *ctas, runtimeStats, /*explain=*/!explain->isAnalyze());
       schemaResolver = std::make_shared<connector::SchemaResolver>(
           connector::ConnectorMetadataRegistry::global());
       schemaResolver->setTargetTable(
           ctas->connectorId(), ctas->tableName(), table);
     } else if (statement->isCreateTable()) {
       const auto* create = statement->as<presto::CreateTableStatement>();
-      createTable(queryId, *create, /*explain=*/true);
+      createTable(queryId, *create, runtimeStats, /*explain=*/true);
       co_yield SqlResultChunk{fmt::format(
           "CREATE TABLE {}{}.{}",
           create->ifNotExists() ? "IF NOT EXISTS " : "",
@@ -870,7 +910,7 @@ SqlQueryRunner::co_runUnchecked(
       co_return;
     } else if (statement->isAddColumn()) {
       const auto* add = statement->as<presto::AddColumnStatement>();
-      addColumn(queryId, *add, /*explain=*/true);
+      addColumn(queryId, *add, runtimeStats, /*explain=*/true);
       co_yield SqlResultChunk{fmt::format(
           "ALTER TABLE {}{}.{} ADD COLUMN {}{} {}",
           add->ifTableExists() ? "IF EXISTS " : "",
@@ -932,7 +972,7 @@ SqlQueryRunner::co_runUnchecked(
 
   if (sqlStatement.isCreateTable()) {
     const auto* create = sqlStatement.as<presto::CreateTableStatement>();
-    auto table = createTable(queryId, *create);
+    auto table = createTable(queryId, *create, runtimeStats);
     if (!table) {
       co_yield SqlResultChunk{fmt::format(
           "Table already exists: {}.{}",
@@ -947,7 +987,7 @@ SqlQueryRunner::co_runUnchecked(
 
   if (sqlStatement.isCreateTableAsSelect()) {
     const auto* ctas = sqlStatement.as<presto::CreateTableAsSelectStatement>();
-    auto table = createTable(queryId, *ctas);
+    auto table = createTable(queryId, *ctas, runtimeStats);
 
     auto schema = std::make_shared<connector::SchemaResolver>(
         connector::ConnectorMetadataRegistry::global());
@@ -979,32 +1019,32 @@ SqlQueryRunner::co_runUnchecked(
   if (sqlStatement.isDropTable()) {
     const auto* drop = sqlStatement.as<presto::DropTableStatement>();
 
-    co_yield SqlResultChunk{dropTable(queryId, *drop)};
+    co_yield SqlResultChunk{dropTable(queryId, *drop, runtimeStats)};
     co_return;
   }
 
   if (sqlStatement.isAddColumn()) {
     const auto* add = sqlStatement.as<presto::AddColumnStatement>();
 
-    co_yield SqlResultChunk{addColumn(queryId, *add)};
+    co_yield SqlResultChunk{addColumn(queryId, *add, runtimeStats)};
     co_return;
   }
 
   if (sqlStatement.isCreateSchema()) {
     const auto* create = sqlStatement.as<presto::CreateSchemaStatement>();
-    co_yield SqlResultChunk{createSchema(queryId, *create)};
+    co_yield SqlResultChunk{createSchema(queryId, *create, runtimeStats)};
     co_return;
   }
 
   if (sqlStatement.isDropSchema()) {
     const auto* drop = sqlStatement.as<presto::DropSchemaStatement>();
-    co_yield SqlResultChunk{dropSchema(queryId, *drop)};
+    co_yield SqlResultChunk{dropSchema(queryId, *drop, runtimeStats)};
     co_return;
   }
 
   if (sqlStatement.isCall()) {
     const auto* call = sqlStatement.as<presto::CallStatement>();
-    co_yield SqlResultChunk{co_await co_call(queryId, *call)};
+    co_yield SqlResultChunk{co_await co_call(queryId, *call, runtimeStats)};
     co_return;
   }
 
@@ -1136,9 +1176,9 @@ std::string SqlQueryRunner::runExplainIo(
   auto queryCtx = newQuery(options);
   PhaseTimer phaseTimer(
       timing.optimize,
-      runtimeStats.get(),
-      QueryRuntimeStats::kOptimizeWallNanos,
-      QueryRuntimeStats::kOptimizeCpuNanos);
+      runtimeStats->sinkFor(facebook::axiom::optimizer::kStatsComponent),
+      facebook::axiom::optimizer::kOptimizeWallNanos,
+      facebook::axiom::optimizer::kOptimizeCpuNanos);
 
   if (useOptimizerV2_) {
     auto resolver = orDefaultSchemaResolver(schemaResolver);
@@ -1148,7 +1188,8 @@ std::string SqlQueryRunner::runExplainIo(
     auto session = makeOptimizerSession(
         queryCtx->queryId(),
         collectConnectorProperties(*sessionConfig_),
-        /*explain=*/true);
+        /*explain=*/true,
+        runtimeStats);
     optimizer::v2::Optimizer optimizer(
         *logicalPlan, *resolver, *session, evaluator, queryCtx);
     return optimizer.explainIo(std::move(outputTable));
@@ -1208,9 +1249,9 @@ std::string SqlQueryRunner::runExplain(
       {
         PhaseTimer phaseTimer(
             timing.optimize,
-            runtimeStats.get(),
-            QueryRuntimeStats::kOptimizeWallNanos,
-            QueryRuntimeStats::kOptimizeCpuNanos);
+            runtimeStats->sinkFor(facebook::axiom::optimizer::kStatsComponent),
+            facebook::axiom::optimizer::kOptimizeWallNanos,
+            facebook::axiom::optimizer::kOptimizeCpuNanos);
         optimize(
             logicalPlan,
             queryCtx,
@@ -1242,9 +1283,9 @@ std::string SqlQueryRunner::runExplain(
       {
         PhaseTimer phaseTimer(
             timing.optimize,
-            runtimeStats.get(),
-            QueryRuntimeStats::kOptimizeWallNanos,
-            QueryRuntimeStats::kOptimizeCpuNanos);
+            runtimeStats->sinkFor(facebook::axiom::optimizer::kStatsComponent),
+            facebook::axiom::optimizer::kOptimizeWallNanos,
+            facebook::axiom::optimizer::kOptimizeCpuNanos);
         optimize(
             logicalPlan,
             queryCtx,
@@ -1272,9 +1313,9 @@ std::string SqlQueryRunner::runExplain(
       {
         PhaseTimer phaseTimer(
             timing.optimize,
-            runtimeStats.get(),
-            QueryRuntimeStats::kOptimizeWallNanos,
-            QueryRuntimeStats::kOptimizeCpuNanos);
+            runtimeStats->sinkFor(facebook::axiom::optimizer::kStatsComponent),
+            facebook::axiom::optimizer::kOptimizeWallNanos,
+            facebook::axiom::optimizer::kOptimizeCpuNanos);
         planAndStats = optimize(
             logicalPlan,
             queryCtx,
@@ -1311,8 +1352,17 @@ SqlQueryRunner::executeSelectOrInsert(
   }
 
   auto queryCtx = newQuery(options);
-  auto planAndStats = optimize(logicalPlan, queryCtx, options);
-  return makeLocalRunner(planAndStats, queryCtx, options, noopRuntimeStats_);
+  auto runtimeStats = std::make_shared<QueryRuntimeStats>();
+  auto planAndStats = optimize(
+      logicalPlan,
+      queryCtx,
+      options,
+      /*checkDerivedTable=*/nullptr,
+      /*checkBestPlan=*/nullptr,
+      /*schemaResolver=*/nullptr,
+      /*explain=*/false,
+      runtimeStats);
+  return makeLocalRunner(planAndStats, queryCtx, options, runtimeStats);
 }
 
 namespace {
@@ -1437,11 +1487,14 @@ folly::coro::AsyncGenerator<velox::RowVectorPtr> co_drainQuery(
 
 connector::ConnectorSessionPtr SqlQueryRunner::makeConnectorSession(
     std::string_view queryId,
-    std::string_view connectorId) const {
+    std::string_view connectorId,
+    const std::shared_ptr<QueryRuntimeStats>& runtimeStats) const {
   return std::make_shared<connector::ConnectorSession>(
       std::string(queryId),
       user_,
-      sessionConfig_->effectiveValues(connectorId));
+      std::string(connectorId),
+      sessionConfig_->effectiveValues(connectorId),
+      runtimeStats);
 }
 
 std::unique_ptr<runner::ProgressReporter> SqlQueryRunner::startProgressReporter(
@@ -1474,9 +1527,9 @@ folly::coro::Task<std::string> SqlQueryRunner::co_runExplainAnalyze(
   {
     PhaseTimer phaseTimer(
         timing.optimize,
-        runtimeStats.get(),
-        QueryRuntimeStats::kOptimizeWallNanos,
-        QueryRuntimeStats::kOptimizeCpuNanos);
+        runtimeStats->sinkFor(facebook::axiom::optimizer::kStatsComponent),
+        facebook::axiom::optimizer::kOptimizeWallNanos,
+        facebook::axiom::optimizer::kOptimizeCpuNanos);
     planAndStats = optimize(
         logicalPlan,
         queryCtx,
@@ -1488,18 +1541,14 @@ folly::coro::Task<std::string> SqlQueryRunner::co_runExplainAnalyze(
         runtimeStats);
   }
 
-  auto runner = makeLocalRunner(
-      planAndStats,
-      queryCtx,
-      options,
-      runtimeStats ? *runtimeStats : noopRuntimeStats_);
+  auto runner = makeLocalRunner(planAndStats, queryCtx, options, runtimeStats);
 
   {
     PhaseTimer phaseTimer(
         timing.execute,
-        runtimeStats.get(),
-        QueryRuntimeStats::kExecuteWallNanos,
-        QueryRuntimeStats::kExecuteCpuNanos);
+        runtimeStats->sinkFor(facebook::axiom::runner::kStatsComponent),
+        facebook::axiom::runner::kExecuteWallNanos,
+        facebook::axiom::runner::kExecuteCpuNanos);
     auto progress =
         startProgressReporter(*runner, queryCtx->queryId(), options);
     // Executed for its runtime stats (printed below); the result batches are
@@ -1520,7 +1569,8 @@ std::shared_ptr<optimizer::OptimizerSession>
 SqlQueryRunner::makeOptimizerSession(
     std::string_view queryId,
     connector::ConnectorProperties connectorProperties,
-    bool explain) {
+    bool explain,
+    const std::shared_ptr<QueryRuntimeStats>& runtimeStats) {
   auto optimizerOptions = optimizer::OptimizerOptions::from(
       sessionConfig_->effectiveValues(kOptimizerPrefix));
   optimizerOptions.explain = explain;
@@ -1528,7 +1578,8 @@ SqlQueryRunner::makeOptimizerSession(
       std::string(queryId),
       user_,
       std::move(optimizerOptions),
-      std::move(connectorProperties));
+      std::move(connectorProperties),
+      runtimeStats);
 }
 
 optimizer::PlanAndStats SqlQueryRunner::optimize(
@@ -1541,6 +1592,7 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
     std::shared_ptr<facebook::axiom::connector::SchemaResolver> schemaResolver,
     bool explain,
     std::shared_ptr<QueryRuntimeStats> runtimeStats) {
+  VELOX_CHECK_NOT_NULL(runtimeStats);
   optimizer::MultiFragmentPlan::Options opts;
   opts.numWorkers = options.numWorkers;
   opts.numDrivers = options.numDrivers;
@@ -1553,13 +1605,14 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
   schemaResolver = orDefaultSchemaResolver(std::move(schemaResolver));
 
   auto connectorProperties = collectConnectorProperties(*sessionConfig_);
-  auto optimizerSession =
-      makeOptimizerSession(queryCtx->queryId(), connectorProperties, explain);
+  auto optimizerSession = makeOptimizerSession(
+      queryCtx->queryId(), connectorProperties, explain, runtimeStats);
   auto runnerSession = std::make_shared<runner::RunnerSession>(
       queryCtx->queryId(),
       user_,
       sessionConfig_->effectiveValues(kRunnerPrefix),
-      std::move(connectorProperties));
+      std::move(connectorProperties),
+      runtimeStats);
 
   if (useOptimizerV2_) {
     VELOX_USER_CHECK(
@@ -1590,8 +1643,7 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
       *history,
       queryCtx,
       evaluator,
-      opts,
-      runtimeStats);
+      opts);
 
   if (checkDerivedTable && !checkDerivedTable(*optimization.rootDt())) {
     return {};
@@ -1624,26 +1676,26 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
     toVeloxCpuNanos = velox::process::threadCpuNanos() - cpuStart;
   }
 
-  if (runtimeStats) {
-    runtimeStats->recordTiming(
-        QueryRuntimeStats::kOptimizeToGraphWallNanos,
-        std::chrono::nanoseconds(toGraphNanos));
-    runtimeStats->recordTiming(
-        QueryRuntimeStats::kOptimizeToGraphCpuNanos,
-        std::chrono::nanoseconds(toGraphCpuNanos));
-    runtimeStats->recordTiming(
-        QueryRuntimeStats::kOptimizeBestPlanWallNanos,
-        std::chrono::nanoseconds(bestPlanNanos));
-    runtimeStats->recordTiming(
-        QueryRuntimeStats::kOptimizeBestPlanCpuNanos,
-        std::chrono::nanoseconds(bestPlanCpuNanos));
-    runtimeStats->recordTiming(
-        QueryRuntimeStats::kOptimizeToVeloxWallNanos,
-        std::chrono::nanoseconds(toVeloxNanos));
-    runtimeStats->recordTiming(
-        QueryRuntimeStats::kOptimizeToVeloxCpuNanos,
-        std::chrono::nanoseconds(toVeloxCpuNanos));
-  }
+  auto sink =
+      runtimeStats->sinkFor(facebook::axiom::optimizer::kStatsComponent);
+  sink.recordTiming(
+      facebook::axiom::optimizer::kOptimizeToGraphWallNanos,
+      std::chrono::nanoseconds(toGraphNanos));
+  sink.recordTiming(
+      facebook::axiom::optimizer::kOptimizeToGraphCpuNanos,
+      std::chrono::nanoseconds(toGraphCpuNanos));
+  sink.recordTiming(
+      facebook::axiom::optimizer::kOptimizeBestPlanWallNanos,
+      std::chrono::nanoseconds(bestPlanNanos));
+  sink.recordTiming(
+      facebook::axiom::optimizer::kOptimizeBestPlanCpuNanos,
+      std::chrono::nanoseconds(bestPlanCpuNanos));
+  sink.recordTiming(
+      facebook::axiom::optimizer::kOptimizeToVeloxWallNanos,
+      std::chrono::nanoseconds(toVeloxNanos));
+  sink.recordTiming(
+      facebook::axiom::optimizer::kOptimizeToVeloxCpuNanos,
+      std::chrono::nanoseconds(toVeloxCpuNanos));
 
   return result;
 }
@@ -1652,21 +1704,23 @@ std::shared_ptr<runner::LocalRunner> SqlQueryRunner::makeLocalRunner(
     optimizer::PlanAndStats& planAndStats,
     const std::shared_ptr<velox::core::QueryCtx>& queryCtx,
     const RunOptions& options,
-    QueryRuntimeStats& runtimeStats) {
+    const std::shared_ptr<QueryRuntimeStats>& runtimeStats) {
   auto runnerSession = std::make_shared<runner::RunnerSession>(
       queryCtx->queryId(),
       user_,
       sessionConfig_->effectiveValues(kRunnerPrefix),
-      collectConnectorProperties(*sessionConfig_));
+      collectConnectorProperties(*sessionConfig_),
+      runtimeStats);
   return std::make_shared<runner::LocalRunner>(
       std::move(runnerSession),
       planAndStats.plan,
       std::move(planAndStats.finishWrite),
       queryCtx,
-      std::make_shared<runner::ConnectorSplitSourceFactory>(runtimeStats),
+      std::make_shared<runner::ConnectorSplitSourceFactory>(
+          runtimeStats->sinkFor(facebook::axiom::runner::kStatsComponent)),
       executorPool_,
       /*baseSpillDirectory=*/"",
-      runtimeStats);
+      runtimeStats->sinkFor(facebook::axiom::runner::kStatsComponent));
 }
 
 folly::coro::AsyncGenerator<velox::RowVectorPtr> SqlQueryRunner::co_showSession(
@@ -1718,7 +1772,13 @@ folly::coro::AsyncGenerator<velox::RowVectorPtr> SqlQueryRunner::co_showSession(
   // parameter would leave it dangling once GCC destroys co_await-operand
   // temporaries at the suspension point.
   auto plan = builder.build();
-  auto generator = co_runLogicalPlan(plan, options, timing, planString);
+  auto generator = co_runLogicalPlan(
+      plan,
+      options,
+      timing,
+      planString,
+      /*schemaResolver=*/nullptr,
+      std::make_shared<QueryRuntimeStats>());
   while (auto batch = co_await generator.next()) {
     co_yield std::move(*batch);
   }
@@ -1732,15 +1792,16 @@ SqlQueryRunner::co_runLogicalPlan(
     std::string& planString,
     std::shared_ptr<facebook::axiom::connector::SchemaResolver> schemaResolver,
     std::shared_ptr<QueryRuntimeStats> runtimeStats) {
+  VELOX_CHECK_NOT_NULL(runtimeStats);
   auto queryCtx = newQuery(options);
 
   optimizer::PlanAndStats planAndStats;
   {
     PhaseTimer phaseTimer(
         timing.optimize,
-        runtimeStats.get(),
-        QueryRuntimeStats::kOptimizeWallNanos,
-        QueryRuntimeStats::kOptimizeCpuNanos);
+        runtimeStats->sinkFor(facebook::axiom::optimizer::kStatsComponent),
+        facebook::axiom::optimizer::kOptimizeWallNanos,
+        facebook::axiom::optimizer::kOptimizeCpuNanos);
     planAndStats = optimize(
         logicalPlan,
         queryCtx,
@@ -1754,18 +1815,14 @@ SqlQueryRunner::co_runLogicalPlan(
 
   planString = planAndStats.toString();
 
-  auto runner = makeLocalRunner(
-      planAndStats,
-      queryCtx,
-      options,
-      runtimeStats ? *runtimeStats : noopRuntimeStats_);
+  auto runner = makeLocalRunner(planAndStats, queryCtx, options, runtimeStats);
 
   {
     PhaseTimer phaseTimer(
         timing.execute,
-        runtimeStats.get(),
-        QueryRuntimeStats::kExecuteWallNanos,
-        QueryRuntimeStats::kExecuteCpuNanos);
+        runtimeStats->sinkFor(facebook::axiom::runner::kStatsComponent),
+        facebook::axiom::runner::kExecuteWallNanos,
+        facebook::axiom::runner::kExecuteCpuNanos);
     auto progress =
         startProgressReporter(*runner, queryCtx->queryId(), options);
     auto generator = co_drainQuery(*runner, options.timeoutMicros);
@@ -1816,7 +1873,8 @@ std::vector<velox::RowVectorPtr> SqlQueryRunner::runShowStatsForQuery(
     auto session = makeOptimizerSession(
         queryCtx->queryId(),
         collectConnectorProperties(*sessionConfig_),
-        /*explain=*/false);
+        /*explain=*/false,
+        std::make_shared<QueryRuntimeStats>());
 
     const auto stats =
         optimizer::v2::Optimizer(
@@ -1859,7 +1917,11 @@ std::vector<velox::RowVectorPtr> SqlQueryRunner::runShowStatsForQuery(
 
           data = builder.rows();
           return false; // Stop optimization.
-        });
+        },
+        /*checkBestPlan=*/nullptr,
+        /*schemaResolver=*/nullptr,
+        /*explain=*/false,
+        std::make_shared<QueryRuntimeStats>());
   }
 
   auto result = std::dynamic_pointer_cast<velox::RowVector>(

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -398,17 +398,24 @@ class SqlQueryRunner {
 
   /// Parses SQL text containing one or more semicolon-separated statements.
   /// @param sql SQL text to parse.
+  /// @param runtimeStats Collector the parser session records
+  /// connector-metadata
+  ///   metrics into. Pass the query's stats to attribute them; tooling that
+  ///   discards metrics passes a throwaway QueryRuntimeStats.
   /// @return Vector of parsed statements.
   std::vector<presto::SqlStatementPtr> parseMultiple(
       std::string_view sql,
-      const RunOptions& options);
+      const RunOptions& options,
+      const std::shared_ptr<facebook::axiom::QueryRuntimeStats>& runtimeStats);
 
   /// Parses SQL text containing one statement.
+  /// @param runtimeStats See parseMultiple().
   /// @return Parsed statement.
   /// @throw VeloxUserError if the SQL text contains multiple statements.
   presto::SqlStatementPtr parseSingle(
       std::string_view sql,
-      const RunOptions& options);
+      const RunOptions& options,
+      const std::shared_ptr<facebook::axiom::QueryRuntimeStats>& runtimeStats);
 
   /// Generates DOT representation of the query graph for a single SELECT
   /// statement. The output can be rendered using Graphviz:
@@ -441,35 +448,42 @@ class SqlQueryRunner {
   facebook::axiom::connector::TablePtr createTable(
       std::string_view queryId,
       const presto::CreateTableStatement& statement,
+      const std::shared_ptr<facebook::axiom::QueryRuntimeStats>& runtimeStats,
       bool explain = false);
 
   facebook::axiom::connector::TablePtr createTable(
       std::string_view queryId,
       const presto::CreateTableAsSelectStatement& statement,
+      const std::shared_ptr<facebook::axiom::QueryRuntimeStats>& runtimeStats,
       bool explain = false);
 
   std::string dropTable(
       std::string_view queryId,
-      const presto::DropTableStatement& statement);
+      const presto::DropTableStatement& statement,
+      const std::shared_ptr<facebook::axiom::QueryRuntimeStats>& runtimeStats);
 
   std::string addColumn(
       std::string_view queryId,
       const presto::AddColumnStatement& statement,
+      const std::shared_ptr<facebook::axiom::QueryRuntimeStats>& runtimeStats,
       bool explain = false);
 
   std::string createSchema(
       std::string_view queryId,
-      const presto::CreateSchemaStatement& statement);
+      const presto::CreateSchemaStatement& statement,
+      const std::shared_ptr<facebook::axiom::QueryRuntimeStats>& runtimeStats);
 
   std::string dropSchema(
       std::string_view queryId,
-      const presto::DropSchemaStatement& statement);
+      const presto::DropSchemaStatement& statement,
+      const std::shared_ptr<facebook::axiom::QueryRuntimeStats>& runtimeStats);
 
   /// Constant-folds the CALL statement's bound arguments and awaits the
   /// procedure's execute(); returns "CALL".
   folly::coro::Task<std::string> co_call(
       std::string_view queryId,
-      const presto::CallStatement& statement);
+      const presto::CallStatement& statement,
+      const std::shared_ptr<facebook::axiom::QueryRuntimeStats>& runtimeStats);
 
   /// Returns the default connector ID set during initialization.
   const std::string& defaultConnectorId() const {
@@ -494,12 +508,14 @@ class SqlQueryRunner {
       const RunOptions& options);
 
   // Builds an OptimizerSession from the current session config's optimizer
-  // properties, attaching 'connectorProperties' and the explain flag.
+  // properties, attaching 'connectorProperties', the explain flag, and
+  // 'runtimeStats' for the session to record metrics through.
   std::shared_ptr<facebook::axiom::optimizer::OptimizerSession>
   makeOptimizerSession(
       std::string_view queryId,
       facebook::axiom::connector::ConnectorProperties connectorProperties,
-      bool explain);
+      bool explain,
+      const std::shared_ptr<facebook::axiom::QueryRuntimeStats>& runtimeStats);
 
   std::string runExplain(
       const facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,
@@ -552,21 +568,19 @@ class SqlQueryRunner {
       const std::shared_ptr<facebook::velox::core::QueryCtx>& queryCtx,
       const RunOptions& options,
       const std::function<bool(
-          const facebook::axiom::optimizer::DerivedTable&)>& checkDerivedTable =
-          nullptr,
+          const facebook::axiom::optimizer::DerivedTable&)>& checkDerivedTable,
       const std::function<bool(const facebook::axiom::optimizer::RelationOp&)>&
-          checkBestPlan = nullptr,
+          checkBestPlan,
       std::shared_ptr<facebook::axiom::connector::SchemaResolver>
-          schemaResolver = nullptr,
-      bool explain = false,
-      std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats =
-          nullptr);
+          schemaResolver,
+      bool explain,
+      std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats);
 
   std::shared_ptr<facebook::axiom::runner::LocalRunner> makeLocalRunner(
       facebook::axiom::optimizer::PlanAndStats& planAndStats,
       const std::shared_ptr<facebook::velox::core::QueryCtx>& queryCtx,
       const RunOptions& options,
-      facebook::axiom::QueryRuntimeStats& runtimeStats);
+      const std::shared_ptr<facebook::axiom::QueryRuntimeStats>& runtimeStats);
 
   // Returns a ProgressReporter polling `runner` (starting the shared scheduler
   // first) when options.onProgress is set, otherwise nullptr. Held behind a
@@ -579,14 +593,14 @@ class SqlQueryRunner {
       const RunOptions& options);
 
   // Runs a parsed SQL statement, writing optimize/execute timing into 'timing'
-  // and the serialized Velox plan into 'planString'.
+  // and the serialized Velox plan into 'planString'. 'runtimeStats' collects
+  // the query's metrics; pass a throwaway to discard them.
   folly::coro::AsyncGenerator<SqlResultChunk> co_runUnchecked(
       const presto::SqlStatement& statement,
       const RunOptions& options,
       QueryTiming& timing,
       std::string& planString,
-      std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats =
-          nullptr);
+      std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats);
 
   folly::coro::AsyncGenerator<facebook::velox::RowVectorPtr> co_showSession(
       const presto::ShowSessionStatement& statement,
@@ -603,16 +617,18 @@ class SqlQueryRunner {
       QueryTiming& timing,
       std::string& planString,
       std::shared_ptr<facebook::axiom::connector::SchemaResolver>
-          schemaResolver = nullptr,
-      std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats =
-          nullptr);
+          schemaResolver,
+      std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats);
 
   // Builds a ConnectorSession for `connectorId` carrying the caller's
-  // queryId, the runner's user, and the connector's effective session
-  // properties from `sessionConfig_`.
+  // queryId, the runner's user, the connector's effective session properties
+  // from `sessionConfig_`, and `runtimeStats` so connector-metadata metrics
+  // land in the query's stats.
   facebook::axiom::connector::ConnectorSessionPtr makeConnectorSession(
       std::string_view queryId,
-      std::string_view connectorId) const;
+      std::string_view connectorId,
+      const std::shared_ptr<facebook::axiom::QueryRuntimeStats>& runtimeStats)
+      const;
 
   // Permission check callback invoked before query execution.
   PermissionCheck permissionCheck_;
@@ -635,9 +651,6 @@ class SqlQueryRunner {
   // Progress-polling scheduler (see constructor). Started idempotently before
   // each progress-reporting query.
   folly::FunctionScheduler* const progressScheduler_;
-
-  // Noop stats instance for code paths that don't track runtime metrics.
-  facebook::axiom::QueryRuntimeStats noopRuntimeStats_;
 };
 
 } // namespace axiom::sql

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -30,6 +30,7 @@
 #include "axiom/cli/tests/SqlQueryRunnerTestBase.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/runner/QueryProgress.h"
+#include "axiom/runner/RunnerMetrics.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "velox/common/base/VeloxException.h"
@@ -304,7 +305,9 @@ TEST_F(SqlQueryRunnerTest, runRejectsMultipleStatements) {
 
 TEST_F(SqlQueryRunnerTest, parseAndRunMixedStatementTypes) {
   auto statements = runner_->parseMultiple(
-      "SELECT 42; EXPLAIN (TYPE LOGICAL) SELECT 1; select 7", {});
+      "SELECT 42; EXPLAIN (TYPE LOGICAL) SELECT 1; select 7",
+      {},
+      std::make_shared<facebook::axiom::QueryRuntimeStats>());
   ASSERT_EQ(3, statements.size());
 
   auto selectResult = runner_->runUnchecked(*statements[0], {});
@@ -352,7 +355,10 @@ TEST_F(SqlQueryRunnerTest, invalidStatementThrows) {
 
 TEST_F(SqlQueryRunnerTest, parseMultipleWithInvalidStatement) {
   EXPECT_THROW(
-      runner_->parseMultiple("SELECT 1; INVALID; SELECT 2", {}),
+      runner_->parseMultiple(
+          "SELECT 1; INVALID; SELECT 2",
+          {},
+          std::make_shared<facebook::axiom::QueryRuntimeStats>()),
       std::exception);
 }
 
@@ -1091,6 +1097,30 @@ TEST_F(SqlQueryRunnerTest, connectorProperties) {
   run("SET SESSION test.list_partitions_error = 'boom from split-gen'");
 
   VELOX_ASSERT_THROW(run("SELECT * FROM t"), "boom from split-gen");
+}
+
+// Split-enumeration metrics recorded by the runner during execution land in the
+// query's QueryRuntimeStats, summed into per-query totals by totalsByName().
+TEST_F(SqlQueryRunnerTest, splitEnumerationMetricsInRuntimeStats) {
+  // One split per appended vector.
+  testConnector_->addTable("t", ROW("x", INTEGER()));
+  auto vector = makeRowVector({makeFlatVector<int32_t>({1})});
+  constexpr int64_t kNumSplits = 3;
+  for (int64_t i = 0; i < kNumSplits; ++i) {
+    testConnector_->appendData("t", vector);
+  }
+
+  std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats;
+  runner_->run(
+      "SELECT * FROM t", {.onComplete = [&](const QueryCompletionInfo& info) {
+        runtimeStats = info.runtimeStats;
+      }});
+
+  ASSERT_NE(runtimeStats, nullptr);
+  const auto metrics = runtimeStats->totalsByName();
+  auto it = metrics.find(std::string(facebook::axiom::runner::kGetSplitsCount));
+  ASSERT_NE(it, metrics.end());
+  EXPECT_EQ(it->second.sum, kNumSplits);
 }
 
 TEST_F(SqlQueryRunnerTest, addColumn) {

--- a/axiom/common/QueryRuntimeStats.cpp
+++ b/axiom/common/QueryRuntimeStats.cpp
@@ -16,6 +16,8 @@
 
 #include "axiom/common/QueryRuntimeStats.h"
 
+#include "velox/common/base/Exceptions.h"
+
 namespace facebook::axiom {
 
 namespace {
@@ -35,14 +37,20 @@ std::string_view unitToString(velox::RuntimeCounter::Unit unit) {
     case velox::RuntimeCounter::Unit::kNone:
       return "NONE";
   }
-  return "NONE";
+  VELOX_UNREACHABLE();
 }
 } // namespace
 
 void mergeRuntimeMetric(
-    folly::ConcurrentHashMap<std::string, velox::RuntimeMetric>& map,
+    RuntimeMetricMap& map,
     const std::string& name,
     const velox::RuntimeMetric& metric) {
+  // Metric names must not contain '/'; toMap() uses '/' to separate the
+  // component id from the name.
+  VELOX_CHECK(
+      name.find('/') == std::string::npos,
+      "Runtime metric name must not contain '/': {}",
+      name);
   auto [it, inserted] = map.try_emplace(name, metric);
   if (inserted) {
     return;
@@ -70,41 +78,59 @@ void mergeRuntimeMetric(
   }
 }
 
-void QueryRuntimeStats::recordTiming(
+void RuntimeStatsSink::recordTiming(
     std::string_view name,
-    std::chrono::nanoseconds duration) {
+    std::chrono::nanoseconds duration) const {
   mergeRuntimeMetric(
-      metrics_,
+      *metrics_,
       std::string(name),
       velox::RuntimeMetric(
           duration.count(), velox::RuntimeCounter::Unit::kNanos));
 }
 
-void QueryRuntimeStats::recordCount(std::string_view name, int64_t value) {
+void RuntimeStatsSink::recordCount(std::string_view name, int64_t value) const {
   mergeRuntimeMetric(
-      metrics_,
+      *metrics_,
       std::string(name),
       velox::RuntimeMetric(value, velox::RuntimeCounter::Unit::kNone));
 }
 
-void QueryRuntimeStats::merge(
+void RuntimeStatsSink::merge(
     std::string_view name,
-    const velox::RuntimeMetric& metric) {
-  mergeRuntimeMetric(metrics_, std::string(name), metric);
+    const velox::RuntimeMetric& metric) const {
+  mergeRuntimeMetric(*metrics_, std::string(name), metric);
+}
+
+RuntimeStatsSink RuntimeStatsSink::throwaway() {
+  return RuntimeStatsSink(std::make_shared<RuntimeMetricMap>());
+}
+
+RuntimeStatsSink QueryRuntimeStats::sinkOrThrowaway(
+    const std::shared_ptr<QueryRuntimeStats>& stats,
+    std::string_view component) {
+  return stats ? stats->sinkFor(component) : RuntimeStatsSink::throwaway();
+}
+
+RuntimeStatsSink QueryRuntimeStats::sinkFor(std::string_view component) {
+  auto [it, inserted] = components_.try_emplace(
+      std::string(component), std::make_shared<RuntimeMetricMap>());
+  return RuntimeStatsSink(it->second);
 }
 
 std::unordered_map<std::string, velox::RuntimeMetric> QueryRuntimeStats::toMap()
     const {
   std::unordered_map<std::string, velox::RuntimeMetric> result;
-  for (const auto& [name, metric] : metrics_) {
-    result.emplace(name, metric);
+  for (const auto& [component, metrics] : components_) {
+    for (const auto& [name, metric] : *metrics) {
+      result.emplace(component + "/" + name, metric);
+    }
   }
   return result;
 }
 
 folly::dynamic QueryRuntimeStats::toDynamic() const {
   folly::dynamic result = folly::dynamic::object();
-  for (const auto& [name, metric] : metrics_) {
+  for (const auto& [name, metric] : totalsByName()) {
     folly::dynamic entry = folly::dynamic::object();
     entry["name"] = name;
     entry["sum"] = metric.sum;
@@ -117,13 +143,27 @@ folly::dynamic QueryRuntimeStats::toDynamic() const {
   return result;
 }
 
+std::unordered_map<std::string, velox::RuntimeMetric>
+QueryRuntimeStats::totalsByName() const {
+  std::unordered_map<std::string, velox::RuntimeMetric> result;
+  for (const auto& [component, metrics] : components_) {
+    for (const auto& [name, metric] : *metrics) {
+      auto [it, inserted] = result.emplace(name, metric);
+      if (!inserted) {
+        it->second.merge(metric);
+      }
+    }
+  }
+  return result;
+}
+
 ScopedCpuWallStatsTimer::~ScopedCpuWallStatsTimer() {
   if (std::this_thread::get_id() == startThreadId_) {
     auto cpuElapsed = velox::process::threadCpuNanos() - cpuStart_;
-    stats_.recordTiming(cpuMetricName_, std::chrono::nanoseconds(cpuElapsed));
+    sink_.recordTiming(cpuMetricName_, std::chrono::nanoseconds(cpuElapsed));
   }
   auto wallElapsed = std::chrono::steady_clock::now() - wallStart_;
-  stats_.recordTiming(wallMetricName_, wallElapsed);
+  sink_.recordTiming(wallMetricName_, wallElapsed);
 }
 
 } // namespace facebook::axiom

--- a/axiom/common/QueryRuntimeStats.h
+++ b/axiom/common/QueryRuntimeStats.h
@@ -16,177 +16,62 @@
 
 #pragma once
 
-#include <chrono>
+#include <memory>
 #include <string>
 #include <string_view>
-#include <thread>
 #include <unordered_map>
 
-#include <folly/concurrency/ConcurrentHashMap.h>
 #include <folly/dynamic.h>
 
-#include "velox/common/base/RuntimeMetrics.h"
-#include "velox/common/process/ProcessBase.h"
+#include "axiom/common/RuntimeStatsSink.h"
 
 namespace facebook::axiom {
 
-/// Accumulates runtime metrics from Axiom's query pipeline (parser, optimizer,
-/// split manager, runner). Each metric is a velox::RuntimeMetric with
-/// sum/count/min/max. Thread-safe — multiple pipeline stages may record
-/// concurrently.
+/// Per-query collector of runtime metrics from Axiom's pipeline (parser,
+/// optimizer, split manager, connectors, runner). Metrics are grouped by
+/// component: identically-named metrics from different components stay
+/// distinct, while metrics within a component aggregate. Components record
+/// through an isolated RuntimeStatsSink and never touch the collector or one
+/// another. Thread-safe: many components and threads may record concurrently.
+///
+/// Example:
+///   QueryRuntimeStats stats;
+///   auto sink = stats.sinkFor(optimizer::kStatsComponent);
+///   sink.recordCount("axiom-candidatesPruned", 3);
+///   auto snapshot = stats.toMap();
 class QueryRuntimeStats {
  public:
-  // Parser.
-  static constexpr std::string_view kParseWallNanos{"axiom-parseWallNanos"};
-  static constexpr std::string_view kParseCpuNanos{"axiom-parseCpuNanos"};
+  /// Returns 'stats' sink for 'component', or a sink over a throwaway map when
+  /// 'stats' is null.
+  static RuntimeStatsSink sinkOrThrowaway(
+      const std::shared_ptr<QueryRuntimeStats>& stats,
+      std::string_view component);
 
-  // Optimizer.
-  static constexpr std::string_view kOptimizeWallNanos{
-      "axiom-optimizeWallNanos"};
-  static constexpr std::string_view kOptimizeCpuNanos{"axiom-optimizeCpuNanos"};
-  static constexpr std::string_view kOptimizeToGraphWallNanos{
-      "axiom-optimizeToGraphWallNanos"};
-  static constexpr std::string_view kOptimizeToGraphCpuNanos{
-      "axiom-optimizeToGraphCpuNanos"};
-  static constexpr std::string_view kOptimizeBestPlanWallNanos{
-      "axiom-optimizeBestPlanWallNanos"};
-  static constexpr std::string_view kOptimizeBestPlanCpuNanos{
-      "axiom-optimizeBestPlanCpuNanos"};
-  static constexpr std::string_view kOptimizeToVeloxWallNanos{
-      "axiom-optimizeToVeloxWallNanos"};
-  static constexpr std::string_view kOptimizeToVeloxCpuNanos{
-      "axiom-optimizeToVeloxCpuNanos"};
+  /// Returns a write-only sink for 'component', creating its view on first use.
+  RuntimeStatsSink sinkFor(std::string_view component);
 
-  // Split manager.
-  static constexpr std::string_view kListPartitionsWallNanos{
-      "axiom-listPartitionsWallNanos"};
-  static constexpr std::string_view kListPartitionsCpuNanos{
-      "axiom-listPartitionsCpuNanos"};
-  static constexpr std::string_view kListPartitionsCount{
-      "axiom-listPartitionsCount"};
-  static constexpr std::string_view kGetSplitsWallNanos{
-      "axiom-getSplitsWallNanos"};
-  static constexpr std::string_view kGetSplitsCpuNanos{
-      "axiom-getSplitsCpuNanos"};
-  static constexpr std::string_view kGetSplitsCount{"axiom-getSplitsCount"};
-
-  // Permission check.
-  static constexpr std::string_view kPermissionCheckWallNanos{
-      "axiom-permissionCheckWallNanos"};
-  static constexpr std::string_view kPermissionCheckCpuNanos{
-      "axiom-permissionCheckCpuNanos"};
-
-  // Connector.
-  static constexpr std::string_view kFindTableWallNanos{
-      "axiom-findTableWallNanos"};
-  static constexpr std::string_view kFindTableCpuNanos{
-      "axiom-findTableCpuNanos"};
-  static constexpr std::string_view kEstimateStatsWallNanos{
-      "axiom-estimateStatsWallNanos"};
-  static constexpr std::string_view kEstimateStatsCpuNanos{
-      "axiom-estimateStatsCpuNanos"};
-
-  // Execution.
-  static constexpr std::string_view kExecuteWallNanos{"axiom-executeWallNanos"};
-  static constexpr std::string_view kExecuteCpuNanos{"axiom-executeCpuNanos"};
-
-  /// Records a wall-clock duration under the given metric name.
-  void recordTiming(std::string_view name, std::chrono::nanoseconds duration);
-
-  /// Records a count (e.g., number of partitions or splits).
-  void recordCount(std::string_view name, int64_t value);
-
-  /// Merges a pre-aggregated metric into this recorder.
-  void merge(std::string_view name, const velox::RuntimeMetric& metric);
-
-  /// Returns a snapshot of all recorded metrics.
+  /// Returns a snapshot of all metrics across components. Each key is the
+  /// metric name qualified by its component id ("<component>/<name>"), so a
+  /// name emitted by more than one component stays a distinct entry. Safe to
+  /// call during execution; reflects everything recorded so far.
   std::unordered_map<std::string, velox::RuntimeMetric> toMap() const;
 
-  /// Serializes all metrics to folly::dynamic for Scribe logging. Format:
-  /// {"metricName": {"sum": N, "count": N, "min": N, "max": N, "unit": "..."}}
+  /// Serializes the per-query totals to folly::dynamic for logging, keyed by
+  /// the bare metric name. Format:
+  /// {"name": {"sum": N, "count": N, "min": N, "max": N, "unit": "..."}}
   folly::dynamic toDynamic() const;
 
- private:
-  folly::ConcurrentHashMap<std::string, velox::RuntimeMetric> metrics_;
-};
-
-/// RAII timer that records a wall-clock duration into QueryRuntimeStats on
-/// destruction. Guarantees the metric is recorded even if the timed scope
-/// exits via exception.
-class ScopedRuntimeStatsTimer {
- public:
-  ScopedRuntimeStatsTimer(QueryRuntimeStats& stats, std::string_view metricName)
-      : stats_(stats),
-        metricName_(metricName),
-        start_(std::chrono::steady_clock::now()) {}
-
-  ~ScopedRuntimeStatsTimer() {
-    stats_.recordTiming(metricName_, std::chrono::steady_clock::now() - start_);
-  }
-
-  ScopedRuntimeStatsTimer(const ScopedRuntimeStatsTimer&) = delete;
-  ScopedRuntimeStatsTimer& operator=(const ScopedRuntimeStatsTimer&) = delete;
+  /// Returns each metric summed across all components, keyed by the bare metric
+  /// name (unlike toMap(), which keys per component). Components emitting the
+  /// same name must use the same unit; a mismatch fails at report time via a
+  /// VELOX_CHECK in RuntimeMetric::merge.
+  std::unordered_map<std::string, velox::RuntimeMetric> totalsByName() const;
 
  private:
-  QueryRuntimeStats& stats_;
-  std::string_view metricName_;
-  std::chrono::steady_clock::time_point start_;
+  // Component id -> that component's metric map. shared_ptr so a
+  // RuntimeStatsSink co-owns its map independently of the collector's lifetime.
+  folly::ConcurrentHashMap<std::string, std::shared_ptr<RuntimeMetricMap>>
+      components_;
 };
-
-/// RAII timer that records both wall-clock and thread CPU durations into
-/// QueryRuntimeStats on destruction. CPU time is only recorded if the
-/// destructor runs on the same thread as the constructor — coroutine
-/// suspension may resume on a different thread, making per-thread CPU
-/// measurement invalid. Wall time is always recorded.
-class ScopedCpuWallStatsTimer {
- public:
-  ScopedCpuWallStatsTimer(
-      QueryRuntimeStats& stats,
-      std::string_view wallMetricName,
-      std::string_view cpuMetricName)
-      : stats_(stats),
-        wallMetricName_(wallMetricName),
-        cpuMetricName_(cpuMetricName),
-        wallStart_(std::chrono::steady_clock::now()),
-        cpuStart_(velox::process::threadCpuNanos()),
-        startThreadId_(std::this_thread::get_id()) {}
-
-  ~ScopedCpuWallStatsTimer();
-
-  ScopedCpuWallStatsTimer(const ScopedCpuWallStatsTimer&) = delete;
-  ScopedCpuWallStatsTimer& operator=(const ScopedCpuWallStatsTimer&) = delete;
-  ScopedCpuWallStatsTimer(ScopedCpuWallStatsTimer&&) = delete;
-  ScopedCpuWallStatsTimer& operator=(ScopedCpuWallStatsTimer&&) = delete;
-
- private:
-  QueryRuntimeStats& stats_;
-  std::string_view wallMetricName_;
-  std::string_view cpuMetricName_;
-  std::chrono::steady_clock::time_point wallStart_;
-  uint64_t cpuStart_;
-  std::thread::id startThreadId_;
-};
-
-/// Records thread CPU time elapsed since 'cpuStart' if still on the same
-/// thread ('startThreadId'). Skips recording when the thread switched (e.g.
-/// after co_await) to avoid invalid per-thread CPU measurements.
-inline void recordCpuIfSameThread(
-    QueryRuntimeStats& stats,
-    std::string_view metricName,
-    uint64_t cpuStart,
-    std::thread::id startThreadId) {
-  if (std::this_thread::get_id() == startThreadId) {
-    stats.recordTiming(
-        metricName,
-        std::chrono::nanoseconds(velox::process::threadCpuNanos() - cpuStart));
-  }
-}
-
-/// Merges 'metric' into 'map' under 'name' using CAS-based optimistic locking.
-/// Shared by QueryRuntimeStats and SchedulerStatsRecorder.
-void mergeRuntimeMetric(
-    folly::ConcurrentHashMap<std::string, velox::RuntimeMetric>& map,
-    const std::string& name,
-    const velox::RuntimeMetric& metric);
 
 } // namespace facebook::axiom

--- a/axiom/common/RuntimeStatsSink.h
+++ b/axiom/common/RuntimeStatsSink.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <thread>
+
+#include <folly/concurrency/ConcurrentHashMap.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/RuntimeMetrics.h"
+#include "velox/common/process/ProcessBase.h"
+
+namespace facebook::axiom {
+
+/// Map of metric name to its aggregated velox::RuntimeMetric. Backs one
+/// component's isolated view within a QueryRuntimeStats collector.
+using RuntimeMetricMap =
+    folly::ConcurrentHashMap<std::string, velox::RuntimeMetric>;
+
+/// Merges 'metric' into 'map' under 'name' using CAS-based optimistic locking.
+void mergeRuntimeMetric(
+    RuntimeMetricMap& map,
+    const std::string& name,
+    const velox::RuntimeMetric& metric);
+
+/// Write-only handle to one component's metrics within a per-query
+/// QueryRuntimeStats collector. A component records through its own sink and
+/// cannot reach the collector or another component's metrics. Cheap to copy
+/// (holds a shared handle to one component's map). Obtain via
+/// QueryRuntimeStats::sinkFor().
+///
+/// Example:
+///   auto sink = stats.sinkFor(optimizer::kStatsComponent);
+///   sink.recordCount("axiom-candidatesPruned", 3);
+class RuntimeStatsSink {
+ public:
+  /// Binds the sink to 'metrics', one component's metric map. Prefer
+  /// QueryRuntimeStats::sinkFor() to obtain a sink.
+  explicit RuntimeStatsSink(std::shared_ptr<RuntimeMetricMap> metrics)
+      : metrics_{std::move(metrics)} {
+    VELOX_CHECK_NOT_NULL(metrics_);
+  }
+
+  /// Returns a sink over a fresh throwaway map, for callers with no collector.
+  static RuntimeStatsSink throwaway();
+
+  /// Records a wall-clock duration under 'name'.
+  void recordTiming(std::string_view name, std::chrono::nanoseconds duration)
+      const;
+
+  /// Records a count (e.g. number of partitions or splits) under 'name'.
+  void recordCount(std::string_view name, int64_t value) const;
+
+  /// Merges a pre-aggregated metric into 'name'.
+  void merge(std::string_view name, const velox::RuntimeMetric& metric) const;
+
+ private:
+  std::shared_ptr<RuntimeMetricMap> metrics_;
+};
+
+/// RAII timer that records both wall-clock and thread CPU durations into a
+/// RuntimeStatsSink on destruction. CPU time is only recorded if the destructor
+/// runs on the same thread as the constructor — coroutine suspension may resume
+/// on a different thread, making per-thread CPU measurement invalid. Wall time
+/// is always recorded.
+///
+/// Example:
+///   {
+///     ScopedCpuWallStatsTimer timer(
+///         stats.sinkFor(optimizer::kStatsComponent),
+///         "axiom-optimizeWallNanos",
+///         "axiom-optimizeCpuNanos");
+///     // ... work to time ...
+///   }
+class ScopedCpuWallStatsTimer {
+ public:
+  ScopedCpuWallStatsTimer(
+      RuntimeStatsSink sink,
+      std::string_view wallMetricName,
+      std::string_view cpuMetricName)
+      : sink_(std::move(sink)),
+        wallMetricName_(wallMetricName),
+        cpuMetricName_(cpuMetricName),
+        wallStart_(std::chrono::steady_clock::now()),
+        cpuStart_(velox::process::threadCpuNanos()),
+        startThreadId_(std::this_thread::get_id()) {}
+
+  ~ScopedCpuWallStatsTimer();
+
+  ScopedCpuWallStatsTimer(const ScopedCpuWallStatsTimer&) = delete;
+  ScopedCpuWallStatsTimer& operator=(const ScopedCpuWallStatsTimer&) = delete;
+  ScopedCpuWallStatsTimer(ScopedCpuWallStatsTimer&&) = delete;
+  ScopedCpuWallStatsTimer& operator=(ScopedCpuWallStatsTimer&&) = delete;
+
+ private:
+  RuntimeStatsSink sink_;
+  std::string_view wallMetricName_;
+  std::string_view cpuMetricName_;
+  std::chrono::steady_clock::time_point wallStart_;
+  uint64_t cpuStart_;
+  std::thread::id startThreadId_;
+};
+
+/// Records thread CPU time elapsed since 'cpuStart' into 'sink' under
+/// 'metricName' only when still on the constructing thread ('startThreadId'). A
+/// thread switch (e.g. after co_await) makes per-thread CPU measurement
+/// invalid, so recording is skipped.
+inline void recordCpuIfSameThread(
+    const RuntimeStatsSink& sink,
+    std::string_view metricName,
+    uint64_t cpuStart,
+    std::thread::id startThreadId) {
+  if (std::this_thread::get_id() == startThreadId) {
+    sink.recordTiming(
+        metricName,
+        std::chrono::nanoseconds(velox::process::threadCpuNanos() - cpuStart));
+  }
+}
+
+} // namespace facebook::axiom

--- a/axiom/common/TrackedExecutor.cpp
+++ b/axiom/common/TrackedExecutor.cpp
@@ -49,15 +49,14 @@ TrackedExecutor::Func TrackedExecutor::wrapFunc(Func func) {
   };
 }
 
-void TrackedExecutor::reportTo(
-    QueryRuntimeStats& stats,
-    std::string_view prefix) const {
-  stats.merge(
+void TrackedExecutor::reportTo(RuntimeStatsSink sink, std::string_view prefix)
+    const {
+  sink.merge(
       fmt::format("{}-{}", prefix, kExecutorWaitNanos), metrics_->waitTime_);
-  stats.merge(
+  sink.merge(
       fmt::format("{}-{}", prefix, kExecutorExecutionWallNanos),
       metrics_->executionWallTime_);
-  stats.merge(
+  sink.merge(
       fmt::format("{}-{}", prefix, kExecutorExecutionCpuNanos),
       metrics_->executionCpuTime_);
 }

--- a/axiom/common/TrackedExecutor.h
+++ b/axiom/common/TrackedExecutor.h
@@ -22,7 +22,7 @@
 #include "velox/common/base/RuntimeMetrics.h"
 
 namespace facebook::axiom {
-class QueryRuntimeStats;
+class RuntimeStatsSink;
 } // namespace facebook::axiom
 
 namespace facebook::axiom {
@@ -62,9 +62,9 @@ class TrackedExecutor final : public folly::Executor {
     return executor_->getNumPriorities();
   }
 
-  /// Reports accumulated metrics to the given stats, prefixing each metric
-  /// name with 'prefix'.
-  void reportTo(QueryRuntimeStats& stats, std::string_view prefix) const;
+  /// Reports accumulated metrics to 'sink', prefixing each metric name with
+  /// 'prefix'.
+  void reportTo(RuntimeStatsSink sink, std::string_view prefix) const;
 
  protected:
   bool keepAliveAcquire() noexcept override {

--- a/axiom/common/tests/QueryRuntimeStatsTest.cpp
+++ b/axiom/common/tests/QueryRuntimeStatsTest.cpp
@@ -16,6 +16,12 @@
 
 #include "axiom/common/QueryRuntimeStats.h"
 
+#include "axiom/connectors/StatsComponents.h"
+#include "axiom/optimizer/OptimizerMetrics.h"
+#include "axiom/runner/RunnerMetrics.h"
+#include "axiom/sql/presto/ParserMetrics.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
 #include <thread>
 
 #include <folly/BenchmarkUtil.h>
@@ -25,16 +31,16 @@
 namespace facebook::axiom {
 namespace {
 
-TEST(QueryRuntimeStatsTest, recordTiming) {
+// Repeated timing recordings of the same name within one component aggregate.
+TEST(QueryRuntimeStatsTest, timingsAggregateWithinComponent) {
   QueryRuntimeStats stats;
-  stats.recordTiming(
-      QueryRuntimeStats::kParseWallNanos, std::chrono::nanoseconds(100));
-  stats.recordTiming(
-      QueryRuntimeStats::kParseWallNanos, std::chrono::nanoseconds(200));
+  auto sink = stats.sinkFor(optimizer::kStatsComponent);
+  sink.recordTiming("axiom-optimizeWallNanos", std::chrono::nanoseconds(100));
+  sink.recordTiming("axiom-optimizeWallNanos", std::chrono::nanoseconds(200));
 
   auto map = stats.toMap();
-  ASSERT_EQ(map.count(std::string(QueryRuntimeStats::kParseWallNanos)), 1);
-  auto& metric = map.at(std::string(QueryRuntimeStats::kParseWallNanos));
+  ASSERT_EQ(map.count("optimizer/axiom-optimizeWallNanos"), 1);
+  const auto& metric = map.at("optimizer/axiom-optimizeWallNanos");
   EXPECT_EQ(metric.sum, 300);
   EXPECT_EQ(metric.count, 2);
   EXPECT_EQ(metric.min, 100);
@@ -42,14 +48,16 @@ TEST(QueryRuntimeStatsTest, recordTiming) {
   EXPECT_EQ(metric.unit, velox::RuntimeCounter::Unit::kNanos);
 }
 
-TEST(QueryRuntimeStatsTest, recordCount) {
+// Repeated count recordings of the same name within one component aggregate.
+TEST(QueryRuntimeStatsTest, countsAggregateWithinComponent) {
   QueryRuntimeStats stats;
-  stats.recordCount(QueryRuntimeStats::kListPartitionsCount, 10);
-  stats.recordCount(QueryRuntimeStats::kListPartitionsCount, 5);
+  auto sink = stats.sinkFor(optimizer::kStatsComponent);
+  sink.recordCount("axiom-candidatesPruned", 10);
+  sink.recordCount("axiom-candidatesPruned", 5);
 
   auto map = stats.toMap();
-  ASSERT_EQ(map.count(std::string(QueryRuntimeStats::kListPartitionsCount)), 1);
-  auto& metric = map.at(std::string(QueryRuntimeStats::kListPartitionsCount));
+  ASSERT_EQ(map.count("optimizer/axiom-candidatesPruned"), 1);
+  const auto& metric = map.at("optimizer/axiom-candidatesPruned");
   EXPECT_EQ(metric.sum, 15);
   EXPECT_EQ(metric.count, 2);
   EXPECT_EQ(metric.min, 5);
@@ -57,53 +65,115 @@ TEST(QueryRuntimeStatsTest, recordCount) {
   EXPECT_EQ(metric.unit, velox::RuntimeCounter::Unit::kNone);
 }
 
-TEST(QueryRuntimeStatsTest, merge) {
+// RuntimeStatsSink::merge folds a pre-aggregated metric into an existing entry.
+TEST(QueryRuntimeStatsTest, mergePreAggregatedMetric) {
   QueryRuntimeStats stats;
-
-  velox::RuntimeMetric existing(500, velox::RuntimeCounter::Unit::kNanos);
-  existing.addValue(300);
-  stats.merge(QueryRuntimeStats::kOptimizeWallNanos, existing);
+  auto sink = stats.sinkFor(optimizer::kStatsComponent);
+  sink.recordCount("axiom-candidatesPruned", 4);
+  velox::RuntimeMetric metric(velox::RuntimeCounter::Unit::kNone);
+  metric.addValue(10);
+  metric.addValue(2);
+  metric.addValue(6);
+  sink.merge("axiom-candidatesPruned", metric);
 
   auto map = stats.toMap();
-  auto& metric = map.at(std::string(QueryRuntimeStats::kOptimizeWallNanos));
-  EXPECT_EQ(metric.sum, 800);
-  EXPECT_EQ(metric.count, 2);
-  EXPECT_EQ(metric.min, 300);
-  EXPECT_EQ(metric.max, 500);
+  ASSERT_EQ(map.count("optimizer/axiom-candidatesPruned"), 1);
+  const auto& merged = map.at("optimizer/axiom-candidatesPruned");
+  EXPECT_EQ(merged.sum, 22);
+  EXPECT_EQ(merged.count, 4);
+  EXPECT_EQ(merged.min, 2);
+  EXPECT_EQ(merged.max, 10);
+  EXPECT_EQ(merged.unit, velox::RuntimeCounter::Unit::kNone);
 }
 
-TEST(QueryRuntimeStatsTest, toDynamic) {
+// A metric name containing '/' collides with the component-id separator used by
+// toMap(), so recording it is rejected.
+TEST(QueryRuntimeStatsTest, rejectsSlashInMetricName) {
   QueryRuntimeStats stats;
-  stats.recordTiming(
-      QueryRuntimeStats::kParseWallNanos, std::chrono::nanoseconds(1000));
-  stats.recordCount(QueryRuntimeStats::kGetSplitsCount, 42);
+  auto sink = stats.sinkFor(optimizer::kStatsComponent);
+  VELOX_ASSERT_THROW(sink.recordCount("a/b", 1), "must not contain");
+}
 
-  auto dynamic = stats.toDynamic();
-  ASSERT_TRUE(dynamic.isObject());
+// The same metric name from two components stays distinct in the flattened
+// view, qualified by component id.
+TEST(QueryRuntimeStatsTest, sameNameAcrossComponentsStaysDistinct) {
+  QueryRuntimeStats stats;
+  auto optimizer = stats.sinkFor(optimizer::kStatsComponent);
+  auto splits = stats.sinkFor(connector::connectorSplits("hive"));
+  optimizer.recordCount("wallNanos", 100);
+  splits.recordCount("wallNanos", 7);
 
-  auto parseKey = std::string(QueryRuntimeStats::kParseWallNanos);
-  ASSERT_TRUE(dynamic.count(parseKey));
-  EXPECT_EQ(dynamic[parseKey]["name"].asString(), parseKey);
-  EXPECT_EQ(dynamic[parseKey]["sum"].asInt(), 1000);
-  EXPECT_EQ(dynamic[parseKey]["count"].asInt(), 1);
-  EXPECT_EQ(dynamic[parseKey]["unit"].asString(), "NANO");
+  auto map = stats.toMap();
+  EXPECT_EQ(map.count("wallNanos"), 0);
+  EXPECT_EQ(map.at("optimizer/wallNanos").sum, 100);
+  EXPECT_EQ(map.at("hive/splits/wallNanos").sum, 7);
+}
 
-  auto splitsKey = std::string(QueryRuntimeStats::kGetSplitsCount);
-  ASSERT_TRUE(dynamic.count(splitsKey));
-  EXPECT_EQ(dynamic[splitsKey]["name"].asString(), splitsKey);
-  EXPECT_EQ(dynamic[splitsKey]["sum"].asInt(), 42);
-  EXPECT_EQ(dynamic[splitsKey]["unit"].asString(), "NONE");
+// totalsByName sums each metric across components into a per-query total keyed
+// by the bare name.
+TEST(QueryRuntimeStatsTest, totalsByNameSumsAcrossComponents) {
+  QueryRuntimeStats stats;
+  stats.sinkFor(optimizer::kStatsComponent).recordCount("wallNanos", 100);
+  stats.sinkFor(connector::connectorSplits("hive")).recordCount("wallNanos", 7);
+  stats.sinkFor(connector::connectorSplits("prism"))
+      .recordCount("wallNanos", 3);
+
+  auto totals = stats.totalsByName();
+  ASSERT_EQ(totals.count("wallNanos"), 1);
+  const auto& total = totals.at("wallNanos");
+  EXPECT_EQ(total.sum, 110);
+  EXPECT_EQ(total.count, 3);
+  EXPECT_EQ(total.min, 3);
+  EXPECT_EQ(total.max, 100);
+}
+
+// Distinct names from different components each appear under their qualified
+// key.
+TEST(QueryRuntimeStatsTest, distinctNamesAcrossComponentsQualified) {
+  QueryRuntimeStats stats;
+  stats.sinkFor(::axiom::sql::presto::kStatsComponent)
+      .recordCount("axiom-parseCount", 1);
+  stats.sinkFor(optimizer::kStatsComponent)
+      .recordCount("axiom-optimizeCount", 2);
+
+  auto map = stats.toMap();
+  ASSERT_EQ(map.count("parser/axiom-parseCount"), 1);
+  ASSERT_EQ(map.count("optimizer/axiom-optimizeCount"), 1);
+  EXPECT_EQ(map.at("parser/axiom-parseCount").sum, 1);
+  EXPECT_EQ(map.at("optimizer/axiom-optimizeCount").sum, 2);
+}
+
+// A snapshot reflects everything recorded so far, including metrics added after
+// an earlier snapshot.
+TEST(QueryRuntimeStatsTest, liveSnapshotComplete) {
+  QueryRuntimeStats stats;
+  stats.sinkFor(::axiom::sql::presto::kStatsComponent)
+      .recordCount("axiom-parseCount", 1);
+
+  auto first = stats.toMap();
+  EXPECT_EQ(first.count("parser/axiom-parseCount"), 1);
+  EXPECT_EQ(first.count("optimizer/axiom-optimizeCount"), 0);
+
+  stats.sinkFor(optimizer::kStatsComponent)
+      .recordCount("axiom-optimizeCount", 2);
+
+  auto second = stats.toMap();
+  EXPECT_EQ(second.count("parser/axiom-parseCount"), 1);
+  EXPECT_EQ(second.count("optimizer/axiom-optimizeCount"), 1);
 }
 
 TEST(QueryRuntimeStatsTest, emptyStats) {
   QueryRuntimeStats stats;
   EXPECT_TRUE(stats.toMap().empty());
+  EXPECT_TRUE(stats.totalsByName().empty());
 
   auto dynamic = stats.toDynamic();
   ASSERT_TRUE(dynamic.isObject());
   EXPECT_TRUE(dynamic.empty());
 }
 
+// Concurrent sinks for the same component share one map, so recordings across
+// threads aggregate without loss.
 TEST(QueryRuntimeStatsTest, concurrentRecording) {
   QueryRuntimeStats stats;
   constexpr int kThreads = 8;
@@ -113,9 +183,10 @@ TEST(QueryRuntimeStatsTest, concurrentRecording) {
   threads.reserve(kThreads);
   for (int i = 0; i < kThreads; ++i) {
     threads.emplace_back([&stats]() {
+      auto sink = stats.sinkFor(runner::kStatsComponent);
       for (int j = 0; j < kIterations; ++j) {
-        stats.recordTiming(
-            QueryRuntimeStats::kExecuteWallNanos, std::chrono::nanoseconds(1));
+        sink.recordTiming(
+            "axiom-executeWallNanos", std::chrono::nanoseconds(1));
       }
     });
   }
@@ -125,18 +196,47 @@ TEST(QueryRuntimeStatsTest, concurrentRecording) {
   }
 
   auto map = stats.toMap();
-  auto& metric = map.at(std::string(QueryRuntimeStats::kExecuteWallNanos));
+  ASSERT_EQ(map.count("runner/axiom-executeWallNanos"), 1);
+  const auto& metric = map.at("runner/axiom-executeWallNanos");
   EXPECT_EQ(metric.sum, kThreads * kIterations);
   EXPECT_EQ(metric.count, kThreads * kIterations);
+}
+
+// toDynamic emits one object per bare metric name with correct sum and unit.
+TEST(QueryRuntimeStatsTest, toDynamicFormat) {
+  QueryRuntimeStats stats;
+  stats.sinkFor(::axiom::sql::presto::kStatsComponent)
+      .recordTiming("axiom-parseWallNanos", std::chrono::nanoseconds(1000));
+  stats.sinkFor(connector::connectorSplits("hive"))
+      .recordCount("axiom-getSplitsCount", 42);
+
+  auto dynamic = stats.toDynamic();
+  ASSERT_TRUE(dynamic.isObject());
+
+  ASSERT_TRUE(dynamic.count("axiom-parseWallNanos"));
+  EXPECT_EQ(
+      dynamic["axiom-parseWallNanos"]["name"].asString(),
+      "axiom-parseWallNanos");
+  EXPECT_EQ(dynamic["axiom-parseWallNanos"]["sum"].asInt(), 1000);
+  EXPECT_EQ(dynamic["axiom-parseWallNanos"]["count"].asInt(), 1);
+  EXPECT_EQ(dynamic["axiom-parseWallNanos"]["unit"].asString(), "NANO");
+
+  ASSERT_TRUE(dynamic.count("axiom-getSplitsCount"));
+  EXPECT_EQ(
+      dynamic["axiom-getSplitsCount"]["name"].asString(),
+      "axiom-getSplitsCount");
+  EXPECT_EQ(dynamic["axiom-getSplitsCount"]["sum"].asInt(), 42);
+  EXPECT_EQ(dynamic["axiom-getSplitsCount"]["count"].asInt(), 1);
+  EXPECT_EQ(dynamic["axiom-getSplitsCount"]["unit"].asString(), "NONE");
 }
 
 TEST(QueryRuntimeStatsTest, scopedCpuWallStatsTimer) {
   QueryRuntimeStats stats;
   {
     ScopedCpuWallStatsTimer timer(
-        stats,
-        QueryRuntimeStats::kParseWallNanos,
-        QueryRuntimeStats::kParseCpuNanos);
+        stats.sinkFor(::axiom::sql::presto::kStatsComponent),
+        "axiom-parseWallNanos",
+        "axiom-parseCpuNanos");
     int64_t sum = 0;
     for (int64_t i = 0; i < 1'000'000; ++i) {
       sum += i;
@@ -144,26 +244,14 @@ TEST(QueryRuntimeStatsTest, scopedCpuWallStatsTimer) {
     folly::doNotOptimizeAway(sum);
   }
   auto map = stats.toMap();
-  ASSERT_EQ(map.count(std::string(QueryRuntimeStats::kParseWallNanos)), 1);
-  ASSERT_EQ(map.count(std::string(QueryRuntimeStats::kParseCpuNanos)), 1);
+  ASSERT_EQ(map.count("parser/axiom-parseWallNanos"), 1);
+  ASSERT_EQ(map.count("parser/axiom-parseCpuNanos"), 1);
 
-  auto wallNanos = map.at(std::string(QueryRuntimeStats::kParseWallNanos)).sum;
-  auto cpuNanos = map.at(std::string(QueryRuntimeStats::kParseCpuNanos)).sum;
+  auto wallNanos = map.at("parser/axiom-parseWallNanos").sum;
+  auto cpuNanos = map.at("parser/axiom-parseCpuNanos").sum;
   EXPECT_GT(wallNanos, 0);
   EXPECT_GT(cpuNanos, 0);
   EXPECT_LE(cpuNanos, wallNanos);
-}
-
-TEST(QueryRuntimeStatsTest, cpuMetricNaming) {
-  QueryRuntimeStats stats;
-  stats.recordTiming(
-      QueryRuntimeStats::kFindTableCpuNanos, std::chrono::nanoseconds(5000));
-
-  auto dynamic = stats.toDynamic();
-  auto key = std::string(QueryRuntimeStats::kFindTableCpuNanos);
-  ASSERT_TRUE(dynamic.count(key));
-  EXPECT_EQ(dynamic[key]["unit"].asString(), "NANO");
-  EXPECT_EQ(dynamic[key]["sum"].asInt(), 5000);
 }
 
 } // namespace

--- a/axiom/common/tests/TrackedExecutorTest.cpp
+++ b/axiom/common/tests/TrackedExecutorTest.cpp
@@ -20,6 +20,7 @@
 #include <folly/executors/SerialExecutor.h>
 #include <gtest/gtest.h>
 #include "axiom/common/QueryRuntimeStats.h"
+#include "axiom/runner/RunnerMetrics.h"
 
 namespace facebook::axiom {
 
@@ -40,9 +41,9 @@ TEST_F(TrackedExecutorTest, tracksExecutionMetrics) {
   done.wait();
 
   QueryRuntimeStats stats;
-  tracked.reportTo(stats, "test");
+  tracked.reportTo(stats.sinkFor(runner::kStatsComponent), "test");
 
-  auto map = stats.toMap();
+  auto map = stats.totalsByName();
   ASSERT_EQ(map.size(), 3);
 
   auto waitKey = fmt::format("test-{}", TrackedExecutor::kExecutorWaitNanos);
@@ -77,9 +78,9 @@ TEST_F(TrackedExecutorTest, tracksMultipleCallbacks) {
   done.wait();
 
   QueryRuntimeStats stats;
-  tracked.reportTo(stats, "multi");
+  tracked.reportTo(stats.sinkFor(runner::kStatsComponent), "multi");
 
-  auto map = stats.toMap();
+  auto map = stats.totalsByName();
   auto wallKey =
       fmt::format("multi-{}", TrackedExecutor::kExecutorExecutionWallNanos);
   ASSERT_EQ(map.count(wallKey), 1);
@@ -93,9 +94,9 @@ TEST_F(TrackedExecutorTest, reportToWithNoCallbacks) {
   TrackedExecutor tracked(std::move(serialExecutor));
 
   QueryRuntimeStats stats;
-  tracked.reportTo(stats, "empty");
+  tracked.reportTo(stats.sinkFor(runner::kStatsComponent), "empty");
 
-  auto map = stats.toMap();
+  auto map = stats.totalsByName();
   for (const auto& [name, metric] : map) {
     EXPECT_EQ(metric.count, 0);
   }

--- a/axiom/connectors/BaseSession.cpp
+++ b/axiom/connectors/BaseSession.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/connectors/BaseSession.h"
+
+#include "axiom/common/QueryRuntimeStats.h"
+
+namespace facebook::axiom::connector {
+
+RuntimeStatsSink BaseSession::statsSink(std::string_view component) const {
+  return QueryRuntimeStats::sinkOrThrowaway(runtimeStats_, component);
+}
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/BaseSession.h
+++ b/axiom/connectors/BaseSession.h
@@ -28,8 +28,9 @@ namespace facebook::axiom::connector {
 /// Map of connector id to that connector's property bag.
 using ConnectorProperties = folly::F14FastMap<std::string, Properties>;
 
-/// Base class for component sessions. Holds queryId, user, and the
-/// per-connector property map; spawns ConnectorSessions on demand.
+/// Base class for component sessions. Holds queryId, user, the per-connector
+/// property map, and an optional query-scoped runtime stats sink; spawns
+/// ConnectorSessions on demand.
 ///
 /// Example:
 ///   class OptimizerSession : public BaseSession { ... };
@@ -39,10 +40,12 @@ class BaseSession {
   BaseSession(
       std::string queryId,
       std::string user,
-      ConnectorProperties connectorProperties)
+      ConnectorProperties connectorProperties,
+      std::shared_ptr<QueryRuntimeStats> runtimeStats)
       : queryId_{std::move(queryId)},
         user_{std::move(user)},
-        connectorProperties_{std::move(connectorProperties)} {}
+        connectorProperties_{std::move(connectorProperties)},
+        runtimeStats_{std::move(runtimeStats)} {}
 
   virtual ~BaseSession() = default;
 
@@ -54,12 +57,21 @@ class BaseSession {
     return user_;
   }
 
-  /// Spawns a ConnectorSession for 'connectorId' carrying queryId, user,
-  /// and that connector's property slice (empty when no properties were set
-  /// for it).
+  /// Returns a sink for 'component' for first-party recorders (parser,
+  /// optimizer, runner). Always valid, even when the session carries no
+  /// collector.
+  RuntimeStatsSink statsSink(std::string_view component) const;
+
+  /// Spawns a ConnectorSession for 'connectorId' carrying queryId, user, the
+  /// connector id, that connector's property slice (empty when no properties
+  /// were set for it), and this session's runtime stats collector.
   ConnectorSessionPtr toConnectorSession(std::string_view connectorId) const {
     return std::make_shared<ConnectorSession>(
-        queryId_, user_, propertiesForConnector(connectorId));
+        queryId_,
+        user_,
+        std::string(connectorId),
+        propertiesForConnector(connectorId),
+        runtimeStats_);
   }
 
  private:
@@ -74,6 +86,7 @@ class BaseSession {
   const std::string queryId_;
   const std::string user_;
   const ConnectorProperties connectorProperties_;
+  const std::shared_ptr<QueryRuntimeStats> runtimeStats_;
 };
 
 } // namespace facebook::axiom::connector

--- a/axiom/connectors/BaseSession.h
+++ b/axiom/connectors/BaseSession.h
@@ -74,6 +74,11 @@ class BaseSession {
         runtimeStats_);
   }
 
+ protected:
+  const ConnectorProperties& connectorProperties() const {
+    return connectorProperties_;
+  }
+
  private:
   Properties propertiesForConnector(std::string_view connectorId) const {
     auto it = connectorProperties_.find(connectorId);

--- a/axiom/connectors/CMakeLists.txt
+++ b/axiom/connectors/CMakeLists.txt
@@ -12,7 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(axiom_connectors ConnectorMetadata.cpp ConnectorMetadataRegistry.cpp SchemaResolver.cpp)
+add_library(
+  axiom_connectors
+  BaseSession.cpp
+  ConnectorMetadata.cpp
+  ConnectorMetadataRegistry.cpp
+  ConnectorSession.cpp
+  SchemaResolver.cpp
+)
 
 target_link_libraries(
   axiom_connectors

--- a/axiom/connectors/ConnectorSession.cpp
+++ b/axiom/connectors/ConnectorSession.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/connectors/ConnectorSession.h"
+
+#include "axiom/common/QueryRuntimeStats.h"
+#include "axiom/connectors/StatsComponents.h"
+
+namespace facebook::axiom::connector {
+
+RuntimeStatsSink ConnectorSession::splitStatsSink() const {
+  return statsSink(connector::connectorSplits(connectorId_));
+}
+
+RuntimeStatsSink ConnectorSession::statsSink(std::string_view component) const {
+  return QueryRuntimeStats::sinkOrThrowaway(runtimeStats_, component);
+}
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/ConnectorSession.h
+++ b/axiom/connectors/ConnectorSession.h
@@ -23,6 +23,11 @@
 
 #include <folly/container/F14Map.h>
 
+namespace facebook::axiom {
+class QueryRuntimeStats;
+class RuntimeStatsSink;
+} // namespace facebook::axiom
+
 namespace facebook::axiom::connector {
 
 /// Property bag for a single component or connector.
@@ -31,13 +36,23 @@ using Properties = folly::F14FastMap<std::string, std::string>;
 class ConnectorSession;
 using ConnectorSessionPtr = std::shared_ptr<ConnectorSession>;
 
-/// Read-only query-specific information passed to connectors.
+/// Query-specific context passed to connectors. The identity and config fields
+/// (queryId, user, connectorId, properties) are read-only. Split-enumeration
+/// metrics are recorded through the write-only sink returned by
+/// splitStatsSink(); the connector boundary never sees the whole collector.
 class ConnectorSession final {
  public:
-  ConnectorSession(std::string queryId, std::string user, Properties properties)
+  ConnectorSession(
+      std::string queryId,
+      std::string user,
+      std::string connectorId,
+      Properties properties,
+      std::shared_ptr<QueryRuntimeStats> runtimeStats)
       : queryId_{std::move(queryId)},
         user_{std::move(user)},
-        properties_{std::move(properties)} {}
+        connectorId_{std::move(connectorId)},
+        properties_{std::move(properties)},
+        runtimeStats_{std::move(runtimeStats)} {}
 
   /// Returns the query identifier.
   const std::string& queryId() const {
@@ -47,6 +62,11 @@ class ConnectorSession final {
   /// Returns the identity of the user who submitted the query.
   const std::string& user() const {
     return user_;
+  }
+
+  /// Returns the id of the connector this session is scoped to.
+  const std::string& connectorId() const {
+    return connectorId_;
   }
 
   /// Returns the value of session property 'name' if set on this session,
@@ -60,10 +80,19 @@ class ConnectorSession final {
     return it->second;
   }
 
+  /// Returns a sink for this connector's split-enumeration metrics. Always
+  /// valid, even when the session carries no collector.
+  RuntimeStatsSink splitStatsSink() const;
+
  private:
+  // Always returns a valid sink; uses a throwaway map when no collector.
+  RuntimeStatsSink statsSink(std::string_view component) const;
+
   const std::string queryId_;
   const std::string user_;
+  const std::string connectorId_;
   const Properties properties_;
+  const std::shared_ptr<QueryRuntimeStats> runtimeStats_;
 };
 
 } // namespace facebook::axiom::connector

--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -18,7 +18,6 @@
 #include <folly/coro/Task.h>
 #include <velox/connectors/Connector.h>
 #include <optional>
-#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorSession.h"
 
 namespace facebook::axiom::connector {
@@ -119,8 +118,6 @@ class ConnectorSplitManager {
   /// Returns a SplitSource that covers the contents of 'partitions'. The set
   /// of partitions is exposed separately so that the caller may process them
   /// in a specific order or distribute them to specific nodes in a cluster.
-  /// Connector implementations may use 'runtimeStats' to record split
-  /// enumeration metrics (e.g., file listing, Metastore RPCs).
   ///
   /// When 'partitionType' is non-null, the connector tags each emitted Split
   /// with a groupId in [0, partitionType->numPartitions()). Pass 'nullptr'
@@ -136,8 +133,7 @@ class ConnectorSplitManager {
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       const std::shared_ptr<PartitionType>& partitionType,
-      std::optional<double> samplePercentage,
-      QueryRuntimeStats& runtimeStats) = 0;
+      std::optional<double> samplePercentage) = 0;
 };
 
 } // namespace facebook::axiom::connector

--- a/axiom/connectors/StatsComponents.h
+++ b/axiom/connectors/StatsComponents.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace facebook::axiom::connector {
+
+/// Returns the QueryRuntimeStats component id for 'connectorId' split
+/// enumeration (e.g. "hive/splits"). A connector qualifies its component by id
+/// so metrics stay distinct across connectors within a single query.
+inline std::string connectorSplits(std::string_view connectorId) {
+  return std::string(connectorId) + "/splits";
+}
+
+} // namespace facebook::axiom::connector

--- a/axiom/connectors/file/core/FileConnectorMetadata.cpp
+++ b/axiom/connectors/file/core/FileConnectorMetadata.cpp
@@ -96,8 +96,7 @@ FileConnectorMetadata::SplitManager::getSplitSource(
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
     const std::shared_ptr<PartitionType>& /*partitionType*/,
-    std::optional<double> samplePercentage,
-    QueryRuntimeStats& /*runtimeStats*/) {
+    std::optional<double> samplePercentage) {
   VELOX_USER_CHECK(
       !samplePercentage.has_value(),
       "SYSTEM sampling is not supported by this connector");

--- a/axiom/connectors/file/core/FileConnectorMetadata.h
+++ b/axiom/connectors/file/core/FileConnectorMetadata.h
@@ -81,8 +81,7 @@ class FileConnectorMetadata : public ConnectorMetadata {
         const velox::connector::ConnectorTableHandlePtr& tableHandle,
         const std::vector<PartitionHandlePtr>& partitions,
         const std::shared_ptr<PartitionType>& partitionType,
-        std::optional<double> samplePercentage,
-        QueryRuntimeStats& runtimeStats) override;
+        std::optional<double> samplePercentage) override;
   };
 
   velox::connector::Connector* connector_;

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -275,8 +275,7 @@ std::shared_ptr<SplitSource> LocalHiveSplitManager::getSplitSource(
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
     const std::shared_ptr<PartitionType>& partitionType,
-    std::optional<double> samplePercentage,
-    QueryRuntimeStats& /*runtimeStats*/) {
+    std::optional<double> samplePercentage) {
   VELOX_USER_CHECK(
       !samplePercentage.has_value(),
       "SYSTEM sampling is not supported by this connector");

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -77,8 +77,7 @@ class LocalHiveSplitManager : public ConnectorSplitManager {
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       const std::shared_ptr<PartitionType>& partitionType,
-      std::optional<double> samplePercentage,
-      QueryRuntimeStats& runtimeStats) override;
+      std::optional<double> samplePercentage) override;
 };
 
 // Write-time stats for a single partition (or the whole table if

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -120,7 +121,9 @@ class LocalHiveConnectorMetadataTest
     return std::make_shared<ConnectorSession>(
         /*queryId=*/"q-test",
         /*user=*/"u-test",
-        Properties{});
+        /*connectorId=*/std::string(velox::exec::test::kHiveConnectorId),
+        Properties{},
+        std::make_shared<QueryRuntimeStats>());
   }
 
   /// Write the specified data to the table with a TableWrite operation. The

--- a/axiom/connectors/system/SystemConnectorMetadata.cpp
+++ b/axiom/connectors/system/SystemConnectorMetadata.cpp
@@ -152,8 +152,7 @@ std::shared_ptr<SplitSource> SystemSplitManager::getSplitSource(
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
     const std::shared_ptr<PartitionType>& /*partitionType*/,
-    std::optional<double> samplePercentage,
-    QueryRuntimeStats& /*runtimeStats*/) {
+    std::optional<double> samplePercentage) {
   VELOX_USER_CHECK(
       !samplePercentage.has_value(),
       "SYSTEM sampling is not supported by this connector");

--- a/axiom/connectors/system/SystemConnectorMetadata.h
+++ b/axiom/connectors/system/SystemConnectorMetadata.h
@@ -122,8 +122,7 @@ class SystemSplitManager : public ConnectorSplitManager {
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       const std::shared_ptr<PartitionType>& partitionType,
-      std::optional<double> samplePercentage,
-      QueryRuntimeStats& runtimeStats) override;
+      std::optional<double> samplePercentage) override;
 };
 
 /// Axiom ConnectorMetadata for the system connector.

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -19,6 +19,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/system/SystemConnector.h"
@@ -165,7 +166,9 @@ class SystemConnectorMetadataTest : public ::testing::Test {
     return std::make_shared<ConnectorSession>(
         /*queryId=*/"test",
         /*user=*/"test",
-        Properties{});
+        /*connectorId=*/std::string(kSystemCatalog),
+        Properties{},
+        std::make_shared<QueryRuntimeStats>());
   }
 
   // Creates a DataSource for the given schema/table through the connector,
@@ -343,14 +346,12 @@ TEST_F(SystemConnectorMetadataTest, splitSource) {
       splitManager->co_listPartitions(session, tableHandle));
   EXPECT_EQ(partitions.size(), 1);
 
-  QueryRuntimeStats noopStats;
   auto splitSource = splitManager->getSplitSource(
       session,
       tableHandle,
       partitions,
       /*partitionType=*/nullptr,
-      /*samplePercentage=*/std::nullopt,
-      noopStats);
+      /*samplePercentage=*/std::nullopt);
   ASSERT_NE(splitSource, nullptr);
 
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -460,8 +460,7 @@ std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& partitions,
     const std::shared_ptr<PartitionType>& partitionType,
-    std::optional<double> samplePercentage,
-    QueryRuntimeStats& /*runtimeStats*/) {
+    std::optional<double> samplePercentage) {
   VELOX_CHECK_NOT_NULL(session);
   const auto& testTable = findTestTableForHandle(tableHandle);
 

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -294,8 +294,7 @@ class TestSplitManager : public ConnectorSplitManager {
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       const std::shared_ptr<PartitionType>& partitionType,
-      std::optional<double> samplePercentage,
-      QueryRuntimeStats& runtimeStats) override;
+      std::optional<double> samplePercentage) override;
 };
 
 class TestColumnHandle : public velox::connector::ColumnHandle {

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/common/SchemaTableName.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 
@@ -58,7 +59,11 @@ class TestConnectorTest : public ::testing::Test, public test::VectorTestBase {
 
   static ConnectorSessionPtr makeSession() {
     return std::make_shared<ConnectorSession>(
-        /*queryId=*/"test", /*user=*/"test", Properties{});
+        /*queryId=*/"test",
+        /*user=*/"test",
+        /*connectorId=*/"test",
+        Properties{},
+        std::make_shared<QueryRuntimeStats>());
   }
 
   std::shared_ptr<TestConnector> connector_;
@@ -165,14 +170,12 @@ CO_TEST_F(TestConnectorTest, splitManager) {
   auto session = makeSession();
   auto partitions =
       co_await splitManager->co_listPartitions(session, tableHandle);
-  QueryRuntimeStats noopStats;
   auto splitSource = splitManager->getSplitSource(
       session,
       tableHandle,
       partitions,
       /*partitionType=*/nullptr,
-      /*samplePercentage=*/std::nullopt,
-      noopStats);
+      /*samplePercentage=*/std::nullopt);
   EXPECT_NE(splitSource, nullptr);
 
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
@@ -637,14 +640,12 @@ CO_TEST_F(TestConnectorTest, bucketedTable) {
   constexpr int32_t kNumGroups = 2;
   auto partitionType = std::make_shared<TestPartitionType>(
       kNumGroups, std::vector<TypePtr>{BIGINT()}, schema);
-  QueryRuntimeStats noopStats;
   auto source = splitManager->getSplitSource(
       session,
       tableHandle,
       partitions,
       partitionType,
-      /*samplePercentage=*/std::nullopt,
-      noopStats);
+      /*samplePercentage=*/std::nullopt);
   std::vector<int32_t> observedGroupIds;
   while (true) {
     auto batch = co_await source->co_getSplits(/*maxSplitCount=*/16);
@@ -736,6 +737,31 @@ TEST_F(TestConnectorTest, bucketedTableMultiColumnKeys) {
         table->data()[i]->childAt(0)->as<SimpleVector<int64_t>>()->valueAt(0);
     EXPECT_EQ(expected[firstKey], table->dataBucketIds()[i]);
   }
+}
+
+// Guards the deliberate contract that a session without a collector hands out a
+// valid split sink whose recordings are silently discarded.
+TEST_F(TestConnectorTest, sessionlessSplitSinkDiscardsMetrics) {
+  ConnectorSession sessionless(
+      /*queryId=*/"test",
+      /*user=*/"test",
+      /*connectorId=*/"test",
+      Properties{},
+      /*runtimeStats=*/nullptr);
+  sessionless.splitStatsSink().recordCount("axiom-getSplitsCount", 1);
+
+  auto stats = std::make_shared<QueryRuntimeStats>();
+  ConnectorSession tracked(
+      /*queryId=*/"test",
+      /*user=*/"test",
+      /*connectorId=*/"test",
+      Properties{},
+      stats);
+  tracked.splitStatsSink().recordCount("axiom-getSplitsCount", 1);
+
+  const auto map = stats->totalsByName();
+  ASSERT_EQ(map.count("axiom-getSplitsCount"), 1);
+  EXPECT_EQ(map.at("axiom-getSplitsCount").sum, 1);
 }
 
 } // namespace

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -88,8 +88,7 @@ std::shared_ptr<SplitSource> TpchSplitManager::getSplitSource(
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
     const std::shared_ptr<PartitionType>& /*partitionType*/,
-    std::optional<double> samplePercentage,
-    QueryRuntimeStats& /*runtimeStats*/) {
+    std::optional<double> samplePercentage) {
   VELOX_USER_CHECK(
       !samplePercentage.has_value(),
       "SYSTEM sampling is not supported by this connector");

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -63,8 +63,7 @@ class TpchSplitManager : public ConnectorSplitManager {
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       const std::shared_ptr<PartitionType>& partitionType,
-      std::optional<double> samplePercentage,
-      QueryRuntimeStats& runtimeStats) override;
+      std::optional<double> samplePercentage) override;
 };
 
 /// A TableLayout for TPCH tables. Implements sampling by generating TPCH data.

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -20,6 +20,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "axiom/common/QueryRuntimeStats.h"
 #include "velox/connectors/tpch/TpchConnector.h"
 #include "velox/expression/Expr.h"
 
@@ -42,7 +43,10 @@ class TpchConnectorMetadataTest : public ::testing::Test {
     return std::make_shared<ConnectorSession>(
         /*queryId=*/"test",
         /*user=*/"test",
-        Properties{});
+        /*connectorId=*/
+        velox::connector::tpch::TpchConnectorFactory::kTpchConnectorName,
+        Properties{},
+        std::make_shared<QueryRuntimeStats>());
   }
 
   std::unique_ptr<velox::connector::tpch::TpchConnector> connector_;
@@ -227,14 +231,12 @@ CO_TEST_F(TpchConnectorMetadataTest, splitGeneration) {
       /*session=*/nullptr, tableHandle);
   CO_ASSERT_EQ(partitions.size(), 1);
 
-  QueryRuntimeStats noopStats;
   auto splitSource = splitManager->getSplitSource(
       /*session=*/nullptr,
       tableHandle,
       partitions,
       /*partitionType=*/nullptr,
-      /*samplePercentage=*/std::nullopt,
-      noopStats);
+      /*samplePercentage=*/std::nullopt);
   CO_ASSERT_NE(splitSource, nullptr);
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
   while (true) {

--- a/axiom/optimizer/JoinSample.cpp
+++ b/axiom/optimizer/JoinSample.cpp
@@ -16,9 +16,11 @@
 
 #include <folly/ScopeGuard.h>
 #include <folly/coro/BlockingWait.h>
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/Plan.h"
 #include "axiom/runner/LocalRunner.h"
+#include "axiom/runner/RunnerMetrics.h"
 #include "velox/common/base/AsyncSource.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/Registerer.h"
@@ -156,16 +158,19 @@ std::shared_ptr<runner::Runner> prepareSampleRunner(
   auto& optimization = queryCtx()->optimization();
   auto plan = optimization->toVelox().toVeloxPlan(
       filter, MultiFragmentPlan::Options::singleNode(), {}, {});
-  auto noopStats = RuntimeStatsSink::throwaway();
+
+  // Isolate sampling metrics from the outer query's collector.
+  auto sampleStats = std::make_shared<QueryRuntimeStats>();
+  auto sampleSink = sampleStats->sinkFor(runner::kStatsComponent);
   return std::make_shared<runner::LocalRunner>(
-      optimization->runnerSession(),
+      optimization->runnerSession()->withIsolatedStats(std::move(sampleStats)),
       std::move(plan.plan),
       std::move(plan.finishWrite),
       sampleQueryCtx(*optimization->veloxQueryCtx()),
-      std::make_shared<runner::ConnectorSplitSourceFactory>(noopStats),
+      std::make_shared<runner::ConnectorSplitSourceFactory>(sampleSink),
       /*outputPool=*/nullptr,
       /*baseSpillDirectory=*/"",
-      noopStats);
+      sampleSink);
 }
 
 // Maps hash value to number of times it appears in a table.

--- a/axiom/optimizer/JoinSample.cpp
+++ b/axiom/optimizer/JoinSample.cpp
@@ -156,7 +156,7 @@ std::shared_ptr<runner::Runner> prepareSampleRunner(
   auto& optimization = queryCtx()->optimization();
   auto plan = optimization->toVelox().toVeloxPlan(
       filter, MultiFragmentPlan::Options::singleNode(), {}, {});
-  static QueryRuntimeStats noopStats;
+  auto noopStats = RuntimeStatsSink::throwaway();
   return std::make_shared<runner::LocalRunner>(
       optimization->runnerSession(),
       std::move(plan.plan),

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -23,6 +23,7 @@
 #include "axiom/optimizer/ConnectorPushdownPass.h"
 #include "axiom/optimizer/Filters.h"
 #include "axiom/optimizer/FunctionRegistry.h"
+#include "axiom/optimizer/OptimizerMetrics.h"
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/PlanUtils.h"
 #include "axiom/optimizer/PrecomputeProjection.h"
@@ -74,8 +75,7 @@ Optimization::Optimization(
     History& history,
     std::shared_ptr<velox::core::QueryCtx> veloxQueryCtx,
     velox::core::ExpressionEvaluator& evaluator,
-    MultiFragmentPlan::Options runnerOptions,
-    std::shared_ptr<QueryRuntimeStats> runtimeStats)
+    MultiFragmentPlan::Options runnerOptions)
     : optimizerSession_{std::move(optimizerSession)},
       runnerSession_{std::move(runnerSession)},
       runnerOptions_(std::move(runnerOptions)),
@@ -87,9 +87,13 @@ Optimization::Optimization(
           isSingleWorker_,
           isSingleDriver_,
           optimizerSession_->options().alwaysPlanPartialAggregation},
-      toGraph_{schema, evaluator, optimizerSession_->options(), runtimeStats},
+      toGraph_{
+          schema,
+          evaluator,
+          optimizerSession_->options(),
+          optimizerSession_->statsSink(kStatsComponent)},
       toVelox_{optimizerSession_, runnerOptions_},
-      runtimeStats_{std::move(runtimeStats)} {
+      statsSink_{optimizerSession_->statsSink(kStatsComponent)} {
   VELOX_CHECK_NOT_NULL(runnerSession_);
   VELOX_CHECK_NOT_NULL(veloxQueryCtx_);
   queryCtx()->optimization() = this;
@@ -211,16 +215,11 @@ void Optimization::estimateAllBaseTableSelectivity(DerivedTable& dt) {
   auto results = blockingWaitOn(
       veloxQueryCtx_->executor(),
       folly::coro::collectAllRange(std::move(tasks)));
-  if (runtimeStats_) {
-    recordCpuIfSameThread(
-        *runtimeStats_,
-        QueryRuntimeStats::kEstimateStatsCpuNanos,
-        estimateCpuStart,
-        estimateThreadId);
-    runtimeStats_->recordTiming(
-        QueryRuntimeStats::kEstimateStatsWallNanos,
-        std::chrono::steady_clock::now() - estimateStart);
-  }
+  recordCpuIfSameThread(
+      statsSink_, kEstimateStatsCpuNanos, estimateCpuStart, estimateThreadId);
+  statsSink_.recordTiming(
+      kEstimateStatsWallNanos,
+      std::chrono::steady_clock::now() - estimateStart);
 
   // Apply results.
   for (auto& [baseTable, taskIndex, columnIndices] : tableTasks) {

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -43,8 +43,7 @@ class Optimization {
       History& history,
       std::shared_ptr<velox::core::QueryCtx> veloxQueryCtx,
       velox::core::ExpressionEvaluator& evaluator,
-      MultiFragmentPlan::Options runnerOptions = {},
-      std::shared_ptr<QueryRuntimeStats> runtimeStats = nullptr);
+      MultiFragmentPlan::Options runnerOptions = {});
 
   /// Simplified API for usage in testing and tooling.
   static PlanAndStats toVeloxPlan(
@@ -519,7 +518,7 @@ class Optimization {
   // captured at Plan construction. See planGroupedLeaves() doc.
   folly::F14FastMap<const Plan*, GroupedLeaves> planGroupedLeaves_;
 
-  std::shared_ptr<QueryRuntimeStats> runtimeStats_;
+  RuntimeStatsSink statsSink_;
 };
 
 /// Captures the producer-side fragment commit. Moves

--- a/axiom/optimizer/OptimizerMetrics.h
+++ b/axiom/optimizer/OptimizerMetrics.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string_view>
+
+namespace facebook::axiom::optimizer {
+
+/// QueryRuntimeStats component id for optimizer metrics.
+inline constexpr std::string_view kStatsComponent{"optimizer"};
+
+/// Runtime-metric names recorded by the optimizer. Producers and consumers
+/// share these constants so a rename cannot silently de-correlate a metric.
+inline constexpr std::string_view kOptimizeWallNanos{"axiom-optimizeWallNanos"};
+inline constexpr std::string_view kOptimizeCpuNanos{"axiom-optimizeCpuNanos"};
+inline constexpr std::string_view kOptimizeToGraphWallNanos{
+    "axiom-optimizeToGraphWallNanos"};
+inline constexpr std::string_view kOptimizeToGraphCpuNanos{
+    "axiom-optimizeToGraphCpuNanos"};
+inline constexpr std::string_view kOptimizeBestPlanWallNanos{
+    "axiom-optimizeBestPlanWallNanos"};
+inline constexpr std::string_view kOptimizeBestPlanCpuNanos{
+    "axiom-optimizeBestPlanCpuNanos"};
+inline constexpr std::string_view kOptimizeToVeloxWallNanos{
+    "axiom-optimizeToVeloxWallNanos"};
+inline constexpr std::string_view kOptimizeToVeloxCpuNanos{
+    "axiom-optimizeToVeloxCpuNanos"};
+
+inline constexpr std::string_view kFindTableWallNanos{
+    "axiom-findTableWallNanos"};
+inline constexpr std::string_view kFindTableCpuNanos{"axiom-findTableCpuNanos"};
+
+inline constexpr std::string_view kEstimateStatsWallNanos{
+    "axiom-estimateStatsWallNanos"};
+inline constexpr std::string_view kEstimateStatsCpuNanos{
+    "axiom-estimateStatsCpuNanos"};
+
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/OptimizerSession.h
+++ b/axiom/optimizer/OptimizerSession.h
@@ -36,11 +36,13 @@ class OptimizerSession final : public connector::BaseSession {
       std::string queryId,
       std::string user,
       OptimizerOptions options,
-      connector::ConnectorProperties connectorProperties)
+      connector::ConnectorProperties connectorProperties,
+      std::shared_ptr<QueryRuntimeStats> runtimeStats)
       : BaseSession(
             std::move(queryId),
             std::move(user),
-            std::move(connectorProperties)),
+            std::move(connectorProperties),
+            std::move(runtimeStats)),
         options_{std::move(options)} {}
 
   const OptimizerOptions& options() const {

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -20,6 +20,7 @@
 #include "axiom/optimizer/Cost.h"
 #include "axiom/optimizer/DerivedTable.h"
 #include "axiom/optimizer/Filters.h"
+#include "axiom/optimizer/OptimizerMetrics.h"
 #include "axiom/optimizer/PlanUtils.h"
 #include "velox/common/process/ProcessBase.h"
 #include "velox/connectors/ConnectorRegistry.h"
@@ -259,15 +260,12 @@ SchemaTableCP FOLLY_NULLABLE Schema::findTable(
   auto findCpuStart = velox::process::threadCpuNanos();
   auto findStart = std::chrono::steady_clock::now();
   auto connectorTable = source_->findTable(std::string(connectorId), tableName);
-  if (runtimeStats_) {
-    runtimeStats_->recordTiming(
-        QueryRuntimeStats::kFindTableCpuNanos,
-        std::chrono::nanoseconds(
-            velox::process::threadCpuNanos() - findCpuStart));
-    runtimeStats_->recordTiming(
-        QueryRuntimeStats::kFindTableWallNanos,
-        std::chrono::steady_clock::now() - findStart);
-  }
+  statsSink_.recordTiming(
+      kFindTableCpuNanos,
+      std::chrono::nanoseconds(
+          velox::process::threadCpuNanos() - findCpuStart));
+  statsSink_.recordTiming(
+      kFindTableWallNanos, std::chrono::steady_clock::now() - findStart);
   if (!connectorTable) {
     return nullptr;
   }

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -442,8 +442,8 @@ class Schema {
   /// Constructs a Schema for producing executable plans, backed by 'source'.
   explicit Schema(
       const connector::SchemaResolver& source,
-      std::shared_ptr<QueryRuntimeStats> runtimeStats = nullptr)
-      : source_{&source}, runtimeStats_{std::move(runtimeStats)} {}
+      RuntimeStatsSink statsSink = RuntimeStatsSink::throwaway())
+      : source_{&source}, statsSink_{std::move(statsSink)} {}
 
   /// Returns the table with 'name' or nullptr if not found, using
   /// the connector specified by connectorId to perform table lookups.
@@ -477,7 +477,7 @@ class Schema {
   using ConnectorMap = folly::F14FastMap<std::string_view, TableMap>;
 
   const connector::SchemaResolver* source_;
-  std::shared_ptr<QueryRuntimeStats> runtimeStats_;
+  RuntimeStatsSink statsSink_;
   mutable ConnectorMap connectorTables_;
   // Holds `connector::Table`s whose ownership is given directly to
   // the Schema rather than resolved through the source. Keeps them

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -195,8 +195,8 @@ ToGraph::ToGraph(
     const connector::SchemaResolver& schema,
     velox::core::ExpressionEvaluator& evaluator,
     const OptimizerOptions& options,
-    std::shared_ptr<QueryRuntimeStats> runtimeStats)
-    : schema_{schema, std::move(runtimeStats)},
+    RuntimeStatsSink statsSink)
+    : schema_{schema, std::move(statsSink)},
       evaluator_{evaluator},
       options_{options},
       functionNames_{queryCtx()->functionNames()} {

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -80,7 +80,7 @@ class ToGraph {
       const connector::SchemaResolver& schemaResolver,
       velox::core::ExpressionEvaluator& evaluator,
       const OptimizerOptions& options,
-      std::shared_ptr<QueryRuntimeStats> runtimeStats = nullptr);
+      RuntimeStatsSink statsSink);
 
   /// Converts 'logicalPlan' to a tree of DerivedTables. Returns the root
   /// DerivedTable. Strips a root OutputNode after SubfieldTracker prunes

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -22,6 +22,7 @@
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <iostream>
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
@@ -34,6 +35,7 @@
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/runner/LocalRunner.h"
+#include "axiom/runner/RunnerMetrics.h"
 #include "axiom/sql/presto/PrestoParser.h"
 #include "velox/benchmarks/QueryBenchmarkBase.h"
 #include "velox/common/caching/SsdCache.h"
@@ -188,7 +190,8 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
             /*queryId=*/"axiom-sql-benchmark",
             /*user=*/"axiom-sql-benchmark",
             ::axiom::sql::presto::ParserOptions{},
-            connector::ConnectorProperties{}));
+            connector::ConnectorProperties{},
+            std::make_shared<axiom::QueryRuntimeStats>()));
 
     history_ = std::make_unique<optimizer::VeloxHistory>();
 
@@ -332,7 +335,11 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
     }
 
     auto session = std::make_shared<connector::ConnectorSession>(
-        "test", "test", connector::Properties{});
+        "test",
+        "test",
+        connector_->connectorId(),
+        connector::Properties{},
+        std::make_shared<axiom::QueryRuntimeStats>());
     auto table = metadata->createTable(
         session,
         statement.tableName(),
@@ -351,7 +358,11 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
     const auto& tableName = statement.tableName();
 
     auto session = std::make_shared<connector::ConnectorSession>(
-        "test", "test", connector::Properties{});
+        "test",
+        "test",
+        connector_->connectorId(),
+        connector::Properties{},
+        std::make_shared<axiom::QueryRuntimeStats>());
     const bool dropped = metadata->dropTable(
         session, tableName, statement.ifExists(), /*explain=*/false);
 
@@ -601,12 +612,14 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
         queryCtx->queryId(),
         /*user=*/"axiom-sql-benchmark",
         std::move(optimizerOptions),
-        connector::ConnectorProperties{});
+        connector::ConnectorProperties{},
+        std::make_shared<axiom::QueryRuntimeStats>());
     auto runnerSession = std::make_shared<runner::RunnerSession>(
         queryCtx->queryId(),
         /*user=*/"axiom-sql-benchmark",
         runner::Properties{},
-        connector::ConnectorProperties{});
+        connector::ConnectorProperties{},
+        std::make_shared<axiom::QueryRuntimeStats>());
 
     optimizer::Optimization optimization(
         std::move(optimizerSession),
@@ -665,16 +678,18 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
         queryCtx->queryId(),
         /*user=*/"axiom-sql-benchmark",
         connector::Properties{},
-        connector::ConnectorProperties{});
+        connector::ConnectorProperties{},
+        std::make_shared<axiom::QueryRuntimeStats>());
     return std::make_shared<runner::LocalRunner>(
         std::move(runnerSession),
         planAndStats.plan,
         std::move(planAndStats.finishWrite),
         queryCtx,
-        std::make_shared<runner::ConnectorSplitSourceFactory>(runtimeStats_),
+        std::make_shared<runner::ConnectorSplitSourceFactory>(
+            runtimeStats_.sinkFor(runner::kStatsComponent)),
         optimizerPool_,
         /*baseSpillDirectory=*/"",
-        runtimeStats_);
+        runtimeStats_.sinkFor(runner::kStatsComponent));
   }
 
   /// Runs a query and returns the result as a single vector in *resultVector,

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -17,6 +17,7 @@
 #include "axiom/optimizer/DerivedTablePrinter.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/logical_plan/PlanBuilder.h"
@@ -72,7 +73,8 @@ class DerivedTablePrinterTest : public ::testing::Test {
             /*queryId=*/"test",
             /*user=*/"test",
             ::axiom::sql::presto::ParserOptions{},
-            connector::ConnectorProperties{})};
+            connector::ConnectorProperties{},
+            std::make_shared<QueryRuntimeStats>())};
     auto statement = parser.parse(sql);
     VELOX_CHECK(statement->isSelect());
 
@@ -107,12 +109,14 @@ class DerivedTablePrinterTest : public ::testing::Test {
         veloxQueryCtx->queryId(),
         "test",
         std::move(options),
-        connector::ConnectorProperties{});
+        connector::ConnectorProperties{},
+        std::make_shared<QueryRuntimeStats>());
     auto runnerSession = std::make_shared<runner::RunnerSession>(
         veloxQueryCtx->queryId(),
         "test",
         runner::Properties{},
-        connector::ConnectorProperties{});
+        connector::ConnectorProperties{},
+        std::make_shared<QueryRuntimeStats>());
 
     Optimization opt{
         optimizerSession,

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -17,6 +17,7 @@
 #include "axiom/optimizer/tests/HiveQueriesTestBase.h"
 #include <gflags/gflags.h>
 #include <optional>
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/logical_plan/PlanBuilder.h"
@@ -94,7 +95,8 @@ void HiveQueriesTestBase::SetUp() {
           /*queryId=*/"test",
           /*user=*/"test",
           ::axiom::sql::presto::ParserOptions{},
-          connector::ConnectorProperties{}));
+          connector::ConnectorProperties{},
+          std::make_shared<QueryRuntimeStats>()));
 }
 
 // static

--- a/axiom/optimizer/tests/HiveQueriesTestBase.h
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
@@ -55,7 +56,11 @@ class HiveQueriesTestBase : public QueryTestBase {
 
   static connector::ConnectorSessionPtr makeSession() {
     return std::make_shared<connector::ConnectorSession>(
-        /*queryId=*/"test", /*user=*/"test", connector::Properties{});
+        /*queryId=*/"test",
+        /*user=*/"test",
+        /*connectorId=*/std::string(velox::exec::test::kHiveConnectorId),
+        connector::Properties{},
+        std::make_shared<QueryRuntimeStats>());
   }
 
   /// Returns a schema of a table.

--- a/axiom/optimizer/tests/PrecomputeProjectionTest.cpp
+++ b/axiom/optimizer/tests/PrecomputeProjectionTest.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/optimizer/PrecomputeProjection.h"
 #include <gtest/gtest.h>
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/Optimization.h"
@@ -69,12 +70,14 @@ class PrecomputeProjectionTest : public ::testing::Test {
         veloxQueryCtx->queryId(),
         "test",
         OptimizerOptions{},
-        connector::ConnectorProperties{});
+        connector::ConnectorProperties{},
+        std::make_shared<QueryRuntimeStats>());
     auto runnerSession = std::make_shared<runner::RunnerSession>(
         veloxQueryCtx->queryId(),
         "test",
         runner::Properties{},
-        connector::ConnectorProperties{});
+        connector::ConnectorProperties{},
+        std::make_shared<QueryRuntimeStats>());
 
     Optimization opt{
         optimizerSession,

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -19,6 +19,7 @@
 #include <ctime>
 
 #include <folly/coro/BlockingWait.h>
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/optimizer/Optimization.h"
@@ -26,6 +27,7 @@
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/optimizer/tests/TestDataPath.h"
 #include "axiom/optimizer/v2/Optimize.h"
+#include "axiom/runner/RunnerMetrics.h"
 #include "axiom/sql/presto/PrestoParser.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
@@ -116,7 +118,8 @@ logical_plan::LogicalPlanNodePtr QueryTestBase::parseSelect(
           /*queryId=*/"test",
           /*user=*/"test",
           ::axiom::sql::presto::ParserOptions{},
-          connector::ConnectorProperties{}));
+          connector::ConnectorProperties{},
+          std::make_shared<QueryRuntimeStats>()));
 
   auto statement = parser.parse(sql);
 
@@ -130,12 +133,20 @@ OptimizerSessionPtr makeOptimizerSession(
     OptimizerOptions options,
     connector::ConnectorProperties connectorProperties) {
   return std::make_shared<OptimizerSession>(
-      queryId, "test", std::move(options), std::move(connectorProperties));
+      queryId,
+      "test",
+      std::move(options),
+      std::move(connectorProperties),
+      std::make_shared<QueryRuntimeStats>());
 }
 
 runner::RunnerSessionPtr makeRunnerSession(const std::string& queryId) {
   return std::make_shared<runner::RunnerSession>(
-      queryId, "test", runner::Properties{}, connector::ConnectorProperties{});
+      queryId,
+      "test",
+      runner::Properties{},
+      connector::ConnectorProperties{},
+      std::make_shared<QueryRuntimeStats>());
 }
 } // namespace
 
@@ -163,16 +174,18 @@ TestResult QueryTestBase::runFragmentedPlan(
       getQueryCtx()->queryId(),
       "test",
       connector::Properties{},
-      connector::ConnectorProperties{});
+      connector::ConnectorProperties{},
+      std::make_shared<QueryRuntimeStats>());
   auto runner = std::make_shared<runner::LocalRunner>(
       std::move(runnerSession),
       planAndStats.plan,
       std::move(planAndStats.finishWrite),
       getQueryCtx(),
-      std::make_shared<runner::ConnectorSplitSourceFactory>(runtimeStats_),
+      std::make_shared<runner::ConnectorSplitSourceFactory>(
+          runtimeStats_.sinkFor(runner::kStatsComponent)),
       optimizerPool_,
       /*baseSpillDirectory=*/"",
-      runtimeStats_);
+      runtimeStats_.sinkFor(runner::kStatsComponent));
 
   SCOPE_EXIT {
     queryCtx_.reset();

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -16,6 +16,7 @@
 #include "axiom/optimizer/RelationOpPrinter.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/logical_plan/PlanBuilder.h"
@@ -123,7 +124,8 @@ class RelationOpPrinterTest : public ::testing::Test {
             /*queryId=*/"test",
             /*user=*/"test",
             ::axiom::sql::presto::ParserOptions{},
-            connector::ConnectorProperties{})};
+            connector::ConnectorProperties{},
+            std::make_shared<QueryRuntimeStats>())};
     auto statement = parser.parse(sql);
     VELOX_CHECK(statement->isSelect());
 
@@ -159,12 +161,14 @@ class RelationOpPrinterTest : public ::testing::Test {
         veloxQueryCtx->queryId(),
         "test",
         std::move(options),
-        connector::ConnectorProperties{});
+        connector::ConnectorProperties{},
+        std::make_shared<QueryRuntimeStats>());
     auto runnerSession = std::make_shared<runner::RunnerSession>(
         veloxQueryCtx->queryId(),
         "test",
         runner::Properties{},
-        connector::ConnectorProperties{});
+        connector::ConnectorProperties{},
+        std::make_shared<QueryRuntimeStats>());
 
     Optimization opt{
         optimizerSession,

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <filesystem>
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
 #include "axiom/optimizer/ConstantExprEvaluator.h"
@@ -116,11 +117,16 @@ void runSetupStatement(
           /*queryId=*/"test",
           /*user=*/"test",
           ::axiom::sql::presto::ParserOptions{},
-          connector::ConnectorProperties{}));
+          connector::ConnectorProperties{},
+          std::make_shared<QueryRuntimeStats>()));
   auto stmt = parser.parse(sql);
 
   auto session = std::make_shared<connector::ConnectorSession>(
-      /*queryId=*/"test", /*user=*/"test", connector::Properties{});
+      /*queryId=*/"test",
+      /*user=*/"test",
+      /*connectorId=*/connectorId,
+      connector::Properties{},
+      std::make_shared<QueryRuntimeStats>());
 
   auto evalOptions = [](const auto& properties) {
     folly::F14FastMap<std::string, velox::Variant> options;

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -125,9 +125,17 @@ std::shared_ptr<runner::LocalRunner> makeLocalRunnerImpl(
   OptimizerOptions optimizerOptions;
   optimizerOptions.syntacticJoinOrder = syntacticJoinOrder;
   auto optimizerSession = std::make_shared<OptimizerSession>(
-      queryId, "test", optimizerOptions, connector::ConnectorProperties{});
+      queryId,
+      "test",
+      optimizerOptions,
+      connector::ConnectorProperties{},
+      std::make_shared<QueryRuntimeStats>());
   auto runnerSession = std::make_shared<runner::RunnerSession>(
-      queryId, "test", runner::Properties{}, connector::ConnectorProperties{});
+      queryId,
+      "test",
+      runner::Properties{},
+      connector::ConnectorProperties{},
+      std::make_shared<QueryRuntimeStats>());
 
   auto planAndStats = plan(
       *logicalPlan,
@@ -138,7 +146,7 @@ std::shared_ptr<runner::LocalRunner> makeLocalRunnerImpl(
       runnerSession,
       queryCtx);
 
-  static QueryRuntimeStats noopStats;
+  static RuntimeStatsSink noopStats = RuntimeStatsSink::throwaway();
   return std::make_shared<runner::LocalRunner>(
       std::move(runnerSession),
       planAndStats.plan,
@@ -236,7 +244,8 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeRunner(
           /*queryId=*/"test",
           /*user=*/"test",
           ::axiom::sql::presto::ParserOptions{},
-          connector::ConnectorProperties{}));
+          connector::ConnectorProperties{},
+          std::make_shared<QueryRuntimeStats>()));
   auto statement = parser.parse(sql, true);
 
   VELOX_CHECK(

--- a/axiom/pyspark/Optimizer.cpp
+++ b/axiom/pyspark/Optimizer.cpp
@@ -17,6 +17,7 @@
 #include "axiom/pyspark/Optimizer.h"
 
 #include <glog/logging.h>
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/SchemaResolver.h"
@@ -83,7 +84,9 @@ facebook::axiom::connector::TablePtr createTable(
   auto session = std::make_shared<facebook::axiom::connector::ConnectorSession>(
       "pyspark_session",
       /*user=*/"pyspark-optimizer",
-      facebook::axiom::connector::Properties{});
+      connectorId,
+      facebook::axiom::connector::Properties{},
+      std::make_shared<facebook::axiom::QueryRuntimeStats>());
   auto table = metadata->createTable(
       session,
       writeNode.tableName(),
@@ -138,12 +141,14 @@ facebook::axiom::optimizer::PlanAndStats optimize(
           queryCtx->queryId(),
           /*user=*/"pyspark-optimizer",
           std::move(optimizerOptions),
-          facebook::axiom::connector::ConnectorProperties{});
+          facebook::axiom::connector::ConnectorProperties{},
+          std::make_shared<facebook::axiom::QueryRuntimeStats>());
   auto runnerSession = std::make_shared<facebook::axiom::runner::RunnerSession>(
       queryCtx->queryId(),
       /*user=*/"pyspark-optimizer",
       facebook::axiom::runner::Properties{},
-      facebook::axiom::connector::ConnectorProperties{});
+      facebook::axiom::connector::ConnectorProperties{},
+      std::make_shared<facebook::axiom::QueryRuntimeStats>());
 
   facebook::axiom::optimizer::Optimization opt(
       std::move(optimizerSession),

--- a/axiom/pyspark/runners/LocalRunner.cpp
+++ b/axiom/pyspark/runners/LocalRunner.cpp
@@ -21,9 +21,11 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/pyspark/Exception.h"
 #include "axiom/pyspark/runners/Runner.h"
 #include "axiom/runner/LocalRunner.h"
+#include "axiom/runner/RunnerMetrics.h"
 #include "velox/core/QueryCtx.h"
 
 DEFINE_int32(num_workers, 4, "Number of in-process workers");
@@ -86,21 +88,22 @@ std::vector<velox::RowVectorPtr> LocalRunner::execute(
 
   auto splitSourceFactory =
       std::make_shared<facebook::axiom::runner::ConnectorSplitSourceFactory>(
-          runtimeStats_);
+          runtimeStats_.sinkFor(facebook::axiom::runner::kStatsComponent));
 
   auto runner = std::make_shared<facebook::axiom::runner::LocalRunner>(
       std::make_shared<facebook::axiom::runner::RunnerSession>(
           queryCtx->queryId(),
           /*user=*/"pyspark-runner",
           facebook::axiom::runner::Properties{},
-          facebook::axiom::connector::ConnectorProperties{}),
+          facebook::axiom::connector::ConnectorProperties{},
+          std::make_shared<facebook::axiom::QueryRuntimeStats>()),
       plan_,
       std::move(finishWrite_),
       queryCtx,
       splitSourceFactory,
       leafPool_,
       /*baseSpillDirectory=*/"",
-      runtimeStats_);
+      runtimeStats_.sinkFor(facebook::axiom::runner::kStatsComponent));
   runner->drain(
       [&](velox::RowVectorPtr batch) { results.push_back(std::move(batch)); });
   return results;

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -24,6 +24,7 @@
 #include <folly/coro/Task.h>
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/runner/RunnerMetrics.h"
 #include "velox/common/base/SpillConfig.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/time/Timer.h"
@@ -33,8 +34,8 @@
 namespace facebook::axiom::runner {
 namespace {
 
-/// Testing proxy for a split source managed by a system with full metadata
-/// access.
+// Testing proxy for a split source managed by a system with full metadata
+// access.
 class SimpleSplitSource : public connector::SplitSource {
  public:
   explicit SimpleSplitSource(
@@ -94,23 +95,13 @@ ConnectorSplitSourceFactory::splitSourceForScan(
   auto partitions = folly::coro::blockingWait(
       splitManager->co_listPartitions(session, handle));
   recordCpuIfSameThread(
-      runtimeStats_,
-      QueryRuntimeStats::kListPartitionsCpuNanos,
-      listCpuStart,
-      listThreadId);
-  runtimeStats_.recordTiming(
-      QueryRuntimeStats::kListPartitionsWallNanos,
-      std::chrono::steady_clock::now() - listStart);
-  runtimeStats_.recordCount(
-      QueryRuntimeStats::kListPartitionsCount, partitions.size());
+      statsSink_, kListPartitionsCpuNanos, listCpuStart, listThreadId);
+  statsSink_.recordTiming(
+      kListPartitionsWallNanos, std::chrono::steady_clock::now() - listStart);
+  statsSink_.recordCount(kListPartitionsCount, partitions.size());
 
   return splitManager->getSplitSource(
-      session,
-      handle,
-      partitions,
-      partitionType,
-      samplePercentage,
-      runtimeStats_);
+      session, handle, partitions, partitionType, samplePercentage);
 }
 
 namespace {
@@ -144,7 +135,7 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
     velox::core::PlanNodeId scanId,
     std::vector<std::shared_ptr<velox::exec::Task>> tasks,
     std::function<void(std::exception_ptr)> onError,
-    QueryRuntimeStats& runtimeStats) {
+    RuntimeStatsSink statsSink) {
   std::exception_ptr ex;
   // Injected by CancellableAsyncScope::add(); the runner's co_reap() requests
   // cancellation on teardown so this loop stops enumerating instead of draining
@@ -189,14 +180,10 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
     }
 
     recordCpuIfSameThread(
-        runtimeStats,
-        QueryRuntimeStats::kGetSplitsCpuNanos,
-        getSplitsCpuStart,
-        getSplitsThreadId);
-    runtimeStats.recordTiming(
-        QueryRuntimeStats::kGetSplitsWallNanos,
-        std::chrono::steady_clock::now() - getSplitsStart);
-    runtimeStats.recordCount(QueryRuntimeStats::kGetSplitsCount, splitCount);
+        statsSink, kGetSplitsCpuNanos, getSplitsCpuStart, getSplitsThreadId);
+    statsSink.recordTiming(
+        kGetSplitsWallNanos, std::chrono::steady_clock::now() - getSplitsStart);
+    statsSink.recordCount(kGetSplitsCount, splitCount);
   } catch (const folly::OperationCancelled&) {
     // co_getSplits() observed the teardown cancellation mid-call. This is a
     // clean stop, not a query error, so do not propagate it to onError().
@@ -265,14 +252,14 @@ LocalRunner::LocalRunner(
     std::shared_ptr<SplitSourceFactory> splitSourceFactory,
     std::shared_ptr<velox::memory::MemoryPool> outputPool,
     std::string baseSpillDirectory,
-    QueryRuntimeStats& runtimeStats)
+    RuntimeStatsSink statsSink)
     : session_{std::move(session)},
       plan_{std::move(plan)},
       fragments_{topologicalSort(plan_->fragments())},
       finishWrite_{std::move(finishWrite)},
       splitSourceFactory_{std::move(splitSourceFactory)},
       baseSpillDirectory_{std::move(baseSpillDirectory)},
-      runtimeStats_(runtimeStats) {
+      statsSink_(std::move(statsSink)) {
   params_.queryCtx = std::move(queryCtx);
   params_.outputPool = std::move(outputPool);
   if (params_.outputPool == nullptr) {
@@ -803,7 +790,7 @@ void LocalRunner::makeStages(
             folly::coro::co_withExecutor(
                 params_.queryCtx->executor(),
                 co_generateAndDistributeSplits(
-                    source, scan->id(), stage, onError, runtimeStats_)));
+                    source, scan->id(), stage, onError, statsSink_)));
       }
 
       for (const auto& input : fragment.inputStages) {

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -75,8 +75,8 @@ class SimpleSplitSourceFactory : public SplitSourceFactory {
 /// Generic SplitSourceFactory that delegates the work to ConnectorSplitManager.
 class ConnectorSplitSourceFactory : public SplitSourceFactory {
  public:
-  explicit ConnectorSplitSourceFactory(QueryRuntimeStats& runtimeStats)
-      : runtimeStats_(runtimeStats) {}
+  explicit ConnectorSplitSourceFactory(RuntimeStatsSink statsSink)
+      : statsSink_(std::move(statsSink)) {}
 
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
@@ -85,7 +85,7 @@ class ConnectorSplitSourceFactory : public SplitSourceFactory {
       std::optional<double> samplePercentage) override;
 
  protected:
-  QueryRuntimeStats& runtimeStats_;
+  RuntimeStatsSink statsSink_;
 };
 
 /// Runner for in-process execution of a distributed plan.
@@ -97,7 +97,8 @@ class LocalRunner : public Runner,
   /// @param baseSpillDirectory Base directory for spill files. If non-empty,
   /// each task gets a unique subdirectory under this path. Empty disables
   /// spilling at the task level.
-  /// @param runtimeStats Optional recorder for split enumeration metrics.
+  /// @param statsSink Sink for split enumeration metrics; pass
+  /// RuntimeStatsSink::throwaway() when the query has no collector.
   LocalRunner(
       RunnerSessionPtr session,
       optimizer::MultiFragmentPlanPtr plan,
@@ -106,7 +107,7 @@ class LocalRunner : public Runner,
       std::shared_ptr<SplitSourceFactory> splitSourceFactory,
       std::shared_ptr<velox::memory::MemoryPool> outputPool,
       std::string baseSpillDirectory,
-      QueryRuntimeStats& runtimeStats);
+      RuntimeStatsSink statsSink);
 
   ~LocalRunner() override;
 
@@ -236,7 +237,7 @@ class LocalRunner : public Runner,
   std::shared_ptr<SplitSourceFactory> splitSourceFactory_;
   // Base directory for task spill files. Empty disables spilling.
   std::string baseSpillDirectory_;
-  QueryRuntimeStats& runtimeStats_;
+  RuntimeStatsSink statsSink_;
   // Cancellable so teardown can stop split enumeration promptly rather than
   // draining each source to noMoreSplits. co_reap() cancelAndJoinAsync()s it.
   folly::coro::CancellableAsyncScope splitScope_{/*throwOnJoin=*/true};

--- a/axiom/runner/RunnerMetrics.h
+++ b/axiom/runner/RunnerMetrics.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string_view>
+
+namespace facebook::axiom::runner {
+
+/// QueryRuntimeStats component id for runner metrics.
+inline constexpr std::string_view kStatsComponent{"runner"};
+
+/// Runtime-metric names recorded by the runner. Producers and consumers share
+/// these constants so a rename cannot silently de-correlate a metric.
+inline constexpr std::string_view kPermissionCheckWallNanos{
+    "axiom-permissionCheckWallNanos"};
+inline constexpr std::string_view kPermissionCheckCpuNanos{
+    "axiom-permissionCheckCpuNanos"};
+
+inline constexpr std::string_view kExecuteWallNanos{"axiom-executeWallNanos"};
+inline constexpr std::string_view kExecuteCpuNanos{"axiom-executeCpuNanos"};
+
+inline constexpr std::string_view kListPartitionsWallNanos{
+    "axiom-listPartitionsWallNanos"};
+inline constexpr std::string_view kListPartitionsCpuNanos{
+    "axiom-listPartitionsCpuNanos"};
+inline constexpr std::string_view kListPartitionsCount{
+    "axiom-listPartitionsCount"};
+
+inline constexpr std::string_view kGetSplitsWallNanos{
+    "axiom-getSplitsWallNanos"};
+inline constexpr std::string_view kGetSplitsCpuNanos{"axiom-getSplitsCpuNanos"};
+inline constexpr std::string_view kGetSplitsCount{"axiom-getSplitsCount"};
+
+} // namespace facebook::axiom::runner

--- a/axiom/runner/RunnerSession.h
+++ b/axiom/runner/RunnerSession.h
@@ -54,6 +54,18 @@ class RunnerSession final : public connector::BaseSession {
     return it->second;
   }
 
+  /// Returns a copy of this session whose sinks record into 'runtimeStats',
+  /// reusing all other identity and configuration.
+  std::shared_ptr<RunnerSession> withIsolatedStats(
+      std::shared_ptr<QueryRuntimeStats> runtimeStats) const {
+    return std::make_shared<RunnerSession>(
+        queryId(),
+        user(),
+        properties_,
+        connectorProperties(),
+        std::move(runtimeStats));
+  }
+
  private:
   const Properties properties_;
 };

--- a/axiom/runner/RunnerSession.h
+++ b/axiom/runner/RunnerSession.h
@@ -36,11 +36,13 @@ class RunnerSession final : public connector::BaseSession {
       std::string queryId,
       std::string user,
       Properties properties,
-      connector::ConnectorProperties connectorProperties)
+      connector::ConnectorProperties connectorProperties,
+      std::shared_ptr<QueryRuntimeStats> runtimeStats)
       : BaseSession(
             std::move(queryId),
             std::move(user),
-            std::move(connectorProperties)),
+            std::move(connectorProperties),
+            std::move(runtimeStats)),
         properties_{std::move(properties)} {}
 
   /// Returns the value of runner-scoped property 'name' if set.

--- a/axiom/runner/tests/LocalRunnerTest.cpp
+++ b/axiom/runner/tests/LocalRunnerTest.cpp
@@ -562,5 +562,43 @@ TEST_F(LocalRunnerTest, splitSourceRecordsIntoSessionStats) {
   EXPECT_EQ(StatsRecordingSplitSource::kMetricValue, it->second.sum);
 }
 
+// Split metrics route to the sample collector, not the outer query's.
+TEST_F(LocalRunnerTest, isolatedSessionKeepsSplitStatsOutOfOuterCollector) {
+  auto scan = makeScanPlan(/*numWorkers=*/1);
+  const auto queryId = scan->options().queryId;
+  auto outerStats = std::make_shared<QueryRuntimeStats>();
+  auto sampleStats = std::make_shared<QueryRuntimeStats>();
+
+  auto sampleSession =
+      makeRunnerSession(queryId, outerStats)->withIsolatedStats(sampleStats);
+  EXPECT_EQ(queryId, sampleSession->queryId());
+  EXPECT_EQ("test", sampleSession->user());
+  auto localRunner = std::make_shared<LocalRunner>(
+      sampleSession,
+      std::move(scan),
+      optimizer::FinishWrite{},
+      makeQueryCtx(queryId),
+      std::make_shared<StatsRecordingSplitSourceFactory>(
+          RuntimeStatsSink::throwaway()),
+      /*outputPool=*/nullptr,
+      /*baseSpillDirectory=*/"",
+      RuntimeStatsSink::throwaway());
+
+  int32_t count = 0;
+  auto generator = localRunner->execute();
+  while (auto rows = folly::coro::blockingWait(generator.next())) {
+    count += (*rows)->size();
+  }
+  folly::coro::blockingWait(localRunner->co_close());
+  EXPECT_EQ(kNumRows, count);
+
+  const std::string metric(StatsRecordingSplitSource::kMetricName);
+  EXPECT_FALSE(outerStats->totalsByName().contains(metric))
+      << "split metric leaked into the outer query stats";
+  EXPECT_EQ(
+      StatsRecordingSplitSource::kMetricValue,
+      sampleStats->totalsByName().at(metric).sum);
+}
+
 } // namespace
 } // namespace facebook::axiom::runner

--- a/axiom/runner/tests/LocalRunnerTest.cpp
+++ b/axiom/runner/tests/LocalRunnerTest.cpp
@@ -24,6 +24,7 @@
 #include <folly/coro/WithCancellation.h>
 #include <folly/synchronization/Baton.h>
 #include <thread>
+#include "axiom/runner/RunnerMetrics.h"
 #include "axiom/runner/tests/DistributedPlanBuilder.h"
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -33,6 +34,53 @@ namespace {
 
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
+
+// Delegates split enumeration to an inner source and records a fixed metric
+// into the session's runtime stats sink at close, so a test can verify a
+// source's metrics reach the query-level stats via the session.
+class StatsRecordingSplitSource : public connector::SplitSource {
+ public:
+  static constexpr std::string_view kMetricName{"testSplitMetric"};
+  static constexpr int64_t kMetricValue{7};
+
+  StatsRecordingSplitSource(
+      std::shared_ptr<connector::SplitSource> inner,
+      RuntimeStatsSink statsSink)
+      : inner_(std::move(inner)), statsSink_(std::move(statsSink)) {}
+
+  folly::coro::Task<connector::SplitBatch> co_getSplits(
+      uint32_t maxSplitCount) override {
+    co_return co_await inner_->co_getSplits(maxSplitCount);
+  }
+
+ protected:
+  folly::coro::Task<void> co_closeImpl() noexcept override {
+    statsSink_.recordCount(kMetricName, kMetricValue);
+    co_await inner_->co_close();
+  }
+
+ private:
+  const std::shared_ptr<connector::SplitSource> inner_;
+  const RuntimeStatsSink statsSink_;
+};
+
+// Wraps every source produced by ConnectorSplitSourceFactory in a
+// StatsRecordingSplitSource that records into the session's stats sink.
+class StatsRecordingSplitSourceFactory : public ConnectorSplitSourceFactory {
+ public:
+  using ConnectorSplitSourceFactory::ConnectorSplitSourceFactory;
+
+  std::shared_ptr<connector::SplitSource> splitSourceForScan(
+      const connector::ConnectorSessionPtr& session,
+      const velox::core::TableScanNode& scan,
+      const std::shared_ptr<connector::PartitionType>& partitionType,
+      std::optional<double> samplePercentage) override {
+    return std::make_shared<StatsRecordingSplitSource>(
+        ConnectorSplitSourceFactory::splitSourceForScan(
+            session, scan, partitionType, samplePercentage),
+        session->splitStatsSink());
+  }
+};
 
 class LocalRunnerTest : public test::LocalRunnerTestBase {
  public:
@@ -143,12 +191,14 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
   }
 
   static axiom::runner::RunnerSessionPtr makeRunnerSession(
-      std::string_view queryId) {
+      std::string_view queryId,
+      std::shared_ptr<QueryRuntimeStats> runtimeStats = nullptr) {
     return std::make_shared<axiom::runner::RunnerSession>(
         std::string(queryId),
         "test",
         axiom::runner::Properties{},
-        axiom::connector::ConnectorProperties{});
+        axiom::connector::ConnectorProperties{},
+        std::move(runtimeStats));
   }
 
   template <typename RunnerT = LocalRunner>
@@ -159,10 +209,11 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
         std::move(plan),
         optimizer::FinishWrite{},
         makeQueryCtx(queryId),
-        std::make_shared<ConnectorSplitSourceFactory>(runtimeStats_),
+        std::make_shared<ConnectorSplitSourceFactory>(
+            runtimeStats_.sinkFor(kStatsComponent)),
         /*outputPool=*/nullptr,
         /*baseSpillDirectory=*/"",
-        runtimeStats_);
+        runtimeStats_.sinkFor(kStatsComponent));
   }
 
   std::shared_ptr<velox::core::PlanNodeIdGenerator> idGenerator_{
@@ -464,10 +515,11 @@ TEST_F(LocalRunnerTest, spillDirectoryWiring) {
       std::move(join),
       optimizer::FinishWrite{},
       std::move(queryCtx),
-      std::make_shared<ConnectorSplitSourceFactory>(runtimeStats_),
+      std::make_shared<ConnectorSplitSourceFactory>(
+          runtimeStats_.sinkFor(kStatsComponent)),
       /*outputPool=*/nullptr,
       spillDir->getPath(),
-      runtimeStats_);
+      runtimeStats_.sinkFor(kStatsComponent));
 
   std::vector<velox::RowVectorPtr> results;
   localRunner->drain(
@@ -475,6 +527,39 @@ TEST_F(LocalRunnerTest, spillDirectoryWiring) {
   EXPECT_EQ(1, results.size());
   EXPECT_EQ(kNumRows, extractSingleInt64(results));
   EXPECT_EQ(Runner::State::kFinished, localRunner->state());
+}
+
+// A SplitSource records its enumeration metrics into the ConnectorSession's
+// stats sink, and they land in the query-level stats object the RunnerSession
+// carries.
+TEST_F(LocalRunnerTest, splitSourceRecordsIntoSessionStats) {
+  auto scan = makeScanPlan(/*numWorkers=*/1);
+  const auto queryId = scan->options().queryId;
+  auto stats = std::make_shared<QueryRuntimeStats>();
+
+  auto localRunner = std::make_shared<LocalRunner>(
+      makeRunnerSession(queryId, stats),
+      std::move(scan),
+      optimizer::FinishWrite{},
+      makeQueryCtx(queryId),
+      std::make_shared<StatsRecordingSplitSourceFactory>(
+          stats->sinkFor(kStatsComponent)),
+      /*outputPool=*/nullptr,
+      /*baseSpillDirectory=*/"",
+      stats->sinkFor(kStatsComponent));
+
+  int32_t count = 0;
+  auto generator = localRunner->execute();
+  while (auto rows = folly::coro::blockingWait(generator.next())) {
+    count += (*rows)->size();
+  }
+  folly::coro::blockingWait(localRunner->co_close());
+  EXPECT_EQ(kNumRows, count);
+
+  const auto map = stats->totalsByName();
+  auto it = map.find(std::string(StatsRecordingSplitSource::kMetricName));
+  ASSERT_NE(it, map.end());
+  EXPECT_EQ(StatsRecordingSplitSource::kMetricValue, it->second.sum);
 }
 
 } // namespace

--- a/axiom/runner/tests/PrestoQueryReplayRunner.cpp
+++ b/axiom/runner/tests/PrestoQueryReplayRunner.cpp
@@ -17,6 +17,7 @@
 #include "axiom/runner/tests/PrestoQueryReplayRunner.h"
 #include <folly/coro/BlockingWait.h>
 #include "axiom/runner/LocalRunner.h"
+#include "axiom/runner/RunnerMetrics.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
@@ -402,14 +403,15 @@ PrestoQueryReplayRunner::run(
           queryId,
           /*user=*/"presto-replay",
           runner::Properties{},
-          connector::ConnectorProperties{}),
+          connector::ConnectorProperties{},
+          std::make_shared<QueryRuntimeStats>()),
       std::move(multiFragmentPlan),
       optimizer::FinishWrite{},
       makeQueryCtx(queryId, queryRootPool),
       std::make_shared<runner::SimpleSplitSourceFactory>(nodeSplitMap),
       /*outputPool=*/nullptr,
       /*baseSpillDirectory=*/"",
-      runtimeStats_);
+      runtimeStats_.sinkFor(kStatsComponent));
 
   std::vector<velox::RowVectorPtr> result;
   try {

--- a/axiom/runner/tests/ProgressReporterTest.cpp
+++ b/axiom/runner/tests/ProgressReporterTest.cpp
@@ -24,8 +24,10 @@
 #include <mutex>
 #include <vector>
 
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorSplitManager.h"
 #include "axiom/runner/LocalRunner.h"
+#include "axiom/runner/RunnerMetrics.h"
 #include "axiom/runner/tests/DistributedPlanBuilder.h"
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
 
@@ -65,9 +67,9 @@ class GatedSplitSource : public connector::SplitSource {
 class GatedSplitSourceFactory : public SplitSourceFactory {
  public:
   GatedSplitSourceFactory(
-      QueryRuntimeStats& runtimeStats,
+      RuntimeStatsSink statsSink,
       std::shared_ptr<folly::coro::Baton> gate)
-      : inner_{runtimeStats}, gate_{std::move(gate)} {}
+      : inner_{std::move(statsSink)}, gate_{std::move(gate)} {}
 
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
@@ -114,7 +116,8 @@ class ProgressReporterTest : public test::LocalRunnerTestBase {
         std::string(queryId),
         "test",
         Properties{},
-        connector::ConnectorProperties{});
+        connector::ConnectorProperties{},
+        std::make_shared<QueryRuntimeStats>());
   }
 
   velox::RowTypePtr rowType_;
@@ -136,10 +139,11 @@ TEST_F(ProgressReporterTest, reportsProgressPerSplit) {
       std::move(plan),
       optimizer::FinishWrite{},
       makeQueryCtx(queryId),
-      std::make_shared<GatedSplitSourceFactory>(runtimeStats_, gate),
+      std::make_shared<GatedSplitSourceFactory>(
+          runtimeStats_.sinkFor(kStatsComponent), gate),
       /*outputPool=*/nullptr,
       /*baseSpillDirectory=*/"",
-      runtimeStats_);
+      runtimeStats_.sinkFor(kStatsComponent));
 
   std::mutex mutex;
   std::condition_variable cv;

--- a/axiom/sql/presto/ParserMetrics.h
+++ b/axiom/sql/presto/ParserMetrics.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string_view>
+
+namespace axiom::sql::presto {
+
+/// QueryRuntimeStats component id for parser metrics.
+inline constexpr std::string_view kStatsComponent{"parser"};
+
+/// Runtime-metric names recorded around parsing. Producers and consumers share
+/// these constants so a rename cannot silently de-correlate a metric.
+inline constexpr std::string_view kParseWallNanos{"axiom-parseWallNanos"};
+inline constexpr std::string_view kParseCpuNanos{"axiom-parseCpuNanos"};
+
+} // namespace axiom::sql::presto

--- a/axiom/sql/presto/ParserSession.h
+++ b/axiom/sql/presto/ParserSession.h
@@ -32,11 +32,13 @@ class ParserSession final : public facebook::axiom::connector::BaseSession {
       std::string queryId,
       std::string user,
       ParserOptions options,
-      facebook::axiom::connector::ConnectorProperties connectorProperties)
+      facebook::axiom::connector::ConnectorProperties connectorProperties,
+      std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats)
       : BaseSession(
             std::move(queryId),
             std::move(user),
-            std::move(connectorProperties)),
+            std::move(connectorProperties),
+            std::move(runtimeStats)),
         options_{std::move(options)} {}
 
   const ParserOptions& options() const {

--- a/axiom/sql/presto/tests/PrestoParserTestBase.h
+++ b/axiom/sql/presto/tests/PrestoParserTestBase.h
@@ -18,6 +18,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/sql/presto/PrestoParser.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
@@ -126,7 +127,8 @@ class PrestoParserTestBase : public testing::Test {
         /*queryId=*/"test",
         /*user=*/"test",
         std::move(options),
-        facebook::axiom::connector::ConnectorProperties{});
+        facebook::axiom::connector::ConnectorProperties{},
+        std::make_shared<facebook::axiom::QueryRuntimeStats>());
   }
 
   /// Creates a PrestoParser configured with the test connector.


### PR DESCRIPTION
Summary:
During planning, the optimizer runs a small join-order sampling query on a `LocalRunner` that reused the outer query's `RunnerSession`. Because split sources record split metrics through the session, the sample's splits were counted under the outer query's `<connectorId>/splits`.

Give the sampling runner its own session over a throwaway `QueryRuntimeStats`, via a new `RunnerSession::withIsolatedStats`. The sample's metrics now stay out of the outer query.

Differential Revision: D112227720
