### PR TITLE
fix(optimizer): Preserve predicates during join reordering (#1692)

### DIFF
--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -31,6 +31,14 @@ class JoinTest : public test::QueryTestBase {
   }
 };
 
+class JoinV2Test : public JoinTest {
+ protected:
+  void SetUp() override {
+    JoinTest::SetUp();
+    useV2_ = true;
+  }
+};
+
 TEST_F(JoinTest, pushdownFilterThroughJoin) {
   testConnector_->addTable("t", ROW({"t_id", "t_data"}, BIGINT()));
   testConnector_->addTable("u", ROW({"u_id", "u_data"}, BIGINT()));
@@ -116,6 +124,128 @@ TEST_F(JoinTest, hyperEdge) {
                      .hashJoin(matchScan("v").build(), core::JoinType::kLeft)
                      .build();
   auto plan = toSingleNodePlan(logicalPlan);
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A key spanning two relations on one side can only be applied where both are
+// already joined, so `v` must come after `t` and `u` even though joining the
+// two smaller tables first looks cheaper.
+TEST_F(JoinV2Test, joinKeyWithMultiRelationOperandIsNotDropped) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
+      ->setStats(
+          1'000'000,
+          {
+              {"a", {.numDistinct = 1'000'000}},
+              {"b", {.numDistinct = 1'000'000}},
+          });
+  testConnector_->addTable("u", ROW({"x", "y", "z"}, BIGINT()))
+      ->setStats(
+          100,
+          {
+              {"x", {.numDistinct = 100}},
+              {"y", {.numDistinct = 100}},
+              {"z", {.numDistinct = 100}},
+          });
+  testConnector_->addTable("v", ROW({"k", "l", "m"}, BIGINT()))
+      ->setStats(
+          10,
+          {
+              {"k", {.numDistinct = 10}},
+              {"l", {.numDistinct = 10}},
+          });
+
+  const auto query =
+      "SELECT m "
+      "FROM t "
+      "JOIN u ON t.a = u.x "
+      "JOIN v ON u.z = v.k AND t.b + u.y = v.l";
+  SCOPED_TRACE(query);
+  const auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+
+  const auto matcher =
+      matchScan("t")
+          .hashJoinInner(
+              matchScan("u").build(),
+              {
+                  .keys = std::vector<std::string>{"a = x"},
+                  .filter = "",
+              })
+          .project({"z", "b + y as key"})
+          .hashJoinInner(
+              matchScan("v").build(),
+              {
+                  .keys = std::vector<std::string>{"z = k", "key = l"},
+                  .filter = "",
+              })
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// The t.a-u.e and t.a-x.j equalities imply a u.e-x.j edge that can attach x
+// before the explicit t-x edge is eligible. It must not strand the additional
+// t.b-x.k key, which is not implied by the inferred edge.
+TEST_F(JoinV2Test, inferredJoinKeyDoesNotDropAdditionalJoinKey) {
+  testConnector_->addTable("t", ROW({"a", "b", "c", "d"}, BIGINT()))
+      ->setStats(
+          100,
+          {
+              {"a", {.numDistinct = 100}},
+              {"b", {.numDistinct = 100}},
+              {"c", {.numDistinct = 100}},
+          });
+  testConnector_->addTable("u", ROW({"e", "f", "g"}, BIGINT()))
+      ->setStats(
+          100,
+          {
+              {"e", {.numDistinct = 100}},
+              {"f", {.numDistinct = 100}},
+              {"g", {.numDistinct = 100}},
+          });
+  testConnector_->addTable("v", ROW({"h"}, BIGINT()))
+      ->setStats(1'000'000, {{"h", {.numDistinct = 1}}});
+  testConnector_->addTable("w", ROW({"i"}, BIGINT()))
+      ->setStats(1, {{"i", {.numDistinct = 1}}});
+  testConnector_->addTable("x", ROW({"j", "k"}, BIGINT()))
+      ->setStats(
+          100, {{"j", {.numDistinct = 100}}, {"k", {.numDistinct = 100}}});
+
+  const auto query =
+      "SELECT d "
+      "FROM ((t JOIN u ON t.a = u.e AND t.b > u.f "
+      "JOIN v ON u.g = v.h) "
+      "LEFT JOIN w ON t.c = w.i) "
+      "JOIN x ON t.a = x.j AND t.b = x.k";
+  SCOPED_TRACE(query);
+  const auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+
+  const auto matcher =
+      matchScan("v")
+          .hashJoinInner(
+              matchScan("t")
+                  .hashJoinInner(
+                      matchScan("u").build(),
+                      {
+                          .keys = std::vector<std::string>{"a = e"},
+                          .filter = "b > f",
+                      })
+                  .hashJoinLeft(
+                      matchScan("w").build(),
+                      {
+                          .keys = std::vector<std::string>{"c = i"},
+                          .filter = "",
+                      })
+                  .build(),
+              {
+                  .keys = std::vector<std::string>{"h = g"},
+                  .filter = "",
+              })
+          .hashJoinInner(
+              matchScan("x").build(),
+              {
+                  .keys = std::vector<std::string>{"a = j", "b = k"},
+                  .filter = "",
+              })
+          .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <unordered_map>
+
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
@@ -32,6 +34,19 @@ class JoinTest : public test::QueryTestBase,
     return lp::PlanBuilder::Context{kTestConnectorId, kDefaultSchema};
   }
 
+  // Adds an all-BIGINT table whose columns each have `numRows` distinct values.
+  void addTableWithStats(
+      const std::string& name,
+      const std::vector<std::string>& columns,
+      int64_t numRows) {
+    std::unordered_map<std::string, connector::ColumnStatistics> stats;
+    for (const auto& column : columns) {
+      stats[column] = {.numDistinct = numRows};
+    }
+    testConnector_->addTable(name, ROW(columns, BIGINT()))
+        ->setStats(numRows, stats);
+  }
+
   using test::QueryTestBase::toSingleNodePlan;
 
   velox::core::PlanNodePtr toSingleNodePlan(std::string_view sql) {
@@ -47,20 +62,8 @@ class JoinTest : public test::QueryTestBase,
 // A derived join must preserve every equality class for its relation pair,
 // including classes not covered by a written edge on that pair.
 TEST_P(JoinTest, derivedCompositeEdgePreservesAllEqualities) {
-  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
-      ->setStats(
-          100,
-          {
-              {"a", {.numDistinct = 100}},
-              {"b", {.numDistinct = 100}},
-          });
-  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
-      ->setStats(
-          1'000'000,
-          {
-              {"x", {.numDistinct = 1'000'000}},
-              {"y", {.numDistinct = 1'000'000}},
-          });
+  addTableWithStats("t", {"a", "b"}, 100);
+  addTableWithStats("u", {"x", "y"}, 1'000'000);
   testConnector_->addTable("v", ROW({"k", "l", "m"}, BIGINT()))
       ->setStats(
           10,
@@ -170,33 +173,6 @@ TEST_P(JoinTest, derivedCompositeEdgePreservesAllEqualities) {
   }
 }
 
-// A CTE joined to itself on both of its columns matches each row only with
-// itself, so the query returns one row per CTE row and v1 plans it. v2
-// reordering drops one of the two equalities; until it stops doing so the
-// guard fails the query, which is what this pins.
-//
-// TODO: Move to join.sql once v2 keeps both equalities.
-TEST_P(JoinTest, selfJoinOnEveryColumn) {
-  const auto query =
-      "WITH "
-      "  ids (id) AS (VALUES (1)), "
-      "  labels (id, label) AS (VALUES (1, 'a'), (1, 'b')), "
-      "  extra (id) AS (VALUES (1)), "
-      "  labeled AS ("
-      "    SELECT ids.id, labels.label FROM ids "
-      "    JOIN labels ON labels.id = ids.id "
-      "    LEFT JOIN extra ON extra.id = ids.id) "
-      "SELECT count(*) FROM labeled AS x "
-      "JOIN labeled AS y ON x.id = y.id AND x.label = y.label";
-
-  if (useV2_) {
-    VELOX_ASSERT_THROW(
-        toSingleNodePlan(query), "Plan does not enforce a join equality");
-  } else {
-    ASSERT_NO_THROW(toSingleNodePlan(query));
-  }
-}
-
 TEST_P(JoinTest, pushdownFilterThroughJoin) {
   testConnector_->addTable("t", ROW({"t_id", "t_data"}, BIGINT()));
   testConnector_->addTable("u", ROW({"u_id", "u_data"}, BIGINT()));
@@ -287,6 +263,61 @@ TEST_P(JoinTest, hyperEdge) {
                      .build();
   auto plan = toSingleNodePlan(logicalPlan);
   AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A key spanning two relations on one side remains enforced when the chosen
+// join order cannot orient it as a join key.
+TEST_P(JoinTest, multiRelationJoinKey) {
+  addTableWithStats("t", {"a", "b"}, 100);
+  addTableWithStats("u", {"x", "y", "z"}, 100);
+  addTableWithStats("v", {"k", "l", "m"}, 10);
+
+  const auto query =
+      "SELECT m "
+      "FROM t "
+      "JOIN u ON t.a = u.x "
+      "JOIN v ON u.z = v.k AND t.b + u.y = v.l";
+  SCOPED_TRACE(query);
+  const auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+
+  const auto matcher = matchScan("t")
+                           .hashJoinInner(
+                               matchScan("u").hashJoinInner(
+                                   matchScan("v"), {.keys = {{"z = k"}}}),
+                               {.keys = {{"a = x"}}})
+                           .filter("l = b + y")
+                           .project({"m"})
+                           .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Join reordering preserves every equality in a composite join condition.
+TEST_P(JoinTest, compositeKeyAboveLeftJoin) {
+  addTableWithStats("t", {"a", "b", "c"}, 100);
+  addTableWithStats("u", {"e"}, 100);
+  addTableWithStats("w", {"i"}, 1);
+  addTableWithStats("x", {"j", "k"}, 1);
+
+  const auto query =
+      "SELECT b "
+      "FROM (t JOIN u ON t.a = u.e LEFT JOIN w ON t.c = w.i) "
+      "JOIN x ON t.a = x.j AND t.b = x.k";
+  SCOPED_TRACE(query);
+  const auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+
+  // TODO: Expect `b = k` as the only filter predicate; the preceding join
+  // already guarantees `a = e`.
+  const auto matcher =
+      matchScan("t")
+          .hashJoinInner(
+              matchScan("u").hashJoinInner(
+                  matchScan("x"), {.keys = {{"e = j"}}}),
+              {.keys = {{"a = e"}}})
+          .filter("a = e AND b = k")
+          .hashJoinLeft(
+              matchScan("w"), {.keys = std::vector<std::string>{"c = i"}})
+          .build();
+  AXIOM_ASSERT_PLAN_V2(plan, matcher);
 }
 
 TEST_P(JoinTest, joinWithFilterOverLimit) {
@@ -1418,10 +1449,7 @@ TEST_P(JoinTest, constantFalseOuterJoinElimination) {
 }
 
 TEST_P(JoinTest, impliedJoins) {
-  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
-      ->setStats(
-          10'000,
-          {{"a", {.numDistinct = 10'000}}, {"b", {.numDistinct = 10'000}}});
+  addTableWithStats("t", {"a", "b"}, 10'000);
   testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
       ->setStats(
           1'000, {{"x", {.numDistinct = 10}}, {"y", {.numDistinct = 1'000}}});
@@ -1542,10 +1570,7 @@ TEST_P(JoinTest, impliedSameInputJoinFilters) {
     GTEST_SKIP() << "Not supported by the V2 optimizer";
   }
 
-  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
-      ->setStats(
-          10'000,
-          {{"a", {.numDistinct = 10'000}}, {"b", {.numDistinct = 10'000}}});
+  addTableWithStats("t", {"a", "b"}, 10'000);
   testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
       ->setStats(
           1'000, {{"x", {.numDistinct = 10}}, {"y", {.numDistinct = 1'000}}});
@@ -1612,10 +1637,7 @@ TEST_P(JoinTest, impliedSameInputJoinFilters) {
 // TODO: Assert the V2 plan after it propagates semi-joins across equivalent
 // join keys.
 TEST_P(JoinTest, impliedSemiJoinPropagation) {
-  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
-      ->setStats(
-          10'000,
-          {{"a", {.numDistinct = 10'000}}, {"b", {.numDistinct = 10'000}}});
+  addTableWithStats("t", {"a", "b"}, 10'000);
   testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()))
       ->setStats(
           1'000, {{"x", {.numDistinct = 10}}, {"y", {.numDistinct = 1'000}}});
@@ -1986,8 +2008,7 @@ TEST_P(JoinTest, impliedSameTableEqualityBelowAggregation) {
 // output, the implied equality can't push below the aggregation and stays
 // as a post-aggregation Filter (HAVING).
 TEST_P(JoinTest, impliedSameTableEqualityInHaving) {
-  testConnector_->addTable("t", ROW({"k"}, BIGINT()))
-      ->setStats(10'000, {{"k", {.numDistinct = 10'000}}});
+  addTableWithStats("t", {"k"}, 10'000);
   testConnector_->addTable("u", ROW({"x"}, BIGINT()))
       ->setStats(1'000, {{"x", {.numDistinct = 10}}});
 
@@ -2477,18 +2498,10 @@ TEST_P(JoinTest, greedySnowflakeLeftDeep) {
       ->setStats(
           10'000'000,
           {{"fact_a", {.numDistinct = 100}}, {"fact_b", {.numDistinct = 100}}});
-  testConnector_->addTable("dim_a", ROW({"da_key", "da_sub"}, BIGINT()))
-      ->setStats(
-          100,
-          {{"da_key", {.numDistinct = 100}}, {"da_sub", {.numDistinct = 100}}});
-  testConnector_->addTable("sub_a", ROW({"sa_key"}, BIGINT()))
-      ->setStats(10, {{"sa_key", {.numDistinct = 10}}});
-  testConnector_->addTable("dim_b", ROW({"db_key", "db_sub"}, BIGINT()))
-      ->setStats(
-          100,
-          {{"db_key", {.numDistinct = 100}}, {"db_sub", {.numDistinct = 100}}});
-  testConnector_->addTable("sub_b", ROW({"sb_key"}, BIGINT()))
-      ->setStats(10, {{"sb_key", {.numDistinct = 10}}});
+  addTableWithStats("dim_a", {"da_key", "da_sub"}, 100);
+  addTableWithStats("sub_a", {"sa_key"}, 10);
+  addTableWithStats("dim_b", {"db_key", "db_sub"}, 100);
+  addTableWithStats("sub_b", {"sb_key"}, 10);
 
   auto ctx = makeContext();
   auto logicalPlan = lp::PlanBuilder{ctx}
@@ -2626,18 +2639,10 @@ TEST_P(JoinTest, dphypGreedySnowflake) {
       ->setStats(
           10'000'000,
           {{"fact_a", {.numDistinct = 100}}, {"fact_b", {.numDistinct = 100}}});
-  testConnector_->addTable("dim_a", ROW({"da_key", "da_sub"}, BIGINT()))
-      ->setStats(
-          100,
-          {{"da_key", {.numDistinct = 100}}, {"da_sub", {.numDistinct = 100}}});
-  testConnector_->addTable("sub_a", ROW({"sa_key"}, BIGINT()))
-      ->setStats(10, {{"sa_key", {.numDistinct = 10}}});
-  testConnector_->addTable("dim_b", ROW({"db_key", "db_sub"}, BIGINT()))
-      ->setStats(
-          100,
-          {{"db_key", {.numDistinct = 100}}, {"db_sub", {.numDistinct = 100}}});
-  testConnector_->addTable("sub_b", ROW({"sb_key"}, BIGINT()))
-      ->setStats(10, {{"sb_key", {.numDistinct = 10}}});
+  addTableWithStats("dim_a", {"da_key", "da_sub"}, 100);
+  addTableWithStats("sub_a", {"sa_key"}, 10);
+  addTableWithStats("dim_b", {"db_key", "db_sub"}, 100);
+  addTableWithStats("sub_b", {"sb_key"}, 10);
 
   auto ctx = makeContext();
   auto logicalPlan = lp::PlanBuilder{ctx}

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -177,3 +177,28 @@ SELECT t1.a, t2.a FROM t t1, t t2, t t3 WHERE t1.a = t3.a AND t1.b < t2.b
 -- even though no pair containing it satisfies t1.b < t2.b.
 -- error_v2: division by zero
 SELECT t1.a, t2.a FROM t t1, t t2 WHERE t1.b < t2.b AND 1000 / (150 - t1.b) > t2.a
+----
+-- A join-key operand that references two relations must remain applicable
+-- when the third relation joins.
+SELECT m
+FROM (VALUES (1, 10), (2, 20)) AS t(a, b)
+JOIN (VALUES (1, 1, 100), (2, 2, 200)) AS u(x, y, z) ON t.a = u.x
+JOIN (
+  VALUES (100, 11, 1001), (100, 99, 1002),
+         (200, 22, 2001), (200, 99, 2002)
+) AS v(k, l, m) ON u.z = v.k AND t.b + u.y = v.l
+----
+-- An inferred u-x equality must not strand the additional t.b = x.k key from
+-- the explicit t-x edge.
+SELECT d
+FROM (((VALUES (1, 10, 100, 101), (2, 20, 200, 202))
+         AS t(a, b, c, d)
+       JOIN (VALUES (1, 5, 10), (2, 10, 20)) AS u(e, f, g)
+         ON t.a = u.e AND t.b > u.f
+       JOIN (
+         VALUES (10), (20)
+       ) AS v(h) ON u.g = v.h)
+      LEFT JOIN (VALUES (100), (300)) AS w(i) ON t.c = w.i)
+JOIN (
+  VALUES (1, 10), (1, 999), (2, 20), (2, 999), (3, 30)
+) AS x(j, k) ON t.a = x.j AND t.b = x.k

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -252,6 +252,47 @@ SELECT t1.a, t2.a FROM t t1, t t2 WHERE if(t1.b > 0, true, 1000 / (150 - t2.b) >
 SELECT t1.b, t2.a FROM (VALUES (150), (100)) AS t1(b), (VALUES (1), (2)) AS t2(a)
 WHERE try(1000 / (150 - t1.b) > t2.a)
 ----
+-- A self-join must enforce every equality after reordering.
+WITH ids (id) AS (VALUES (1)),
+     labels (id, label) AS (VALUES (1, 'a'), (1, 'b')),
+     extra (id) AS (VALUES (1)),
+     labeled AS (
+       SELECT ids.id, labels.label
+       FROM ids
+       JOIN labels ON labels.id = ids.id
+       LEFT JOIN extra ON extra.id = ids.id)
+SELECT count(*)
+FROM labeled AS x
+JOIN labeled AS y ON x.id = y.id AND x.label = y.label
+----
+-- A join-key operand that references two relations must remain applicable
+-- when the third relation joins.
+SELECT m
+FROM (VALUES (1, 10)) AS t(a, b)
+JOIN (VALUES (1, 1, 100)) AS u(x, y, z) ON t.a = u.x
+JOIN (VALUES (100, 11, 1001), (100, 99, 1002)) AS v(k, l, m)
+  ON u.z = v.k AND t.b + u.y = v.l
+----
+-- Reordering a semi-join nested between inner joins must preserve every
+-- equality and return the matching row.
+-- duckdb: SELECT 1 AS s
+WITH n AS (
+       SELECT i AS k
+       FROM UNNEST(sequence(1, 1)) AS t(i)),
+     b(k) AS (VALUES (1)),
+     d(k) AS (VALUES (1))
+SELECT ax.k
+FROM (
+  SELECT a.k
+  FROM n AS a
+  JOIN n AS x ON a.k = x.k
+  WHERE EXISTS (
+    SELECT 1
+    FROM b LEFT JOIN d ON b.k = d.k
+    WHERE b.k = a.k)
+) AS ax
+JOIN n AS c ON ax.k = c.k
+----
 -- Two parallel equality chains connect t through u to v.
 SELECT v.m
 FROM (

--- a/axiom/optimizer/v2/CostModel.cpp
+++ b/axiom/optimizer/v2/CostModel.cpp
@@ -54,9 +54,9 @@ void mergeConstraints(const ConstraintMap& from, ConstraintMap& into) {
   }
 }
 
-// Row count of one side of an edge: the product of the cardinalities of the
-// leaf relations the side spans. Fixed per relation (leaf estimates), so it is
-// independent of join order. Unknown if any relation's cardinality is unknown.
+// Row count of one endpoint side of an edge: the product of its relations'
+// cardinalities. Fixed per relation (leaf estimates), so it is independent of
+// join order. Unknown if any relation's cardinality is unknown.
 std::optional<float> sideRowCount(
     const RelationSet& side,
     const JoinHypergraph& graph) {
@@ -105,29 +105,28 @@ std::optional<float> innerEdgeSelectivity(
     jointNdvLeft *= *leftNdv;
     jointNdvRight *= *rightNdv;
   }
-  if (const auto leftRows = sideRowCount(edge.left(), graph)) {
+  if (const auto leftRows = sideRowCount(edge.leftEndpoints(), graph)) {
     jointNdvLeft = std::min(jointNdvLeft, *leftRows);
   }
-  if (const auto rightRows = sideRowCount(edge.right(), graph)) {
+  if (const auto rightRows = sideRowCount(edge.rightEndpoints(), graph)) {
     jointNdvRight = std::min(jointNdvRight, *rightRows);
   }
   return 1.0f / std::max(jointNdvLeft, jointNdvRight);
 }
 
-// Applies the selectivities of `extraEdges` — the inner edges that crossed
-// alongside an Unnest or an outer join, which the emitter puts in a Filter
-// above it. An edge whose selectivity is unknown is left out rather than making
-// the cover uncostable: a filter can only reduce, so the unfiltered count stays
-// a valid upper bound, whereas an unknown would drop every candidate for the
-// cover and leave the join graph unplannable.
-std::optional<float> applyExtraEdges(
+// Applies the selectivities of filter edges that the emitter puts in a
+// Filter above an operator. An edge whose selectivity is unknown is left out
+// rather than making the cover uncostable: a filter can only reduce, so the
+// unfiltered count stays a valid upper bound, whereas an unknown would drop
+// every candidate for the cover and leave the join graph unplannable.
+std::optional<float> applyFilterEdges(
     std::optional<float> cardinality,
-    const std::vector<size_t>& extraEdges,
+    const std::vector<size_t>& filterEdges,
     const JoinHypergraph& graph,
     const ConstraintMap& constraints) {
-  for (size_t extraIndex : extraEdges) {
-    if (const auto selectivity = innerEdgeSelectivity(
-            graph.edges()[extraIndex], graph, constraints)) {
+  for (size_t index : filterEdges) {
+    if (const auto selectivity =
+            innerEdgeSelectivity(graph.edges()[index], graph, constraints)) {
       cardinality = mul(cardinality, *selectivity);
     }
   }
@@ -156,11 +155,11 @@ ExprVector appliedConjuncts(const JoinOp& join, const JoinHypergraph& graph) {
 }
 
 // Product of the operand cardinalities and the selectivities of the edges
-// crossing the join: its primary edge, plus the extra edges of a cyclic cover
-// when the primary is inner and they join it as keys. This is the inner-join
-// match count, and — for an all-inner cover — the cover's output cardinality.
-// Under a non-inner primary the extra edges filter the shaped output instead,
-// so they are applied by the caller after the join type has been accounted for.
+// crossing the join: its primary edge, plus the key edges of a cyclic cover
+// when the primary is inner. This is the inner-join match count, and — for an
+// all-inner cover — the cover's output cardinality. Filter edges constrain the
+// shaped output instead, so they are applied by the caller after the join type
+// has been accounted for.
 std::optional<float> innerMatchCardinality(
     const JoinOp& join,
     const JoinHypergraph& graph,
@@ -173,10 +172,10 @@ std::optional<float> innerMatchCardinality(
   if (edge.joinType() != velox::core::JoinType::kInner) {
     return matched;
   }
-  for (size_t extraIndex : join.extraEdges) {
+  for (size_t keyEdgeIndex : join.keyEdges) {
     matched = mul(
         matched,
-        innerEdgeSelectivity(graph.edges()[extraIndex], graph, constraints));
+        innerEdgeSelectivity(graph.edges()[keyEdgeIndex], graph, constraints));
   }
   return matched;
 }
@@ -226,10 +225,10 @@ Cost leafCost(
 // Records the estimate for an unnest cover: the input cover's constraints
 // pass through (the unnest adds columns but does not change the
 // input columns' NDVs) and its cardinality scales by the unnest fanout, then by
-// the filters the emitter applies on the expansion: the edges that crossed
-// alongside the unnest (see `applyExtraEdges`) and the pool conjuncts this
-// cover makes ready that the input cover did not already apply. A conjunct of
-// unknown selectivity is skipped for the same reason an edge is.
+// the filters the emitter applies on the expansion: its filter edges and the
+// pool conjuncts this cover makes ready that the input cover did not already
+// apply. A conjunct of unknown selectivity is skipped for the same reason an
+// edge is.
 const Estimate& unnestEstimate(
     const UnnestOp& unnest,
     const JoinHypergraph& graph,
@@ -242,9 +241,9 @@ const Estimate& unnestEstimate(
   const Estimate& input = coverEstimate(unnest.input->cover(), bySet);
   Estimate result;
   mergeConstraints(input.constraints, result.constraints);
-  std::optional<float> cardinality = applyExtraEdges(
+  std::optional<float> cardinality = applyFilterEdges(
       mul(input.cardinality, kDefaultUnnestFanout),
-      unnest.extraEdges,
+      unnest.filterEdges,
       graph,
       result.constraints);
   ExprVector conjuncts;
@@ -320,7 +319,8 @@ joinEstimate(const JoinOp& join, const JoinHypergraph& graph, BySetMap& bySet) {
       join, graph, result.constraints, left.cardinality, right.cardinality);
   // Operands are passed in the edge's orientation, which `outputCardinality`
   // requires for kAnti: a reversed antijoin swaps them but has no flipped type.
-  const bool edgeLeftIsPhysicalLeft = edge.left().isSubset(join.left->cover());
+  const bool edgeLeftIsPhysicalLeft =
+      edge.leftEligibility().isSubset(join.left->cover());
   std::optional<float> cardinality = JoinFanout::outputCardinality(
       edge.joinType(),
       edgeLeftIsPhysicalLeft ? left.cardinality : right.cardinality,
@@ -328,13 +328,11 @@ joinEstimate(const JoinOp& join, const JoinHypergraph& graph, BySetMap& bySet) {
       matched,
       appliedConjuncts(join, graph),
       result.constraints);
-  // Extra edges under a non-inner primary are a filter above the join, so they
-  // reduce what the join type shaped — including the null-padded rows, which
-  // fail an equality on the padded side.
-  if (edge.joinType() != velox::core::JoinType::kInner) {
-    cardinality = applyExtraEdges(
-        cardinality, join.extraEdges, graph, result.constraints);
-  }
+  // Filter edges run above the join, so they reduce what the join
+  // type shaped — including null-padded rows, which fail an equality on the
+  // padded side.
+  cardinality = applyFilterEdges(
+      cardinality, join.filterEdges, graph, result.constraints);
   result.cardinality = maxOf(1.0f, cardinality);
   return bySet.emplace(cover, std::move(result)).first->second;
 }
@@ -354,7 +352,8 @@ Cost hashJoinCost(
   ExprVector leftKeys;
   ExprVector rightKeys;
   const auto addEdgeKeys = [&](const JoinEdge& edgeToAdd) {
-    const bool leftIsLeft = edgeToAdd.left().isSubset(join.left->cover());
+    const bool leftIsLeft =
+        edgeToAdd.leftEligibility().isSubset(join.left->cover());
     const auto& edgeLeftKeys =
         leftIsLeft ? edgeToAdd.leftKeys() : edgeToAdd.rightKeys();
     const auto& edgeRightKeys =
@@ -364,8 +363,8 @@ Cost hashJoinCost(
         rightKeys.end(), edgeRightKeys.begin(), edgeRightKeys.end());
   };
   addEdgeKeys(edge);
-  for (size_t extraIndex : join.extraEdges) {
-    addEdgeKeys(graph.edges()[extraIndex]);
+  for (size_t keyEdgeIndex : join.keyEdges) {
+    addEdgeKeys(graph.edges()[keyEdgeIndex]);
   }
 
   // Pure non-equi edges have no keys; treat them as if they had one

--- a/axiom/optimizer/v2/DPhyp.cpp
+++ b/axiom/optimizer/v2/DPhyp.cpp
@@ -214,9 +214,10 @@ class Enumerator {
   // classic GOO heuristic of keeping intermediate results small; the
   // build/probe orientation within a chosen pair is still cost-optimal
   // (cardinality is orientation-invariant). Returns the component's root plan,
-  // or nullptr if a relation's cardinality is unknown. Reuses any matching
-  // subplans already in the memo (all memoized subplans are valid), so a
-  // partially-filled memo from an overflowed `solveComponent` is fine.
+  // or nullptr if a join cannot be costed or an earlier irrevocable merge
+  // leaves no partition that can apply every newly internal edge. Reuses any
+  // matching subplans already in the memo (all memoized subplans are valid),
+  // so a partially-filled memo from an overflowed `solveComponent` is fine.
   MemoOpCP greedy(RelationSet component) {
     budget_.disable();
     initLeaves(component);
@@ -247,10 +248,11 @@ class Enumerator {
           combined.unionSet(fragments[j]);
           emitCsgCmp(fragments[i], fragments[j]);
           const auto it = memo_.find(combined);
-          // emitCsgCmp records a pair only when an edge connects it and the
-          // join is costable — considerCandidate drops uncostable plans — so a
-          // missing entry means no edge or an unknown-NDV join key, and a
-          // present entry always has a known cardinality.
+          // emitCsgCmp records a pair only when an edge connects it, every edge
+          // made internal by the merge can be applied, and the join is
+          // costable. A missing entry can therefore mean no edge, a partition
+          // that would strand an edge, or an unknown-NDV join key. A present
+          // entry always has a known cardinality.
           if (it == memo_.end()) {
             continue;
           }
@@ -264,13 +266,12 @@ class Enumerator {
         }
       }
       if (!bestCardinality.has_value()) {
-        // No remaining fragment pair can be costed into a single join. In a
-        // connected component connectivity is never the blocker — contracting
-        // merged fragments keeps the graph connected, so an edge-joined pair
-        // always exists — so every such pair must have unknown cardinality (a
-        // join key without NDV). Genuine cross products are split into separate
-        // components upstream, not handled here. Caller falls back to syntactic
-        // order.
+        // No remaining fragment pair can be emitted. Connectivity guarantees
+        // that some pair is edge-connected, but an earlier irrevocable merge
+        // may have made another edge impossible to apply at that partition;
+        // otherwise required statistics are missing. Genuine cross products
+        // are split into separate components upstream. Caller falls back to
+        // syntactic order.
         return nullptr;
       }
       fragments[bestLeft] = bestCombined;
@@ -338,22 +339,30 @@ class Enumerator {
     RelationSet combined{subgraph};
     combined.unionSet(complement);
 
-    // Collect every edge crossing this partition (TES-covered). Standard
-    // DPhyp applies all predicates connecting the two subgraphs at the join;
-    // with a cyclic join graph more than one edge can cross.
+    // Every edge that becomes internal to `combined` must be applied at this
+    // join. Edges already internal to a child were applied below; edges not yet
+    // contained in `combined` remain available above.
     folly::small_vector<std::pair<size_t, bool>, 4> crossing;
     for (size_t edgeIndex{0}; edgeIndex < graph_.edges().size(); ++edgeIndex) {
       const auto& edge = graph_.edges()[edgeIndex];
+      RelationSet endpoints{edge.left()};
+      endpoints.unionSet(edge.right());
+      if (endpoints.isSubset(subgraph) || endpoints.isSubset(complement)) {
+        continue;
+      }
+      if (!endpoints.isSubset(combined)) {
+        continue;
+      }
+
       const bool forward =
           edge.left().isSubset(subgraph) && edge.right().isSubset(complement);
       const bool reverse =
           edge.left().isSubset(complement) && edge.right().isSubset(subgraph);
-      if (!forward && !reverse) {
-        continue;
-      }
-      // Skip edges whose TES is not yet covered.
-      if (!graph_.tes()[edgeIndex].isSubset(combined)) {
-        continue;
+      if ((!forward && !reverse) ||
+          !graph_.tes()[edgeIndex].isSubset(combined)) {
+        // The memo key contains only the cover, not pending predicates. Once
+        // this edge's endpoints become internal, no later join can apply it.
+        return;
       }
       crossing.push_back({edgeIndex, forward});
     }
@@ -993,7 +1002,8 @@ std::vector<MemoOpCP> DPhyp::enumerate(
       root = it == memo_.end() ? nullptr : it->second.cheapest();
     }
     if (root == nullptr) {
-      // A component has no costable plan: some relation or edge lacked stats.
+      // Greedy could not assemble a plan because some join lacked stats or an
+      // earlier merge left no partition that could apply every internal edge.
       // Signal whole-cluster fall back to syntactic order by returning empty.
       return {};
     }

--- a/axiom/optimizer/v2/DPhyp.cpp
+++ b/axiom/optimizer/v2/DPhyp.cpp
@@ -53,14 +53,16 @@ namespace {
 // True for the join types whose output keeps both sides' columns, so an inner
 // equality applied above the join can still read them. Semi and anti keep only
 // one side, so a co-crossing inner edge has nowhere to go.
-bool isOuterJoin(velox::core::JoinType joinType) {
-  return joinType == velox::core::JoinType::kLeft ||
+bool keepsBothInputs(velox::core::JoinType joinType) {
+  return joinType == velox::core::JoinType::kInner ||
+      joinType == velox::core::JoinType::kLeft ||
       joinType == velox::core::JoinType::kRight ||
       joinType == velox::core::JoinType::kFull;
 }
 
-// Vertices reachable from `set` via one hyperedge whose "other" side
-// is fully outside `set`. Excludes any vertex in `forbidden`.
+// Returns the minimum relation id from each reachable opposite hyperedge side,
+// provided the whole side is outside both `set` and `forbidden`. The minimum is
+// DPhyp's canonical seed for growing that side without emitting duplicates.
 RelationSet neighborhood(
     const JoinHypergraph& graph,
     RelationSet set,
@@ -68,16 +70,20 @@ RelationSet neighborhood(
   RelationSet result;
   for (const auto& edge : graph.edges()) {
     RelationSet other;
-    if (edge.left().isSubset(set) && !edge.right().hasIntersection(set)) {
-      other = edge.right();
+    if (edge.leftEligibility().isSubset(set) &&
+        !edge.rightEligibility().hasIntersection(set)) {
+      other = edge.rightEligibility();
     } else if (
-        edge.right().isSubset(set) && !edge.left().hasIntersection(set)) {
-      other = edge.left();
+        edge.rightEligibility().isSubset(set) &&
+        !edge.leftEligibility().hasIntersection(set)) {
+      other = edge.leftEligibility();
     } else {
       continue;
     }
-    other.except(forbidden);
-    result.unionSet(other);
+    if (other.hasIntersection(forbidden)) {
+      continue;
+    }
+    result.add(other.min());
   }
   return result;
 }
@@ -171,7 +177,7 @@ class EnumerationBudget {
   bool enforced_;
 };
 
-// Moerkotte/Neumann 2006 DPhyp (csg/cmp recursion).
+// Moerkotte/Neumann 2008 DPhyp (csg/cmp recursion).
 class Enumerator {
  public:
   // `enumerationBudget` caps the csg/cmp pairs evaluated before falling back to
@@ -272,10 +278,9 @@ class Enumerator {
           combined.unionSet(fragments[j]);
           emitCsgCmp(fragments[i], fragments[j]);
           const auto it = memo_.find(combined);
-          // emitCsgCmp records a pair only when an edge connects it and the
-          // join is costable — considerCandidate drops uncostable plans — so a
-          // missing entry means no edge or an unknown-NDV join key, and a
-          // present entry always has a known cardinality.
+          // emitCsgCmp records a pair only when it is valid and costable —
+          // considerCandidate drops uncostable plans — so a present entry
+          // always has a known cardinality.
           if (it == memo_.end()) {
             continue;
           }
@@ -294,13 +299,8 @@ class Enumerator {
         if (expandOneFragment(fragments)) {
           continue;
         }
-        // No remaining fragment pair can be costed into a single join. In a
-        // connected component connectivity is never the blocker — contracting
-        // merged fragments keeps the graph connected, so an edge-joined pair
-        // always exists — so every such pair must have unknown cardinality (a
-        // join key without NDV). Genuine cross products are split into separate
-        // components upstream, not handled here. Caller falls back to syntactic
-        // order.
+        // No remaining fragment pair produces a valid costable join. The
+        // caller falls back to syntactic order.
         return nullptr;
       }
       fragments[bestLeft] = bestCombined;
@@ -326,11 +326,11 @@ class Enumerator {
       for (const auto& edge : graph_.edges()) {
         RelationSet reached{set};
         reached.unionSet(gained);
-        if (!edge.isUnnest() || !edge.left().isSubset(reached) ||
-            edge.right().isSubset(reached)) {
+        if (!edge.isUnnest() || !edge.leftEligibility().isSubset(reached) ||
+            edge.rightEligibility().isSubset(reached)) {
           continue;
         }
-        gained.unionSet(edge.right());
+        gained.unionSet(edge.rightEligibility());
         grown = true;
       }
     }
@@ -356,11 +356,10 @@ class Enumerator {
         if (edge.isUnnest()) {
           continue;
         }
-        RelationSet endpoints{edge.left()};
-        endpoints.unionSet(edge.right());
+        const RelationSet edgeTes = edge.totalEligibility();
         // An edge wholly inside the expanded fragment joins nothing new; only
         // one reaching outside can merge this fragment with another.
-        if (!endpoints.hasIntersection(gained) || endpoints.isSubset(reached)) {
+        if (!edgeTes.hasIntersection(gained) || edgeTes.isSubset(reached)) {
           continue;
         }
         const RelationSet before = fragment;
@@ -368,8 +367,8 @@ class Enumerator {
         if (fragment != before) {
           return true;
         }
-        // The expansion has no costable plan. Leave this fragment alone and
-        // look for another; expanding it again would not get any further.
+        // The expansion has no valid costable plan. Leave this fragment alone
+        // and look for another; expanding it again would not get any further.
         break;
       }
     }
@@ -386,12 +385,12 @@ class Enumerator {
       for (size_t edgeIndex{0}; edgeIndex < graph_.edges().size();
            ++edgeIndex) {
         const auto& edge = graph_.edges()[edgeIndex];
-        if (!edge.isUnnest() || !edge.left().isSubset(set) ||
-            edge.right().isSubset(set)) {
+        if (!edge.isUnnest() || !edge.leftEligibility().isSubset(set) ||
+            edge.rightEligibility().isSubset(set)) {
           continue;
         }
         RelationSet expanded{set};
-        expanded.unionSet(edge.right());
+        expanded.unionSet(edge.rightEligibility());
         emitUnnest(set, edgeIndex, expanded, {});
         if (cheapestPlan(expanded) == nullptr) {
           continue;
@@ -470,18 +469,32 @@ class Enumerator {
     // DPhyp applies all predicates connecting the two subgraphs at the join;
     // with a cyclic join graph more than one edge can cross.
     folly::small_vector<std::pair<size_t, bool>, 4> crossing;
+    // Inner edges whose two sides do not split across this partition. They
+    // cannot be join keys here, but an inner join keeps every column they
+    // read, so the emitter applies them above it rather than losing the
+    // partition.
+    std::vector<size_t> filterEdges;
     for (size_t edgeIndex{0}; edgeIndex < graph_.edges().size(); ++edgeIndex) {
       const auto& edge = graph_.edges()[edgeIndex];
-      const bool forward =
-          edge.left().isSubset(subgraph) && edge.right().isSubset(complement);
-      const bool reverse =
-          edge.left().isSubset(complement) && edge.right().isSubset(subgraph);
-      if (!forward && !reverse) {
+      const RelationSet edgeTes = edge.totalEligibility();
+      if (edgeTes.isSubset(subgraph) || edgeTes.isSubset(complement)) {
         continue;
       }
-      // Skip edges whose TES is not yet covered.
-      if (!graph_.tes()[edgeIndex].isSubset(combined)) {
+      if (!edgeTes.isSubset(combined)) {
         continue;
+      }
+
+      const bool forward = edge.leftEligibility().isSubset(subgraph) &&
+          edge.rightEligibility().isSubset(complement);
+      const bool reverse = edge.leftEligibility().isSubset(complement) &&
+          edge.rightEligibility().isSubset(subgraph);
+      if (!forward && !reverse) {
+        if (!edge.isUnnest() &&
+            edge.joinType() == velox::core::JoinType::kInner) {
+          filterEdges.push_back(edgeIndex);
+          continue;
+        }
+        return;
       }
       crossing.push_back({edgeIndex, forward});
     }
@@ -489,14 +502,27 @@ class Enumerator {
     if (crossing.empty()) {
       return;
     }
+
+    // Filter edges are evaluated above the primary operator and may reference
+    // either input. A semi or anti join discards one input's columns, so its
+    // output cannot safely evaluate them.
+    const auto canApplyFilterEdges = [&](size_t edgeIndex) {
+      const auto& edge = graph_.edges()[edgeIndex];
+      return filterEdges.empty() || edge.isUnnest() ||
+          keepsBothInputs(edge.joinType());
+    };
     if (crossing.size() == 1) {
+      if (!canApplyFilterEdges(crossing[0].first)) {
+        return;
+      }
       applyCrossingEdge(
           crossing[0].first,
           crossing[0].second,
           subgraph,
           complement,
           combined,
-          {});
+          {},
+          std::move(filterEdges));
       return;
     }
 
@@ -523,12 +549,14 @@ class Enumerator {
 
     if (specialPosition.has_value()) {
       const size_t specialEdge = crossing[*specialPosition].first;
-      std::vector<size_t> residual;
-      residual.reserve(crossing.size() - 1);
+      filterEdges.reserve(filterEdges.size() + crossing.size() - 1);
       for (size_t i = 0; i < crossing.size(); ++i) {
         if (i != *specialPosition) {
-          residual.push_back(crossing[i].first);
+          filterEdges.push_back(crossing[i].first);
         }
+      }
+      if (!canApplyFilterEdges(specialEdge)) {
+        return;
       }
       applyCrossingEdge(
           specialEdge,
@@ -536,7 +564,8 @@ class Enumerator {
           subgraph,
           complement,
           combined,
-          std::move(residual));
+          {},
+          std::move(filterEdges));
       return;
     }
 
@@ -544,7 +573,7 @@ class Enumerator {
     // keys. Reaching here with an Unnest or a non-inner edge means two or more
     // of them cross, which has no single well-defined step; fail rather than
     // drop a predicate.
-    for (const auto& [edgeIndex, forward] : crossing) {
+    for (const auto& [edgeIndex, _] : crossing) {
       const auto& edge = graph_.edges()[edgeIndex];
       VELOX_CHECK(
           edge.joinType() == velox::core::JoinType::kInner && !edge.isUnnest(),
@@ -597,8 +626,8 @@ class Enumerator {
 
     const size_t primary{crossing.front().first};
     markClasses(graph_.edges()[primary]);
-    std::vector<size_t> extras;
-    extras.reserve(crossing.size() - 1);
+    std::vector<size_t> keyEdges;
+    keyEdges.reserve(crossing.size() - 1);
     for (size_t i = 1; i < crossing.size(); ++i) {
       const size_t edgeIndex = crossing[i].first;
       const JoinEdge& edge = graph_.edges()[edgeIndex];
@@ -606,7 +635,7 @@ class Enumerator {
         continue;
       }
       markClasses(edge);
-      extras.push_back(edgeIndex);
+      keyEdges.push_back(edgeIndex);
     }
     considerCandidate(
         leftPlan,
@@ -615,7 +644,8 @@ class Enumerator {
         velox::core::JoinType::kInner,
         combined,
         /*reversedAnti=*/false,
-        extras);
+        keyEdges,
+        filterEdges);
     considerCandidate(
         rightPlan,
         leftPlan,
@@ -623,7 +653,8 @@ class Enumerator {
         velox::core::JoinType::kInner,
         combined,
         /*reversedAnti=*/false,
-        extras);
+        keyEdges,
+        filterEdges);
   }
 
   // Applies the edge crossing this partition: an Unnest expands the side
@@ -635,7 +666,8 @@ class Enumerator {
       RelationSet subgraph,
       RelationSet complement,
       RelationSet combined,
-      std::vector<size_t> extraEdges) {
+      std::vector<size_t> keyEdges,
+      std::vector<size_t> filterEdges) {
     const auto& edge = graph_.edges()[edgeIndex];
     if (edge.isUnnest()) {
       // Enumeration never seeds a subgraph from the Unnest relation and grows
@@ -643,10 +675,11 @@ class Enumerator {
       // the complement, alone. A complement holding anything else is a set the
       // enumeration cannot build; expanding it would record a plan under a
       // cover it never assembled.
-      if (complement != edge.right()) {
+      if (complement != edge.rightEligibility()) {
         return;
       }
-      emitUnnest(subgraph, edgeIndex, combined, std::move(extraEdges));
+      VELOX_DCHECK(keyEdges.empty());
+      emitUnnest(subgraph, edgeIndex, combined, std::move(filterEdges));
       return;
     }
 
@@ -661,7 +694,8 @@ class Enumerator {
         leftPlan,
         rightPlan,
         combined,
-        std::move(extraEdges));
+        std::move(keyEdges),
+        std::move(filterEdges));
   }
 
   // Adds the candidate that expands `inputSet`'s plan by the Unnest relation
@@ -671,7 +705,7 @@ class Enumerator {
       RelationSet inputSet,
       size_t edgeIndex,
       RelationSet combined,
-      std::vector<size_t> extraEdges) {
+      std::vector<size_t> filterEdges) {
     MemoOpCP input = cheapestPlan(inputSet);
     if (input == nullptr) {
       return;
@@ -681,8 +715,8 @@ class Enumerator {
         Cost{},
         input,
         edgeIndex,
-        graph_.edges()[edgeIndex].right(),
-        std::move(extraEdges));
+        graph_.edges()[edgeIndex].rightEndpoints(),
+        std::move(filterEdges));
     // The memo is keyed by cover, so a candidate filed under a set it does not
     // cover would claim relations no operator below it reads.
     VELOX_DCHECK_EQ(candidate->cover().bits(), combined.bits());
@@ -695,22 +729,28 @@ class Enumerator {
 
   // Emits join candidates for a single edge crossing the partition,
   // preserving orientation rules (native-only for anti / null-aware
-  // semi-project; both orientations otherwise). `extraEdges` are
-  // co-crossing inner edges the emitter applies as a filter above the join.
+  // semi-project; both orientations otherwise). `keyEdges` become additional
+  // join keys; `filterEdges` are applied as a filter above the join.
   void emitSingleEdge(
       size_t edgeIndex,
       bool forward,
       MemoOpCP leftPlan,
       MemoOpCP rightPlan,
       RelationSet combined,
-      std::vector<size_t> extraEdges) {
+      std::vector<size_t> keyEdges,
+      std::vector<size_t> filterEdges) {
     const auto& edge = graph_.edges()[edgeIndex];
-    // Extra edges reach the emitter as a filter above the join, which only an
-    // outer join can carry: it keeps every column the equalities read. Semi and
-    // anti keep one side only.
+    // An additional key edge contributes hash keys and a filter edge becomes
+    // a filter above the join. Either way the join must keep every column the
+    // equalities read, which inner and outer joins do. Semi and anti keep one
+    // side only.
     VELOX_CHECK(
-        extraEdges.empty() || isOuterJoin(edge.joinType()),
-        "An edge crossing a join partition alongside a {} edge is not supported",
+        keyEdges.empty() || edge.joinType() == velox::core::JoinType::kInner,
+        "An additional join-key edge alongside a {} edge is not supported",
+        edge.joinTypeName());
+    VELOX_CHECK(
+        filterEdges.empty() || keepsBothInputs(edge.joinType()),
+        "A filter edge alongside a {} edge is not supported",
         edge.joinTypeName());
     // `probeOnLeft` plays the edge's left operand; `probeOnRight` its right.
     MemoOpCP probeOnLeft = forward ? leftPlan : rightPlan;
@@ -727,7 +767,8 @@ class Enumerator {
           edge.joinType(),
           combined,
           /*reversedAnti=*/false,
-          std::move(extraEdges));
+          std::move(keyEdges),
+          std::move(filterEdges));
       // Antijoin can additionally build on the preserved (left) side by
       // probing with the right input (the reversed orientation).
       if (edge.joinType() == velox::core::JoinType::kAnti &&
@@ -744,8 +785,8 @@ class Enumerator {
     }
 
     // Flip the joinType when the subgraph plays the edge's right operand. The
-    // extra edges are equalities filtering the output, so they are carried
-    // unchanged into either orientation.
+    // Filter edges are equalities evaluated above the output, so they are
+    // carried unchanged into either orientation.
     const auto leftTypeForSubgraph =
         forward ? edge.joinType() : flipJoinType(edge.joinType());
     considerCandidate(
@@ -755,7 +796,8 @@ class Enumerator {
         leftTypeForSubgraph,
         combined,
         /*reversedAnti=*/false,
-        extraEdges);
+        keyEdges,
+        filterEdges);
     considerCandidate(
         rightPlan,
         leftPlan,
@@ -763,7 +805,8 @@ class Enumerator {
         flipJoinType(leftTypeForSubgraph),
         combined,
         /*reversedAnti=*/false,
-        std::move(extraEdges));
+        std::move(keyEdges),
+        std::move(filterEdges));
   }
 
   // Records an enforcement exchange and returns a stable pointer to it.
@@ -887,23 +930,23 @@ class Enumerator {
   }
 
   // Equi-keys oriented to the physical (left, right) children across the
-  // primary and extra edges.
+  // primary edge and additional key edges.
   std::pair<ExprVector, ExprVector> orientedKeys(
       MemoOpCP left,
       size_t edgeIndex,
-      const std::vector<size_t>& extraEdges) {
+      const std::vector<size_t>& keyEdges) {
     ExprVector leftKeys;
     ExprVector rightKeys;
     const auto collect = [&](const JoinEdge& edge) {
-      const bool leftIsLeft = edge.left().isSubset(left->cover());
+      const bool leftIsLeft = edge.leftEligibility().isSubset(left->cover());
       const auto& edgeLeft = leftIsLeft ? edge.leftKeys() : edge.rightKeys();
       const auto& edgeRight = leftIsLeft ? edge.rightKeys() : edge.leftKeys();
       leftKeys.insert(leftKeys.end(), edgeLeft.begin(), edgeLeft.end());
       rightKeys.insert(rightKeys.end(), edgeRight.begin(), edgeRight.end());
     };
     collect(graph_.edges()[edgeIndex]);
-    for (size_t extra : extraEdges) {
-      collect(graph_.edges()[extra]);
+    for (size_t keyEdgeIndex : keyEdges) {
+      collect(graph_.edges()[keyEdgeIndex]);
     }
     return {std::move(leftKeys), std::move(rightKeys)};
   }
@@ -937,7 +980,8 @@ class Enumerator {
       velox::core::JoinType joinType,
       RelationSet combined,
       bool reversedAnti,
-      std::vector<size_t> extraEdges,
+      std::vector<size_t> keyEdges,
+      std::vector<size_t> filterEdges,
       Partitioning outputPartitioning) {
     // One budget unit per candidate, not per csg/cmp pair: at numWorkers>1 a
     // pair fans out into several distribution variants, so candidate count is
@@ -950,7 +994,8 @@ class Enumerator {
         edgeIndex,
         joinType,
         reversedAnti,
-        std::move(extraEdges),
+        std::move(keyEdges),
+        std::move(filterEdges),
         std::move(outputPartitioning));
     candidate->cost = costModel_.cost(candidate.get(), graph_);
     // An uncostable subplan cannot be ranked or built on; drop it.
@@ -973,7 +1018,8 @@ class Enumerator {
       velox::core::JoinType joinType,
       RelationSet combined,
       bool reversedAnti,
-      const std::vector<size_t>& extraEdges) {
+      const std::vector<size_t>& keyEdges,
+      const std::vector<size_t>& filterEdges) {
     MemoOpCP leftBucketed = bucketedOn(left->cover(), leftKeys);
     MemoOpCP rightBucketed = bucketedOn(right->cover(), rightKeys);
     if (leftBucketed == nullptr && rightBucketed == nullptr) {
@@ -993,7 +1039,8 @@ class Enumerator {
           joinType,
           combined,
           reversedAnti,
-          extraEdges,
+          keyEdges,
+          filterEdges,
           std::move(outputPartitioning));
     };
 
@@ -1040,7 +1087,8 @@ class Enumerator {
       velox::core::JoinType joinType,
       RelationSet combined,
       bool reversedAnti = false,
-      std::vector<size_t> extraEdges = {}) {
+      std::vector<size_t> keyEdges = {},
+      std::vector<size_t> filterEdges = {}) {
     // Single-fragment: children as selected, no exchange, no output
     // partitioning.
     if (numWorkers_ == 1) {
@@ -1051,7 +1099,8 @@ class Enumerator {
           joinType,
           combined,
           reversedAnti,
-          std::move(extraEdges),
+          std::move(keyEdges),
+          std::move(filterEdges),
           {});
       return;
     }
@@ -1068,12 +1117,12 @@ class Enumerator {
           joinType,
           combined,
           reversedAnti,
-          extraEdges,
+          keyEdges,
+          filterEdges,
           Partitioning::globalGather());
     }
 
-    const auto [leftKeys, rightKeys] =
-        orientedKeys(left, edgeIndex, extraEdges);
+    const auto [leftKeys, rightKeys] = orientedKeys(left, edgeIndex, keyEdges);
     if (!leftKeys.empty()) {
       // Partition strategy: co-partition both inputs on the join keys; the
       // output is partitioned on the keys for same-key reuse above. A
@@ -1083,9 +1132,9 @@ class Enumerator {
       // orientation.
       const auto& edge = graph_.edges()[edgeIndex];
       const bool existenceOnLeft =
-          edge.nullAware() && edge.right().isSubset(left->cover());
+          edge.nullAware() && edge.rightEligibility().isSubset(left->cover());
       const bool existenceOnRight =
-          edge.nullAware() && edge.right().isSubset(right->cover());
+          edge.nullAware() && edge.rightEligibility().isSubset(right->cover());
       MemoOpCP leftPart =
           repartitioned(left->cover(), leftKeys, existenceOnLeft);
       MemoOpCP rightPart =
@@ -1098,7 +1147,8 @@ class Enumerator {
             joinType,
             combined,
             reversedAnti,
-            extraEdges,
+            keyEdges,
+            filterEdges,
             Partitioning::globalHash(keysInCoverSchema(leftKeys, combined)));
       }
 
@@ -1115,7 +1165,8 @@ class Enumerator {
             joinType,
             combined,
             reversedAnti,
-            extraEdges);
+            keyEdges,
+            filterEdges);
       }
     }
 
@@ -1134,7 +1185,8 @@ class Enumerator {
             joinType,
             combined,
             reversedAnti,
-            extraEdges,
+            keyEdges,
+            filterEdges,
             left->outputPartitioning());
       }
     }
@@ -1237,7 +1289,8 @@ void collectAppliedEdges(MemoOpCP plan, folly::F14FastSet<size_t>& applied) {
     case MemoOpKind::kJoin: {
       const auto* join = plan->as<JoinOp>();
       applied.insert(join->edgeIndex);
-      applied.insert(join->extraEdges.begin(), join->extraEdges.end());
+      applied.insert(join->keyEdges.begin(), join->keyEdges.end());
+      applied.insert(join->filterEdges.begin(), join->filterEdges.end());
       collectAppliedEdges(join->left, applied);
       collectAppliedEdges(join->right, applied);
       return;
@@ -1245,7 +1298,7 @@ void collectAppliedEdges(MemoOpCP plan, folly::F14FastSet<size_t>& applied) {
     case MemoOpKind::kUnnest: {
       const auto* unnest = plan->as<UnnestOp>();
       applied.insert(unnest->edgeIndex);
-      applied.insert(unnest->extraEdges.begin(), unnest->extraEdges.end());
+      applied.insert(unnest->filterEdges.begin(), unnest->filterEdges.end());
       collectAppliedEdges(unnest->input, applied);
       return;
     }
@@ -1299,8 +1352,8 @@ const MemoOp* DPhyp::enumerate() {
 
   const auto rootIt = memo_.find(allRelations);
   if (rootIt == memo_.end()) {
-    // No costable plan for the full set: some relation or edge lacked stats.
-    // The caller falls back to the query's syntactic join order.
+    // No valid costable plan for the full set. The caller falls back to the
+    // query's syntactic join order.
     return nullptr;
   }
   MemoOpCP root = rootIt->second.cheapest();
@@ -1335,8 +1388,8 @@ std::vector<MemoOpCP> DPhyp::enumerate(
       root = it == memo_.end() ? nullptr : it->second.cheapest();
     }
     if (root == nullptr) {
-      // A component has no costable plan: some relation or edge lacked stats.
-      // Signal whole-cluster fall back to syntactic order by returning empty.
+      // A component has no valid costable plan. Signal whole-cluster fallback
+      // to syntactic order by returning empty.
       return {};
     }
     roots.push_back(root);

--- a/axiom/optimizer/v2/DPhyp.h
+++ b/axiom/optimizer/v2/DPhyp.h
@@ -32,7 +32,7 @@ namespace facebook::axiom::optimizer::v2 {
 class CostModel;
 
 /// Bottom-up DP join-order enumeration over a `JoinHypergraph`
-/// (Moerkotte/Neumann 2006 DPhyp: connected-subgraph + complement
+/// (Moerkotte/Neumann 2008 DPhyp: connected-subgraph + complement
 /// enumeration).
 ///
 /// Invariants:
@@ -56,10 +56,9 @@ class DPhyp {
       int32_t numWorkers,
       int64_t broadcastSizeLimit);
 
-  /// Runs the enumeration and returns the root `MemoOp` for the full
-  /// relation set, or nullptr when no costable plan exists (some relation
-  /// or edge had unknown cost). A nullptr return tells the caller to fall
-  /// back to the query's syntactic join order.
+  /// Runs the enumeration and returns the root `MemoOp` for the full relation
+  /// set, or nullptr when no valid costable plan was produced. A nullptr
+  /// return tells the caller to fall back to the query's syntactic join order.
   MemoOpCP enumerate();
 
   /// Runs enumeration once and returns the optimal plan for each
@@ -67,8 +66,8 @@ class DPhyp {
   /// relation set and together they must cover all relations. Use when
   /// the hypergraph is disconnected (genuine cross products); the caller
   /// combines the per-component plans with cross joins. Returns an empty
-  /// vector when any component has no costable plan (some relation or edge
-  /// had unknown cost), telling the caller to fall back to syntactic order.
+  /// vector when any component has no valid costable plan, telling the caller
+  /// to fall back to syntactic order.
   std::vector<MemoOpCP> enumerate(const std::vector<RelationSet>& components);
 
  private:

--- a/axiom/optimizer/v2/DPhyp.h
+++ b/axiom/optimizer/v2/DPhyp.h
@@ -57,9 +57,10 @@ class DPhyp {
       int64_t broadcastSizeLimit);
 
   /// Runs the enumeration and returns the root `MemoOp` for the full
-  /// relation set, or nullptr when no costable plan exists (some relation
-  /// or edge had unknown cost). A nullptr return tells the caller to fall
-  /// back to the query's syntactic join order.
+  /// relation set, or nullptr when no costable plan exists or budget fallback
+  /// makes an irrevocable greedy merge that leaves no valid next partition. A
+  /// nullptr return tells the caller to fall back to the query's syntactic join
+  /// order.
   MemoOpCP enumerate();
 
   /// Runs enumeration once and returns the optimal plan for each
@@ -67,8 +68,9 @@ class DPhyp {
   /// relation set and together they must cover all relations. Use when
   /// the hypergraph is disconnected (genuine cross products); the caller
   /// combines the per-component plans with cross joins. Returns an empty
-  /// vector when any component has no costable plan (some relation or edge
-  /// had unknown cost), telling the caller to fall back to syntactic order.
+  /// vector when any component has no costable plan or greedy cannot assemble
+  /// one after budget fallback, telling the caller to fall back to syntactic
+  /// order.
   std::vector<MemoOpCP> enumerate(const std::vector<RelationSet>& components);
 
  private:

--- a/axiom/optimizer/v2/HypergraphBuilder.cpp
+++ b/axiom/optimizer/v2/HypergraphBuilder.cpp
@@ -79,76 +79,124 @@ RelationSet keyRelationsOrOperand(
   return operand;
 }
 
-// Per-Join leaf covers of left and right operands, with the
-// kRight-to-kLeft normalization baked in: for an IR `kRight`
-// join, `left`/`right` are swapped and `joinType` is `kLeft`.
-// The rest of the pipeline never sees `kRight`.
-struct JoinLeaves {
-  RelationSet left;
-  RelationSet right;
-  velox::core::JoinType joinType;
+// Records each Join's normalized operands. `leftLeaves` and `rightLeaves`
+// contain leaf-relation ids used by the algebraic TES rules; a constant-input
+// Unnest is itself a leaf. `leftRelations` and `rightRelations` additionally
+// contain dependent Unnest relation ids used to split the completed TES into
+// hyperedge sides. Right-form joins are stored in their equivalent left form.
+struct JoinInputs {
+  RelationSet leftLeaves;
+  RelationSet rightLeaves;
+  RelationSet leftRelations;
+  RelationSet rightRelations;
+  velox::core::JoinType joinType{velox::core::JoinType::kInner};
 };
 
-// Returns the subtree leaves of `node`; populates `leaves[J]` for
-// every Join `J` reached during the walk. For an IR `kRight` join,
-// `leaves[J]` records the swapped operands and `joinType = kLeft`.
-// Unnest nodes are not in `leafIds`; descend into `input()`.
-RelationSet populateJoinLeaves(
+// Tracks leaf relations and complete hypergraph-relation coverage for a
+// subtree.
+struct SubtreeRelations {
+  RelationSet leaves;
+  RelationSet allRelations;
+};
+
+// Returns the leaf relations and all hypergraph relations below `node`, and
+// records the normalized operands of every Join reached during the walk.
+SubtreeRelations populateJoinInputs(
     NodeCP node,
     const folly::F14FastMap<NodeCP, int8_t>& leafIds,
     const folly::F14FastMap<UnnestCP, int8_t>& unnestIds,
-    folly::F14FastMap<JoinCP, JoinLeaves>& leaves) {
+    folly::F14FastMap<JoinCP, JoinInputs>& inputs) {
   const auto it = leafIds.find(node);
   if (it != leafIds.end()) {
-    return RelationSet::singleton(it->second);
+    const RelationSet relation = RelationSet::singleton(it->second);
+    return {relation, relation};
   }
   if (node->is(NodeType::kUnnest)) {
-    // The cluster does not contain the input of an Unnest of a constant, so
-    // the Unnest's own relation is all its subtree contributes.
     const auto* unnest = node->as<Unnest>();
     NodeCP input = unnest->input();
+    const int8_t unnestId = unnestIds.at(unnest);
+    // The cluster does not contain the input of an Unnest of a constant, so
+    // the Unnest's own relation is all its subtree contributes.
     if (input->outputColumns().empty()) {
-      return RelationSet::singleton(unnestIds.at(unnest));
+      const RelationSet relation = RelationSet::singleton(unnestId);
+      return {relation, relation};
     }
-    return populateJoinLeaves(input, leafIds, unnestIds, leaves);
+    SubtreeRelations subtree =
+        populateJoinInputs(input, leafIds, unnestIds, inputs);
+    subtree.allRelations.add(unnestId);
+    return subtree;
   }
   const auto* join = node->as<Join>();
-  const RelationSet leftLeaves =
-      populateJoinLeaves(join->left(), leafIds, unnestIds, leaves);
-  const RelationSet rightLeaves =
-      populateJoinLeaves(join->right(), leafIds, unnestIds, leaves);
+  const SubtreeRelations left =
+      populateJoinInputs(join->left(), leafIds, unnestIds, inputs);
+  const SubtreeRelations right =
+      populateJoinInputs(join->right(), leafIds, unnestIds, inputs);
   // Normalize right-form joins to their left form by swapping operands.
   // kRight, kRightSemiFilter and kRightSemiProject each map to the
   // matching left-form type; the rest of the pipeline never sees a
   // right-form join.
   switch (join->joinType()) {
     case velox::core::JoinType::kRight:
-      leaves[join] = JoinLeaves{
-          .left = rightLeaves,
-          .right = leftLeaves,
+      inputs[join] = JoinInputs{
+          .leftLeaves = right.leaves,
+          .rightLeaves = left.leaves,
+          .leftRelations = right.allRelations,
+          .rightRelations = left.allRelations,
           .joinType = velox::core::JoinType::kLeft};
       break;
     case velox::core::JoinType::kRightSemiFilter:
-      leaves[join] = JoinLeaves{
-          .left = rightLeaves,
-          .right = leftLeaves,
+      inputs[join] = JoinInputs{
+          .leftLeaves = right.leaves,
+          .rightLeaves = left.leaves,
+          .leftRelations = right.allRelations,
+          .rightRelations = left.allRelations,
           .joinType = velox::core::JoinType::kLeftSemiFilter};
       break;
     case velox::core::JoinType::kRightSemiProject:
-      leaves[join] = JoinLeaves{
-          .left = rightLeaves,
-          .right = leftLeaves,
+      inputs[join] = JoinInputs{
+          .leftLeaves = right.leaves,
+          .rightLeaves = left.leaves,
+          .leftRelations = right.allRelations,
+          .rightRelations = left.allRelations,
           .joinType = velox::core::JoinType::kLeftSemiProject};
       break;
     default:
-      leaves[join] = JoinLeaves{
-          .left = leftLeaves,
-          .right = rightLeaves,
+      inputs[join] = JoinInputs{
+          .leftLeaves = left.leaves,
+          .rightLeaves = right.leaves,
+          .leftRelations = left.allRelations,
+          .rightRelations = right.allRelations,
           .joinType = join->joinType()};
   }
-  RelationSet subtree{leftLeaves};
-  subtree.unionSet(rightLeaves);
+  SubtreeRelations subtree{left};
+  subtree.leaves.unionSet(right.leaves);
+  subtree.allRelations.unionSet(right.allRelations);
   return subtree;
+}
+
+// Splits an operator's total TES between its normalized input covers.
+std::pair<RelationSet, RelationSet> splitTes(
+    const RelationSet& tes,
+    const RelationSet& normalizedLeftRelations,
+    const RelationSet& normalizedRightRelations) {
+  VELOX_CHECK(
+      !normalizedLeftRelations.hasIntersection(normalizedRightRelations),
+      "Normalized join inputs must be disjoint: left={}, right={}",
+      normalizedLeftRelations.bits(),
+      normalizedRightRelations.bits());
+  RelationSet inputRelations{normalizedLeftRelations};
+  inputRelations.unionSet(normalizedRightRelations);
+  VELOX_CHECK(
+      tes.isSubset(inputRelations),
+      "TES must be contained in the normalized join inputs: tes={}, inputs={}",
+      tes.bits(),
+      inputRelations.bits());
+
+  RelationSet leftTes{tes};
+  leftTes.intersect(normalizedLeftRelations);
+  RelationSet rightTes{tes};
+  rightTes.intersect(normalizedRightRelations);
+  return {leftTes, rightTes};
 }
 
 // Returns the leaves an ancestor join must add to its TES to keep
@@ -162,7 +210,7 @@ RelationSet tesExpansion(
     const RelationSet& parentSes,
     bool leftSide,
     const folly::F14FastMap<NodeCP, int8_t>& leafIds,
-    const folly::F14FastMap<JoinCP, JoinLeaves>& leaves) {
+    const folly::F14FastMap<JoinCP, JoinInputs>& inputs) {
   if (leafIds.contains(node)) {
     return RelationSet{};
   }
@@ -173,19 +221,19 @@ RelationSet tesExpansion(
       return RelationSet{};
     }
     return tesExpansion(
-        input, parentType, parentSes, leftSide, leafIds, leaves);
+        input, parentType, parentSes, leftSide, leafIds, inputs);
   }
 
   const auto* childJoin = node->as<Join>();
-  const auto& childLeaves = leaves.at(childJoin);
+  const auto& childInputs = inputs.at(childJoin);
 
   // CD-A: for a LEFT-subtree descendant the M/N table is keyed
   // `(child, parent)`. For a RIGHT-subtree descendant the roles
-  // flip to `(parent, child)`. `childLeaves.joinType` is already
+  // flip to `(parent, child)`. `childInputs.joinType` is already
   // normalized (never kRight).
   auto props = leftSide
-      ? AlgebraicProperties::derive(childLeaves.joinType, parentType)
-      : AlgebraicProperties::derive(parentType, childLeaves.joinType);
+      ? AlgebraicProperties::derive(childInputs.joinType, parentType)
+      : AlgebraicProperties::derive(parentType, childInputs.joinType);
 
   // When the parent's referenced relations overlap a child
   // operand that the equivalence's syntactic precondition
@@ -193,21 +241,21 @@ RelationSet tesExpansion(
   // Skip for inner-over-inner where commutativity makes the
   // equivalences hold regardless of predicate placement.
   const bool involvesOuter =
-      childLeaves.joinType != velox::core::JoinType::kInner ||
+      childInputs.joinType != velox::core::JoinType::kInner ||
       parentType != velox::core::JoinType::kInner;
   if (involvesOuter) {
     if (leftSide) {
-      if (parentSes.hasIntersection(childLeaves.left)) {
+      if (parentSes.hasIntersection(childInputs.leftLeaves)) {
         props.associative = false;
       }
-      if (parentSes.hasIntersection(childLeaves.right)) {
+      if (parentSes.hasIntersection(childInputs.rightLeaves)) {
         props.leftAsscom = false;
       }
     } else {
-      if (parentSes.hasIntersection(childLeaves.right)) {
+      if (parentSes.hasIntersection(childInputs.rightLeaves)) {
         props.associative = false;
       }
-      if (parentSes.hasIntersection(childLeaves.left)) {
+      if (parentSes.hasIntersection(childInputs.leftLeaves)) {
         props.rightAsscom = false;
       }
     }
@@ -216,23 +264,23 @@ RelationSet tesExpansion(
   RelationSet expansion;
   if (leftSide) {
     if (!props.leftAsscom) {
-      expansion.unionSet(childLeaves.right);
+      expansion.unionSet(childInputs.rightLeaves);
     }
     if (!props.associative) {
-      expansion.unionSet(childLeaves.left);
+      expansion.unionSet(childInputs.leftLeaves);
     }
   } else {
     if (!props.rightAsscom) {
-      expansion.unionSet(childLeaves.left);
+      expansion.unionSet(childInputs.leftLeaves);
     }
     if (!props.associative) {
-      expansion.unionSet(childLeaves.right);
+      expansion.unionSet(childInputs.rightLeaves);
     }
   }
   expansion.unionSet(tesExpansion(
-      childJoin->left(), parentType, parentSes, leftSide, leafIds, leaves));
+      childJoin->left(), parentType, parentSes, leftSide, leafIds, inputs));
   expansion.unionSet(tesExpansion(
-      childJoin->right(), parentType, parentSes, leftSide, leafIds, leaves));
+      childJoin->right(), parentType, parentSes, leftSide, leafIds, inputs));
   return expansion;
 }
 
@@ -348,10 +396,10 @@ void addTransitiveInnerEdges(
   for (DerivedEdgeSpec& derivedEdge : derivedEdges) {
     const RelationSet left = RelationSet::singleton(derivedEdge.leftRelation);
     const RelationSet right = RelationSet::singleton(derivedEdge.rightRelation);
-    RelationSet tes{left};
-    tes.unionSet(right);
     graph.addEdge(
         JoinEdge{
+            left,
+            right,
             left,
             right,
             std::move(derivedEdge.leftKeys),
@@ -359,8 +407,7 @@ void addTransitiveInnerEdges(
             ExprVector{},
             velox::core::JoinType::kInner,
             /*nullAware=*/false,
-            /*nullAsValue=*/false},
-        tes);
+            /*nullAsValue=*/false});
   }
 }
 
@@ -434,10 +481,10 @@ JoinHypergraph HypergraphBuilder::build(
     }
   }
 
-  // Build the unnest edge for each Unnest that depends on a relation
-  // of the cluster, and record every Unnest's input relations (the relation ids
-  // its input subtree contributes, resolved via the now-complete columnToLeaf)
-  // for the outer-join barrier applied in the cluster-join loop.
+  // Builds each Unnest edge and records the relation ids referenced by the
+  // Unnest input's output columns. These data dependencies determine whether
+  // an outer join must precede or follow the Unnest; they are distinct from the
+  // complete structural subtree membership recorded in `joinInputs` below.
   folly::F14FastMap<int8_t, RelationSet> unnestInputRelations;
   for (UnnestCP unnest : cluster.unnests) {
     const int8_t id = unnestIds.at(unnest);
@@ -460,17 +507,14 @@ JoinHypergraph HypergraphBuilder::build(
         !inputRelations.empty(),
         "Unnest input subtree must contribute at least one cluster relation");
 
-    RelationSet tes{inputRelations};
-    tes.add(id);
-    graph.addEdge(
-        JoinEdge::unnest(inputRelations, RelationSet::singleton(id)), tes);
+    graph.addEdge(JoinEdge::unnest(inputRelations, RelationSet::singleton(id)));
   }
 
-  folly::F14FastMap<JoinCP, JoinLeaves> joinLeaves;
-  populateJoinLeaves(cluster.root, leafIds, unnestIds, joinLeaves);
+  folly::F14FastMap<JoinCP, JoinInputs> joinInputs;
+  populateJoinInputs(cluster.root, leafIds, unnestIds, joinInputs);
 
   for (JoinCP join : cluster.joins) {
-    const auto& leaves = joinLeaves.at(join);
+    const auto& inputs = joinInputs.at(join);
     if (join->isInner()) {
       // Group keys by endpoint relation-pair and emit one edge per group.
       // Keys sharing an endpoint (a composite key) stay on one edge so
@@ -496,9 +540,9 @@ JoinHypergraph HypergraphBuilder::build(
           rightKeys.push_back(join->rightKeys()[i]);
         }
         const RelationSet leftSet{
-            keyRelationsOrOperand(leftKeys, columnToLeaf, leaves.left)};
+            keyRelationsOrOperand(leftKeys, columnToLeaf, inputs.leftLeaves)};
         const RelationSet rightSet{
-            keyRelationsOrOperand(rightKeys, columnToLeaf, leaves.right)};
+            keyRelationsOrOperand(rightKeys, columnToLeaf, inputs.rightLeaves)};
         RelationSet ses{leftSet};
         ses.unionSet(rightSet);
         RelationSet tes{ses};
@@ -508,26 +552,29 @@ JoinHypergraph HypergraphBuilder::build(
             ses,
             /*leftSide=*/true,
             leafIds,
-            joinLeaves));
+            joinInputs));
         tes.unionSet(tesExpansion(
             join->right(),
             join->joinType(),
             ses,
             /*leftSide=*/false,
             leafIds,
-            joinLeaves));
+            joinInputs));
+        auto [leftTes, rightTes] =
+            splitTes(tes, inputs.leftRelations, inputs.rightRelations);
 
         graph.addEdge(
             JoinEdge{
                 leftSet,
                 rightSet,
+                leftTes,
+                rightTes,
                 leftKeys,
                 rightKeys,
                 ExprVector{},
                 join->joinType(),
                 /*nullAware=*/false,
-                /*nullAsValue=*/false},
-            tes);
+                /*nullAsValue=*/false});
       }
 
       for (ExprCP conjunct : join->filter()) {
@@ -536,8 +583,7 @@ JoinHypergraph HypergraphBuilder::build(
       }
     } else {
       // Swap keys when the IR join is a right-form join so the edge's
-      // leftKeys reference `leaves.left` (already right-normalized to the
-      // matching left form in populateJoinLeaves).
+      // leftKeys reference the normalized left input.
       const bool flip = join->joinType() == velox::core::JoinType::kRight ||
           join->joinType() == velox::core::JoinType::kRightSemiFilter ||
           join->joinType() == velox::core::JoinType::kRightSemiProject;
@@ -549,9 +595,9 @@ JoinHypergraph HypergraphBuilder::build(
       NodeCP normalizedRightChild = flip ? join->left() : join->right();
 
       const RelationSet leftSet{
-          keyRelationsOrOperand(edgeLeftKeys, columnToLeaf, leaves.left)};
-      const RelationSet rightSet{
-          keyRelationsOrOperand(edgeRightKeys, columnToLeaf, leaves.right)};
+          keyRelationsOrOperand(edgeLeftKeys, columnToLeaf, inputs.leftLeaves)};
+      const RelationSet rightSet{keyRelationsOrOperand(
+          edgeRightKeys, columnToLeaf, inputs.rightLeaves)};
       RelationSet ses{leftSet};
       ses.unionSet(rightSet);
       for (ExprCP conjunct : join->filter()) {
@@ -560,25 +606,30 @@ JoinHypergraph HypergraphBuilder::build(
       RelationSet tes{ses};
       tes.unionSet(tesExpansion(
           normalizedLeftChild,
-          leaves.joinType,
+          inputs.joinType,
           ses,
           /*leftSide=*/true,
           leafIds,
-          joinLeaves));
+          joinInputs));
       tes.unionSet(tesExpansion(
           normalizedRightChild,
-          leaves.joinType,
+          inputs.joinType,
           ses,
           /*leftSide=*/false,
           leafIds,
-          joinLeaves));
+          joinInputs));
+
+      // `populateJoinInputs` already applies the same right-form operand swap
+      // as the normalized child selection above.
+      const RelationSet& normalizedLeftRelations = inputs.leftRelations;
+      const RelationSet& normalizedRightRelations = inputs.rightRelations;
 
       // Outer-join barrier: if an Unnest's input subtree contributes a relation
       // on this outer join's null-padded side, the unnest edge must fire before
       // the outer join. Otherwise null-padding flows into UNNEST and rows drop.
       // Expand TES to include the Unnest relation id so DPhyp pins the order.
-      RelationSet joinRelations{leaves.left};
-      joinRelations.unionSet(leaves.right);
+      RelationSet joinRelations{inputs.leftLeaves};
+      joinRelations.unionSet(inputs.rightLeaves);
       for (const auto& [unnestId, inputRelations] : unnestInputRelations) {
         // An outer join inside the Unnest's input subtree is already ordered
         // before the Unnest by the unnest edge. The barrier would demand the
@@ -588,16 +639,24 @@ JoinHypergraph HypergraphBuilder::build(
           continue;
         }
         RelationSet nullPaddedSide;
-        if (leaves.joinType == velox::core::JoinType::kLeft) {
-          nullPaddedSide = leaves.right;
-        } else if (leaves.joinType == velox::core::JoinType::kFull) {
-          nullPaddedSide = leaves.left;
-          nullPaddedSide.unionSet(leaves.right);
+        if (inputs.joinType == velox::core::JoinType::kLeft) {
+          nullPaddedSide = inputs.rightLeaves;
+        } else if (inputs.joinType == velox::core::JoinType::kFull) {
+          nullPaddedSide = inputs.leftLeaves;
+          nullPaddedSide.unionSet(inputs.rightLeaves);
         }
         if (nullPaddedSide.hasIntersection(inputRelations)) {
+          VELOX_CHECK(
+              normalizedLeftRelations.contains(unnestId) ||
+                  normalizedRightRelations.contains(unnestId),
+              "Unnest must belong to one normalized join side: {}",
+              static_cast<int32_t>(unnestId));
           tes.add(unnestId);
         }
       }
+
+      auto [leftTes, rightTes] =
+          splitTes(tes, normalizedLeftRelations, normalizedRightRelations);
 
       // kLeftSemiProject preserves the left side and appends a mark; the
       // Join (and its Apply origin) build outputColumns as
@@ -606,7 +665,7 @@ JoinHypergraph HypergraphBuilder::build(
       // mark through reordering. The filtering forms (kLeftSemiFilter /
       // kAnti) carry no mark.
       ColumnCP markColumn =
-          leaves.joinType == velox::core::JoinType::kLeftSemiProject
+          inputs.joinType == velox::core::JoinType::kLeftSemiProject
           ? join->markColumn()
           : nullptr;
 
@@ -614,14 +673,15 @@ JoinHypergraph HypergraphBuilder::build(
           JoinEdge{
               leftSet,
               rightSet,
+              leftTes,
+              rightTes,
               edgeLeftKeys,
               edgeRightKeys,
               join->filter(),
-              leaves.joinType,
+              inputs.joinType,
               join->nullAware(),
               join->nullAsValue(),
-              markColumn},
-          tes);
+              markColumn});
     }
   }
 

--- a/axiom/optimizer/v2/JoinEdge.h
+++ b/axiom/optimizer/v2/JoinEdge.h
@@ -45,30 +45,36 @@ inline bool canBroadcastBuild(velox::core::JoinType joinType) {
       joinType == JoinType::kLeftSemiProject || joinType == JoinType::kAnti;
 }
 
-/// A hyperedge in a join cluster's hypergraph. Three flavors:
+/// A hyperedge in a join cluster's hypergraph. For join edges,
+/// `leftEndpoints()` and `rightEndpoints()` are the relation sets directly
+/// referenced by the corresponding key expressions. `leftEligibility()` and
+/// `rightEligibility()` are the disjoint hypernodes that must lie on opposite
+/// sides of an enumerated partition.
 ///
 ///   - Inner equi-join. `filter` is empty; non-equi conjuncts live in
 ///     `JoinHypergraph::filterConjuncts` so DPhyp can place them at
 ///     the lowest eligible join. `nullAware` and `nullAsValue` are
 ///     unused.
-///   - Outer equi-join (LEFT / RIGHT / FULL). `filter` carries the
-///     ON-clause non-equi conjuncts bound to this edge — moving them
-///     above would let null-padded rows pass through, changing
-///     semantics. `nullAware` and `nullAsValue` carry Velox null
+///   - Non-inner equi-join (outer, semi, or anti). `filter` carries conjuncts
+///     bound to this edge because moving them can change null-padding or
+///     existence semantics. `nullAware` and `nullAsValue` carry Velox null
 ///     semantics.
-///   - Unnest. Built by `JoinEdge::unnest`. `left` covers the
-///     relations whose subtree feeds the Unnest; `right` is the
-///     single Unnest relation. No equi-keys, no filter;
-///     `isUnnest()` discriminates. Unlike the other flavors this
-///     edge never becomes a join: an Unnest expands the rows of the
-///     relations on `left` rather than pairing two inputs, so DPhyp
-///     lowers it to a unary `UnnestOp` over whichever plan covers
-///     `left`. The edge states connectivity and ordering — the
-///     Unnest relation is reachable only through it, so no plan
-///     holds that relation without the relations it expands.
+///   - Unnest. Built by `JoinEdge::unnest`. Its endpoint and eligibility sides
+///     are identical: `leftEndpoints()` covers the relations whose subtree
+///     feeds the Unnest and `rightEndpoints()` is the single Unnest relation.
+///     No equi-keys, no filter; `isUnnest()` discriminates. Unlike the other
+///     flavors this edge never becomes a join: an Unnest expands the rows of
+///     the relations on `leftEndpoints()` rather than pairing two inputs, so
+///     DPhyp lowers it to a unary `UnnestOp` over whichever plan covers those
+///     relations. The edge states
+///     connectivity and ordering — the Unnest relation is reachable only
+///     through it, so no plan holds that relation without the relations it
+///     expands.
 ///
 /// Invariants:
-///   - `left` and `right` are non-empty and disjoint.
+///   - Both pairs of sides are non-empty and disjoint.
+///   - `leftEndpoints()` is a subset of `leftEligibility()`; likewise on the
+///     right.
 ///   - Equi-join flavors: `leftKeys.size() == rightKeys.size()` and
 ///     is non-empty.
 ///   - Unnest flavor: `leftKeys` / `rightKeys` / `filter` empty;
@@ -76,8 +82,10 @@ inline bool canBroadcastBuild(velox::core::JoinType joinType) {
 class JoinEdge {
  public:
   JoinEdge(
-      RelationSet left,
-      RelationSet right,
+      RelationSet leftEndpoints,
+      RelationSet rightEndpoints,
+      RelationSet leftEligibility,
+      RelationSet rightEligibility,
       ExprVector leftKeys,
       ExprVector rightKeys,
       ExprVector filter,
@@ -85,8 +93,10 @@ class JoinEdge {
       bool nullAware,
       bool nullAsValue,
       ColumnCP markColumn = nullptr)
-      : left_{std::move(left)},
-        right_{std::move(right)},
+      : leftEndpoints_{std::move(leftEndpoints)},
+        rightEndpoints_{std::move(rightEndpoints)},
+        leftEligibility_{std::move(leftEligibility)},
+        rightEligibility_{std::move(rightEligibility)},
         leftKeys_{std::move(leftKeys)},
         rightKeys_{std::move(rightKeys)},
         filter_{std::move(filter)},
@@ -94,9 +104,14 @@ class JoinEdge {
         nullAware_{nullAware},
         nullAsValue_{nullAsValue},
         markColumn_{markColumn} {
-    VELOX_CHECK(!left_.empty());
-    VELOX_CHECK(!right_.empty());
-    VELOX_CHECK(!left_.hasIntersection(right_));
+    VELOX_CHECK(!leftEndpoints_.empty());
+    VELOX_CHECK(!rightEndpoints_.empty());
+    VELOX_CHECK(!leftEndpoints_.hasIntersection(rightEndpoints_));
+    VELOX_CHECK(!leftEligibility_.empty());
+    VELOX_CHECK(!rightEligibility_.empty());
+    VELOX_CHECK(!leftEligibility_.hasIntersection(rightEligibility_));
+    VELOX_CHECK(leftEndpoints_.isSubset(leftEligibility_));
+    VELOX_CHECK(rightEndpoints_.isSubset(rightEligibility_));
     VELOX_CHECK_EQ(leftKeys_.size(), rightKeys_.size());
     VELOX_CHECK(
         !leftKeys_.empty(), "Equi-join edge must carry at least one key pair");
@@ -119,12 +134,29 @@ class JoinEdge {
     return JoinEdge{std::move(left), std::move(right)};
   }
 
-  const RelationSet& left() const {
-    return left_;
+  /// Relations in the left endpoint set.
+  const RelationSet& leftEndpoints() const {
+    return leftEndpoints_;
   }
 
-  const RelationSet& right() const {
-    return right_;
+  /// Relations in the right endpoint set.
+  const RelationSet& rightEndpoints() const {
+    return rightEndpoints_;
+  }
+
+  /// Relations on the left eligibility side of this hyperedge.
+  const RelationSet& leftEligibility() const {
+    return leftEligibility_;
+  }
+
+  /// Relations on the right eligibility side of this hyperedge.
+  const RelationSet& rightEligibility() const {
+    return rightEligibility_;
+  }
+
+  /// Returns the Total Eligibility Set of this edge.
+  RelationSet totalEligibility() const {
+    return RelationSet{leftEligibility_.bits() | rightEligibility_.bits()};
   }
 
   /// Equi-join keys aligned by position with `rightKeys()`.
@@ -172,17 +204,21 @@ class JoinEdge {
  private:
   // Builds an unnest edge; see the `unnest` factory.
   JoinEdge(RelationSet left, RelationSet right)
-      : left_{std::move(left)},
-        right_{std::move(right)},
+      : leftEndpoints_{std::move(left)},
+        rightEndpoints_{std::move(right)},
+        leftEligibility_{leftEndpoints_},
+        rightEligibility_{rightEndpoints_},
         joinType_{velox::core::JoinType::kInner},
         isUnnest_{true} {
-    VELOX_CHECK(!left_.empty());
-    VELOX_CHECK(!right_.empty());
-    VELOX_CHECK(!left_.hasIntersection(right_));
+    VELOX_CHECK(!leftEndpoints_.empty());
+    VELOX_CHECK(!rightEndpoints_.empty());
+    VELOX_CHECK(!leftEndpoints_.hasIntersection(rightEndpoints_));
   }
 
-  RelationSet left_;
-  RelationSet right_;
+  RelationSet leftEndpoints_;
+  RelationSet rightEndpoints_;
+  RelationSet leftEligibility_;
+  RelationSet rightEligibility_;
   ExprVector leftKeys_;
   ExprVector rightKeys_;
   ExprVector filter_;

--- a/axiom/optimizer/v2/JoinHypergraph.cpp
+++ b/axiom/optimizer/v2/JoinHypergraph.cpp
@@ -67,13 +67,12 @@ RelationSet JoinHypergraph::connectedComponent(
   while (changed) {
     changed = false;
     for (const auto& edge : edges_) {
-      RelationSet endpoints{edge.left()};
-      endpoints.unionSet(edge.right());
-      if (!endpoints.isSubset(bound)) {
+      const RelationSet edgeTes = edge.totalEligibility();
+      if (!edgeTes.isSubset(bound)) {
         continue;
       }
-      if (endpoints.hasIntersection(reached) && !endpoints.isSubset(reached)) {
-        reached.unionSet(endpoints);
+      if (edgeTes.hasIntersection(reached) && !edgeTes.isSubset(reached)) {
+        reached.unionSet(edgeTes);
         changed = true;
       }
     }
@@ -100,7 +99,7 @@ void JoinHypergraph::checkConsistency() const {
     }
     bool found = false;
     for (const auto& edge : edges_) {
-      if (edge.isUnnest() && edge.right().contains(id)) {
+      if (edge.isUnnest() && edge.rightEndpoints().contains(id)) {
         found = true;
         break;
       }
@@ -185,9 +184,8 @@ folly::F14FastMap<ColumnCP, ColumnCP> JoinHypergraph::coverColumnReps(
     if (!provesKeyEquality(edge.joinType())) {
       continue;
     }
-    RelationSet endpoints{edge.left()};
-    endpoints.unionSet(edge.right());
-    if (!endpoints.isSubset(cover)) {
+    const RelationSet edgeTes = edge.totalEligibility();
+    if (!edgeTes.isSubset(cover)) {
       continue;
     }
     const auto& leftKeys = edge.leftKeys();
@@ -227,15 +225,14 @@ PlanObjectSet JoinHypergraph::coverOutputColumns(
   }
   PlanObjectSet neededAbove = targetColumns_;
   for (const auto& edge : edges_) {
-    RelationSet endpoints{edge.left()};
-    endpoints.unionSet(edge.right());
-    if (!endpoints.isSubset(cover)) {
+    const RelationSet edgeTes = edge.totalEligibility();
+    if (!edgeTes.isSubset(cover)) {
       neededAbove.unionColumns(edge.leftKeys());
       neededAbove.unionColumns(edge.rightKeys());
       neededAbove.unionColumns(edge.filter());
       if (edge.isUnnest()) {
         // An Unnest not yet applied reads what it expands from below.
-        neededAbove.unionColumns(relation(edge.right().min())
+        neededAbove.unionColumns(relation(edge.rightEndpoints().min())
                                      .node()
                                      ->as<Unnest>()
                                      ->unnestExpressions());
@@ -262,23 +259,20 @@ PlanObjectSet JoinHypergraph::coverOutputColumns(
       .first->second;
 }
 
-void JoinHypergraph::addEdge(JoinEdge edge, RelationSet tes) {
-  RelationSet touched{edge.left()};
-  touched.unionSet(edge.right());
-  VELOX_CHECK(touched.isSubset(tes), "Edge endpoints must be a subset of TES");
+void JoinHypergraph::addEdge(JoinEdge edge) {
+  const RelationSet eligibility = edge.totalEligibility();
   VELOX_CHECK(
-      tes.isSubset(relationIds_),
-      "TES must reference only relations already added");
+      eligibility.isSubset(relationIds_),
+      "Edge eligibility must reference only relations already added");
   if (edge.isUnnest()) {
     // Relations are registered before the Unnests over them. Enumeration
     // relies on this: a set holding an expanded relation always holds a
     // smaller id, so such a set is never enumerated from the expanded
     // relation as its seed.
-    VELOX_CHECK_LT(edge.left().min(), edge.right().min());
-    expandedRelationIds_.unionSet(edge.right());
+    VELOX_CHECK_LT(edge.leftEndpoints().min(), edge.rightEndpoints().min());
+    expandedRelationIds_.unionSet(edge.rightEndpoints());
   }
   edges_.push_back(std::move(edge));
-  tes_.push_back(tes);
   invalidateCoverCaches();
 }
 

--- a/axiom/optimizer/v2/JoinHypergraph.h
+++ b/axiom/optimizer/v2/JoinHypergraph.h
@@ -48,20 +48,17 @@ struct FilterConjunct {
 /// The hypergraph DPhyp enumerates over: a set of relations
 /// (atomic join inputs) connected by hyperedges (predicates).
 ///
-/// Each edge carries a Total Eligibility Set (TES) — the relations that
-/// must already be in the joined set before the edge can fire.
+/// Each edge's eligibility sides form its Total Eligibility Set (TES) — the
+/// relations that must already be in the joined set before the edge can fire.
 ///
 /// Typical use: call `addRelation` once for each base input, then
-/// `addEdge` once for each predicate, then pass the result to
-/// DPhyp for plan enumeration. Edges and their TES are stored in
-/// parallel: `tes()[i]` is the TES of `edges()[i]`.
+/// `addEdge` once for each predicate, then pass the result to DPhyp for plan
+/// enumeration.
 ///
 /// Invariants (maintained across construction):
 ///   - `relations()[i].id() == i`.
 ///   - Every relation id referenced by an edge is in
 ///     `[0, relations().size())`.
-///   - `tes()[i]` is a superset of
-///     `edges()[i].left() ∪ edges()[i].right()`.
 class JoinHypergraph {
  public:
   /// Constructs a Relation with the next assigned id and adds it
@@ -88,10 +85,9 @@ class JoinHypergraph {
     return expandedRelationIds_;
   }
 
-  /// Appends an edge with its TES. `tes` must be a superset of
-  /// `edge.left() ∪ edge.right()`, and every relation referenced
-  /// by `edge` or `tes` must already be in `relations()`.
-  void addEdge(JoinEdge edge, RelationSet tes);
+  /// Appends an edge whose endpoints and eligibility sides must reference only
+  /// relations already in `relations()`. Throws if this invariant is violated.
+  void addEdge(JoinEdge edge);
 
   /// Throws unless `appliedEdges` — the edges a finished plan applies, indexed
   /// into `edges()` — enforce every edge's equalities. A plan that drops one
@@ -166,14 +162,8 @@ class JoinHypergraph {
     return edges_;
   }
 
-  /// Per-edge Total Eligibility Sets, aligned with `edges()`:
-  /// `tes()[i]` is the TES of `edges()[i]`.
-  const std::vector<RelationSet>& tes() const {
-    return tes_;
-  }
-
   /// Returns the set of relations reachable from `seed` by repeatedly
-  /// following edges whose endpoints are entirely within `bound`.
+  /// following edges whose eligibility sides are entirely within `bound`.
   RelationSet connectedComponent(RelationSet seed, RelationSet bound) const;
 
   /// Checks that all relations are connected to each other via
@@ -189,8 +179,6 @@ class JoinHypergraph {
   // Indexed by relation id.
   std::vector<Relation> relations_;
   std::vector<JoinEdge> edges_;
-  // Parallel to `edges_`: `tes_[i]` is the TES of `edges_[i]`.
-  std::vector<RelationSet> tes_;
   std::vector<FilterConjunct> filterConjuncts_;
   // Bitset of every relation id currently in the hypergraph.
   RelationSet relationIds_;

--- a/axiom/optimizer/v2/JoinTreeEmitter.cpp
+++ b/axiom/optimizer/v2/JoinTreeEmitter.cpp
@@ -49,7 +49,7 @@ void appendNarrowed(
 // `graph.coverOutputColumns(cover)`, which collapses each within-cover
 // equi-group to one representative — exactly the set the cost model charges
 // for, so the executed plan matches its estimated width. The one exception is
-// an outer join carrying extra edges, which keeps both columns of each so the
+// a join carrying filter edges, which keeps both columns of each so the
 // filter above it can read them. Left-then-right order is preserved. A column
 // produced by no relation in `cover` (e.g. a semijoin mark synthesized below,
 // or a key a shuffle materialized) is outside the demand universe and is always
@@ -210,20 +210,19 @@ NodeCP restoreTargets(
       {node, std::move(exprs), ColumnVector{targets}});
 }
 
-// The equalities of `extraEdges` — the inner edges that crossed the same
-// partition as an Unnest or an outer join, which cannot take them as keys.
-// Equality is symmetric, so the edges' orientation does not matter here. Inner
-// edges carry no filter (`JoinEdge` enforces that), so the keys are the whole
-// predicate.
-ExprVector extraEdgeEqualities(
-    const std::vector<size_t>& extraEdges,
+// Returns the equalities evaluated by a Filter above an operator. Equality is
+// symmetric, so the edges'
+// orientation does not matter here. Inner edges carry no filter (`JoinEdge`
+// enforces that), so the keys are the whole predicate.
+ExprVector filterEdgeEqualities(
+    const std::vector<size_t>& filterEdges,
     const ExprFactory::ExprSubstitution& substitution,
     EmitState& state) {
   ExprVector predicates;
-  for (size_t extraIndex : extraEdges) {
-    const auto& extra = state.graph.edges()[extraIndex];
-    const auto& leftKeys = extra.leftKeys();
-    const auto& rightKeys = extra.rightKeys();
+  for (size_t index : filterEdges) {
+    const auto& edge = state.graph.edges()[index];
+    const auto& leftKeys = edge.leftKeys();
+    const auto& rightKeys = edge.rightKeys();
     VELOX_CHECK_EQ(leftKeys.size(), rightKeys.size());
     for (size_t i = 0; i < leftKeys.size(); ++i) {
       predicates.push_back(state.exprs.makeEq(leftKeys[i], rightKeys[i]));
@@ -265,7 +264,7 @@ NodeCP emitLeaf(const LeafOp* leaf, EmitState& state) {
 // original Unnest IR node stored on the Unnest relation.
 Emitted buildUnnest(const UnnestOp* unnest, Emitted input, EmitState& state) {
   const auto& edge = state.graph.edges()[unnest->edgeIndex];
-  const int8_t unnestRelId = edge.right().min();
+  const int8_t unnestRelId = edge.rightEndpoints().min();
   const auto* origUnnest =
       state.graph.relation(unnestRelId).node()->as<Unnest>();
 
@@ -285,7 +284,8 @@ Emitted buildUnnest(const UnnestOp* unnest, Emitted input, EmitState& state) {
       substitution,
       state);
   appendAll(
-      predicates, extraEdgeEqualities(unnest->extraEdges, substitution, state));
+      predicates,
+      filterEdgeEqualities(unnest->filterEdges, substitution, state));
 
   // The expansion replicates the columns a consumer above the cover demands,
   // plus those the predicates above read: the Filter sits on this node's
@@ -439,32 +439,32 @@ Emitted buildJoin(
     outputColumns = std::move(*narrowed);
   }
 
-  // If DPhyp chose the swapped orientation, edge.left() covers
+  // If DPhyp chose the swapped orientation, the left eligibility side covers
   // join->right; swap keys.
   ExprVector leftKeys{edge.leftKeys()};
   ExprVector rightKeys{edge.rightKeys()};
-  if (edge.left().isSubset(join->right->cover())) {
+  if (edge.leftEligibility().isSubset(join->right->cover())) {
     std::swap(leftKeys, rightKeys);
   }
 
   // Additional inner edges this join applies (a cyclic join graph can have
   // several edges crossing one partition), each orientation-corrected
-  // independently. Under an inner join they conjoin into its keys. Under an
-  // outer join they cannot: a condition null-pads the rows it rejects, while
-  // these must drop them, so they filter the join's output instead — which is
-  // what applying the inner join above the outer one means. Inner edges carry
-  // no filter (their non-equi conjuncts live in the hypergraph's filter pool).
-  if (isInner) {
-    for (size_t extraIndex : join->extraEdges) {
-      const auto& extra = state.graph.edges()[extraIndex];
-      ExprVector extraLeftKeys{extra.leftKeys()};
-      ExprVector extraRightKeys{extra.rightKeys()};
-      if (extra.left().isSubset(join->right->cover())) {
-        std::swap(extraLeftKeys, extraRightKeys);
-      }
-      appendAll(leftKeys, extraLeftKeys);
-      appendAll(rightKeys, extraRightKeys);
+  // independently. `keyEdges` are guaranteed to split across the two
+  // children, so they conjoin into the join keys. Filter edges are kept
+  // separately.
+  VELOX_DCHECK(isInner || join->keyEdges.empty());
+  for (size_t keyEdgeIndex : join->keyEdges) {
+    const auto& keyEdge = state.graph.edges()[keyEdgeIndex];
+    const bool forward =
+        keyEdge.leftEligibility().isSubset(join->left->cover()) &&
+        keyEdge.rightEligibility().isSubset(join->right->cover());
+    ExprVector keyEdgeLeftKeys{keyEdge.leftKeys()};
+    ExprVector keyEdgeRightKeys{keyEdge.rightKeys()};
+    if (!forward) {
+      std::swap(keyEdgeLeftKeys, keyEdgeRightKeys);
     }
+    appendAll(leftKeys, keyEdgeLeftKeys);
+    appendAll(rightKeys, keyEdgeRightKeys);
   }
 
   ExprVector filter;
@@ -480,14 +480,13 @@ Emitted buildJoin(
   leftKeys = rewrite(leftKeys, substitution, state);
   rightKeys = rewrite(rightKeys, substitution, state);
   filter = rewrite(filter, substitution, state);
-  // A non-inner join applies its own condition — the edge's filter, above —
-  // and everything else this cover makes ready goes above it: the extra edges'
-  // equalities, and the pool conjuncts no child could apply. Neither can join
-  // the condition, which would null-pad the rows they reject instead of
-  // dropping them.
-  ExprVector aboveJoin;
+  // A non-inner join applies its edge filter as the join condition. Conjuncts
+  // newly eligible at this cover and filter-edge equalities run above the
+  // join; putting them in a non-inner condition would null-pad rejected rows
+  // instead of dropping them.
+  ExprVector aboveJoin =
+      filterEdgeEqualities(join->filterEdges, substitution, state);
   if (!isInner) {
-    aboveJoin = extraEdgeEqualities(join->extraEdges, substitution, state);
     appendAll(
         aboveJoin,
         rewrite(
@@ -496,7 +495,7 @@ Emitted buildJoin(
             state));
   }
 
-  // The cover collapses the equated columns of an extra edge to one
+  // The cover collapses the equated columns of a filter edge to one
   // representative, so the narrowed output carries only that one. The filter
   // reads both, and both are emitted by the children — the collapse spans the
   // two child covers, so neither child applied it — so keep them here.

--- a/axiom/optimizer/v2/MemoOp.cpp
+++ b/axiom/optimizer/v2/MemoOp.cpp
@@ -55,7 +55,8 @@ JoinOp::JoinOp(
     size_t edge,
     velox::core::JoinType type,
     bool reversedAnti,
-    std::vector<size_t> extraEdges,
+    std::vector<size_t> keyEdges,
+    std::vector<size_t> filterEdges,
     Partitioning outputPartitioning)
     : MemoOp{cost, MemoOpKind::kJoin, std::move(outputPartitioning)},
       left{leftChild},
@@ -63,7 +64,8 @@ JoinOp::JoinOp(
       edgeIndex{edge},
       joinType{type},
       reversedAnti{reversedAnti},
-      extraEdges{std::move(extraEdges)},
+      keyEdges{std::move(keyEdges)},
+      filterEdges{std::move(filterEdges)},
       cover_{combinedCover(leftChild, rightChild)} {}
 
 UnnestOp::UnnestOp(
@@ -71,12 +73,12 @@ UnnestOp::UnnestOp(
     MemoOpCP inputChild,
     size_t edge,
     RelationSet unnestRelation,
-    std::vector<size_t> extraEdges)
+    std::vector<size_t> filterEdges)
     // Unnest expands rows within a task, so the input's partitioning survives.
     : MemoOp{cost, MemoOpKind::kUnnest, inputChild->outputPartitioning()},
       input{inputChild},
       edgeIndex{edge},
-      extraEdges{std::move(extraEdges)},
+      filterEdges{std::move(filterEdges)},
       cover_{expandedCover(inputChild, unnestRelation)} {}
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/MemoOp.h
+++ b/axiom/optimizer/v2/MemoOp.h
@@ -103,9 +103,10 @@ class LeafOp : public MemoOp {
   }
 };
 
-/// Join entry: combines two child subplans via the predicate at
-/// `graph.edges()[edgeIndex]`. `joinType` records the join
-/// semantic chosen.
+/// Combines two child subplans via the predicate at
+/// `graph.edges()[edgeIndex]`. Key edges contribute additional hash keys and
+/// filter edges become a Filter above the join. `joinType` records the chosen
+/// physical orientation.
 class JoinOp : public MemoOp {
  public:
   MemoOpCP const left;
@@ -121,11 +122,16 @@ class JoinOp : public MemoOp {
   const bool reversedAnti;
 
   /// Additional inner equi-join edges that also cross this join's partition
-  /// and are applied together with `edgeIndex`. Standard DPhyp conjoins all
-  /// predicates connecting the two subgraphs; with a cyclic join graph more
-  /// than one edge can cross a single partition. Empty for the common
-  /// single-edge join; every entry is a `kInner` equi-edge.
-  const std::vector<size_t> extraEdges;
+  /// and supply hash keys. Standard DPhyp conjoins all predicates connecting
+  /// the two subgraphs; with a cyclic join graph more than one edge can cross a
+  /// single partition. Empty for the common single-edge join; every entry is a
+  /// `kInner` equi-edge.
+  const std::vector<size_t> keyEdges;
+
+  /// Inner equi-join edges evaluated by a Filter above this join. The join
+  /// keeps both inputs' columns, so their equalities remain readable without
+  /// participating in the partitioning decision.
+  const std::vector<size_t> filterEdges;
 
   JoinOp(
       Cost cost,
@@ -134,7 +140,8 @@ class JoinOp : public MemoOp {
       size_t edge,
       velox::core::JoinType type,
       bool reversedAnti = false,
-      std::vector<size_t> extraEdges = {},
+      std::vector<size_t> keyEdges = {},
+      std::vector<size_t> filterEdges = {},
       Partitioning outputPartitioning = {});
 
   RelationSet cover() const override {
@@ -146,27 +153,26 @@ class JoinOp : public MemoOp {
 };
 
 /// Unnest entry: expands `input` by the Unnest relation at
-/// `graph.edges()[edgeIndex].right()`, adding that relation to the cover. Unary
-/// because an Unnest has no plan of its own — it produces rows only for the
-/// input it expands — so a relation set containing the Unnest relation is
-/// reachable only through this op, applied once the input relations are
-/// covered. Which input it is applied to is the placement DPhyp costs.
+/// `graph.edges()[edgeIndex].rightEndpoints()`, adding that relation to the
+/// cover. Unary because an Unnest has no plan of its own — it produces rows
+/// only for the input it expands — so a relation set containing the Unnest
+/// relation is reachable only through this op, applied once the input relations
+/// are covered. Which input it is applied to is the placement DPhyp costs.
 class UnnestOp : public MemoOp {
  public:
   MemoOpCP const input;
   const size_t edgeIndex;
 
-  /// Inner equi-join edges that also cross the partition this Unnest was
-  /// applied at, and are applied as a filter above it. See
-  /// `JoinOp::extraEdges`.
-  const std::vector<size_t> extraEdges;
+  /// Inner equi-join edges evaluated by a Filter above this Unnest. The
+  /// expansion keeps the columns their equalities read.
+  const std::vector<size_t> filterEdges;
 
   UnnestOp(
       Cost cost,
       MemoOpCP inputChild,
       size_t edge,
       RelationSet unnestRelation,
-      std::vector<size_t> extraEdges);
+      std::vector<size_t> filterEdges);
 
   RelationSet cover() const override {
     return cover_;

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -145,17 +145,17 @@ folly::F14FastSet<const Join*> markProducersReadInCluster(
 }
 
 // True if some relation appears in an edge's TES but in no edge's left/right
-// endpoints. Such a relation is connected only by correlation (e.g. an outer
-// table referenced inside a decorrelated subquery), so DPhyp — which grows
-// subgraphs along edge endpoints — cannot assemble it. Dissolving a cross
-// join that strands such a relation produces an unplannable graph.
+// key endpoints. Such a relation is connected only by correlation (e.g. an
+// outer table referenced inside a decorrelated subquery), so DPhyp cannot grow
+// a subgraph to include it. Dissolving a cross join that strands such a
+// relation produces an unplannable graph.
 bool hasEndpointStrandedRelation(const JoinHypergraph& graph) {
   RelationSet endpoints;
   RelationSet tesUnion;
-  for (size_t i = 0; i < graph.edges().size(); ++i) {
-    endpoints.unionSet(graph.edges()[i].left());
-    endpoints.unionSet(graph.edges()[i].right());
-    tesUnion.unionSet(graph.tes()[i]);
+  for (const auto& edge : graph.edges()) {
+    endpoints.unionSet(edge.leftEndpoints());
+    endpoints.unionSet(edge.rightEndpoints());
+    tesUnion.unionSet(edge.totalEligibility());
   }
   tesUnion.except(endpoints);
   return !tesUnion.empty();
@@ -436,10 +436,10 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
     JoinHypergraph graph = buildGraph();
 
     // Dissolving a cross join can strand a correlation-only relation (in an
-    // edge's TES but no edge's endpoints), which DPhyp cannot assemble. Redo
-    // without dissolving so that relation stays bundled with its cross-join
-    // partner. Clusters that benefit from dissolution have no stranded
-    // relation and keep the dissolved form.
+    // edge's TES but no edge's key endpoints), which DPhyp cannot assemble.
+    // Redo without dissolving so that relation stays bundled with its
+    // cross-join partner. Clusters that benefit from dissolution have no
+    // stranded relation and keep the dissolved form.
     if (hasEndpointStrandedRelation(graph)) {
       cluster = JoinCluster{};
       cluster.root = node;
@@ -463,7 +463,8 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
       }
       return id;
     };
-    for (const RelationSet& tes : graph.tes()) {
+    for (const auto& edge : graph.edges()) {
+      const RelationSet tes = edge.totalEligibility();
       int32_t representative = -1;
       tes.forEach([&](int32_t id) {
         if (representative < 0) {
@@ -495,8 +496,8 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
         options_.broadcastSizeLimit};
     if (components.size() == 1) {
       MemoOpCP root = dphyp.enumerate();
-      // No costable plan (a relation or join key lacked stats): keep the
-      // cluster in query order.
+      // Enumeration found no valid costable plan; keep the cluster in query
+      // order.
       if (root == nullptr) {
         return rewriteUnclusteredJoin(node, context);
       }

--- a/axiom/optimizer/v2/PlanPhysicalPass.h
+++ b/axiom/optimizer/v2/PlanPhysicalPass.h
@@ -38,8 +38,8 @@ class PlanPhysicalPass {
   ///
   /// When `options.syntacticJoinOrder` is true, cost-based reordering is
   /// disabled and every join keeps the order written in the query. The same
-  /// query-order fallback also kicks in per cluster when DPhyp cannot cost a
-  /// plan (a relation or join key lacked statistics).
+  /// query-order fallback also kicks in per cluster when DPhyp produces no
+  /// valid costable plan.
   /// `options.dphypEnumerationBudget` caps DPhyp's enumeration before it falls
   /// back to greedy join ordering; <= 0 means unlimited. `numWorkers` is the
   /// target task count; when > 1 the walk generates remote-exchange candidates

--- a/axiom/optimizer/v2/docs/JoinEnumerationScaling.md
+++ b/axiom/optimizer/v2/docs/JoinEnumerationScaling.md
@@ -26,7 +26,7 @@ This is the worst case for both enumerators, for different reasons:
   (orderings × join-method × build-side at each level) — super-factorial. It is
   the *tie* that disables pruning, not the raw ordering count, which is why even
   N=6 hangs.
-- **v2 DPhyp** (Moerkotte/Neumann 2006) is a memoized bottom-up DP over connected
+- **v2 DPhyp** (Moerkotte/Neumann 2008) is a memoized bottom-up DP over connected
   subgraph / complement pairs. It has no pruning to disable, so ties don't hurt
   it — but on a clique the number of csg-cmp pairs is `3^N - 2^(N+1) + 1` ≈ **3^N**
   (vs polynomial ~O(N^3) on a plain chain). Exponential, but far below N!.

--- a/axiom/optimizer/v2/tests/JoinHypergraphTest.cpp
+++ b/axiom/optimizer/v2/tests/JoinHypergraphTest.cpp
@@ -15,7 +15,12 @@
  */
 
 #include "axiom/optimizer/v2/JoinHypergraph.h"
+
+#include <array>
+
 #include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/EstimateProvider.h"
+#include "axiom/optimizer/v2/HypergraphBuilder.h"
 #include "axiom/optimizer/v2/tests/UnitTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
 
@@ -25,12 +30,45 @@ namespace {
 class JoinHypergraphTest : public UnitTestBase {
  protected:
   NodeCP makeLeaf() {
-    optimizer::ColumnVector columns{makeColumn("a", velox::BIGINT())};
-    return builder_->makeEmptyValues(std::move(columns));
+    return makeLeaf("a");
   }
 
   ExprCP makePredicate() {
     return builder_->makeBoolean(true);
+  }
+
+  NodeCP makeLeaf(std::string_view name) {
+    optimizer::ColumnVector columns{makeColumn(name, velox::BIGINT())};
+    return builder_->makeEmptyValues(std::move(columns));
+  }
+
+  JoinCP
+  makeEquiJoin(NodeCP left, NodeCP right, velox::core::JoinType joinType) {
+    using velox::core::JoinType;
+    ColumnVector outputColumns;
+    switch (joinType) {
+      case JoinType::kRightSemiFilter:
+        outputColumns = right->outputColumns();
+        break;
+      case JoinType::kRightSemiProject:
+        outputColumns = right->outputColumns();
+        outputColumns.push_back(makeColumn("mark", velox::BOOLEAN()));
+        break;
+      default:
+        outputColumns = left->outputColumns();
+        outputColumns.insert(
+            outputColumns.end(),
+            right->outputColumns().begin(),
+            right->outputColumns().end());
+    }
+    return builder_->make<Join>(Join::Key{
+        .left = left,
+        .right = right,
+        .joinType = joinType,
+        .leftKeys = {left->outputColumns().front()},
+        .rightKeys = {right->outputColumns().front()},
+        .outputColumns = std::move(outputColumns),
+    });
   }
 };
 
@@ -48,10 +86,10 @@ TEST_F(JoinHypergraphTest, connectivity) {
   aSet.add(aId);
   RelationSet bSet;
   bSet.add(bId);
-  RelationSet abSet{aSet};
-  abSet.unionSet(bSet);
   graph.addEdge(
       JoinEdge{
+          aSet,
+          bSet,
           aSet,
           bSet,
           ExprVector{makePredicate()},
@@ -59,16 +97,15 @@ TEST_F(JoinHypergraphTest, connectivity) {
           ExprVector{},
           velox::core::JoinType::kInner,
           /*nullAware=*/false,
-          /*nullAsValue=*/false},
-      abSet);
+          /*nullAsValue=*/false});
   VELOX_ASSERT_THROW(graph.checkConsistency(), "not connected");
 
   RelationSet cSet;
   cSet.add(cId);
-  RelationSet bcSet{bSet};
-  bcSet.unionSet(cSet);
   graph.addEdge(
       JoinEdge{
+          bSet,
+          cSet,
           bSet,
           cSet,
           ExprVector{makePredicate()},
@@ -76,9 +113,92 @@ TEST_F(JoinHypergraphTest, connectivity) {
           ExprVector{},
           velox::core::JoinType::kInner,
           /*nullAware=*/false,
-          /*nullAsValue=*/false},
-      bcSet);
+          /*nullAsValue=*/false});
   ASSERT_NO_THROW(graph.checkConsistency());
+}
+
+// A non-inner join remains pinned to its complete normalized operands even
+// when its keys reference only one relation on each side.
+TEST_F(JoinHypergraphTest, nonInnerEligibility) {
+  using velox::core::JoinType;
+  struct TestCase {
+    JoinType inputType;
+    JoinType normalizedType;
+    bool rightForm;
+  };
+  const std::array<TestCase, 4> testCases{{
+      {JoinType::kLeft, JoinType::kLeft, false},
+      {JoinType::kRight, JoinType::kLeft, true},
+      {JoinType::kRightSemiFilter, JoinType::kLeftSemiFilter, true},
+      {JoinType::kRightSemiProject, JoinType::kLeftSemiProject, true},
+  }};
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(velox::core::JoinTypeName::toName(testCase.inputType));
+    NodeCP a = makeLeaf("a");
+    NodeCP b = makeLeaf("b");
+    NodeCP x = makeLeaf("x");
+    JoinCP bx = makeEquiJoin(b, x, JoinType::kInner);
+    JoinCP root = testCase.rightForm ? makeEquiJoin(bx, a, testCase.inputType)
+                                     : makeEquiJoin(a, bx, testCase.inputType);
+
+    JoinCluster cluster{
+        .root = root,
+        .leaves = {a, b, x},
+        .joins = {root, bx},
+    };
+    EstimateProvider estimateProvider;
+    const JoinHypergraph graph =
+        HypergraphBuilder::build(cluster, cluster.leaves, estimateProvider);
+
+    const JoinEdge* rootEdge = nullptr;
+    for (const auto& edge : graph.edges()) {
+      if (edge.joinType() == testCase.normalizedType) {
+        rootEdge = &edge;
+        break;
+      }
+    }
+    ASSERT_NE(rootEdge, nullptr);
+
+    const RelationSet aSet = RelationSet::singleton(0);
+    const RelationSet bSet = RelationSet::singleton(1);
+    RelationSet bxSet{bSet};
+    bxSet.add(2);
+    EXPECT_EQ(rootEdge->leftEndpoints(), aSet);
+    EXPECT_EQ(rootEdge->rightEndpoints(), bSet);
+    EXPECT_EQ(rootEdge->leftEligibility(), aSet);
+    EXPECT_EQ(rootEdge->rightEligibility(), bxSet);
+  }
+}
+
+// A relation required only for eligibility still belongs to the edge's
+// connected component.
+TEST_F(JoinHypergraphTest, connectedViaEligibility) {
+  JoinHypergraph graph;
+  const RelationSet aSet =
+      RelationSet::singleton(graph.addRelation(makeLeaf(), 100, {}));
+  const RelationSet bSet =
+      RelationSet::singleton(graph.addRelation(makeLeaf(), 200, {}));
+  const RelationSet xSet =
+      RelationSet::singleton(graph.addRelation(makeLeaf(), 300, {}));
+  RelationSet rightEligibility{bSet};
+  rightEligibility.unionSet(xSet);
+  graph.addEdge(
+      JoinEdge{
+          aSet,
+          bSet,
+          aSet,
+          rightEligibility,
+          ExprVector{makePredicate()},
+          ExprVector{makePredicate()},
+          ExprVector{},
+          velox::core::JoinType::kInner,
+          /*nullAware=*/false,
+          /*nullAsValue=*/false});
+
+  RelationSet allRelations{aSet};
+  allRelations.unionSet(rightEligibility);
+  EXPECT_EQ(graph.connectedComponent(aSet, allRelations), allRelations);
 }
 
 // Relation ids are bounded by `RelationSet::kMaxRelations`. The


### PR DESCRIPTION
Summary:

The v2 optimizer can drop an equality while reordering joins and return rows excluded by the query. For example:

```sql
WITH ids (id) AS (VALUES (1)),
     labels (id, label) AS (VALUES (1, 'a'), (1, 'b')),
     extra (id) AS (VALUES (1)),
     labeled AS (
       SELECT ids.id, labels.label
       FROM ids
       JOIN labels ON labels.id = ids.id
       LEFT JOIN extra ON extra.id = ids.id)
SELECT count(*)
FROM labeled AS x
JOIN labeled AS y ON x.id = y.id AND x.label = y.label
```

This returns 4 instead of 2 because the reordered plan joins on `id` but never applies `x.label = y.label`.

In DPhyp (Moerkotte and Neumann, “Dynamic Programming Strikes Back,” SIGMOD 2008), an edge applies when its two sides lie in opposite partition members. Conflict detection generalizes those endpoints into left and right total eligibility sets. Our implementation instead tested key endpoints and a separate, unoriented total eligibility set. Consequently, an edge could be unavailable when its endpoints split and no longer split when all eligibility relations were present, so its predicate was applied nowhere.

`JoinEdge` now stores oriented eligibility sides separately from key endpoints, and partition applicability uses those sides. Constructing them requires complete normalized input covers, including dependent `Unnest` relations; the associated Unnest changes preserve existing placement behavior.

When an inner equality is eligible but cannot serve as a key for the selected partition, it is recorded in `filterEdges` and emitted as a Filter above the join. This is sound because an inner join retains both inputs’ columns. Equivalent non-inner partitions remain rejected because moving their equality would change null-padding or existence semantics.

Reviewed By: mbasmanova

Differential Revision: D115500970


