### PR TITLE
fix(logical_plan): Name UNNEST columns by their relation alias (#1701)

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -1064,6 +1064,17 @@ PlanBuilder& PlanBuilder::unnest(
   std::vector<ExprPtr> exprs;
   std::vector<std::vector<std::string>> outputNames;
 
+  // A column the query did not name. The relation alias still names it, so
+  // `alias.*` finds it; it has no name of its own to reference it by.
+  auto addUnnamedUnnestOutput = [&](const std::string& hint) {
+    outputNames.back().emplace_back(newName(hint));
+    if (alias.has_value()) {
+      unnestMapping.add(
+          NameMappings::QualifiedName{alias, outputNames.back().back()},
+          outputNames.back().back());
+    }
+  };
+
   auto addUnnestOutput = [&](const std::string& name, const std::string& hint) {
     if (name.empty()) {
       VELOX_USER_CHECK(
@@ -1096,7 +1107,7 @@ PlanBuilder& PlanBuilder::unnest(
           VELOX_USER_CHECK_LT(index, unnestAliases.size());
           addUnnestOutput(unnestAliases[index], kElementHint);
         } else {
-          outputNames.back().emplace_back(newName(kElementHint));
+          addUnnamedUnnestOutput(kElementHint);
         }
         break;
 
@@ -1110,8 +1121,8 @@ PlanBuilder& PlanBuilder::unnest(
           addUnnestOutput(unnestAliases[index], kKeyHint);
           addUnnestOutput(unnestAliases[index], kValueHint);
         } else {
-          outputNames.back().emplace_back(newName(kKeyHint));
-          outputNames.back().emplace_back(newName(kValueHint));
+          addUnnamedUnnestOutput(kKeyHint);
+          addUnnamedUnnestOutput(kValueHint);
         }
         break;
 
@@ -1134,6 +1145,11 @@ PlanBuilder& PlanBuilder::unnest(
       unnestMapping.addUserName(*ordinalityName, "");
     } else {
       ordinalityName = newName("ordinality");
+      if (alias.has_value()) {
+        unnestMapping.add(
+            NameMappings::QualifiedName{alias, *ordinalityName},
+            *ordinalityName);
+      }
     }
   }
 

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -74,6 +74,9 @@ CROSS JOIN UNNEST(t.items) _(r)
 JOIN (VALUES (1, 10), (1, 20)) u(c, k) ON u.k = r.k AND u.c = 1
 JOIN (VALUES (1, 10)) v(c, k) ON v.k = u.k AND v.c = 1
 ----
+-- `alias.*` on an UNNEST relation whose alias carries no column list.
+SELECT u.* FROM (VALUES (1, ARRAY[10, 20])) AS s(a, b) CROSS JOIN UNNEST(b) AS u
+----
 -- Chained LEFT JOINs with same-named columns and GROUP BY.
 -- a.ds must group by a's column, not c's.
 SELECT a.ds

--- a/axiom/optimizer/tests/sql/sort.sql
+++ b/axiom/optimizer/tests/sql/sort.sql
@@ -28,3 +28,11 @@ SELECT * FROM t ORDER BY b + c DESC
 -- ORDER BY an expression, descending on one key and ascending on another.
 -- ordered
 SELECT * FROM t ORDER BY a * -1 DESC, b + c ASC
+----
+-- ORDER BY a qualified key naming one side of a join, where both sides
+-- contribute a column of that name.
+-- ordered
+SELECT y.v AS v
+FROM (VALUES (1, 10), (2, 5)) x(k, v)
+JOIN (VALUES (1, 200), (2, 300)) y(k, v) ON x.k = y.k
+ORDER BY x.v DESC

--- a/axiom/sql/presto/SortProjection.cpp
+++ b/axiom/sql/presto/SortProjection.cpp
@@ -104,13 +104,19 @@ size_t lookupSortKey(
   if (preResolvedOrdinal != 0) {
     return preResolvedOrdinal;
   }
-  if (sortKey.alias().has_value()) {
+
+  // Only an unqualified name can match a SELECT output name. A qualified key
+  // (`t.a`) names a column of an input relation, so it resolves by expression
+  // below even when two inputs put that name in the output.
+  if (sortKey.alias().has_value() &&
+      core::FieldAccessExpr::tryAsRootColumn(sortKey.expr()) != nullptr) {
     auto it = index.byAlias.find(sortKey.alias().value());
     if (it != index.byAlias.end()) {
       VELOX_USER_CHECK_NE(it->second, 0, "Column is ambiguous: {}", it->first);
       return it->second;
     }
   }
+
   auto resolved = replaceAliases(sortKey.expr(), index.byAlias, projections);
   auto it = index.byExpr.find(resolved);
   return it != index.byExpr.end() ? it->second : 0;

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -95,6 +95,15 @@ TEST_F(PrestoParserTest, unnest) {
         "WITH a AS (SELECT array[1,2,3] as x) SELECT t.x + 1 FROM a, unnest(A.x) as T(X)",
         matcher);
   }
+
+  // A relation alias with no column list still names the unnested relation, so
+  // `alias.*` expands to the unnested column.
+  {
+    auto plan = parseSelect(
+        "SELECT u.* FROM (VALUES (1, ARRAY[10, 20])) AS t(a, b) "
+        "CROSS JOIN UNNEST(b) AS u");
+    EXPECT_EQ(1, plan->outputType()->size());
+  }
 }
 
 TEST_F(PrestoParserTest, lateralJoin) {

--- a/axiom/sql/presto/tests/SortParserTest.cpp
+++ b/axiom/sql/presto/tests/SortParserTest.cpp
@@ -295,6 +295,21 @@ TEST_F(SortParserTest, starWithHiddenColumn) {
       ::testing::Pointwise(::testing::Eq(), {"a", "b"}));
 }
 
+// A qualified sort key names one side of a join, so it resolves even when both
+// sides contribute an output column of that name.
+TEST_F(SortParserTest, qualifiedSortKeyWithDuplicateOutputNames) {
+  connector_->addTable("t", ROW({"k", "v"}, INTEGER()));
+
+  testSelect(
+      "SELECT x.*, y.* FROM t x JOIN t y ON x.k = y.k "
+      "ORDER BY x.v DESC",
+      matchScan()
+          .join(matchScan().build(), {"left_k", "left_v", "right_k", "right_v"})
+          .project({"left_k", "left_v", "right_k", "right_v"})
+          .sort({"left_v desc"})
+          .output({"k", "v", "k", "v"}));
+}
+
 TEST_F(SortParserTest, joinedTable) {
   testSelect(
       "SELECT n_name "


### PR DESCRIPTION
Summary:

Expanding an UNNEST relation alias failed when the alias carried no column list:

    SELECT u.* FROM (VALUES (1, ARRAY[10, 20])) AS t(a, b) CROSS JOIN UNNEST(b) AS u

reported `Alias not found: u`. Presto returns the unnested column. Writing a column list (`AS u(x)`) or a bare `*` already worked.

An unnested column takes its name from a column alias, a per-expression alias, or neither. In the last case the column got a generated name and no mapping at all, so nothing tied it to the relation alias and star expansion found no columns for `u`. Such a column now maps to the relation alias, as it already does when the query names it. The same applies to a map's key and value columns and to an unaliased WITH ORDINALITY column, so the star covers everything the relation produces.

Reviewed By: amitkdutta

Differential Revision: D115822139


