### PR TITLE
feat: Add legacy_timestamp_with_timezone query config

### DIFF
--- a/axiom/cli/tests/CliTest.md
+++ b/axiom/cli/tests/CliTest.md
@@ -274,8 +274,9 @@ Session 'execution.session_timezone' set to 'UTC'
 Name*| Value*| Default*| Type*| Description (glob)
 *-+-*-+-*-+-* (glob)
 execution.adjust_timestamp_to_session_timezone*| true*| false*| BOOLEAN*| * (glob)
+execution.legacy_timestamp_with_timezone*| true*| true*| BOOLEAN*| * (glob)
 execution.session_timezone*| UTC*|*| STRING*| * (glob)
-(2 rows in 1 batches)
+(3 rows in 1 batches)
 
 ```
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/18405

Declares and registers the `legacy_timestamp_with_timezone` query config, default `true`, and documents it in `configs.rst` next to `adjust_timestamp_to_session_timezone`. No code reads it yet; the Presto session property binds to this key while the rendering changes land separately. Registering it adds one row to `SHOW SESSION`.

Reviewed By: bikramSingh91

Differential Revision: D114809615


