### PR TITLE
fix(optimizer): Register nested UNNESTs in dependency order

### DIFF
--- a/axiom/optimizer/tests/sql/unnest.sql
+++ b/axiom/optimizer/tests/sql/unnest.sql
@@ -104,3 +104,10 @@ WHERE EXISTS (
   SELECT 1
   FROM (VALUES (ARRAY[8, 5])) AS m(data) CROSS JOIN UNNEST(data) AS t(e)
   WHERE e > a.x)
+----
+-- Returns the innermost element that matches the joined value 1.
+SELECT c
+FROM arrays AS t
+CROSS JOIN UNNEST(t.nested) AS n(b)
+CROSS JOIN UNNEST(n.b) AS m(c)
+JOIN (VALUES (1)) AS u(x) ON c = u.x

--- a/axiom/optimizer/v2/HypergraphBuilder.cpp
+++ b/axiom/optimizer/v2/HypergraphBuilder.cpp
@@ -357,10 +357,9 @@ JoinHypergraph HypergraphBuilder::build(
     }
   }
 
-  // Admit Unnest relations and extend the column-resolution map so the
-  // Unnest's produced columns resolve to the Unnest's relation id.
-  // Innermost first, so a dependent Unnest sees the Unnest feeding its
-  // input already registered.
+  // Admit Unnest relations in post-order so input Unnests receive lower ids
+  // than the Unnests that depend on them. Extend the column-resolution map so
+  // each Unnest's produced columns resolve to its relation id.
   folly::F14FastMap<UnnestCP, int8_t> unnestIds;
   for (UnnestCP unnest : cluster.unnests) {
     PlanObjectSet producedColumns;

--- a/axiom/optimizer/v2/JoinCluster.h
+++ b/axiom/optimizer/v2/JoinCluster.h
@@ -32,10 +32,11 @@ namespace facebook::axiom::optimizer::v2 {
 ///
 /// `unnests` records Unnest IR nodes the cluster collection
 /// descended through. Each becomes its own relation in the
-/// hypergraph, connected to the leaves contributed by its input
-/// subtree via an unnest edge. Order is descent order (innermost
-/// first) so dependent chains (`UNNEST(u1.x) u2`) have `u1`'s
-/// cardinality computed before `u2`'s.
+/// hypergraph, connected to the relations contributed by its input
+/// subtree via an unnest edge. Order is post order, i.e., an input Unnest
+/// appears before any Unnest that consumes its output, so input relations
+/// receive lower ids than the dependent Unnest, as required by DPhyp
+/// enumeration.
 struct JoinCluster {
   JoinCP root;
   std::vector<NodeCP> leaves;

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -99,7 +99,6 @@ void collectCluster(
   }
   if (node->is(NodeType::kUnnest)) {
     const auto* unnest = node->as<Unnest>();
-    cluster.unnests.push_back(unnest);
     // An Unnest of a constant, as in UNNEST(ARRAY[1, 2]), reads a subtree that
     // produces no columns. No predicate can reference it, so it is not a
     // relation of the cluster; the Unnest emits it as its own input.
@@ -107,6 +106,8 @@ void collectCluster(
     if (!input->outputColumns().empty()) {
       collectCluster(input, cluster, dissolveCrossJoins);
     }
+    // Preserve JoinCluster's post-order invariant.
+    cluster.unnests.push_back(unnest);
     return;
   }
   cluster.leaves.push_back(node);


### PR DESCRIPTION
Summary:
A query that joins a value produced by nested UNNESTs failed during V2 optimizer planning:

    VeloxRuntimeError, INVALID_STATE
    Reason: (4 vs. 3)

The root cause is that DPhyp requires an UNNEST's input relations to have lower relation IDs than the dependent UNNEST. However, join-cluster collection recorded an UNNEST before descending into its input, assigning nested UNNEST relations in the opposite order.

This PR fixes this issue by recording UNNESTs in post-order so each input is registered before the UNNEST that depends on it.

Differential Revision: D115529964


