### PR TITLE
refactor(core): Make UnnestNode output names std::optional (#1622)

### DIFF
--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1704,7 +1704,7 @@ velox::core::PlanNodePtr ToVelox::makeUnnest(
   auto input = makeFragment(op.input(), fragment, stages);
 
   const auto* ordinalityColumn = op.unnestTable->ordinalityColumn;
-  std::vector<std::string> unnestNames;
+  std::vector<std::optional<std::string>> unnestNames;
   unnestNames.reserve(op.unnestTable->columns.size());
   for (const auto* column : op.unnestTable->columns) {
     if (column == ordinalityColumn) {

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1665,7 +1665,7 @@ velox::core::PlanNodePtr ToVelox::makeUnnest(
   auto input = makeFragment(op.input(), fragment, stages);
 
   const auto* ordinalityColumn = op.unnestTable->ordinalityColumn;
-  std::vector<std::string> unnestNames;
+  std::vector<std::optional<std::string>> unnestNames;
   unnestNames.reserve(op.unnestTable->columns.size());
   for (const auto* column : op.unnestTable->columns) {
     if (column == ordinalityColumn) {

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -1569,10 +1569,10 @@ velox::core::PlanNodePtr Emitter::emitUnnest(const Unnest& unnest) {
   std::vector<velox::core::FieldAccessTypedExprPtr> unnestVariables =
       toFieldAccessList(unnest.unnestExpressions(), "Unnest expression");
 
-  std::vector<std::string> unnestNames;
+  std::vector<std::optional<std::string>> unnestNames;
   for (const auto& perExpr : unnest.unnestColumns()) {
     for (ColumnCP column : perExpr) {
-      unnestNames.push_back(column->outputName());
+      unnestNames.emplace_back(column->outputName());
     }
   }
 

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -1538,10 +1538,10 @@ velox::core::PlanNodePtr Emitter::emitUnnest(const Unnest& unnest) {
   std::vector<velox::core::FieldAccessTypedExprPtr> unnestVariables =
       toFieldAccessList(unnest.unnestExpressions(), "Unnest expression");
 
-  std::vector<std::string> unnestNames;
+  std::vector<std::optional<std::string>> unnestNames;
   for (const auto& perExpr : unnest.unnestColumns()) {
     for (ColumnCP column : perExpr) {
-      unnestNames.push_back(column->outputName());
+      unnestNames.emplace_back(column->outputName());
     }
   }
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/velox/pull/18213

Migrate `UnnestNode::unnestNames` from `std::vector<std::string>` to `std::vector<std::optional<std::string>>`. This is a no-functional-change refactor: every entry remains present and behavior is unchanged. It is the enabling type migration for #17678 (allow `UnnestNode` to skip unused output columns); a follow-up gives `std::nullopt` its pruning meaning in the operator.

The previous `std::vector<std::string>` constructor is retained behind `VELOX_ENABLE_BACKWARD_COMPATIBILITY` so backward-compatibility consumers continue to build unchanged; all other call sites move to the new API. Optional names are serialized with an explicit null-tolerant encoding.

Part of #17678.

Reviewed By: stellameta, xiaoxmeng

Differential Revision: D112583571


