### PR TITLE
refactor(stats): Reuse ConcurrentRuntimeStatWriter (#1697)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -101,10 +101,10 @@ class PhaseTimer {
     // read it below.
     timer_.reset();
     if (runtimeStats_ != nullptr) {
-      runtimeStats_->recordTiming(
+      runtimeStats_->addTiming(
           wallKey_, std::chrono::microseconds(wallMicros_));
       const auto cpuNs = velox::process::threadCpuNanos() - cpuStartNanos_;
-      runtimeStats_->recordTiming(cpuKey_, std::chrono::nanoseconds(cpuNs));
+      runtimeStats_->addTiming(cpuKey_, std::chrono::nanoseconds(cpuNs));
     }
   }
 
@@ -691,10 +691,10 @@ SqlQueryRunner::co_run(std::string sql, RunOptions options) {
     }
     completionInfo.startInfo.queryType = statement->kind();
     completionInfo.referencedTables = statement->referencedTables();
-    completionInfo.runtimeStats->recordTiming(
+    completionInfo.runtimeStats->addTiming(
         QueryRuntimeStats::kParseWallNanos,
         std::chrono::microseconds(completionInfo.timing.parse));
-    completionInfo.runtimeStats->recordTiming(
+    completionInfo.runtimeStats->addTiming(
         QueryRuntimeStats::kParseCpuNanos,
         std::chrono::nanoseconds(parseCpuNanos));
 
@@ -705,12 +705,12 @@ SqlQueryRunner::co_run(std::string sql, RunOptions options) {
           completionInfo,
           statement->views(),
           statement->referencedTables());
-      completionInfo.runtimeStats->recordTiming(
+      completionInfo.runtimeStats->addTiming(
           QueryRuntimeStats::kPermissionCheckCpuNanos,
           std::chrono::nanoseconds(
               velox::process::threadCpuNanos() - permissionCpuStart));
     }
-    completionInfo.runtimeStats->recordTiming(
+    completionInfo.runtimeStats->addTiming(
         QueryRuntimeStats::kPermissionCheckWallNanos,
         std::chrono::microseconds(completionInfo.timing.checkPermission));
 
@@ -1558,10 +1558,10 @@ folly::coro::AsyncGenerator<velox::RowVectorPtr> co_drainQuery(
   }
 
   if (runtimeStats != nullptr) {
-    runtimeStats->recordTiming(
+    runtimeStats->addTiming(
         QueryRuntimeStats::kExecuteWallNanos,
         std::chrono::microseconds(wallMicros));
-    runtimeStats->recordTiming(
+    runtimeStats->addTiming(
         QueryRuntimeStats::kExecuteCpuNanos,
         std::chrono::nanoseconds(executionCpuNanos(runner)));
   }
@@ -1768,22 +1768,22 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
   }
 
   if (runtimeStats) {
-    runtimeStats->recordTiming(
+    runtimeStats->addTiming(
         QueryRuntimeStats::kOptimizeToGraphWallNanos,
         std::chrono::nanoseconds(toGraphNanos));
-    runtimeStats->recordTiming(
+    runtimeStats->addTiming(
         QueryRuntimeStats::kOptimizeToGraphCpuNanos,
         std::chrono::nanoseconds(toGraphCpuNanos));
-    runtimeStats->recordTiming(
+    runtimeStats->addTiming(
         QueryRuntimeStats::kOptimizeBestPlanWallNanos,
         std::chrono::nanoseconds(bestPlanNanos));
-    runtimeStats->recordTiming(
+    runtimeStats->addTiming(
         QueryRuntimeStats::kOptimizeBestPlanCpuNanos,
         std::chrono::nanoseconds(bestPlanCpuNanos));
-    runtimeStats->recordTiming(
+    runtimeStats->addTiming(
         QueryRuntimeStats::kOptimizeToVeloxWallNanos,
         std::chrono::nanoseconds(toVeloxNanos));
-    runtimeStats->recordTiming(
+    runtimeStats->addTiming(
         QueryRuntimeStats::kOptimizeToVeloxCpuNanos,
         std::chrono::nanoseconds(toVeloxCpuNanos));
   }

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -629,10 +629,10 @@ TEST_F(SqlQueryRunnerTest, executionCpuTimingUsesVeloxTaskStats) {
 
   ASSERT_TRUE(finalProgress.has_value());
   ASSERT_NE(completion.runtimeStats, nullptr);
-  const auto runtimeStats = completion.runtimeStats->toMap();
-  const auto executeCpuMetric = runtimeStats.find(
+  const auto metrics = completion.runtimeStats->runtimeStats();
+  const auto executeCpuMetric = metrics.find(
       std::string(facebook::axiom::QueryRuntimeStats::kExecuteCpuNanos));
-  ASSERT_NE(executeCpuMetric, runtimeStats.end());
+  ASSERT_NE(executeCpuMetric, metrics.end());
 
   const auto progressCpuNanos = finalProgress->stats.cpuTimeMicros * 1'000;
   EXPECT_GT(progressCpuNanos, 0);

--- a/axiom/common/QueryRuntimeStats.cpp
+++ b/axiom/common/QueryRuntimeStats.cpp
@@ -19,13 +19,6 @@
 namespace facebook::axiom {
 
 namespace {
-bool runtimeMetricEquals(
-    const velox::RuntimeMetric& lhs,
-    const velox::RuntimeMetric& rhs) {
-  return lhs.sum == rhs.sum && lhs.count == rhs.count && lhs.min == rhs.min &&
-      lhs.max == rhs.max && lhs.unit == rhs.unit;
-}
-
 std::string_view unitToString(velox::RuntimeCounter::Unit unit) {
   switch (unit) {
     case velox::RuntimeCounter::Unit::kNanos:
@@ -39,84 +32,9 @@ std::string_view unitToString(velox::RuntimeCounter::Unit unit) {
 }
 } // namespace
 
-void mergeRuntimeMetric(
-    folly::ConcurrentHashMap<std::string, velox::RuntimeMetric>& map,
-    const std::string& name,
-    const velox::RuntimeMetric& metric) {
-  auto [it, inserted] = map.try_emplace(name, metric);
-  if (inserted) {
-    return;
-  }
-  while (true) {
-    auto current = it->second;
-    auto updated = current;
-    updated.merge(metric);
-    auto result = map.assign_if(
-        name,
-        std::move(updated),
-        [&current](const velox::RuntimeMetric& existing) {
-          return runtimeMetricEquals(existing, current);
-        });
-    if (result.has_value()) {
-      return;
-    }
-    it = map.find(name);
-    if (it == map.cend()) {
-      std::tie(it, inserted) = map.try_emplace(name, metric);
-      if (inserted) {
-        return;
-      }
-    }
-  }
-}
-
-void QueryRuntimeStats::recordTiming(
-    std::string_view name,
-    std::chrono::nanoseconds duration) {
-  mergeRuntimeMetric(
-      metrics_,
-      std::string(name),
-      velox::RuntimeMetric(
-          duration.count(), velox::RuntimeCounter::Unit::kNanos));
-}
-
-void QueryRuntimeStats::recordCount(std::string_view name, int64_t value) {
-  mergeRuntimeMetric(
-      metrics_,
-      std::string(name),
-      velox::RuntimeMetric(value, velox::RuntimeCounter::Unit::kNone));
-}
-
-void QueryRuntimeStats::merge(
-    std::string_view name,
-    const velox::RuntimeMetric& metric) {
-  mergeRuntimeMetric(metrics_, std::string(name), metric);
-}
-
-void QueryRuntimeStats::setRuntimeStat(
-    std::string_view name,
-    const velox::RuntimeMetric& metric) {
-  metrics_.insert_or_assign(std::string(name), metric);
-}
-
-void QueryRuntimeStats::addRuntimeStat(
-    std::string_view name,
-    const velox::RuntimeCounter& counter) {
-  merge(name, velox::RuntimeMetric(counter.value, counter.unit));
-}
-
-std::unordered_map<std::string, velox::RuntimeMetric> QueryRuntimeStats::toMap()
-    const {
-  std::unordered_map<std::string, velox::RuntimeMetric> result;
-  for (const auto& [name, metric] : metrics_) {
-    result.emplace(name, metric);
-  }
-  return result;
-}
-
 folly::dynamic QueryRuntimeStats::toDynamic() const {
   folly::dynamic result = folly::dynamic::object();
-  for (const auto& [name, metric] : metrics_) {
+  for (const auto& [name, metric] : runtimeStats()) {
     folly::dynamic entry = folly::dynamic::object();
     entry["name"] = name;
     entry["sum"] = metric.sum;
@@ -132,10 +50,10 @@ folly::dynamic QueryRuntimeStats::toDynamic() const {
 ScopedCpuWallStatsTimer::~ScopedCpuWallStatsTimer() {
   if (std::this_thread::get_id() == startThreadId_) {
     auto cpuElapsed = velox::process::threadCpuNanos() - cpuStart_;
-    stats_.recordTiming(cpuMetricName_, std::chrono::nanoseconds(cpuElapsed));
+    stats_.addTiming(cpuMetricName_, std::chrono::nanoseconds(cpuElapsed));
   }
   auto wallElapsed = std::chrono::steady_clock::now() - wallStart_;
-  stats_.recordTiming(wallMetricName_, wallElapsed);
+  stats_.addTiming(wallMetricName_, wallElapsed);
 }
 
 } // namespace facebook::axiom

--- a/axiom/common/QueryRuntimeStats.h
+++ b/axiom/common/QueryRuntimeStats.h
@@ -17,25 +17,20 @@
 #pragma once
 
 #include <chrono>
-#include <string>
 #include <string_view>
 #include <thread>
-#include <unordered_map>
 
-#include <folly/concurrency/ConcurrentHashMap.h>
 #include <folly/dynamic.h>
 
-#include "velox/common/base/RuntimeMetrics.h"
+#include "velox/common/base/ConcurrentRuntimeStatWriter.h"
 #include "velox/common/process/ProcessBase.h"
 
 namespace facebook::axiom {
 
-/// Accumulates runtime metrics from Axiom's query pipeline (parser, optimizer,
-/// split manager, runner). Each metric is a velox::RuntimeMetric with
-/// sum/count/min/max. Thread-safe — multiple pipeline stages may record
-/// concurrently. Implements velox::BaseRuntimeStatWriter so instrumented Velox
-/// components (e.g. velox::TrackedExecutor) can report directly into it.
-class QueryRuntimeStats : public velox::BaseRuntimeStatWriter {
+/// Names the runtime metrics Axiom's query pipeline records and serializes them
+/// for logging; the accumulate-by-name store is the base's. Thread-safe, so
+/// pipeline stages may record concurrently.
+class QueryRuntimeStats : public velox::ConcurrentRuntimeStatWriter {
  public:
   // Parser.
   static constexpr std::string_view kParseWallNanos{"axiom-parseWallNanos"};
@@ -91,33 +86,9 @@ class QueryRuntimeStats : public velox::BaseRuntimeStatWriter {
   static constexpr std::string_view kExecuteWallNanos{"axiom-executeWallNanos"};
   static constexpr std::string_view kExecuteCpuNanos{"axiom-executeCpuNanos"};
 
-  /// Records a wall-clock duration under the given metric name.
-  void recordTiming(std::string_view name, std::chrono::nanoseconds duration);
-
-  /// Records a count (e.g., number of partitions or splits).
-  void recordCount(std::string_view name, int64_t value);
-
-  /// Merges a pre-aggregated metric into this recorder.
-  void merge(std::string_view name, const velox::RuntimeMetric& metric);
-
-  /// Sets 'metric' under 'name', replacing any existing value.
-  void setRuntimeStat(std::string_view name, const velox::RuntimeMetric& metric)
-      override;
-
-  /// Adds 'counter' as one sample under 'name', accumulating across calls.
-  void addRuntimeStat(
-      std::string_view name,
-      const velox::RuntimeCounter& counter) override;
-
-  /// Returns a snapshot of all recorded metrics.
-  std::unordered_map<std::string, velox::RuntimeMetric> toMap() const;
-
   /// Serializes all metrics to folly::dynamic for Scribe logging. Format:
   /// {"metricName": {"sum": N, "count": N, "min": N, "max": N, "unit": "..."}}
   folly::dynamic toDynamic() const;
-
- private:
-  folly::ConcurrentHashMap<std::string, velox::RuntimeMetric> metrics_;
 };
 
 /// RAII timer that records a wall-clock duration into QueryRuntimeStats on
@@ -131,7 +102,7 @@ class ScopedRuntimeStatsTimer {
         start_(std::chrono::steady_clock::now()) {}
 
   ~ScopedRuntimeStatsTimer() {
-    stats_.recordTiming(metricName_, std::chrono::steady_clock::now() - start_);
+    stats_.addTiming(metricName_, std::chrono::steady_clock::now() - start_);
   }
 
   ScopedRuntimeStatsTimer(const ScopedRuntimeStatsTimer&) = delete;
@@ -186,17 +157,10 @@ inline void recordCpuIfSameThread(
     uint64_t cpuStart,
     std::thread::id startThreadId) {
   if (std::this_thread::get_id() == startThreadId) {
-    stats.recordTiming(
+    stats.addTiming(
         metricName,
         std::chrono::nanoseconds(velox::process::threadCpuNanos() - cpuStart));
   }
 }
-
-/// Merges 'metric' into 'map' under 'name' using CAS-based optimistic locking.
-/// Shared by QueryRuntimeStats and SchedulerStatsRecorder.
-void mergeRuntimeMetric(
-    folly::ConcurrentHashMap<std::string, velox::RuntimeMetric>& map,
-    const std::string& name,
-    const velox::RuntimeMetric& metric);
 
 } // namespace facebook::axiom

--- a/axiom/common/tests/QueryRuntimeStatsTest.cpp
+++ b/axiom/common/tests/QueryRuntimeStatsTest.cpp
@@ -16,108 +16,18 @@
 
 #include "axiom/common/QueryRuntimeStats.h"
 
-#include <thread>
-
 #include <folly/BenchmarkUtil.h>
-#include <folly/json.h>
+#include <folly/dynamic.h>
 #include <gtest/gtest.h>
 
 namespace facebook::axiom {
 namespace {
 
-TEST(QueryRuntimeStatsTest, recordTiming) {
-  QueryRuntimeStats stats;
-  stats.recordTiming(
-      QueryRuntimeStats::kParseWallNanos, std::chrono::nanoseconds(100));
-  stats.recordTiming(
-      QueryRuntimeStats::kParseWallNanos, std::chrono::nanoseconds(200));
-
-  auto map = stats.toMap();
-  ASSERT_EQ(map.count(std::string(QueryRuntimeStats::kParseWallNanos)), 1);
-  auto& metric = map.at(std::string(QueryRuntimeStats::kParseWallNanos));
-  EXPECT_EQ(metric.sum, 300);
-  EXPECT_EQ(metric.count, 2);
-  EXPECT_EQ(metric.min, 100);
-  EXPECT_EQ(metric.max, 200);
-  EXPECT_EQ(metric.unit, velox::RuntimeCounter::Unit::kNanos);
-}
-
-TEST(QueryRuntimeStatsTest, recordCount) {
-  QueryRuntimeStats stats;
-  stats.recordCount(QueryRuntimeStats::kListPartitionsCount, 10);
-  stats.recordCount(QueryRuntimeStats::kListPartitionsCount, 5);
-
-  auto map = stats.toMap();
-  ASSERT_EQ(map.count(std::string(QueryRuntimeStats::kListPartitionsCount)), 1);
-  auto& metric = map.at(std::string(QueryRuntimeStats::kListPartitionsCount));
-  EXPECT_EQ(metric.sum, 15);
-  EXPECT_EQ(metric.count, 2);
-  EXPECT_EQ(metric.min, 5);
-  EXPECT_EQ(metric.max, 10);
-  EXPECT_EQ(metric.unit, velox::RuntimeCounter::Unit::kNone);
-}
-
-TEST(QueryRuntimeStatsTest, merge) {
-  QueryRuntimeStats stats;
-
-  velox::RuntimeMetric existing(500, velox::RuntimeCounter::Unit::kNanos);
-  existing.addValue(300);
-  stats.merge(QueryRuntimeStats::kOptimizeWallNanos, existing);
-
-  auto map = stats.toMap();
-  auto& metric = map.at(std::string(QueryRuntimeStats::kOptimizeWallNanos));
-  EXPECT_EQ(metric.sum, 800);
-  EXPECT_EQ(metric.count, 2);
-  EXPECT_EQ(metric.min, 300);
-  EXPECT_EQ(metric.max, 500);
-}
-
-TEST(QueryRuntimeStatsTest, setRuntimeStat) {
-  QueryRuntimeStats stats;
-  velox::BaseRuntimeStatWriter& writer = stats;
-
-  velox::RuntimeMetric first(100, velox::RuntimeCounter::Unit::kNanos);
-  writer.setRuntimeStat(QueryRuntimeStats::kOptimizeWallNanos, first);
-
-  velox::RuntimeMetric second(500, velox::RuntimeCounter::Unit::kNanos);
-  second.addValue(300);
-  writer.setRuntimeStat(QueryRuntimeStats::kOptimizeWallNanos, second);
-
-  // The second value replaces the first rather than accumulating.
-  auto map = stats.toMap();
-  auto& metric = map.at(std::string(QueryRuntimeStats::kOptimizeWallNanos));
-  EXPECT_EQ(metric.sum, 800);
-  EXPECT_EQ(metric.count, 2);
-  EXPECT_EQ(metric.min, 300);
-  EXPECT_EQ(metric.max, 500);
-  EXPECT_EQ(metric.unit, velox::RuntimeCounter::Unit::kNanos);
-}
-
-TEST(QueryRuntimeStatsTest, addRuntimeStat) {
-  QueryRuntimeStats stats;
-  velox::BaseRuntimeStatWriter& writer = stats;
-
-  writer.addRuntimeStat(
-      QueryRuntimeStats::kGetSplitsCount,
-      velox::RuntimeCounter(7, velox::RuntimeCounter::Unit::kNone));
-  writer.addRuntimeStat(
-      QueryRuntimeStats::kGetSplitsCount,
-      velox::RuntimeCounter(3, velox::RuntimeCounter::Unit::kNone));
-
-  auto map = stats.toMap();
-  auto& metric = map.at(std::string(QueryRuntimeStats::kGetSplitsCount));
-  EXPECT_EQ(metric.sum, 10);
-  EXPECT_EQ(metric.count, 2);
-  EXPECT_EQ(metric.min, 3);
-  EXPECT_EQ(metric.max, 7);
-  EXPECT_EQ(metric.unit, velox::RuntimeCounter::Unit::kNone);
-}
-
 TEST(QueryRuntimeStatsTest, toDynamic) {
   QueryRuntimeStats stats;
-  stats.recordTiming(
+  stats.addTiming(
       QueryRuntimeStats::kParseWallNanos, std::chrono::nanoseconds(1000));
-  stats.recordCount(QueryRuntimeStats::kGetSplitsCount, 42);
+  stats.addCount(QueryRuntimeStats::kGetSplitsCount, 42);
 
   auto dynamic = stats.toDynamic();
   ASSERT_TRUE(dynamic.isObject());
@@ -127,6 +37,8 @@ TEST(QueryRuntimeStatsTest, toDynamic) {
   EXPECT_EQ(dynamic[parseKey]["name"].asString(), parseKey);
   EXPECT_EQ(dynamic[parseKey]["sum"].asInt(), 1000);
   EXPECT_EQ(dynamic[parseKey]["count"].asInt(), 1);
+  EXPECT_EQ(dynamic[parseKey]["min"].asInt(), 1000);
+  EXPECT_EQ(dynamic[parseKey]["max"].asInt(), 1000);
   EXPECT_EQ(dynamic[parseKey]["unit"].asString(), "NANO");
 
   auto splitsKey = std::string(QueryRuntimeStats::kGetSplitsCount);
@@ -138,37 +50,11 @@ TEST(QueryRuntimeStatsTest, toDynamic) {
 
 TEST(QueryRuntimeStatsTest, emptyStats) {
   QueryRuntimeStats stats;
-  EXPECT_TRUE(stats.toMap().empty());
+  EXPECT_TRUE(stats.runtimeStats().empty());
 
   auto dynamic = stats.toDynamic();
   ASSERT_TRUE(dynamic.isObject());
   EXPECT_TRUE(dynamic.empty());
-}
-
-TEST(QueryRuntimeStatsTest, concurrentRecording) {
-  QueryRuntimeStats stats;
-  constexpr int kThreads = 8;
-  constexpr int kIterations = 1000;
-
-  std::vector<std::thread> threads;
-  threads.reserve(kThreads);
-  for (int i = 0; i < kThreads; ++i) {
-    threads.emplace_back([&stats]() {
-      for (int j = 0; j < kIterations; ++j) {
-        stats.recordTiming(
-            QueryRuntimeStats::kExecuteWallNanos, std::chrono::nanoseconds(1));
-      }
-    });
-  }
-
-  for (auto& t : threads) {
-    t.join();
-  }
-
-  auto map = stats.toMap();
-  auto& metric = map.at(std::string(QueryRuntimeStats::kExecuteWallNanos));
-  EXPECT_EQ(metric.sum, kThreads * kIterations);
-  EXPECT_EQ(metric.count, kThreads * kIterations);
 }
 
 TEST(QueryRuntimeStatsTest, scopedCpuWallStatsTimer) {
@@ -184,7 +70,7 @@ TEST(QueryRuntimeStatsTest, scopedCpuWallStatsTimer) {
     }
     folly::doNotOptimizeAway(sum);
   }
-  auto map = stats.toMap();
+  auto map = stats.runtimeStats();
   ASSERT_EQ(map.count(std::string(QueryRuntimeStats::kParseWallNanos)), 1);
   ASSERT_EQ(map.count(std::string(QueryRuntimeStats::kParseCpuNanos)), 1);
 
@@ -197,7 +83,7 @@ TEST(QueryRuntimeStatsTest, scopedCpuWallStatsTimer) {
 
 TEST(QueryRuntimeStatsTest, cpuMetricNaming) {
   QueryRuntimeStats stats;
-  stats.recordTiming(
+  stats.addTiming(
       QueryRuntimeStats::kFindTableCpuNanos, std::chrono::nanoseconds(5000));
 
   auto dynamic = stats.toDynamic();

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -218,7 +218,7 @@ void Optimization::estimateAllBaseTableSelectivity(DerivedTable& dt) {
         QueryRuntimeStats::kEstimateStatsCpuNanos,
         estimateCpuStart,
         estimateThreadId);
-    runtimeStats_->recordTiming(
+    runtimeStats_->addTiming(
         QueryRuntimeStats::kEstimateStatsWallNanos,
         std::chrono::steady_clock::now() - estimateStart);
   }

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -274,11 +274,11 @@ SchemaTableCP FOLLY_NULLABLE Schema::findTable(
   auto findStart = std::chrono::steady_clock::now();
   auto connectorTable = source_->findTable(std::string(connectorId), tableName);
   if (runtimeStats_) {
-    runtimeStats_->recordTiming(
+    runtimeStats_->addTiming(
         QueryRuntimeStats::kFindTableCpuNanos,
         std::chrono::nanoseconds(
             velox::process::threadCpuNanos() - findCpuStart));
-    runtimeStats_->recordTiming(
+    runtimeStats_->addTiming(
         QueryRuntimeStats::kFindTableWallNanos,
         std::chrono::steady_clock::now() - findStart);
   }

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -98,10 +98,10 @@ ConnectorSplitSourceFactory::splitSourceForScan(
       QueryRuntimeStats::kListPartitionsCpuNanos,
       listCpuStart,
       listThreadId);
-  runtimeStats_.recordTiming(
+  runtimeStats_.addTiming(
       QueryRuntimeStats::kListPartitionsWallNanos,
       std::chrono::steady_clock::now() - listStart);
-  runtimeStats_.recordCount(
+  runtimeStats_.addCount(
       QueryRuntimeStats::kListPartitionsCount, partitions.size());
 
   return splitManager->getSplitSource(
@@ -203,10 +203,10 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
         QueryRuntimeStats::kGetSplitsCpuNanos,
         getSplitsCpuStart,
         getSplitsThreadId);
-    runtimeStats.recordTiming(
+    runtimeStats.addTiming(
         QueryRuntimeStats::kGetSplitsWallNanos,
         std::chrono::steady_clock::now() - getSplitsStart);
-    runtimeStats.recordCount(QueryRuntimeStats::kGetSplitsCount, splitCount);
+    runtimeStats.addCount(QueryRuntimeStats::kGetSplitsCount, splitCount);
   } catch (const folly::OperationCancelled&) {
     // co_getSplits() observed the teardown cancellation mid-call. This is a
     // clean stop, not a query error, so do not propagate it to onError().


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/243


`QueryRuntimeStats` previously used a hand-rolled, thread-safe “accumulate-by-name” implementation: a `folly::ConcurrentHashMap` plus a CAS retry loop. Update `QueryRuntimeStats` to use Velox `ConcurrentRuntimeStatWriter` that provides this functionality.

Cleanup includes:

- Removing `QueryRuntimeStats` methods that duplicate base functionality: `recordTiming`, `recordCount`, the `setRuntimeStat`/`addRuntimeStat` overrides, and `toMap()`.
- Removing tests that now only exercise the base implementation. Velox already covers this in `ConcurrentRuntimeStatWriterTest.cpp`.
- Removing `merge()`, since its only caller created a single-sample metric solely for merging.

Correctness/consistency changes:
- `runtimeStats()` now snapshots under a single read lock.
- The old `toMap()` iterated without a lock, so readers could observe a snapshot torn across keys.

Performance/implementation notes:
- Recording moves from a lock-free map to a single mutex.
- Nothing records per row or per batch, the hottest path is per-RPC, so the write rate is well below the point where this would matter.
- The old CAS loop also effectively serialized under contention, because retries happen exactly when two threads hit the same name.

Reviewed By: mbasmanova

Differential Revision: D114985931


