### PR TITLE
feat(optimizer): Estimate bytes read from storage on the plan (#1666)

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -437,6 +437,13 @@ struct FilteredTableStats {
   /// co_estimateStats. Either empty (no column stats available) or has the
   /// same size as 'columns', in the same order.
   std::vector<ColumnStatistics> columnStats;
+
+  /// Estimated on-disk (compressed) size in bytes of the data read after
+  /// partition pruning, i.e. the bytes read from storage. `nullopt` if the
+  /// connector has no estimate. This is a leaf-level quantity taken from
+  /// collected table statistics, independent of downstream cardinality
+  /// estimation.
+  std::optional<uint64_t> dataSize;
 };
 
 /// Folds, into 'stats', the selectivity and refined column statistics of
@@ -867,6 +874,15 @@ class Table : public std::enable_shared_from_this<Table> {
   /// if the connector has no estimate; downstream cost-based decisions
   /// fall back to safe defaults rather than a fabricated value.
   virtual std::optional<uint64_t> numRows() const = 0;
+
+  /// Returns an estimate of the on-disk (compressed) size in bytes of 'this',
+  /// i.e. the bytes read from storage for a full scan. `nullopt` if the
+  /// connector has no estimate. Partitioned connectors may return `nullopt`
+  /// here and instead provide a partition-pruned per-query estimate via
+  /// TableLayout::co_estimateStats.
+  virtual std::optional<uint64_t> dataSize() const {
+    return std::nullopt;
+  }
 
   /// Returns the table properties specified at creation time (e.g. format,
   /// partitioned_by, bucket_count). Connectors must store all properties

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -427,6 +427,13 @@ struct FilteredTableStats {
   /// co_estimateStats. Either empty (no column stats available) or has the
   /// same size as 'columns', in the same order.
   std::vector<ColumnStatistics> columnStats;
+
+  /// Estimated on-disk (compressed) size in bytes of the data read after
+  /// partition pruning, i.e. the bytes read from storage. `nullopt` if the
+  /// connector has no estimate. This is a leaf-level quantity taken from
+  /// collected table statistics, independent of downstream cardinality
+  /// estimation.
+  std::optional<uint64_t> dataSize;
 };
 
 /// Folds, into 'stats', the selectivity and refined column statistics of
@@ -852,6 +859,15 @@ class Table : public std::enable_shared_from_this<Table> {
   /// if the connector has no estimate; downstream cost-based decisions
   /// fall back to safe defaults rather than a fabricated value.
   virtual std::optional<uint64_t> numRows() const = 0;
+
+  /// Returns an estimate of the on-disk (compressed) size in bytes of 'this',
+  /// i.e. the bytes read from storage for a full scan. `nullopt` if the
+  /// connector has no estimate. Partitioned connectors may return `nullopt`
+  /// here and instead provide a partition-pruned per-query estimate via
+  /// TableLayout::co_estimateStats.
+  virtual std::optional<uint64_t> dataSize() const {
+    return std::nullopt;
+  }
 
   /// Returns the table properties specified at creation time (e.g. format,
   /// partitioned_by, bucket_count). Connectors must store all properties

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -991,6 +991,15 @@ void TestConnectorMetadata::setStats(
   it->second->setStats(numRows, columnStats);
 }
 
+void TestConnectorMetadata::setDataSize(
+    const SchemaTableName& tableName,
+    uint64_t dataSize) {
+  auto it = tables_.find(tableName);
+  VELOX_CHECK(
+      it != tables_.end(), "Table doesn't exist: {}", tableName.toString());
+  it->second->setDataSize(dataSize);
+}
+
 TestDataSource::TestDataSource(
     const velox::RowTypePtr& outputType,
     const velox::connector::ColumnHandleMap& handles,
@@ -1314,6 +1323,12 @@ void TestConnector::setStats(
     uint64_t numRows,
     const std::unordered_map<std::string, ColumnStatistics>& columnStats) {
   metadata_->setStats(tableName, numRows, columnStats);
+}
+
+void TestConnector::setDataSize(
+    const SchemaTableName& tableName,
+    uint64_t dataSize) {
+  metadata_->setDataSize(tableName, dataSize);
 }
 
 std::shared_ptr<velox::connector::Connector> TestConnectorFactory::newConnector(

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -992,6 +992,15 @@ void TestConnectorMetadata::setStats(
   it->second->setStats(numRows, columnStats);
 }
 
+void TestConnectorMetadata::setDataSize(
+    const SchemaTableName& tableName,
+    uint64_t dataSize) {
+  auto it = tables_.find(tableName);
+  VELOX_CHECK(
+      it != tables_.end(), "Table doesn't exist: {}", tableName.toString());
+  it->second->setDataSize(dataSize);
+}
+
 TestDataSource::TestDataSource(
     const velox::RowTypePtr& outputType,
     const velox::connector::ColumnHandleMap& handles,
@@ -1315,6 +1324,12 @@ void TestConnector::setStats(
     uint64_t numRows,
     const std::unordered_map<std::string, ColumnStatistics>& columnStats) {
   metadata_->setStats(tableName, numRows, columnStats);
+}
+
+void TestConnector::setDataSize(
+    const SchemaTableName& tableName,
+    uint64_t dataSize) {
+  metadata_->setDataSize(tableName, dataSize);
 }
 
 std::shared_ptr<velox::connector::Connector> TestConnectorFactory::newConnector(

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -186,6 +186,10 @@ class TestTable : public Table {
     return data_.empty() ? numRows_ : dataRows_;
   }
 
+  std::optional<uint64_t> dataSize() const override {
+    return dataSize_;
+  }
+
   const std::vector<velox::RowVectorPtr>& data() const {
     return data_;
   }
@@ -220,6 +224,12 @@ class TestTable : public Table {
       uint64_t numRows,
       const std::unordered_map<std::string, ColumnStatistics>& columnStats);
 
+  /// Sets the on-disk data size reported by dataSize(), for exercising
+  /// data-size-based optimizer estimates.
+  void setDataSize(uint64_t dataSize) {
+    dataSize_ = dataSize;
+  }
+
  private:
   // Per-column state for incremental stat computation during addData.
   struct ColumnTracker {
@@ -247,6 +257,7 @@ class TestTable : public Table {
   std::vector<int32_t> dataBucketIds_;
   uint64_t numRows_{0};
   uint64_t dataRows_{0};
+  std::optional<uint64_t> dataSize_;
   std::vector<ColumnTracker> columnTrackers_;
 
   std::optional<TestBucketSpec> bucketSpec_;
@@ -565,6 +576,9 @@ class TestConnectorMetadata : public ConnectorMetadata {
       const SchemaTableName& tableName,
       uint64_t numRows,
       const std::unordered_map<std::string, ColumnStatistics>& columnStats);
+
+  /// See TestTable::setDataSize.
+  void setDataSize(const SchemaTableName& tableName, uint64_t dataSize);
 
   TablePtr createTable(
       const ConnectorSessionPtr& session,
@@ -895,6 +909,14 @@ class TestConnector : public velox::connector::Connector {
       uint64_t numRows,
       const std::unordered_map<std::string, ColumnStatistics>& columnStats) {
     setStats({std::string(kDefaultSchema), tableName}, numRows, columnStats);
+  }
+
+  /// Sets the on-disk data size for the table with the specified name.
+  void setDataSize(const SchemaTableName& tableName, uint64_t dataSize);
+
+  /// Convenience overload that uses kDefaultSchema as the schema.
+  void setDataSize(const std::string& tableName, uint64_t dataSize) {
+    setDataSize({std::string(kDefaultSchema), tableName}, dataSize);
   }
 
   bool dropTableIfExists(const SchemaTableName& name);

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -186,6 +186,10 @@ class TestTable : public Table {
     return data_.empty() ? numRows_ : dataRows_;
   }
 
+  std::optional<uint64_t> dataSize() const override {
+    return dataSize_;
+  }
+
   const std::vector<velox::RowVectorPtr>& data() const {
     return data_;
   }
@@ -220,6 +224,12 @@ class TestTable : public Table {
       uint64_t numRows,
       const std::unordered_map<std::string, ColumnStatistics>& columnStats);
 
+  /// Sets the on-disk data size reported by dataSize(), for exercising
+  /// data-size-based optimizer estimates.
+  void setDataSize(uint64_t dataSize) {
+    dataSize_ = dataSize;
+  }
+
  private:
   // Per-column state for incremental stat computation during addData.
   struct ColumnTracker {
@@ -247,6 +257,7 @@ class TestTable : public Table {
   std::vector<int32_t> dataBucketIds_;
   uint64_t numRows_{0};
   uint64_t dataRows_{0};
+  std::optional<uint64_t> dataSize_;
   std::vector<ColumnTracker> columnTrackers_;
 
   std::optional<TestBucketSpec> bucketSpec_;
@@ -565,6 +576,9 @@ class TestConnectorMetadata : public ConnectorMetadata {
       const SchemaTableName& tableName,
       uint64_t numRows,
       const std::unordered_map<std::string, ColumnStatistics>& columnStats);
+
+  /// See TestTable::setDataSize.
+  void setDataSize(const SchemaTableName& tableName, uint64_t dataSize);
 
   TablePtr createTable(
       const ConnectorSessionPtr& session,
@@ -894,6 +908,14 @@ class TestConnector : public velox::connector::Connector {
       uint64_t numRows,
       const std::unordered_map<std::string, ColumnStatistics>& columnStats) {
     setStats({std::string(kDefaultSchema), tableName}, numRows, columnStats);
+  }
+
+  /// Sets the on-disk data size for the table with the specified name.
+  void setDataSize(const SchemaTableName& tableName, uint64_t dataSize);
+
+  /// Convenience overload that uses kDefaultSchema as the schema.
+  void setDataSize(const std::string& tableName, uint64_t dataSize) {
+    setDataSize({std::string(kDefaultSchema), tableName}, dataSize);
   }
 
   bool dropTableIfExists(const SchemaTableName& name);

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -27,6 +27,7 @@
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/PlanUtils.h"
 #include "axiom/optimizer/PrecomputeProjection.h"
+#include "axiom/optimizer/Schema.h"
 #include "axiom/optimizer/StatsFilterSelectivityEstimator.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "folly/coro/BlockingWait.h"
@@ -283,12 +284,21 @@ void Optimization::applyFilteredStats(
     }
   }
 
+  // Bytes read from storage are fixed by partition pruning, already reflected
+  // in stats->dataSize, so they are not scaled by row-level filter selectivity.
+  // Only refine when the connector estimated a size; otherwise keep the
+  // whole-table seed from schemaTable->dataSize.
+  if (auto dataSize = toSignedByteCount(stats->dataSize)) {
+    baseTable.filteredDataSize = dataSize;
+  }
+
   // The connector accounted for the filters it accepted into the handle in
   // numRows. Post-apply selectivity for the filters createTableHandle rejected
   // (kept as ExprCP), which the optimizer owns.
   const auto& rejectedFilters =
       toVelox_.leafData(baseTable.id())->rejectedExprs;
   if (rejectedFilters.empty()) {
+    // Connector estimated all filters.
     baseTable.filteredCardinality = stats->numRows;
     return;
   }

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -26,6 +26,7 @@
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/PlanUtils.h"
 #include "axiom/optimizer/PrecomputeProjection.h"
+#include "axiom/optimizer/Schema.h"
 #include "axiom/optimizer/StatsFilterSelectivityEstimator.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "folly/coro/BlockingWait.h"
@@ -294,12 +295,21 @@ void Optimization::applyFilteredStats(
     }
   }
 
+  // Bytes read from storage are fixed by partition pruning, already reflected
+  // in stats->dataSize, so they are not scaled by row-level filter selectivity.
+  // Only refine when the connector estimated a size; otherwise keep the
+  // whole-table seed from schemaTable->dataSize.
+  if (auto dataSize = toSignedByteCount(stats->dataSize)) {
+    baseTable.filteredDataSize = dataSize;
+  }
+
   // The connector accounted for the filters it accepted into the handle in
   // numRows. Post-apply selectivity for the filters createTableHandle rejected
   // (kept as ExprCP), which the optimizer owns.
   const auto& rejectedFilters =
       toVelox_.leafData(baseTable.id())->rejectedExprs;
   if (rejectedFilters.empty()) {
+    // Connector estimated all filters.
     baseTable.filteredCardinality = stats->numRows;
     return;
   }

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1157,6 +1157,12 @@ struct BaseTable : public TableObject {
   /// the cardinality is unknown.
   std::optional<float> filteredCardinality{0};
 
+  /// Estimated on-disk (compressed) bytes read from storage for this scan after
+  /// partition pruning. Initialized to schemaTable->dataSize. Not scaled by
+  /// row-level filter selectivity: a scan reads the matching partitions' bytes
+  /// before rows are filtered. nullopt when no data-size estimate is available.
+  std::optional<int64_t> filteredDataSize;
+
   SubfieldSet controlSubfields;
 
   SubfieldSet payloadSubfields;

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -160,11 +160,20 @@ std::optional<float> connectorCardinality(
   }
   return std::max<float>(1, static_cast<float>(*numRows));
 }
+
+// Propagates the connector's on-disk data-size estimate, or `nullopt` when the
+// connector reports none. Kept as an integer byte count: unlike cardinality it
+// is never scaled by selectivity, so float would only lose precision.
+std::optional<int64_t> connectorDataSize(
+    const connector::Table& connectorTable) {
+  return toSignedByteCount(connectorTable.dataSize());
+}
 } // namespace
 
 SchemaTable::SchemaTable(const connector::Table& connectorTable)
     : connectorTable{&connectorTable},
-      cardinality{connectorCardinality(connectorTable)} {}
+      cardinality{connectorCardinality(connectorTable)},
+      dataSize{connectorDataSize(connectorTable)} {}
 
 SchemaTableCP Schema::buildSchemaTable(
     const connector::Table& connectorTable) const {

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -151,6 +151,14 @@ std::optional<float> connectorCardinality(
   }
   return std::max<float>(1, static_cast<float>(*numRows));
 }
+
+// Propagates the connector's on-disk data-size estimate, or `nullopt` when the
+// connector reports none. Kept as an integer byte count: unlike cardinality it
+// is never scaled by selectivity, so float would only lose precision.
+std::optional<int64_t> connectorDataSize(
+    const connector::Table& connectorTable) {
+  return toSignedByteCount(connectorTable.dataSize());
+}
 } // namespace
 
 Value Value::fromColumnStatistics(
@@ -184,7 +192,8 @@ Value Value::fromColumnStatistics(
 
 SchemaTable::SchemaTable(const connector::Table& connectorTable)
     : connectorTable{&connectorTable},
-      cardinality{connectorCardinality(connectorTable)} {}
+      cardinality{connectorCardinality(connectorTable)},
+      dataSize{connectorDataSize(connectorTable)} {}
 
 SchemaTableCP Schema::buildSchemaTable(
     const connector::Table& connectorTable) const {

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -17,6 +17,9 @@
 #pragma once
 
 #include <folly/CppAttributes.h>
+#include <cstdint>
+#include <limits>
+#include <optional>
 #include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/optimizer/PlanObject.h"
@@ -34,6 +37,18 @@ using NameMap = QGF14FastMap<Name, T>;
 
 using VariantCP = const velox::Variant*;
 using TypeCP = const velox::Type*;
+
+/// Converts a connector byte count to the optimizer's signed representation,
+/// returning nullopt when absent or too large to represent as int64_t (e.g. a
+/// UINT64_MAX "unknown" sentinel), so a corrupt size never becomes a negative
+/// estimate downstream.
+inline std::optional<int64_t> toSignedByteCount(std::optional<uint64_t> bytes) {
+  if (!bytes.has_value() ||
+      *bytes > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+    return std::nullopt;
+  }
+  return static_cast<int64_t>(*bytes);
+}
 
 /// Represents constraints on a column value or intermediate result.
 // TODO: Refactor to separate schema facts from statistical estimates:
@@ -421,6 +436,12 @@ struct SchemaTable {
   const connector::Table* const connectorTable;
 
   const std::optional<float> cardinality;
+
+  /// Estimated on-disk (compressed) size in bytes of the whole table, or
+  /// nullopt when the connector reports none. Partitioned connectors report
+  /// nullopt here; the pruned per-query estimate flows through
+  /// BaseTable::filteredDataSize.
+  const std::optional<int64_t> dataSize;
 
   /// Maps column name to schema column.
   NameMap<ColumnCP> columns;

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -17,6 +17,9 @@
 #pragma once
 
 #include <folly/CppAttributes.h>
+#include <cstdint>
+#include <limits>
+#include <optional>
 #include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/optimizer/PlanObject.h"
@@ -34,6 +37,28 @@ using NameMap = QGF14FastMap<Name, T>;
 
 using VariantCP = const velox::Variant*;
 using TypeCP = const velox::Type*;
+
+/// Converts a connector byte count to the optimizer's signed representation,
+/// returning nullopt when absent or too large to represent as int64_t (e.g. a
+/// UINT64_MAX "unknown" sentinel), so a corrupt size never becomes a negative
+/// estimate downstream.
+inline std::optional<int64_t> toSignedByteCount(std::optional<uint64_t> bytes) {
+  if (!bytes.has_value() ||
+      *bytes > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+    return std::nullopt;
+  }
+  return static_cast<int64_t>(*bytes);
+}
+
+/// Adds a non-negative byte count to a running total, saturating at int64_t
+/// max. A plan may scan more bytes than a signed 64-bit total can hold;
+/// clamping keeps the estimate monotonic instead of wrapping negative.
+inline int64_t addByteCounts(int64_t total, int64_t bytes) {
+  if (total > std::numeric_limits<int64_t>::max() - bytes) {
+    return std::numeric_limits<int64_t>::max();
+  }
+  return total + bytes;
+}
 
 /// Represents constraints on a column value or intermediate result.
 // TODO: Refactor to separate schema facts from statistical estimates:
@@ -430,6 +455,12 @@ struct SchemaTable {
   const connector::Table* const connectorTable;
 
   const std::optional<float> cardinality;
+
+  /// Estimated on-disk (compressed) size in bytes of the whole table, or
+  /// nullopt when the connector reports none. Partitioned connectors report
+  /// nullopt here; the pruned per-query estimate flows through
+  /// BaseTable::filteredDataSize.
+  const std::optional<int64_t> dataSize;
 
   /// Maps column name to schema column.
   NameMap<ColumnCP> columns;

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -2547,6 +2547,7 @@ BaseTable* initBaseTable(
   baseTable->cname = cname;
   baseTable->schemaTable = schemaTable;
   baseTable->filteredCardinality = schemaTable->cardinality;
+  baseTable->filteredDataSize = schemaTable->dataSize;
   planLeaves[&planNode] = baseTable;
   return baseTable;
 }

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -2546,6 +2546,7 @@ BaseTable* initBaseTable(
   baseTable->cname = cname;
   baseTable->schemaTable = schemaTable;
   baseTable->filteredCardinality = schemaTable->cardinality;
+  baseTable->filteredDataSize = schemaTable->dataSize;
   planLeaves[&planNode] = baseTable;
   return baseTable;
 }

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -539,6 +539,7 @@ PlanAndStats ToVelox::toVeloxPlan(
 
   prediction_.clear();
   nodeHistory_.clear();
+  estimatedScanBytes_.reset();
   relationOpToNodeId_.clear();
   currentConsumerGroupedLeaves_ = nullptr;
   groupedLeaves_ = &groupedLeaves;
@@ -638,7 +639,8 @@ PlanAndStats ToVelox::toVeloxPlan(
       std::move(multiFragmentPlan),
       std::move(nodeHistory_),
       std::move(prediction_),
-      std::move(finishWrite)};
+      std::move(finishWrite),
+      estimatedScanBytes_};
 }
 
 velox::RowTypePtr ToVelox::makeOutputType(const ColumnVector& columns) const {
@@ -1545,6 +1547,11 @@ velox::core::PlanNodePtr ToVelox::makeScan(
   }
 
   makePredictionAndHistory(result->id(), &scan);
+
+  if (scan.baseTable->filteredDataSize.has_value()) {
+    estimatedScanBytes_ =
+        estimatedScanBytes_.value_or(0) + *scan.baseTable->filteredDataSize;
+  }
 
   columnAlteredTypes_.clear();
   return result;

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -545,6 +545,7 @@ PlanAndStats ToVelox::toVeloxPlan(
 
   prediction_.clear();
   nodeHistory_.clear();
+  estimatedScanBytes_.reset();
   relationOpToNodeId_.clear();
   currentConsumerGroupedLeaves_ = nullptr;
   groupedLeaves_ = &groupedLeaves;
@@ -644,7 +645,8 @@ PlanAndStats ToVelox::toVeloxPlan(
       std::move(multiFragmentPlan),
       std::move(nodeHistory_),
       std::move(prediction_),
-      std::move(finishWrite)};
+      std::move(finishWrite),
+      estimatedScanBytes_};
 }
 
 velox::RowTypePtr ToVelox::makeOutputType(const ColumnVector& columns) const {
@@ -1554,6 +1556,11 @@ velox::core::PlanNodePtr ToVelox::makeScan(
   }
 
   makePredictionAndHistory(result->id(), &scan);
+
+  if (scan.baseTable->filteredDataSize.has_value()) {
+    estimatedScanBytes_ = addByteCounts(
+        estimatedScanBytes_.value_or(0), *scan.baseTable->filteredDataSize);
+  }
 
   columnAlteredTypes_.clear();
   return result;

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -51,6 +51,11 @@ struct PlanAndStats {
   NodePredictionMap prediction;
   FinishWrite finishWrite;
 
+  /// Sum of the on-disk (compressed) bytes read from storage over the table
+  /// scans that reported a data-size estimate. A lower bound when some scans
+  /// lack an estimate; nullopt only when no scan reported one.
+  std::optional<int64_t> estimatedScanBytes;
+
   /// Returns a string representation of the plan annotated with estimates from
   /// 'prediction'.
   std::string toString() const;
@@ -380,6 +385,10 @@ class ToVelox {
 
   // Predicted cardinality and memory for nodes to record in history.
   NodePredictionMap prediction_;
+
+  // Accumulated on-disk bytes read across the plan's table scans that reported
+  // a data-size estimate. nullopt until the first scan contributes.
+  std::optional<int64_t> estimatedScanBytes_;
 
   // On when producing a remaining filter for table scan, where columns must
   // correspond 1:1 to the schema.

--- a/axiom/optimizer/tests/CardinalityEstimationTest.cpp
+++ b/axiom/optimizer/tests/CardinalityEstimationTest.cpp
@@ -238,6 +238,100 @@ TEST_F(CardinalityEstimationTest, scanWithFilter) {
   });
 }
 
+// Verifies estimatedScanBytes plumbing through both optimizers (v1 and v2).
+class EstimatedScanBytesTest : public test::QueryTestBase,
+                               public ::testing::WithParamInterface<bool> {
+ protected:
+  void SetUp() override {
+    test::QueryTestBase::SetUp();
+    useV2_ = GetParam();
+  }
+
+  // Optimizes 'sql' through the full ToVelox pipeline and returns the
+  // plan-level stats, which carry estimatedScanBytes.
+  optimizer::PlanAndStats planStatsFor(const std::string& sql) {
+    auto logicalPlan = parseSelect(sql, kTestConnectorId);
+    OptimizerOptions options;
+    options.sampleJoins = false;
+    options.sampleFilters = false;
+    return planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4}, options);
+  }
+};
+
+// Verifies that PlanAndStats.estimatedScanBytes carries the connector's
+// on-disk data size for a single table scan.
+TEST_P(EstimatedScanBytesTest, singleScan) {
+  auto table = testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  table->setStats(1'000, {{"a", {.numDistinct = 100}}});
+  table->setDataSize(4'096);
+
+  auto stats = planStatsFor("SELECT a FROM t");
+  ASSERT_TRUE(stats.estimatedScanBytes.has_value());
+  EXPECT_EQ(*stats.estimatedScanBytes, 4'096);
+}
+
+// Verifies that a scan whose connector reports no data size leaves
+// estimatedScanBytes unset rather than reporting a zero-byte scan.
+TEST_P(EstimatedScanBytesTest, unsetWithoutDataSize) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(1'000, {{"a", {.numDistinct = 100}}});
+
+  auto stats = planStatsFor("SELECT a FROM t");
+  EXPECT_FALSE(stats.estimatedScanBytes.has_value());
+}
+
+// Verifies that two scans each contribute their data size and the plan-level
+// estimate sums them.
+TEST_P(EstimatedScanBytesTest, sumsAcrossScans) {
+  auto t = testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  t->setStats(1'000, {{"a", {.numDistinct = 100}}});
+  t->setDataSize(4'096);
+
+  auto u = testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()));
+  u->setStats(1'000, {{"x", {.numDistinct = 100}}});
+  u->setDataSize(1'024);
+
+  auto stats = planStatsFor("SELECT a, y FROM t JOIN u ON a = x");
+  ASSERT_TRUE(stats.estimatedScanBytes.has_value());
+  EXPECT_EQ(*stats.estimatedScanBytes, 4'096 + 1'024);
+}
+
+// Verifies that when only some scans report a size, the estimate is the sum
+// over the scans that did (a lower bound) and is not wiped out by the scan
+// that reported none.
+TEST_P(EstimatedScanBytesTest, lowerBoundOnPartialCoverage) {
+  auto t = testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  t->setStats(1'000, {{"a", {.numDistinct = 100}}});
+  t->setDataSize(4'096);
+
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 100}}});
+
+  auto stats = planStatsFor("SELECT a, y FROM t JOIN u ON a = x");
+  ASSERT_TRUE(stats.estimatedScanBytes.has_value());
+  EXPECT_EQ(*stats.estimatedScanBytes, 4'096);
+}
+
+// Verifies that a total exceeding int64_t saturates at the maximum instead of
+// wrapping to a negative estimate.
+TEST_P(EstimatedScanBytesTest, sumSaturatesAtMax) {
+  constexpr int64_t kMaxBytes = std::numeric_limits<int64_t>::max();
+
+  auto t = testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  t->setStats(1'000, {{"a", {.numDistinct = 100}}});
+  t->setDataSize(kMaxBytes);
+
+  auto u = testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()));
+  u->setStats(1'000, {{"x", {.numDistinct = 100}}});
+  u->setDataSize(kMaxBytes);
+
+  auto stats = planStatsFor("SELECT a, y FROM t JOIN u ON a = x");
+  ASSERT_TRUE(stats.estimatedScanBytes.has_value());
+  EXPECT_EQ(*stats.estimatedScanBytes, kMaxBytes);
+}
+
+AXIOM_INSTANTIATE_V1_V2(EstimatedScanBytesTest);
+
 // Verifies cardinality estimation for aggregation: output cardinality
 // should be capped at the number of distinct values of the grouping key.
 TEST_F(CardinalityEstimationTest, aggregation) {

--- a/axiom/optimizer/tests/CardinalityEstimationTest.cpp
+++ b/axiom/optimizer/tests/CardinalityEstimationTest.cpp
@@ -238,6 +238,82 @@ TEST_F(CardinalityEstimationTest, scanWithFilter) {
   });
 }
 
+// Verifies estimatedScanBytes plumbing through both optimizers (v1 and v2).
+class EstimatedScanBytesTest : public test::QueryTestBase,
+                               public ::testing::WithParamInterface<bool> {
+ protected:
+  void SetUp() override {
+    test::QueryTestBase::SetUp();
+    useV2_ = GetParam();
+  }
+
+  // Optimizes 'sql' through the full ToVelox pipeline and returns the
+  // plan-level stats, which carry estimatedScanBytes.
+  optimizer::PlanAndStats planStatsFor(const std::string& sql) {
+    auto logicalPlan = parseSelect(sql, kTestConnectorId);
+    OptimizerOptions options;
+    options.sampleJoins = false;
+    options.sampleFilters = false;
+    return planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4}, options);
+  }
+};
+
+// Verifies that PlanAndStats.estimatedScanBytes carries the connector's
+// on-disk data size for a single table scan.
+TEST_P(EstimatedScanBytesTest, singleScan) {
+  auto table = testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  table->setStats(1'000, {{"a", {.numDistinct = 100}}});
+  table->setDataSize(4'096);
+
+  auto stats = planStatsFor("SELECT a FROM t");
+  ASSERT_TRUE(stats.estimatedScanBytes.has_value());
+  EXPECT_EQ(*stats.estimatedScanBytes, 4'096);
+}
+
+// Verifies that a scan whose connector reports no data size leaves
+// estimatedScanBytes unset rather than reporting a zero-byte scan.
+TEST_P(EstimatedScanBytesTest, unsetWithoutDataSize) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(1'000, {{"a", {.numDistinct = 100}}});
+
+  auto stats = planStatsFor("SELECT a FROM t");
+  EXPECT_FALSE(stats.estimatedScanBytes.has_value());
+}
+
+// Verifies that two scans each contribute their data size and the plan-level
+// estimate sums them.
+TEST_P(EstimatedScanBytesTest, sumsAcrossScans) {
+  auto t = testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  t->setStats(1'000, {{"a", {.numDistinct = 100}}});
+  t->setDataSize(4'096);
+
+  auto u = testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()));
+  u->setStats(1'000, {{"x", {.numDistinct = 100}}});
+  u->setDataSize(1'024);
+
+  auto stats = planStatsFor("SELECT a, y FROM t JOIN u ON a = x");
+  ASSERT_TRUE(stats.estimatedScanBytes.has_value());
+  EXPECT_EQ(*stats.estimatedScanBytes, 4'096 + 1'024);
+}
+
+// Verifies that when only some scans report a size, the estimate is the sum
+// over the scans that did (a lower bound) and is not wiped out by the scan
+// that reported none.
+TEST_P(EstimatedScanBytesTest, lowerBoundOnPartialCoverage) {
+  auto t = testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  t->setStats(1'000, {{"a", {.numDistinct = 100}}});
+  t->setDataSize(4'096);
+
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
+      ->setStats(1'000, {{"x", {.numDistinct = 100}}});
+
+  auto stats = planStatsFor("SELECT a, y FROM t JOIN u ON a = x");
+  ASSERT_TRUE(stats.estimatedScanBytes.has_value());
+  EXPECT_EQ(*stats.estimatedScanBytes, 4'096);
+}
+
+AXIOM_INSTANTIATE_V1_V2(EstimatedScanBytesTest);
+
 // Verifies cardinality estimation for aggregation: output cardinality
 // should be capped at the number of distinct values of the grouping key.
 TEST_F(CardinalityEstimationTest, aggregation) {

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -522,6 +522,11 @@ class Emitter {
   // takePrediction.
   NodePredictionMap prediction_;
 
+  // Accumulated on-disk bytes read across the plan's table scans that reported
+  // a data-size estimate; moved out via takeEstimatedScanBytes. nullopt until
+  // the first scan contributes.
+  std::optional<int64_t> estimatedScanBytes_;
+
  public:
   // Lowers 'root' (plus the output rename to 'outputNames') into fragments,
   // returning them with the root fragment last.
@@ -539,6 +544,11 @@ class Emitter {
   // Transfers the per-node cardinality predictions collected during emit.
   NodePredictionMap takePrediction() {
     return std::move(prediction_);
+  }
+
+  // Transfers the summed on-disk scan-bytes estimate collected during emit.
+  std::optional<int64_t> takeEstimatedScanBytes() {
+    return std::move(estimatedScanBytes_);
   }
 };
 
@@ -658,6 +668,14 @@ velox::core::PlanNodePtr Emitter::emitScan(const Scan& scan) {
       velox::ROW(std::move(scanOutputNames), std::move(scanOutputTypes)),
       tableHandle,
       std::move(assignments));
+
+  // Sum the per-scan on-disk estimate into the plan-level total. Only scans
+  // that reported a size contribute, so the total is a lower bound when some
+  // scans lack an estimate.
+  if (scan.baseTable()->filteredDataSize.has_value()) {
+    estimatedScanBytes_ =
+        estimatedScanBytes_.value_or(0) + *scan.baseTable()->filteredDataSize;
+  }
 
   // A scan of a bucketed table is a grouped leaf: it runs per bucket-group
   // under grouped execution, tagging the fragment as bucketed. The layout's
@@ -2173,7 +2191,8 @@ EmitPass::Result EmitPass::run(
   return Result{
       std::move(fragments),
       emitter.takeFinishWrite(),
-      emitter.takePrediction()};
+      emitter.takePrediction(),
+      emitter.takeEstimatedScanBytes()};
 }
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -542,6 +542,11 @@ class Emitter {
   // takePrediction.
   NodePredictionMap prediction_;
 
+  // Accumulated on-disk bytes read across the plan's table scans that reported
+  // a data-size estimate; moved out via takeEstimatedScanBytes. nullopt until
+  // the first scan contributes.
+  std::optional<int64_t> estimatedScanBytes_;
+
  public:
   // Lowers 'root' (plus the output rename to 'outputNames') into fragments,
   // returning them with the root fragment last.
@@ -559,6 +564,11 @@ class Emitter {
   // Transfers the per-node cardinality predictions collected during emit.
   NodePredictionMap takePrediction() {
     return std::move(prediction_);
+  }
+
+  // Transfers the summed on-disk scan-bytes estimate collected during emit.
+  std::optional<int64_t> takeEstimatedScanBytes() {
+    return std::move(estimatedScanBytes_);
   }
 };
 
@@ -695,6 +705,14 @@ velox::core::PlanNodePtr Emitter::emitScan(const Scan& scan) {
       velox::ROW(std::move(scanOutputNames), std::move(scanOutputTypes)),
       tableHandle,
       std::move(assignments));
+
+  // Sum the per-scan on-disk estimate into the plan-level total. Only scans
+  // that reported a size contribute, so the total is a lower bound when some
+  // scans lack an estimate.
+  if (scan.baseTable()->filteredDataSize.has_value()) {
+    estimatedScanBytes_ = addByteCounts(
+        estimatedScanBytes_.value_or(0), *scan.baseTable()->filteredDataSize);
+  }
 
   // A scan of a bucketed table is a grouped leaf: it runs per bucket-group
   // under grouped execution, tagging the fragment as bucketed. The layout's
@@ -2320,7 +2338,8 @@ EmitPass::Result EmitPass::run(
   return Result{
       std::move(fragments),
       emitter.takeFinishWrite(),
-      emitter.takePrediction()};
+      emitter.takePrediction(),
+      emitter.takeEstimatedScanBytes()};
 }
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/EmitPass.h
+++ b/axiom/optimizer/v2/EmitPass.h
@@ -38,6 +38,9 @@ class EmitPass {
     /// Per-node estimated cardinality, keyed by emitted `PlanNodeId`, for
     /// EXPLAIN. Empty when estimates are unavailable.
     NodePredictionMap prediction;
+    /// Summed on-disk bytes read across the plan's table scans that reported a
+    /// data-size estimate; nullopt when no scan reported one.
+    std::optional<int64_t> estimatedScanBytes;
   };
 
   /// Lowers the tree-IR rooted at 'root' into fragments, projecting to the

--- a/axiom/optimizer/v2/EstimateLeafStatsPass.cpp
+++ b/axiom/optimizer/v2/EstimateLeafStatsPass.cpp
@@ -76,6 +76,14 @@ void applyFilteredStats(
     }
   }
 
+  // Bytes read from storage are fixed by partition pruning, already reflected
+  // in stats->dataSize, so they are not scaled by row-level filter selectivity.
+  // Only refine when the connector estimated a size; otherwise keep the
+  // whole-table seed from schemaTable->dataSize.
+  if (auto dataSize = toSignedByteCount(stats->dataSize)) {
+    baseTable->filteredDataSize = dataSize;
+  }
+
   // The connector accounted for its accepted filters in numRows. Post-apply
   // selectivity for the filters createTableHandle rejected (kept as ExprCP).
   if (rejectedFilters.empty()) {

--- a/axiom/optimizer/v2/EstimateLeafStatsPass.cpp
+++ b/axiom/optimizer/v2/EstimateLeafStatsPass.cpp
@@ -87,6 +87,14 @@ void applyFilteredStats(
     }
   }
 
+  // Bytes read from storage are fixed by partition pruning, already reflected
+  // in stats->dataSize, so they are not scaled by row-level filter selectivity.
+  // Only refine when the connector estimated a size; otherwise keep the
+  // whole-table seed from schemaTable->dataSize.
+  if (auto dataSize = toSignedByteCount(stats->dataSize)) {
+    baseTable->filteredDataSize = dataSize;
+  }
+
   // The connector accounted for its accepted filters in numRows. Post-apply
   // selectivity for the filters createTableHandle rejected (kept as ExprCP).
   if (rejectedFilters.empty()) {

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -110,6 +110,7 @@ PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
       std::move(emitted.fragments), options);
   result.finishWrite = std::move(emitted.finishWrite);
   result.prediction = std::move(emitted.prediction);
+  result.estimatedScanBytes = emitted.estimatedScanBytes;
 
   // The plan's output must have one column per logical-plan output column. A
   // TableWrite root emits write-stats rows instead of the query columns, so it

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -109,6 +109,7 @@ PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
       std::move(emitted.fragments), options);
   result.finishWrite = std::move(emitted.finishWrite);
   result.prediction = std::move(emitted.prediction);
+  result.estimatedScanBytes = emitted.estimatedScanBytes;
 
   // The plan's output must have one column per logical-plan output column. A
   // TableWrite root emits write-stats rows instead of the query columns, so it

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -750,6 +750,7 @@ Translated Translator::translateScan(
   auto* baseTable = make<BaseTable>();
   baseTable->cname = toName(fmt::format("t{}", baseTableCounter_++));
   baseTable->schemaTable = schemaTable;
+  baseTable->filteredDataSize = schemaTable->dataSize;
   // filteredCardinality stays 0 until estimateLeafStats populates it from
   // connector stats; cardinality estimation falls back to constraint-based
   // selectivity while it is unset.

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -747,6 +747,7 @@ Translated Translator::translateScan(
   auto* baseTable = make<BaseTable>();
   baseTable->cname = toName(fmt::format("t{}", baseTableCounter_++));
   baseTable->schemaTable = schemaTable;
+  baseTable->filteredDataSize = schemaTable->dataSize;
   // filteredCardinality stays 0 until estimateLeafStats populates it from
   // connector stats; cardinality estimation falls back to constraint-based
   // selectivity while it is unset.


### PR DESCRIPTION
Summary:

Carry the connector's on-disk data-size estimate through the optimizer and expose a query-level `estimatedScanBytes` on `PlanAndStats`, summed across the plan's table scans. `SchemaTable` picks up the whole-table `dataSize`; `BaseTable::filteredDataSize` holds the partition-pruned per-scan estimate, seeded from the schema table and refined from `FilteredTableStats` when the connector estimates a scan.

Unlike `filteredCardinality`, the data-size estimate is not scaled by row-level filter selectivity: a scan reads the matching partitions' bytes before rows are filtered, so partition pruning (already reflected in the connector estimate) is what determines bytes read.

Implemented on both the v1 and v2 optimizers.

Differential Revision: D113570498


