### PR TITLE
fix(optimizer): Accept a repeated join equality in v2 (#1698)

### DIFF
--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -82,6 +82,12 @@ LEFT JOIN (VALUES ('d3')) b(ds) ON (a.ds = b.ds)
 LEFT JOIN (SELECT 'x' as ds WHERE false) c ON (a.ds = c.ds)
 GROUP BY 1
 ----
+-- A repeated equi-condition joins on that pair once.
+SELECT * FROM (VALUES (1)) t(a) JOIN (VALUES (1)) u(b) ON t.a = u.b AND t.a = u.b
+----
+-- Same, with the repeat written in the opposite orientation.
+SELECT * FROM (VALUES (1)) t(a) JOIN (VALUES (1)) u(b) ON t.a = u.b AND u.b = t.a
+----
 -- Same-table equality from equivalence class: a = b is inferred and pushed
 -- as a filter on the left side. Only rows where a = b survive, projecting
 -- (a, b): (1, 1), (3, 3), (5, 5).

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -286,6 +286,15 @@ SELECT t.a NOT IN (SELECT t2.a FROM t t2 WHERE t2.b = t.b AND t2.c = t.c) FROM t
 -- Correlated IN subquery with mixed equality and non-equality correlation.
 SELECT t.a IN (SELECT t2.a FROM t t2 WHERE t2.b = t.b AND t2.c < t.c) FROM t
 ----
+-- '= ANY' means IN.
+SELECT t.a = ANY (SELECT t2.a FROM t t2 WHERE t2.b = t.b) FROM t
+----
+-- '= SOME' means IN.
+SELECT t.a = SOME (SELECT t2.a FROM t t2 WHERE t2.b = t.b) FROM t
+----
+-- '<> ALL' means NOT IN.
+SELECT t.a <> ALL (SELECT t2.a FROM t t2 WHERE t2.b = t.b) FROM t
+----
 -- Correlated NOT IN subquery with mixed equality and non-equality correlation.
 SELECT t.a NOT IN (SELECT t2.a FROM t t2 WHERE t2.b = t.b AND t2.c < t.c) FROM t
 ----

--- a/axiom/optimizer/v2/Builder.cpp
+++ b/axiom/optimizer/v2/Builder.cpp
@@ -147,6 +147,44 @@ const optimizer::Aggregate* Builder::makeAggregate(
   return aggregate;
 }
 
+void Builder::dropRepeatedKeyPairs(Join::Key& key) {
+  const size_t numKeys = key.leftKeys.size();
+
+  // Interned expressions compare by pointer. A pair repeating one that was
+  // itself dropped also repeats the pair that one was dropped for, so
+  // comparing against all earlier positions needs no separate kept set.
+  const auto repeatsEarlier = [&](size_t index) {
+    for (size_t earlier = 0; earlier < index; ++earlier) {
+      if (key.leftKeys[earlier] == key.leftKeys[index] &&
+          key.rightKeys[earlier] == key.rightKeys[index]) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  size_t firstRepeat = 0;
+  while (firstRepeat < numKeys && !repeatsEarlier(firstRepeat)) {
+    ++firstRepeat;
+  }
+  if (firstRepeat == numKeys) {
+    return;
+  }
+
+  ExprVector leftKeys{key.leftKeys.begin(), key.leftKeys.begin() + firstRepeat};
+  ExprVector rightKeys{
+      key.rightKeys.begin(), key.rightKeys.begin() + firstRepeat};
+  for (size_t i = firstRepeat + 1; i < numKeys; ++i) {
+    if (!repeatsEarlier(i)) {
+      leftKeys.push_back(key.leftKeys[i]);
+      rightKeys.push_back(key.rightKeys[i]);
+    }
+  }
+
+  key.leftKeys = std::move(leftKeys);
+  key.rightKeys = std::move(rightKeys);
+}
+
 void Builder::addEquivalences(const Join::Key& key) {
   if (key.joinType != velox::core::JoinType::kInner) {
     return;

--- a/axiom/optimizer/v2/Builder.h
+++ b/axiom/optimizer/v2/Builder.h
@@ -51,8 +51,17 @@ class Builder {
   /// (transparent, no allocation on a hit); on a miss, moves the key into the
   /// newly constructed node. `Expr` leaves use `makeLiteral` / `makeCall` /
   /// `makeAggregate`.
+  ///
+  /// A `Join` key is normalized first: a repeated equi-key pair is dropped, so
+  /// the node's keys can be fewer than 'key' holds and joins differing only in
+  /// a repeated equality are one node.
   template <typename T>
   const T* make(typename T::Key key) {
+    if constexpr (std::is_same_v<T, Join>) {
+      // Before the lookup: a join that repeats an equality is the same join
+      // as one that states it once.
+      dropRepeatedKeyPairs(key);
+    }
     auto& dedup = setFor<T>();
     if (auto it = dedup.find(key); it != dedup.end()) {
       return *it;
@@ -168,6 +177,10 @@ class Builder {
   // No-op for non-inner joins (an outer join's build key may be null-padded, so
   // its columns are not equal on every row) and for non-column keys.
   static void addEquivalences(const Join::Key& key);
+
+  // Drops key pairs equal to an earlier pair. `a = b AND a = b` is one
+  // equality.
+  static void dropRepeatedKeyPairs(Join::Key& key);
 
   template <typename T>
   auto& setFor() {

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -779,6 +779,36 @@ TypePtr ExpressionPlanner::resolveType(const TypeSignaturePtr& type) {
   return veloxType;
 }
 
+namespace {
+
+// `= ANY` and `= SOME` mean IN, and `<> ALL` means NOT IN, with the same null
+// and empty-subquery semantics. Fails for the other combinations.
+bool lowersToNotIn(const QuantifiedComparisonExpression& comparison) {
+  using Operator = ComparisonExpression::Operator;
+  using Quantifier = QuantifiedComparisonExpression::Quantifier;
+
+  const auto op = comparison.op();
+  const auto quantifier = comparison.quantifier();
+
+  if (op == Operator::kEqual &&
+      (quantifier == Quantifier::kAny || quantifier == Quantifier::kSome)) {
+    return false;
+  }
+
+  if (op == Operator::kNotEqual && quantifier == Quantifier::kAll) {
+    return true;
+  }
+
+  AXIOM_PRESTO_SYNTAX_FAIL(
+      comparison.location(),
+      std::string{toSqlString(quantifier)},
+      "Quantified comparison is not supported: {} {}",
+      toSqlString(op),
+      toSqlString(quantifier));
+}
+
+} // namespace
+
 lp::ExprApi ExpressionPlanner::toExpr(
     const ExpressionPtr& node,
     ExprOptions options) {
@@ -952,6 +982,16 @@ lp::ExprApi ExpressionPlanner::toExpr(
       auto* exists = node->as<ExistsPredicate>();
       return lp::Exists(planSubquery(
           exists->subquery()->as<SubqueryExpression>(), /*scalar=*/false));
+    }
+
+    case NodeType::kQuantifiedComparisonExpression: {
+      auto* comparison = node->as<QuantifiedComparisonExpression>();
+      const bool negated = lowersToNotIn(*comparison);
+      auto in = lp::Call(
+          "in",
+          toExpr(comparison->value(), options),
+          toExpr(comparison->subquery(), options));
+      return negated ? lp::Call("not", in) : in;
     }
 
     case NodeType::kCast: {

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1869,6 +1869,13 @@ std::any AstBuilder::visitLogicalBinary(
 
 namespace {
 
+// Returns the token type of a single-terminal rule context's only child.
+size_t terminalTokenType(antlr4::tree::ParseTree* node) {
+  return dynamic_cast<antlr4::tree::TerminalNode*>(node)
+      ->getSymbol()
+      ->getType();
+}
+
 ComparisonExpression::Operator toComparisonOperator(size_t tokenType) {
   switch (tokenType) {
     case PrestoSqlParser::EQ:
@@ -1896,19 +1903,49 @@ std::any AstBuilder::visitComparison(PrestoSqlParser::ComparisonContext* ctx) {
   auto leftExpr = visitExpression(ctx->value);
   auto rightExpr = visitExpression(ctx->right);
 
-  auto operatorToken = ctx->comparisonOperator()->children[0];
-  auto terminalNode = dynamic_cast<antlr4::tree::TerminalNode*>(operatorToken);
-  auto op = toComparisonOperator(terminalNode->getSymbol()->getType());
+  auto op = toComparisonOperator(
+      terminalTokenType(ctx->comparisonOperator()->children[0]));
 
   return std::static_pointer_cast<Expression>(
       std::make_shared<ComparisonExpression>(
           getLocation(ctx), op, leftExpr, rightExpr));
 }
 
+namespace {
+
+QuantifiedComparisonExpression::Quantifier toQuantifier(size_t tokenType) {
+  switch (tokenType) {
+    case PrestoSqlParser::ALL:
+      return QuantifiedComparisonExpression::Quantifier::kAll;
+    case PrestoSqlParser::ANY:
+      return QuantifiedComparisonExpression::Quantifier::kAny;
+    case PrestoSqlParser::SOME:
+      return QuantifiedComparisonExpression::Quantifier::kSome;
+    default:
+      VELOX_UNREACHABLE(
+          "Unexpected comparison quantifier token: {}", tokenType);
+  }
+}
+
+} // namespace
+
 std::any AstBuilder::visitQuantifiedComparison(
     PrestoSqlParser::QuantifiedComparisonContext* ctx) {
   trace("visitQuantifiedComparison");
-  return visitChildren("visitQuantifiedComparison", ctx);
+
+  auto op = toComparisonOperator(
+      terminalTokenType(ctx->comparisonOperator()->children[0]));
+  auto quantifier =
+      toQuantifier(terminalTokenType(ctx->comparisonQuantifier()->children[0]));
+
+  return std::static_pointer_cast<Expression>(
+      std::make_shared<QuantifiedComparisonExpression>(
+          getLocation(ctx),
+          op,
+          quantifier,
+          visitExpression(ctx->value),
+          std::make_shared<SubqueryExpression>(
+              getLocation(ctx), visitTyped<Statement>(ctx->query()))));
 }
 
 namespace {

--- a/axiom/sql/presto/ast/AstExpressions.h
+++ b/axiom/sql/presto/ast/AstExpressions.h
@@ -356,6 +356,9 @@ class ComparisonExpression : public Expression {
   ExpressionPtr right_;
 };
 
+/// Returns the SQL spelling of 'op', e.g. "<=".
+std::string_view toSqlString(ComparisonExpression::Operator op);
+
 class BetweenPredicate : public Expression {
  public:
   BetweenPredicate(
@@ -638,6 +641,10 @@ class QuantifiedComparisonExpression : public Expression {
   ExpressionPtr value_;
   ExpressionPtr subquery_;
 };
+
+/// Returns the SQL spelling of 'quantifier', e.g. "ANY".
+std::string_view toSqlString(
+    QuantifiedComparisonExpression::Quantifier quantifier);
 
 // Logical Expressions
 

--- a/axiom/sql/presto/ast/AstNodesAll.cpp
+++ b/axiom/sql/presto/ast/AstNodesAll.cpp
@@ -248,6 +248,39 @@ const auto& nodeTypeNames() {
 
 AXIOM_DEFINE_ENUM_NAME(NodeType, nodeTypeNames);
 
+std::string_view toSqlString(ComparisonExpression::Operator op) {
+  switch (op) {
+    case ComparisonExpression::Operator::kEqual:
+      return "=";
+    case ComparisonExpression::Operator::kNotEqual:
+      return "!=";
+    case ComparisonExpression::Operator::kLessThan:
+      return "<";
+    case ComparisonExpression::Operator::kLessThanOrEqual:
+      return "<=";
+    case ComparisonExpression::Operator::kGreaterThan:
+      return ">";
+    case ComparisonExpression::Operator::kGreaterThanOrEqual:
+      return ">=";
+    case ComparisonExpression::Operator::kIsDistinctFrom:
+      return "IS DISTINCT FROM";
+  }
+  VELOX_UNREACHABLE("Unsupported comparison operator");
+}
+
+std::string_view toSqlString(
+    QuantifiedComparisonExpression::Quantifier quantifier) {
+  switch (quantifier) {
+    case QuantifiedComparisonExpression::Quantifier::kAll:
+      return "ALL";
+    case QuantifiedComparisonExpression::Quantifier::kAny:
+      return "ANY";
+    case QuantifiedComparisonExpression::Quantifier::kSome:
+      return "SOME";
+  }
+  VELOX_UNREACHABLE("Unsupported comparison quantifier");
+}
+
 // Literal implementations
 void BooleanLiteral::accept(AstVisitor* visitor) {
   visitor->visitBooleanLiteral(this);

--- a/axiom/sql/presto/ast/AstPrinter.cpp
+++ b/axiom/sql/presto/ast/AstPrinter.cpp
@@ -98,27 +98,6 @@ std::string toString(ArithmeticBinaryExpression::Operator op) {
   VELOX_FAIL("Unsupported arithmetic operator");
 }
 
-std::string toString(ComparisonExpression::Operator op) {
-  switch (op) {
-    case ComparisonExpression::Operator::kEqual:
-      return "=";
-    case ComparisonExpression::Operator::kNotEqual:
-      return "!=";
-    case ComparisonExpression::Operator::kLessThan:
-      return "<";
-    case ComparisonExpression::Operator::kLessThanOrEqual:
-      return "<=";
-    case ComparisonExpression::Operator::kGreaterThan:
-      return ">";
-    case ComparisonExpression::Operator::kGreaterThanOrEqual:
-      return ">=";
-    case ComparisonExpression::Operator::kIsDistinctFrom:
-      return "IS DISTINCT FROM";
-    default:
-      VELOX_FAIL("Unsupported comparison operator");
-  }
-}
-
 std::string toString(SortItem::Ordering ordering) {
   switch (ordering) {
     case SortItem::Ordering::kAscending:
@@ -414,7 +393,7 @@ void AstPrinter::visitJoinOn(JoinOn* node) {
 
 void AstPrinter::visitComparisonExpression(ComparisonExpression* node) {
   printHeader("Comparison", node, [&](std::ostream& out) {
-    out << toString(node->op());
+    out << toSqlString(node->op());
   });
 
   indent_++;
@@ -595,7 +574,9 @@ void AstPrinter::visitExistsPredicate(ExistsPredicate* node) {
 
 void AstPrinter::visitQuantifiedComparisonExpression(
     QuantifiedComparisonExpression* node) {
-  printHeader("QuantifiedComparison", node);
+  printHeader("QuantifiedComparison", node, [&](std::ostream& out) {
+    out << toSqlString(node->op()) << " " << toSqlString(node->quantifier());
+  });
 
   indent_++;
   printChild("Value", node->value());

--- a/axiom/sql/presto/tests/ExprMatcher.cpp
+++ b/axiom/sql/presto/tests/ExprMatcher.cpp
@@ -33,20 +33,12 @@ namespace {
     return false;                              \
   }
 
-bool isWildcard(const velox::core::ExprPtr& expr) {
+bool isWildcard(const velox::core::ExprPtr& expr, std::string_view name) {
   if (!expr->is(velox::core::IExpr::Kind::kCall)) {
     return false;
   }
   const auto* call = expr->as<velox::core::CallExpr>();
-  return call->name() == ExprMatcher::kWildcard && call->inputs().empty();
-}
-
-bool isExistsWildcard(const velox::core::ExprPtr& expr) {
-  if (!expr->is(velox::core::IExpr::Kind::kCall)) {
-    return false;
-  }
-  const auto* call = expr->as<velox::core::CallExpr>();
-  return call->name() == ExprMatcher::kExistsWildcard && call->inputs().empty();
+  return call->name() == name && call->inputs().empty();
 }
 
 // Forward declaration for mutual recursion.
@@ -407,11 +399,11 @@ bool matchImpl(const ExprPtr& actual, const velox::core::ExprPtr& expected) {
   VELOX_CHECK_NOT_NULL(actual);
   VELOX_CHECK_NOT_NULL(expected);
 
-  if (isWildcard(expected)) {
+  if (isWildcard(expected, ExprMatcher::kWildcard)) {
     return true;
   }
 
-  if (isExistsWildcard(expected)) {
+  if (isWildcard(expected, ExprMatcher::kExistsWildcard)) {
     if (actual->kind() != ExprKind::kSpecialForm) {
       ADD_FAILURE() << "Expected EXISTS (any_exists() wildcard), got "
                     << actual->kindName() << ".";
@@ -421,6 +413,15 @@ bool matchImpl(const ExprPtr& actual, const velox::core::ExprPtr& expected) {
     if (form != SpecialForm::kExists) {
       ADD_FAILURE() << "Expected EXISTS special form, got "
                     << SpecialFormName::toName(form) << ".";
+      return false;
+    }
+    return true;
+  }
+
+  if (isWildcard(expected, ExprMatcher::kSubqueryWildcard)) {
+    if (actual->kind() != ExprKind::kSubquery) {
+      ADD_FAILURE() << "Expected a subquery (any_subquery() wildcard), got "
+                    << actual->kindName() << ".";
       return false;
     }
     return true;

--- a/axiom/sql/presto/tests/ExprMatcher.h
+++ b/axiom/sql/presto/tests/ExprMatcher.h
@@ -36,6 +36,11 @@ class ExprMatcher {
   /// cannot be spelled in expected strings.
   static constexpr std::string_view kExistsWildcard = "any_exists";
 
+  /// Matches any actual subquery, for the same reason as `kExistsWildcard`.
+  /// Lets an expected string spell the shape around one, e.g.
+  /// `"in"(x, any_subquery())`.
+  static constexpr std::string_view kSubqueryWildcard = "any_subquery";
+
   /// Returns true if the trees match. On mismatch, sets gtest failures
   /// with SCOPED_TRACE context showing the path through the tree.
   static bool match(

--- a/axiom/sql/presto/tests/ExprMatcherTest.cpp
+++ b/axiom/sql/presto/tests/ExprMatcherTest.cpp
@@ -73,13 +73,23 @@ velox::core::ExprPtr existsWildcard() {
       std::nullopt);
 }
 
-ExprPtr exists() {
+velox::core::ExprPtr subqueryWildcard() {
+  return std::make_shared<velox::core::CallExpr>(
+      std::string{ExprMatcher::kSubqueryWildcard},
+      std::vector<velox::core::ExprPtr>{},
+      std::nullopt);
+}
+
+ExprPtr subquery() {
   auto subqueryPlan = std::make_shared<ValuesNode>(
       "values_0",
       ROW({"x"}, {BIGINT()}),
       ValuesNode::Variants{Variant::row({42LL})});
-  auto subquery = std::make_shared<SubqueryExpr>(subqueryPlan);
-  return specialForm(BOOLEAN(), SpecialForm::kExists, {subquery});
+  return std::make_shared<SubqueryExpr>(subqueryPlan);
+}
+
+ExprPtr exists() {
+  return specialForm(BOOLEAN(), SpecialForm::kExists, {subquery()});
 }
 
 class ExprMatcherTest : public testing::Test {
@@ -365,6 +375,27 @@ TEST_F(ExprMatcherTest, existsWildcardRejectsNonExists) {
   EXPECT_NONFATAL_FAILURE(
       ExprMatcher::match(coalesce, existsWildcard()),
       "Expected EXISTS special form, got COALESCE.");
+}
+
+TEST_F(ExprMatcherTest, subqueryWildcardMatchesSubquery) {
+  ExprMatcher::match(subquery(), subqueryWildcard());
+}
+
+TEST_F(ExprMatcherTest, subqueryWildcardMatchesNestedSubquery) {
+  auto in = specialForm(
+      BOOLEAN(), SpecialForm::kIn, {field(BIGINT(), "a"), subquery()});
+  ExprMatcher::match(
+      in,
+      std::make_shared<velox::core::CallExpr>(
+          "in",
+          std::vector<velox::core::ExprPtr>{parseExpr("a"), subqueryWildcard()},
+          std::nullopt));
+}
+
+TEST_F(ExprMatcherTest, subqueryWildcardRejectsNonSubquery) {
+  EXPECT_NONFATAL_FAILURE(
+      ExprMatcher::match(field(BOOLEAN(), "a"), subqueryWildcard()),
+      "Expected a subquery (any_subquery() wildcard)");
 }
 
 } // namespace

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -712,36 +712,45 @@ TEST_F(ExpressionParserTest, in) {
       "n_nationkey in (1, 2, 3)",
       "IN(n_nationkey, CAST(1 AS BIGINT), CAST(2 AS BIGINT), CAST(3 AS BIGINT))");
 
-  auto assertInSubquery = [](const lp::ExprPtr& expr) {
-    ASSERT_EQ(lp::ExprKind::kSpecialForm, expr->kind());
-    auto& in = *expr->as<lp::SpecialFormExpr>();
-    ASSERT_EQ(in.form(), lp::SpecialForm::kIn);
-    ASSERT_EQ(in.inputs().size(), 2);
-    ASSERT_EQ(lp::ExprKind::kInputReference, in.inputAt(0)->kind());
-    ASSERT_EQ(lp::ExprKind::kSubquery, in.inputAt(1)->kind());
-  };
-
   // Subquery IN in WHERE clause produces a filter with IN(column, subquery).
   testSelect(
       "SELECT * FROM nation WHERE n_regionkey IN (SELECT r_regionkey FROM region WHERE r_name like 'A%')",
-      matchScan()
-          .filter([&](const auto& node) {
-            auto filter = std::dynamic_pointer_cast<const lp::FilterNode>(node);
-            assertInSubquery(filter->predicate());
-          })
-          .output());
+      matchScan().filter(R"("in"(n_regionkey, any_subquery()))").output());
 
   // Subquery IN in SELECT clause produces a project with IN(column, subquery).
   testSelect(
       "SELECT n_regionkey IN (SELECT r_regionkey FROM region WHERE r_name like 'A%') FROM nation",
-      matchScan()
-          .project([&](const auto& node) {
-            auto project =
-                std::dynamic_pointer_cast<const lp::ProjectNode>(node);
-            ASSERT_EQ(project->expressions().size(), 1);
-            assertInSubquery(project->expressionAt(0));
-          })
-          .output());
+      matchScan().project({R"("in"(n_regionkey, any_subquery()))"}).output());
+}
+
+TEST_F(ExpressionParserTest, quantifiedComparison) {
+  // '= ANY' and '= SOME' mean IN; '<> ALL' means NOT IN.
+  testSelect(
+      "SELECT * FROM nation WHERE n_regionkey = ANY (SELECT r_regionkey FROM region)",
+      matchScan().filter(R"("in"(n_regionkey, any_subquery()))").output());
+  testSelect(
+      "SELECT * FROM nation WHERE n_regionkey = SOME (SELECT r_regionkey FROM region)",
+      matchScan().filter(R"("in"(n_regionkey, any_subquery()))").output());
+  testSelect(
+      "SELECT * FROM nation WHERE n_regionkey <> ALL (SELECT r_regionkey FROM region)",
+      matchScan().filter(R"(not("in"(n_regionkey, any_subquery())))").output());
+
+  // The remaining operator and quantifier combinations have no lowering.
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(
+          "SELECT * FROM nation "
+          "WHERE n_regionkey > ALL (SELECT r_regionkey FROM region)"),
+      "Quantified comparison is not supported: > ALL");
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(
+          "SELECT * FROM nation "
+          "WHERE n_regionkey <= ANY (SELECT r_regionkey FROM region)"),
+      "Quantified comparison is not supported: <= ANY");
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(
+          "SELECT * FROM nation "
+          "WHERE n_regionkey = ALL (SELECT r_regionkey FROM region)"),
+      "Quantified comparison is not supported: = ALL");
 }
 
 TEST_F(ExpressionParserTest, notLike) {

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
@@ -215,9 +215,6 @@ class JoinMatcher : public LogicalPlanMatcherImpl<JoinNode> {
   const std::vector<std::string> outputAliases_;
 };
 
-// Matches a FilterNode with the specified expression. The expected expression
-// is parsed with DuckDB and printed in a format compatible with
-// lp::ExprPrinter, then compared against the filter expression's toString().
 class FilterMatcher : public LogicalPlanMatcherImpl<FilterNode> {
  public:
   FilterMatcher(
@@ -323,7 +320,6 @@ class LimitMatcher : public LogicalPlanMatcherImpl<LimitNode> {
 // - String constructor: parses with DuckDB, corrects window frame defaults.
 // - ExprApi constructor: uses the expression directly, applies SQL standard
 //   default frame when none is specified.
-// Both paths compare against expressionAt(i)->toString().
 class ProjectMatcher : public LogicalPlanMatcherImpl<ProjectNode> {
  public:
   ProjectMatcher(

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.h
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.h
@@ -138,16 +138,17 @@ class LogicalPlanMatcherBuilder {
   LogicalPlanMatcherBuilder& filter(OnMatchCallback onMatch = nullptr);
 
   /// Matches a FilterNode with the specified expression. The expected
-  /// expression is parsed with DuckDB and compared against the filter
-  /// expression's toString(). Supports symbol rewriting.
+  /// expression is parsed with DuckDB and matched structurally against the
+  /// filter expression, so `ExprMatcher` wildcards apply. Supports symbol
+  /// rewriting.
   LogicalPlanMatcherBuilder& filter(const std::string& expression);
 
   /// Matches a ProjectNode.
   LogicalPlanMatcherBuilder& project(OnMatchCallback onMatch = nullptr);
 
   /// Matches a ProjectNode with the specified expressions. Each expected
-  /// expression is parsed with DuckDB and printed in a format compatible with
-  /// lp::ExprPrinter, then compared against expressionAt(i)->toString().
+  /// expression is parsed with DuckDB and matched structurally against
+  /// expressionAt(i), so `ExprMatcher` wildcards apply.
   LogicalPlanMatcherBuilder& project(
       const std::vector<std::string>& expressions);
 


### PR DESCRIPTION
Summary:

A join that states the same equality twice failed under the v2 optimizer:

    SELECT * FROM (VALUES (1)) t(a) JOIN (VALUES (1)) u(b) ON t.a = u.b AND t.a = u.b

fails with `Duplicate join condition: "c0" = "c0_0"`, from the Velox plan checker Axiom runs on every plan it emits. Presto accepts the query and so does v1, which drops a repeated pair as it collects join keys.

v2 now drops them too, in `Builder::make<Join>` before the node is interned. That is the one point every join passes through, so the translate, pushdown, decorrelate, and join-tree paths are covered at once, and a join repeating an equality interns to the same node as one stating it once.

The repeat also double-counted that pair's NDV in the join's cardinality estimate, since the estimate multiplies per-key NDVs.

Differential Revision: D115812226


