### PR TITLE
fix(hive): Support TIMESTAMP partition columns (#1619)

### DIFF
--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -17,10 +17,8 @@
 #include "axiom/connectors/hive/HiveConnectorMetadata.h"
 
 #include <fmt/ranges.h>
-#include <folly/Conv.h>
 #include <algorithm>
 #include <utility>
-#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/TableHandle.h"
@@ -198,7 +196,8 @@ HiveTableLayout::HiveTableLayout(
     const std::vector<SortOrder>& sortOrder,
     std::vector<const Column*> lookupKeys,
     std::vector<const Column*> hivePartitionedByColumns,
-    velox::dwio::common::FileFormat fileFormat)
+    velox::dwio::common::FileFormat fileFormat,
+    std::shared_ptr<const HiveMetadataConfig> hiveMetadataConfig)
     : TableLayout(
           label,
           table,
@@ -210,6 +209,7 @@ HiveTableLayout::HiveTableLayout(
           std::move(lookupKeys),
           /*supportsScan=*/true),
       fileFormat_(fileFormat),
+      hiveMetadataConfig_(std::move(hiveMetadataConfig)),
       hivePartitionColumns_(std::move(hivePartitionedByColumns)),
       numBuckets_(numPartitions),
       partitionType_{
@@ -219,29 +219,64 @@ HiveTableLayout::HiveTableLayout(
                     extractPartitionKeyTypes(partitionedByColumns))
               : nullptr} {
   VELOX_CHECK_EQ(sortedByColumns.size(), sortOrder.size());
+  VELOX_CHECK_NOT_NULL(hiveMetadataConfig_);
 }
 
-// static
-velox::Variant HiveTableLayout::partitionValueToVariant(
+HivePartitionValueConverter::HivePartitionValueConverter(
+    TimestampMode timestampMode)
+    : timestampMode_(timestampMode) {}
+
+velox::Variant HivePartitionValueConverter::toVariant(
     std::string_view value,
-    const velox::Type& type) {
-  switch (type.kind()) {
-    case velox::TypeKind::BOOLEAN:
-      return velox::Variant(folly::to<bool>(value));
-    case velox::TypeKind::TINYINT:
-      return velox::Variant(folly::to<int8_t>(value));
-    case velox::TypeKind::SMALLINT:
-      return velox::Variant(folly::to<int16_t>(value));
-    case velox::TypeKind::INTEGER:
-      return velox::Variant(folly::to<int32_t>(value));
-    case velox::TypeKind::BIGINT:
-      return velox::Variant(folly::to<int64_t>(value));
-    case velox::TypeKind::VARCHAR:
-      return velox::Variant(std::string(value));
-    default:
-      VELOX_UNREACHABLE(
-          "Unsupported partition column type: {}", type.toString());
+    const velox::Type& type) const {
+  return velox::connector::hive::PartitionValue::fromString(
+      value,
+      type,
+      timestampMode_,
+      velox::connector::hive::PartitionValue::DateMode::kIsoString);
+}
+
+std::optional<std::string> HivePartitionValueConverter::toPartitionString(
+    const velox::Variant& value,
+    const velox::Type& type) const {
+  if (value.isNull()) {
+    return std::nullopt;
   }
+
+  if (type.kind() == velox::TypeKind::TIMESTAMP &&
+      type.equivalent(*velox::TIMESTAMP()) &&
+      timestampMode_ == TimestampMode::kLocalTime) {
+    auto timestamp = value.value<velox::TypeKind::TIMESTAMP>();
+    // Shifting either extreme overflows, so neither has a local-time name.
+    if (timestamp == velox::Timestamp::min() ||
+        timestamp == velox::Timestamp::max()) {
+      return std::nullopt;
+    }
+    // A DST fold maps two instants to one local time, so the round trip does
+    // not return the original.
+    const auto original = timestamp;
+    timestamp.toTimezone(velox::Timestamp::defaultTimezone());
+    timestamp.toGMT(velox::Timestamp::defaultTimezone());
+    if (timestamp != original) {
+      return std::nullopt;
+    }
+  }
+
+  return velox::connector::hive::PartitionValue::toString(
+      value,
+      type,
+      timestampMode_,
+      velox::connector::hive::PartitionValue::DateMode::kIsoString);
+}
+
+HivePartitionValueConverter HiveTableLayout::partitionValueConverter(
+    const ConnectorSessionPtr& session) const {
+  const bool readTimestampAsLocalTime =
+      hiveMetadataConfig_->readTimestampPartitionValueAsLocalTime(session);
+  return HivePartitionValueConverter(
+      readTimestampAsLocalTime
+          ? HivePartitionValueConverter::TimestampMode::kLocalTime
+          : HivePartitionValueConverter::TimestampMode::kUtc);
 }
 
 namespace {
@@ -462,9 +497,14 @@ velox::common::SubfieldFilters deleteFilters(
 } // namespace
 
 ConnectorWriteHandlePtr HiveConnectorMetadata::makeDeleteWriteHandle(
+    const ConnectorSessionPtr& session,
     const TablePtr& table,
     velox::common::SubfieldFilters filters) const {
-  return std::make_shared<HiveDeleteWriteHandle>(table, std::move(filters));
+  const auto* hiveLayout =
+      dynamic_cast<const HiveTableLayout*>(table->layouts()[0]);
+  VELOX_CHECK_NOT_NULL(hiveLayout);
+  return std::make_shared<HiveDeleteWriteHandle>(
+      table, std::move(filters), hiveLayout->partitionValueConverter(session));
 }
 
 ConnectorWriteHandlePtr HiveConnectorMetadata::beginWrite(
@@ -484,7 +524,8 @@ ConnectorWriteHandlePtr HiveConnectorMetadata::beginWrite(
   VELOX_CHECK_NOT_NULL(hiveLayout);
 
   if (kind == WriteKind::kDelete) {
-    return makeDeleteWriteHandle(table, deleteFilters(*hiveLayout, scanHandle));
+    return makeDeleteWriteHandle(
+        session, table, deleteFilters(*hiveLayout, scanHandle));
   }
   auto storageFormat = hiveLayout->fileFormat();
 

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -17,9 +17,11 @@
 #pragma once
 
 #include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "folly/CppAttributes.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/connectors/hive/PartitionValue.h"
 #include "velox/dwio/common/Options.h"
 
 namespace facebook::axiom::connector::hive {
@@ -119,6 +121,34 @@ class HiveTable : public Table {
   std::vector<std::string> ioColumnPriority() const override;
 };
 
+/// Converts Hive partition values using one timestamp interpretation.
+///
+/// HivePartitionValueConverter converter(
+///     HivePartitionValueConverter::TimestampMode::kLocalTime);
+/// auto value = converter.toVariant(
+///     "2020-01-01 12:34:56", *velox::TIMESTAMP());
+class HivePartitionValueConverter {
+ public:
+  using TimestampMode = velox::connector::hive::PartitionValue::TimestampMode;
+
+  /// Uses 'timestampMode' for plain TIMESTAMP values.
+  explicit HivePartitionValueConverter(TimestampMode timestampMode);
+
+  /// Converts a non-null partition string to a typed value.
+  velox::Variant toVariant(std::string_view value, const velox::Type& type)
+      const;
+
+  /// Converts a typed value to the partition string the Metastore stores.
+  /// Returns nullopt when no unambiguous string exists, as for a local-time
+  /// TIMESTAMP inside a DST fold.
+  std::optional<std::string> toPartitionString(
+      const velox::Variant& value,
+      const velox::Type& type) const;
+
+ private:
+  const TimestampMode timestampMode_;
+};
+
 /// Describes a Hive table layout. Adds a file format and a list of
 /// Hive partitioning columns and an optional bucket count to the base
 /// TableLayout. The partitioning in TableLayout referes to bucketing.
@@ -146,7 +176,8 @@ class HiveTableLayout : public TableLayout {
       const std::vector<SortOrder>& sortOrder,
       std::vector<const Column*> lookupKeys,
       std::vector<const Column*> hivePartitionedByColumns,
-      velox::dwio::common::FileFormat fileFormat);
+      velox::dwio::common::FileFormat fileFormat,
+      std::shared_ptr<const HiveMetadataConfig> hiveMetadataConfig);
 
   velox::dwio::common::FileFormat fileFormat() const {
     return fileFormat_;
@@ -156,11 +187,9 @@ class HiveTableLayout : public TableLayout {
     return hivePartitionColumns_;
   }
 
-  /// Converts a Hive partition-key string to a Variant of 'type'. Fails for a
-  /// type that cannot appear as a partition key.
-  static velox::Variant partitionValueToVariant(
-      std::string_view value,
-      const velox::Type& type);
+  /// Creates a converter using the session-over-connector timestamp setting.
+  HivePartitionValueConverter partitionValueConverter(
+      const ConnectorSessionPtr& session) const;
 
   std::optional<int32_t> numBuckets() const {
     return numBuckets_;
@@ -208,6 +237,7 @@ class HiveTableLayout : public TableLayout {
       FilteredTableStats& stats) const;
 
   const velox::dwio::common::FileFormat fileFormat_;
+  const std::shared_ptr<const HiveMetadataConfig> hiveMetadataConfig_;
   const std::vector<const Column*> hivePartitionColumns_;
   const std::optional<int32_t> numBuckets_;
   const std::shared_ptr<const HivePartitionType> partitionType_;
@@ -295,8 +325,15 @@ class HiveWriteOptions {
 /// materialized here.
 class HiveDeleteWriteHandle : public ConnectorWriteHandle {
  public:
-  HiveDeleteWriteHandle(TablePtr table, velox::common::SubfieldFilters filters)
-      : table_{std::move(table)}, filters_{std::move(filters)} {}
+  /// 'converter' is resolved from the session that issued the DELETE, so the
+  /// partitions removed at commit are the ones the query selected.
+  HiveDeleteWriteHandle(
+      TablePtr table,
+      velox::common::SubfieldFilters filters,
+      HivePartitionValueConverter converter)
+      : table_{std::move(table)},
+        filters_{std::move(filters)},
+        converter_{std::move(converter)} {}
 
   const TablePtr& table() const {
     return table_;
@@ -306,11 +343,16 @@ class HiveDeleteWriteHandle : public ConnectorWriteHandle {
     return filters_;
   }
 
+  const HivePartitionValueConverter& partitionValueConverter() const {
+    return converter_;
+  }
+
   std::string toString() const override;
 
  private:
   const TablePtr table_;
   const velox::common::SubfieldFilters filters_;
+  const HivePartitionValueConverter converter_;
 };
 
 class HiveConnectorMetadata : public ConnectorMetadata {
@@ -337,6 +379,7 @@ class HiveConnectorMetadata : public ConnectorMetadata {
   // on partition columns. A connector overrides this to carry its own
   // description of the delete.
   virtual ConnectorWriteHandlePtr makeDeleteWriteHandle(
+      const ConnectorSessionPtr& session,
       const TablePtr& table,
       velox::common::SubfieldFilters filters) const;
 

--- a/axiom/connectors/hive/HiveMetadataConfig.cpp
+++ b/axiom/connectors/hive/HiveMetadataConfig.cpp
@@ -15,7 +15,11 @@
  */
 
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
+
+#include <unordered_map>
+
 #include "velox/common/config/Config.h"
+#include "velox/connectors/hive/HiveConfig.h"
 
 namespace facebook::axiom::connector::hive {
 
@@ -25,6 +29,46 @@ std::string HiveMetadataConfig::localDataPath() const {
 
 std::string HiveMetadataConfig::localFileFormat() const {
   return config_->get<std::string>(kLocalFileFormat, "");
+}
+
+bool HiveMetadataConfig::readTimestampPartitionValueAsLocalTime(
+    const ConnectorSessionPtr& session) const {
+  std::unordered_map<std::string, std::string> sessionProperties;
+  if (session != nullptr) {
+    const auto addProperty = [&](const std::string& key) {
+      if (const auto value = session->property(key)) {
+        sessionProperties.emplace(key, std::string(*value));
+      }
+    };
+    const std::string sessionKey = velox::connector::hive::FileConfig::
+        kReadTimestampPartitionValueAsLocalTimeSession;
+    addProperty(sessionKey);
+    addProperty(connectorId_ + "." + sessionKey);
+  }
+
+  const velox::config::ConfigBase sessionConfig(std::move(sessionProperties));
+  return readTimestampPartitionValueAsLocalTime(&sessionConfig);
+}
+
+bool HiveMetadataConfig::readTimestampPartitionValueAsLocalTime(
+    const velox::config::ConfigBase* sessionProperties) const {
+  const std::string sessionKey = velox::connector::hive::FileConfig::
+      kReadTimestampPartitionValueAsLocalTimeSession;
+
+  // HiveConfig reads the unprefixed spelling only. The prefixed spelling is
+  // more specific, so it is applied last and wins.
+  std::unordered_map<std::string, std::string> normalized;
+  if (sessionProperties != nullptr) {
+    for (const auto& key : {sessionKey, connectorId_ + "." + sessionKey}) {
+      if (const auto value = sessionProperties->get<std::string>(key)) {
+        normalized[sessionKey] = *value;
+      }
+    }
+  }
+
+  velox::config::ConfigBase sessionConfig(std::move(normalized));
+  return velox::connector::hive::HiveConfig(config_)
+      .readTimestampPartitionValueAsLocalTime(&sessionConfig);
 }
 
 } // namespace facebook::axiom::connector::hive

--- a/axiom/connectors/hive/HiveMetadataConfig.h
+++ b/axiom/connectors/hive/HiveMetadataConfig.h
@@ -16,7 +16,10 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
+
+#include "axiom/connectors/ConnectorSession.h"
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox::config {
@@ -46,14 +49,27 @@ class HiveMetadataConfig {
 
   std::string localFileFormat() const;
 
+  /// Applies the session override when present, otherwise the connector
+  /// setting.
+  bool readTimestampPartitionValueAsLocalTime(
+      const ConnectorSessionPtr& session) const;
+
+  /// Applies the same precedence to a caller-supplied property map, for
+  /// callers holding session properties rather than a session.
+  bool readTimestampPartitionValueAsLocalTime(
+      const velox::config::ConfigBase* sessionProperties) const;
+
   /// HiveMetadataConfig may be initialized from a base config which also
   /// contains execution config defined in velox/connectors/hive/HiveConfig.h,
   /// so some additional properties may be present which are not defined here.
-  explicit HiveMetadataConfig(
-      std::shared_ptr<const velox::config::ConfigBase> config)
-      : config_{std::move(config)} {
+  /// 'connectorId' is the catalog name a session may prefix a property with.
+  HiveMetadataConfig(
+      std::shared_ptr<const velox::config::ConfigBase> config,
+      std::string connectorId)
+      : config_{std::move(config)}, connectorId_{std::move(connectorId)} {
     VELOX_CHECK_NOT_NULL(
         config_, "Config is null for HiveMetadataConfig initialization");
+    VELOX_CHECK(!connectorId_.empty(), "HiveMetadataConfig needs a connector");
   }
 
  protected:
@@ -63,6 +79,7 @@ class HiveMetadataConfig {
 
  private:
   std::shared_ptr<const velox::config::ConfigBase> config_;
+  const std::string connectorId_;
 };
 
 } // namespace facebook::axiom::connector::hive

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -30,7 +30,9 @@
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/HivePartitionName.h"
+#include "velox/dwio/catalog/fbhive/FileUtils.h"
 #include "velox/expression/Expr.h"
+#include "velox/type/Filter.h"
 
 namespace facebook::axiom::connector::hive {
 
@@ -147,34 +149,6 @@ std::vector<const FileInfo*> filterFilesByTableHandle(
   return selectedFiles;
 }
 
-// Tests a partition key value against a filter. 'value' is the string from the
-// directory name (e.g. "2" from "k=2"). 'type' determines how to convert the
-// string before testing.
-bool testPartitionValue(
-    const velox::common::Filter& filter,
-    const std::optional<std::string>& value,
-    const velox::Type& type) {
-  if (!value.has_value()) {
-    return filter.testNull();
-  }
-
-  switch (type.kind()) {
-    case velox::TypeKind::BOOLEAN:
-      return filter.testBool(folly::to<bool>(value.value()));
-    case velox::TypeKind::TINYINT:
-    case velox::TypeKind::SMALLINT:
-    case velox::TypeKind::INTEGER:
-    case velox::TypeKind::BIGINT:
-      return filter.testInt64(folly::to<int64_t>(value.value()));
-    case velox::TypeKind::VARCHAR:
-      return filter.testBytes(
-          value.value().c_str(), static_cast<int32_t>(value.value().size()));
-    default:
-      VELOX_UNREACHABLE(
-          "Unsupported partition column type: {}", type.toString());
-  }
-}
-
 // A single-column filter over a partition key, read from the table handle.
 struct PartitionFilter {
   std::string columnName;
@@ -182,33 +156,71 @@ struct PartitionFilter {
   const Column* column;
 };
 
+enum class MissingPartitionKeyPolicy {
+  kDoesNotMatch,
+  kFail,
+};
+
+// Tests one partition-key string against 'filter'. A NULL partition is stored
+// as a sentinel that is not a value of 'type', so it is tested as null rather
+// than converted.
+bool partitionValueMatchesFilter(
+    const velox::common::Filter& filter,
+    std::string_view value,
+    const velox::Type& type,
+    const HivePartitionValueConverter& converter) {
+  if (value ==
+      velox::dwio::catalog::fbhive::FileUtils::kDefaultPartitionValue) {
+    return filter.testNull();
+  }
+  return velox::common::applyFilter(filter, converter.toVariant(value, type));
+}
+
+// Tests all partition filters. A missing key either rejects the partition or
+// fails according to 'missingKeyPolicy'.
+bool partitionMatchesFilters(
+    const PartitionStats& partition,
+    const std::vector<PartitionFilter>& partitionFilters,
+    const HivePartitionValueConverter& converter,
+    MissingPartitionKeyPolicy missingKeyPolicy) {
+  for (const auto& partitionFilter : partitionFilters) {
+    VELOX_CHECK_NOT_NULL(partitionFilter.filter);
+    VELOX_CHECK_NOT_NULL(partitionFilter.column);
+    const auto it = partition.partitionKeys.find(partitionFilter.columnName);
+    if (it == partition.partitionKeys.end()) {
+      VELOX_CHECK(
+          missingKeyPolicy != MissingPartitionKeyPolicy::kFail,
+          "Partition is missing a value for partition column '{}'",
+          partitionFilter.columnName);
+      return false;
+    }
+    if (!partitionValueMatchesFilter(
+            *partitionFilter.filter,
+            it->second,
+            *partitionFilter.column->type(),
+            converter)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // Estimates table stats from persisted partition-level stats. Matches
 // partitions against the partition-key filters, merges matching partitions'
 // column stats, and returns them aligned 1:1 with 'requestedColumns'.
 FilteredTableStats estimateStatsFromPartitionStats(
     const std::vector<PartitionStats>& partitionStats,
     const std::vector<PartitionFilter>& partitionFilters,
-    const std::vector<const Column*>& requestedColumns) {
+    const std::vector<const Column*>& requestedColumns,
+    const HivePartitionValueConverter& converter) {
   uint64_t totalRows{0};
   std::vector<ColumnStatistics> mergedColumnStats;
   for (const auto& partition : partitionStats) {
-    bool matched = true;
-    for (const auto& partitionFilter : partitionFilters) {
-      VELOX_CHECK_NOT_NULL(partitionFilter.column);
-      auto it = partition.partitionKeys.find(partitionFilter.columnName);
-      if (it == partition.partitionKeys.end()) {
-        matched = false;
-        break;
-      }
-      if (!testPartitionValue(
-              *partitionFilter.filter,
-              it->second,
-              *partitionFilter.column->type())) {
-        matched = false;
-        break;
-      }
-    }
-    if (!matched) {
+    if (!partitionMatchesFilters(
+            partition,
+            partitionFilters,
+            converter,
+            MissingPartitionKeyPolicy::kDoesNotMatch)) {
       continue;
     }
 
@@ -372,7 +384,8 @@ LocalHiveConnectorMetadata::LocalHiveConnectorMetadata(
       splitManager_(this),
       hiveMetadataConfig_(
           std::make_shared<HiveMetadataConfig>(
-              hiveConnector->connectorConfig())) {
+              hiveConnector->connectorConfig(),
+              hiveConnector->connectorId())) {
   VELOX_CHECK_NOT_NULL(rootPool_, "LocalHiveConnectorMetadata requires a pool");
 }
 
@@ -559,7 +572,7 @@ std::pair<int64_t, int64_t> LocalHiveTableLayout::sample(
 
 folly::coro::Task<std::optional<FilteredTableStats>>
 LocalHiveTableLayout::co_estimateStats(
-    ConnectorSessionPtr /*session*/,
+    ConnectorSessionPtr session,
     velox::connector::ConnectorTableHandlePtr tableHandle,
     std::vector<std::string> columns,
     const FilterSelectivityEstimator& estimator) const {
@@ -581,6 +594,8 @@ LocalHiveTableLayout::co_estimateStats(
     requestedColumns.push_back(column);
   }
 
+  const auto converter = partitionValueConverter(session);
+
   // Partition-key subfield filters drive the base estimate from partition
   // metadata; the remaining accepted filters are folded in by the shared
   // HiveTableLayout helper below.
@@ -594,14 +609,14 @@ LocalHiveTableLayout::co_estimateStats(
   }
 
   auto stats = estimateStatsFromPartitionStats(
-      partitionStats_, partitionFilters, requestedColumns);
+      partitionStats_, partitionFilters, requestedColumns, converter);
   foldNonPartitionFilterStats(*hiveHandle, estimator, stats);
   co_return stats;
 }
 
 folly::coro::Task<std::optional<std::vector<MetadataCountGroup>>>
 LocalHiveTableLayout::co_metadataCounts(
-    ConnectorSessionPtr /*session*/,
+    ConnectorSessionPtr session,
     velox::connector::ConnectorTableHandlePtr tableHandle,
     std::vector<std::string> groupingColumns,
     std::vector<std::string> columns) const {
@@ -625,6 +640,8 @@ LocalHiveTableLayout::co_metadataCounts(
     }
     groupingKeyColumns.push_back(it->second);
   }
+
+  const auto converter = partitionValueConverter(session);
 
   // The counts are exact, so every filter pushed into the handle must be
   // resolvable from partition metadata; decline otherwise. A remaining filter,
@@ -664,19 +681,11 @@ LocalHiveTableLayout::co_metadataCounts(
   std::vector<std::vector<int64_t>> nonNullCounts;
   folly::F14FastMap<std::string, size_t> groupIndex;
   for (const auto& partition : partitionStats_) {
-    bool matched = true;
-    for (const auto& partitionFilter : partitionFilters) {
-      auto it = partition.partitionKeys.find(partitionFilter.columnName);
-      if (it == partition.partitionKeys.end() ||
-          !testPartitionValue(
-              *partitionFilter.filter,
-              it->second,
-              *partitionFilter.column->type())) {
-        matched = false;
-        break;
-      }
-    }
-    if (!matched) {
+    if (!partitionMatchesFilters(
+            partition,
+            partitionFilters,
+            converter,
+            MissingPartitionKeyPolicy::kDoesNotMatch)) {
       continue;
     }
 
@@ -695,9 +704,7 @@ LocalHiveTableLayout::co_metadataCounts(
       }
       groupKey += it->second;
       groupKey += '\0';
-      keyValues.push_back(
-          HiveTableLayout::partitionValueToVariant(
-              it->second, *column->type()));
+      keyValues.push_back(converter.toVariant(it->second, *column->type()));
     }
 
     auto [it, inserted] = groupIndex.try_emplace(groupKey, groups.size());
@@ -742,6 +749,8 @@ std::unique_ptr<DiscretePredicates> LocalHiveTableLayout::discretePredicates(
     return nullptr;
   }
 
+  const auto converter = partitionValueConverter(session);
+
   std::optional<int64_t> maxPartitions;
   if (session != nullptr) {
     if (auto value = session->property(
@@ -761,30 +770,25 @@ std::unique_ptr<DiscretePredicates> LocalHiveTableLayout::discretePredicates(
     partitionColumnsByName.emplace(column->name(), column);
   }
 
+  std::vector<PartitionFilter> partitionFilters;
+  partitionFilters.reserve(subfieldFilters.size());
+  for (const auto& [subfield, filter] : subfieldFilters) {
+    const auto columnIt = partitionColumnsByName.find(subfield.baseName());
+    VELOX_CHECK(
+        columnIt != partitionColumnsByName.end(),
+        "discretePredicates got a filter on non-partition column '{}'",
+        subfield.baseName());
+    partitionFilters.push_back(
+        {subfield.baseName(), filter.get(), columnIt->second});
+  }
+
   std::vector<velox::Variant> rows;
   for (const auto& partition : partitionStats_) {
-    bool matched{true};
-    for (const auto& [subfield, filter] : subfieldFilters) {
-      auto columnIt = partitionColumnsByName.find(subfield.baseName());
-      // The listing enumerates only partition columns, so every pushed filter
-      // must be on one (guaranteed by the caller's discrete-column
-      // precondition).
-      VELOX_CHECK(
-          columnIt != partitionColumnsByName.end(),
-          "discretePredicates got a filter on non-partition column '{}'",
-          subfield.baseName());
-      auto valueIt = partition.partitionKeys.find(subfield.baseName());
-      VELOX_CHECK(
-          valueIt != partition.partitionKeys.end(),
-          "Partition is missing a value for partition column '{}'",
-          subfield.baseName());
-      if (!testPartitionValue(
-              *filter, valueIt->second, *columnIt->second->type())) {
-        matched = false;
-        break;
-      }
-    }
-    if (!matched) {
+    if (!partitionMatchesFilters(
+            partition,
+            partitionFilters,
+            converter,
+            MissingPartitionKeyPolicy::kFail)) {
       continue;
     }
 
@@ -796,9 +800,7 @@ std::unique_ptr<DiscretePredicates> LocalHiveTableLayout::discretePredicates(
           valueIt != partition.partitionKeys.end(),
           "Partition is missing a value for partition column '{}'",
           column->name());
-      values.push_back(
-          HiveTableLayout::partitionValueToVariant(
-              valueIt->second, *column->type()));
+      values.push_back(converter.toVariant(valueIt->second, *column->type()));
     }
     rows.push_back(velox::Variant::row(std::move(values)));
 
@@ -1274,7 +1276,8 @@ std::string parsePartitionValue(
       "Expected a '{}=<value>' partition directory, found: {}",
       expectedColumn,
       dirName);
-  return dirName.substr(prefix.size());
+  return velox::dwio::catalog::fbhive::FileUtils::unescapePathName(
+      dirName.substr(prefix.size()));
 }
 
 // Partition key values of one partition, keyed by column name.
@@ -1730,6 +1733,7 @@ std::optional<int64_t> LocalHiveConnectorMetadata::removePartitions(
 
   std::vector<fs::path> matchedPartitions;
   int64_t rows{0};
+  const auto& converter = handle.partitionValueConverter();
   visitPartitions(
       partitionColumnNames(*layout),
       path,
@@ -1738,8 +1742,8 @@ std::optional<int64_t> LocalHiveConnectorMetadata::removePartitions(
       [&](size_t level, const std::string& value) {
         const auto* filter = filters[level];
         return filter == nullptr ||
-            testPartitionValue(
-                   *filter, value, *partitionColumns[level]->type());
+            partitionValueMatchesFilter(
+                   *filter, value, *partitionColumns[level]->type(), converter);
       },
       [&](const fs::path& leaf, const PartitionKeys& /*keys*/) {
         rows += readPartitionStats(leaf).numRows;

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -125,8 +125,8 @@ class LocalHiveTableLayout : public HiveTableLayout {
             sortOrder,
             std::move(lookupKeys),
             std::move(hivePartitionColumns),
-            fileFormat),
-        hiveMetadataConfig_(std::move(hiveMetadataConfig)),
+            fileFormat,
+            std::move(hiveMetadataConfig)),
         serdeParameters_(std::move(serdeParameters)) {}
 
   bool supportsSampling() const override {
@@ -195,8 +195,6 @@ class LocalHiveTableLayout : public HiveTableLayout {
       velox::connector::ConnectorTableHandlePtr tableHandle) const override;
 
  private:
-  // Configuration for local Hive metadata.
-  std::shared_ptr<HiveMetadataConfig> hiveMetadataConfig_;
   std::vector<std::unique_ptr<const FileInfo>> files_;
   std::vector<std::unique_ptr<const FileInfo>> ownedFiles_;
   // Per-partition (or per-table for unpartitioned) write-time stats loaded

--- a/axiom/connectors/hive/LocalTableMetadata.cpp
+++ b/axiom/connectors/hive/LocalTableMetadata.cpp
@@ -22,6 +22,7 @@
 #include <folly/json.h>
 
 #include "velox/common/base/Fs.h"
+#include "velox/dwio/catalog/fbhive/FileUtils.h"
 
 namespace facebook::axiom::connector::hive {
 
@@ -213,7 +214,9 @@ void FileInfo::listFiles(
       std::vector<std::string> parts;
       folly::split('=', dir, parts);
       if (parts.size() == 2) {
-        file->partitionKeys[parts.at(0)] = parts.at(1);
+        using velox::dwio::catalog::fbhive::FileUtils;
+        file->partitionKeys[parts.at(0)] =
+            FileUtils::unescapePathName(parts.at(1));
       }
     }
     result.push_back(std::move(file));

--- a/axiom/connectors/hive/tests/HiveMetadataConfigTest.cpp
+++ b/axiom/connectors/hive/tests/HiveMetadataConfigTest.cpp
@@ -17,16 +17,24 @@
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "gtest/gtest.h"
 #include "velox/common/config/Config.h"
+#include "velox/connectors/hive/HiveConfig.h"
 
 namespace facebook::axiom::connector::hive {
 namespace {
 
+ConnectorSessionPtr makeSession(Properties properties) {
+  return std::make_shared<ConnectorSession>(
+      "query", "user", std::move(properties));
+}
+
 TEST(HiveMetadataConfigTest, defaultConfig) {
   HiveMetadataConfig config(
       std::make_shared<velox::config::ConfigBase>(
-          std::unordered_map<std::string, std::string>()));
+          std::unordered_map<std::string, std::string>()),
+      "hive");
   ASSERT_EQ(config.localDataPath(), "");
   ASSERT_EQ(config.localFileFormat(), "");
+  EXPECT_TRUE(config.readTimestampPartitionValueAsLocalTime(nullptr));
 }
 
 TEST(HiveMetadataConfigTest, overrideConfig) {
@@ -34,9 +42,30 @@ TEST(HiveMetadataConfigTest, overrideConfig) {
       {HiveMetadataConfig::kLocalDataPath, "/path/to/data"},
       {HiveMetadataConfig::kLocalFileFormat, "parquet"}};
   HiveMetadataConfig config(
-      std::make_shared<velox::config::ConfigBase>(std::move(properties)));
+      std::make_shared<velox::config::ConfigBase>(std::move(properties)),
+      "hive");
   ASSERT_EQ(config.localDataPath(), "/path/to/data");
   ASSERT_EQ(config.localFileFormat(), "parquet");
+}
+
+TEST(HiveMetadataConfigTest, timestampPartitionSetting) {
+  HiveMetadataConfig config(
+      std::make_shared<velox::config::ConfigBase>(
+          std::unordered_map<std::string, std::string>{
+              {velox::connector::hive::FileConfig::
+                   kReadTimestampPartitionValueAsLocalTime,
+               "false"}}),
+      "hive");
+  EXPECT_FALSE(config.readTimestampPartitionValueAsLocalTime(makeSession({})));
+  EXPECT_TRUE(config.readTimestampPartitionValueAsLocalTime(makeSession(
+      {{velox::connector::hive::FileConfig::
+            kReadTimestampPartitionValueAsLocalTimeSession,
+        "true"}})));
+  EXPECT_TRUE(config.readTimestampPartitionValueAsLocalTime(makeSession(
+      {{std::string("hive.") +
+            velox::connector::hive::FileConfig::
+                kReadTimestampPartitionValueAsLocalTimeSession,
+        "true"}})));
 }
 
 } // namespace

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -18,9 +18,12 @@
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/runner/tests/LocalRunnerTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HivePartitionFunction.h"
+#include "velox/dwio/catalog/fbhive/FileUtils.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/type/TimestampConversion.h"
 
 #include <folly/init/Init.h>
 #include <filesystem>
@@ -87,6 +90,13 @@ class LocalHiveConnectorMetadataTest
     return layout;
   }
 
+  // Tests set partition stats on a layout the metadata hands back as const.
+  static LocalHiveTableLayout* mutableLayout(const TablePtr& table) {
+    auto* layout = const_cast<LocalHiveTableLayout*>(getLayout(table));
+    VELOX_CHECK_NOT_NULL(layout);
+    return layout;
+  }
+
   void compareTableLayout(
       const LocalHiveTableLayout& expected,
       const LocalHiveTableLayout& layout) {
@@ -116,11 +126,15 @@ class LocalHiveConnectorMetadataTest
     compareTableLayout(*getLayout(expected), *getLayout(table));
   }
 
-  static ConnectorSessionPtr makeSession() {
+  static ConnectorSessionPtr makeSession(Properties properties) {
     return std::make_shared<ConnectorSession>(
         /*queryId=*/"q-test",
         /*user=*/"u-test",
-        Properties{});
+        std::move(properties));
+  }
+
+  static ConnectorSessionPtr makeSession() {
+    return makeSession(Properties{});
   }
 
   /// Write the specified data to the table with a TableWrite operation. The
@@ -408,6 +422,193 @@ TEST_F(LocalHiveConnectorMetadataTest, createTable) {
   compareTableLayout(table, metadata_->findTable({kDefaultSchema, "test"}));
   compareTableData(
       "test", data, {{"ds", partition}}, dwio::common::FileFormat::PARQUET);
+}
+
+TEST_F(LocalHiveConnectorMetadataTest, partitionValueIsUnescaped) {
+  auto tableType = ROW({{"data", BIGINT()}, {"p", VARCHAR()}});
+  folly::F14FastMap<std::string, velox::Variant> options = {
+      {HiveWriteOptions::kPartitionedBy, velox::Variant::array({"p"})},
+      {HiveWriteOptions::kFileFormat, "parquet"},
+  };
+  auto session = makeSession();
+  auto table = metadata_->createTable(
+      session,
+      {kDefaultSchema, "escaped_partition"},
+      tableType,
+      options,
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+
+  auto data = makeRowVector(
+      tableType->names(),
+      {
+          makeFlatVector<int64_t>({0, 1, 2, 3}),
+          makeConstant<std::string>("2020-01-01 12:34:56", 4),
+      });
+  writeToTable(
+      table, data, WriteKind::kCreate, dwio::common::FileFormat::PARQUET);
+
+  const auto* layout =
+      getLayout(metadata_->findTable({kDefaultSchema, "escaped_partition"}));
+  ASSERT_FALSE(layout->files().empty());
+  EXPECT_NE(layout->files()[0]->path.find("%3A"), std::string::npos);
+  EXPECT_EQ(layout->files()[0]->partitionKeys.at("p"), "2020-01-01 12:34:56");
+}
+
+TEST_F(
+    LocalHiveConnectorMetadataTest,
+    timestampPartitionFilterUsesSessionSetting) {
+  auto tableType = ROW({{"data", BIGINT()}, {"p", TIMESTAMP()}});
+  folly::F14FastMap<std::string, velox::Variant> options = {
+      {HiveWriteOptions::kPartitionedBy, velox::Variant::array({"p"})},
+      {HiveWriteOptions::kFileFormat, "parquet"},
+  };
+  auto table = metadata_->createTable(
+      makeSession(),
+      {kDefaultSchema, "timestamp_partition"},
+      tableType,
+      options,
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+
+  auto unshifted =
+      velox::util::fromTimestampString(
+          "2020-01-01 12:34:56", velox::util::TimestampParseMode::kPrestoCast)
+          .value();
+  auto shifted = unshifted;
+  shifted.toGMT(velox::Timestamp::defaultTimezone());
+  auto& layout = *mutableLayout(table);
+  layout.setPartitionStats({PartitionStats{
+      .partitionKeys = {{"p", "2020-01-01 12:34:56"}},
+      .numRows = 4,
+  }});
+  const auto* partitionColumn = layout.table().findColumn("p");
+  ASSERT_NE(partitionColumn, nullptr);
+
+  auto verify = [&](bool readAsLocalTime, const velox::Timestamp& expected) {
+    velox::common::SubfieldFilters filters;
+    filters.emplace(
+        velox::common::Subfield("p"),
+        std::make_unique<velox::common::TimestampRange>(
+            expected, expected, /*nullAllowed=*/false));
+    auto tableHandle =
+        std::make_shared<velox::connector::hive::HiveTableHandle>(
+            layout.connectorId(),
+            "timestamp_partition",
+            std::move(filters),
+            /*remainingFilter=*/nullptr,
+            /*dataColumns=*/nullptr);
+    auto session = makeSession(
+        {{velox::connector::hive::HiveConfig::
+              kReadTimestampPartitionValueAsLocalTimeSession,
+          readAsLocalTime ? "true" : "false"}});
+    auto predicates = layout.discretePredicates(
+        session, {partitionColumn}, std::move(tableHandle));
+    auto* predicateSource = predicates.get();
+    VELOX_CHECK_NOT_NULL(predicateSource);
+    auto rows = predicateSource->next();
+    ASSERT_EQ(rows.size(), 1);
+    ASSERT_EQ(rows.front().row().size(), 1);
+    EXPECT_EQ(
+        rows.front().row().front().value<velox::TypeKind::TIMESTAMP>(),
+        expected);
+  };
+
+  verify(/*readAsLocalTime=*/true, shifted);
+  verify(/*readAsLocalTime=*/false, unshifted);
+}
+
+TEST_F(LocalHiveConnectorMetadataTest, datePartitionFilter) {
+  auto tableType = ROW({{"data", BIGINT()}, {"p", DATE()}});
+  folly::F14FastMap<std::string, velox::Variant> options = {
+      {HiveWriteOptions::kPartitionedBy, velox::Variant::array({"p"})},
+      {HiveWriteOptions::kFileFormat, "parquet"},
+  };
+  auto table = metadata_->createTable(
+      makeSession(),
+      {kDefaultSchema, "date_partition"},
+      tableType,
+      options,
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+
+  auto* layout = mutableLayout(table);
+  layout->setPartitionStats(
+      {{.partitionKeys = {{"p", "2020-01-02"}}, .numRows = 1},
+       {.partitionKeys = {{"p", "2020-01-03"}}, .numRows = 1}});
+  const auto* partitionColumn = layout->table().findColumn("p");
+  ASSERT_NE(partitionColumn, nullptr);
+  const auto expected = DATE()->toDays("2020-01-02");
+
+  velox::common::SubfieldFilters filters;
+  filters.emplace(
+      velox::common::Subfield("p"),
+      std::make_unique<velox::common::BigintRange>(
+          expected, expected, /*nullAllowed=*/false));
+  auto tableHandle = std::make_shared<velox::connector::hive::HiveTableHandle>(
+      layout->connectorId(),
+      "date_partition",
+      std::move(filters),
+      /*remainingFilter=*/nullptr,
+      /*dataColumns=*/nullptr);
+  auto predicates = layout->discretePredicates(
+      makeSession(), {partitionColumn}, std::move(tableHandle));
+  auto* predicateSource = predicates.get();
+  VELOX_CHECK_NOT_NULL(predicateSource);
+  const auto rows = predicateSource->next();
+  ASSERT_EQ(rows.size(), 1);
+  EXPECT_EQ(
+      rows.front().row().front().value<velox::TypeKind::INTEGER>(), expected);
+}
+
+// A NULL partition is stored as the __HIVE_DEFAULT_PARTITION__ sentinel, which
+// is not a value of the column type.
+TEST_F(LocalHiveConnectorMetadataTest, nullPartitionValueIsNotConverted) {
+  auto tableType = ROW({{"data", BIGINT()}, {"p", DATE()}});
+  folly::F14FastMap<std::string, velox::Variant> options = {
+      {HiveWriteOptions::kPartitionedBy, velox::Variant::array({"p"})},
+      {HiveWriteOptions::kFileFormat, "parquet"},
+  };
+  auto table = metadata_->createTable(
+      makeSession(),
+      {kDefaultSchema, "null_partition"},
+      tableType,
+      options,
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+
+  auto* layout = mutableLayout(table);
+  const std::string sentinel{
+      velox::dwio::catalog::fbhive::FileUtils::kDefaultPartitionValue};
+  layout->setPartitionStats(
+      {{.partitionKeys = {{"p", "2020-01-02"}}, .numRows = 1},
+       {.partitionKeys = {{"p", sentinel}}, .numRows = 1}});
+  const auto* partitionColumn = layout->table().findColumn("p");
+  ASSERT_NE(partitionColumn, nullptr);
+  const auto expected = DATE()->toDays("2020-01-02");
+
+  velox::common::SubfieldFilters filters;
+  filters.emplace(
+      velox::common::Subfield("p"),
+      std::make_unique<velox::common::BigintRange>(
+          expected, expected, /*nullAllowed=*/false));
+  auto tableHandle = std::make_shared<velox::connector::hive::HiveTableHandle>(
+      layout->connectorId(),
+      "null_partition",
+      std::move(filters),
+      /*remainingFilter=*/nullptr,
+      /*dataColumns=*/nullptr);
+  auto predicates = layout->discretePredicates(
+      makeSession(), {partitionColumn}, std::move(tableHandle));
+  auto* predicateSource = predicates.get();
+  VELOX_CHECK_NOT_NULL(predicateSource);
+
+  // The NULL partition does not match a nullAllowed=false filter, and it must
+  // not fail conversion either.
+  const auto rows = predicateSource->next();
+  ASSERT_EQ(rows.size(), 1);
+  EXPECT_EQ(
+      rows.front().row().front().value<velox::TypeKind::INTEGER>(), expected);
 }
 
 TEST_F(LocalHiveConnectorMetadataTest, addColumn) {


### PR DESCRIPTION
Summary:

Queries against Hive tables with typed `TIMESTAMP` partition columns failed during planning with `Unsupported partition column type: TIMESTAMP`. The metadata paths converted partition strings with a local type switch that had no timestamp case and could disagree with the Hive reader about local-time interpretation.

Partition values now convert through the shared Velox `PartitionValue` in both directions: `fromString` to read a partition name, `toString` to build one. Reusing the writer's own naming for the reverse direction is what lets a pushed-down timestamp predicate match, because the Metastore compares partition text rather than typed values. Timestamp mode resolves with session-over-connector precedence, so a plain `TIMESTAMP` follows `reader.timestamp_partition_value_as_local_time` while a `TIMESTAMP_UTC` is unaffected.

`HivePartitionValueConverter` holds the resolved mode and is the one object the metadata paths share, so partition pruning, statistics, grouped metadata counts, and discrete predicates cannot disagree about a value. It declines to name a value with no unambiguous partition string, such as a local-time `TIMESTAMP` inside a DST fold.

Hive escapes characters such as `:` in partition directory names. Components are decoded before typed conversion so a timestamp reaches planning in its original form.

Differential Revision: D112868275


