### PR TITLE
fix(parser): Bind a qualified ORDER BY key to its column (#1700)

### DIFF
--- a/axiom/optimizer/tests/sql/sort.sql
+++ b/axiom/optimizer/tests/sql/sort.sql
@@ -28,3 +28,11 @@ SELECT * FROM t ORDER BY b + c DESC
 -- ORDER BY an expression, descending on one key and ascending on another.
 -- ordered
 SELECT * FROM t ORDER BY a * -1 DESC, b + c ASC
+----
+-- ORDER BY a qualified key naming one side of a join, where both sides
+-- contribute a column of that name.
+-- ordered
+SELECT y.v AS v
+FROM (VALUES (1, 10), (2, 5)) x(k, v)
+JOIN (VALUES (1, 200), (2, 300)) y(k, v) ON x.k = y.k
+ORDER BY x.v DESC

--- a/axiom/sql/presto/SortProjection.cpp
+++ b/axiom/sql/presto/SortProjection.cpp
@@ -104,13 +104,19 @@ size_t lookupSortKey(
   if (preResolvedOrdinal != 0) {
     return preResolvedOrdinal;
   }
-  if (sortKey.alias().has_value()) {
+
+  // Only an unqualified name can match a SELECT output name. A qualified key
+  // (`t.a`) names a column of an input relation, so it resolves by expression
+  // below even when two inputs put that name in the output.
+  if (sortKey.alias().has_value() &&
+      core::FieldAccessExpr::tryAsRootColumn(sortKey.expr()) != nullptr) {
     auto it = index.byAlias.find(sortKey.alias().value());
     if (it != index.byAlias.end()) {
       VELOX_USER_CHECK_NE(it->second, 0, "Column is ambiguous: {}", it->first);
       return it->second;
     }
   }
+
   auto resolved = replaceAliases(sortKey.expr(), index.byAlias, projections);
   auto it = index.byExpr.find(resolved);
   return it != index.byExpr.end() ? it->second : 0;

--- a/axiom/sql/presto/tests/SortParserTest.cpp
+++ b/axiom/sql/presto/tests/SortParserTest.cpp
@@ -295,6 +295,21 @@ TEST_F(SortParserTest, starWithHiddenColumn) {
       ::testing::Pointwise(::testing::Eq(), {"a", "b"}));
 }
 
+// A qualified sort key names one side of a join, so it resolves even when both
+// sides contribute an output column of that name.
+TEST_F(SortParserTest, qualifiedSortKeyWithDuplicateOutputNames) {
+  connector_->addTable("t", ROW({"k", "v"}, INTEGER()));
+
+  testSelect(
+      "SELECT x.*, y.* FROM t x JOIN t y ON x.k = y.k "
+      "ORDER BY x.v DESC",
+      matchScan()
+          .join(matchScan().build(), {"left_k", "left_v", "right_k", "right_v"})
+          .project({"left_k", "left_v", "right_k", "right_v"})
+          .sort({"left_v desc"})
+          .output({"k", "v", "k", "v"}));
+}
+
 TEST_F(SortParserTest, joinedTable) {
   testSelect(
       "SELECT n_name "


### PR DESCRIPTION
Summary:

Ordering by a qualified column failed when both sides of a join contribute that name:

    SELECT x.*, y.* FROM t x JOIN t y ON x.k = y.k ORDER BY x.v DESC

reported `Column is ambiguous: v`, though `x.v` names exactly one column. Presto runs this query.

Worse, where a SELECT alias shadowed the name the query ran and sorted by the wrong column: `SELECT y.v AS v FROM t x JOIN t y ON x.k = y.k ORDER BY x.v DESC` sorted by `y.v`, returning rows in the wrong order.

A sort key carries its name as an alias whether or not the source qualified it, and resolution matched that name against the SELECT output names before considering the expression. Only an unqualified name can refer to an output column, so that match now applies to a bare column reference alone; a qualified key resolves by expression instead.

Reviewed By: amitkdutta

Differential Revision: D115821184


