### PR TITLE
fix(connectors): Do not throw from ~SplitSource

### DIFF
--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <folly/coro/Task.h>
+#include <glog/logging.h>
 #include <velox/connectors/Connector.h>
 #include <optional>
 #include "axiom/common/QueryRuntimeStats.h"
@@ -69,8 +70,8 @@ class SplitSource {
   SplitSource& operator=(SplitSource&&) = delete;
 
   virtual ~SplitSource() {
-    VELOX_CHECK(
-        closed_, "co_close() must be called before destroying SplitSource");
+    // A destructor is implicitly noexcept, so this must not throw.
+    LOG_IF(ERROR, !closed_) << "SplitSource destroyed without co_close()";
   }
 
   /// Returns up to 'maxSplitCount' splits, or fewer if the source is


### PR DESCRIPTION
Summary:
A `SplitSource` subclass whose constructor throws aborted the process instead of failing the query. The base destructor runs while the constructor's exception propagates and asserts that `co_close()` was called; a destructor is implicitly `noexcept`, so that assertion's throw reaches `std::terminate`:

    terminate called after throwing an instance of 'facebook::velox::VeloxRuntimeError'
    Reason: co_close() must be called before destroying SplitSource

The invariant is unsatisfiable on that path — the base subobject is destroyed precisely because the derived constructor threw, so no caller ever held an object to close.

Reports the missing close with `LOG(ERROR)` instead of throwing.

The report now also fires when a subclass constructor throws, where nothing leaked. Telling that apart from a real leak needs state the base class does not carry, so this keeps the report unconditional rather than guessing.

Differential Revision: D115604701


