### PR TITLE
fix(parser): Lower NORMALIZE to a normalize() call (#1684)

### DIFF
--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -2328,7 +2328,23 @@ std::any AstBuilder::visitParameter(PrestoSqlParser::ParameterContext* ctx) {
 
 std::any AstBuilder::visitNormalize(PrestoSqlParser::NormalizeContext* ctx) {
   trace("visitNormalize");
-  return visitChildren("visitNormalize", ctx);
+
+  // NORMALIZE(value) lowers to normalize(value) and NORMALIZE(value, form) to
+  // normalize(value, form). The single-argument normalize() defaults the form
+  // to NFC in Velox, so no default is supplied here.
+  std::vector<ExpressionPtr> arguments{
+      visitTyped<Expression>(ctx->valueExpression())};
+  if (ctx->normalForm() != nullptr) {
+    arguments.push_back(
+        std::make_shared<StringLiteral>(
+            getLocation(ctx), ctx->normalForm()->getText()));
+  }
+
+  return std::static_pointer_cast<Expression>(std::make_shared<FunctionCall>(
+      getLocation(ctx),
+      std::make_shared<QualifiedName>(
+          getLocation(ctx), std::vector<std::string>{"normalize"}),
+      arguments));
 }
 
 std::any AstBuilder::visitIntervalLiteral(

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -640,6 +640,57 @@ TEST_F(ExpressionParserTest, jsonLiteral) {
       R"({"a": 1})");
 }
 
+TEST_F(ExpressionParserTest, normalize) {
+  // The 1-arg normalize() defaults the form to NFC in Velox.
+  {
+    SCOPED_TRACE("normalize('abc')");
+    auto expr = parseExpr("normalize('abc')");
+    ASSERT_TRUE(expr->isCall());
+    auto* call = expr->as<lp::CallExpr>();
+    EXPECT_EQ(call->name(), "normalize");
+    ASSERT_EQ(call->inputs().size(), 1);
+    ASSERT_TRUE(call->inputAt(0)->isConstant());
+    EXPECT_EQ(
+        call->inputAt(0)
+            ->as<lp::ConstantExpr>()
+            ->value()
+            ->value<TypeKind::VARCHAR>(),
+        "abc");
+  }
+
+  auto checkForm = [&](const std::string& sql,
+                       const std::string& expectedForm) {
+    SCOPED_TRACE(sql);
+    auto expr = parseExpr(sql);
+    ASSERT_TRUE(expr->isCall());
+    auto* call = expr->as<lp::CallExpr>();
+    EXPECT_EQ(call->name(), "normalize");
+    ASSERT_EQ(call->inputs().size(), 2);
+    ASSERT_TRUE(call->inputAt(0)->isConstant());
+    EXPECT_EQ(
+        call->inputAt(0)
+            ->as<lp::ConstantExpr>()
+            ->value()
+            ->value<TypeKind::VARCHAR>(),
+        "abc");
+    ASSERT_TRUE(call->inputAt(1)->isConstant());
+    EXPECT_EQ(
+        call->inputAt(1)
+            ->as<lp::ConstantExpr>()
+            ->value()
+            ->value<TypeKind::VARCHAR>(),
+        expectedForm);
+  };
+
+  checkForm("normalize('abc', NFC)", "NFC");
+  checkForm("normalize('abc', NFD)", "NFD");
+  checkForm("normalize('abc', NFKC)", "NFKC");
+  checkForm("normalize('abc', NFKD)", "NFKD");
+
+  // The form is passed through as written, not upper-cased.
+  checkForm("normalize('abc', nfc)", "nfc");
+}
+
 TEST_F(ExpressionParserTest, atTimeZone) {
   // AT TIME ZONE translates to at_timezone().
   EXPECT_EQ(


### PR DESCRIPTION
Summary:

NORMALIZE(value [, form]) was handled by an unimplemented
`AstBuilder::visitNormalize` stub that forwarded to the guarded
`visitChildren` helper, so every NORMALIZE expression raised
"visitChildren called with more than one child" at AST-build time,
while Presto/Prestissimo accept it.

Build the corresponding `normalize` function call: `normalize(value)`
for NORMALIZE(value), or `normalize(value, form)` when a normalization
form keyword is given. Velox's single-argument `normalize` defaults the
form to NFC, so the parser passes only the form the user actually wrote
instead of injecting a default. Velox already registers both signatures,
so no engine change is needed; the v1 and v2 optimizers both run these
queries now.

Reviewed By: natashasehgal, HeidiHan0000

Differential Revision: D115426913


