### PR TITLE
fix(optimizer): Keep partitioning in row-preserving nodes (#1702)

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -1064,6 +1064,17 @@ PlanBuilder& PlanBuilder::unnest(
   std::vector<ExprPtr> exprs;
   std::vector<std::vector<std::string>> outputNames;
 
+  // A column the query did not name. The relation alias still names it, so
+  // `alias.*` finds it; it has no name of its own to reference it by.
+  auto addUnnamedUnnestOutput = [&](const std::string& hint) {
+    outputNames.back().emplace_back(newName(hint));
+    if (alias.has_value()) {
+      unnestMapping.add(
+          NameMappings::QualifiedName{alias, outputNames.back().back()},
+          outputNames.back().back());
+    }
+  };
+
   auto addUnnestOutput = [&](const std::string& name, const std::string& hint) {
     if (name.empty()) {
       VELOX_USER_CHECK(
@@ -1096,7 +1107,7 @@ PlanBuilder& PlanBuilder::unnest(
           VELOX_USER_CHECK_LT(index, unnestAliases.size());
           addUnnestOutput(unnestAliases[index], kElementHint);
         } else {
-          outputNames.back().emplace_back(newName(kElementHint));
+          addUnnamedUnnestOutput(kElementHint);
         }
         break;
 
@@ -1110,8 +1121,8 @@ PlanBuilder& PlanBuilder::unnest(
           addUnnestOutput(unnestAliases[index], kKeyHint);
           addUnnestOutput(unnestAliases[index], kValueHint);
         } else {
-          outputNames.back().emplace_back(newName(kKeyHint));
-          outputNames.back().emplace_back(newName(kValueHint));
+          addUnnamedUnnestOutput(kKeyHint);
+          addUnnamedUnnestOutput(kValueHint);
         }
         break;
 
@@ -1134,6 +1145,11 @@ PlanBuilder& PlanBuilder::unnest(
       unnestMapping.addUserName(*ordinalityName, "");
     } else {
       ordinalityName = newName("ordinality");
+      if (alias.has_value()) {
+        unnestMapping.add(
+            NameMappings::QualifiedName{alias, *ordinalityName},
+            *ordinalityName);
+      }
     }
   }
 

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -74,6 +74,9 @@ CROSS JOIN UNNEST(t.items) _(r)
 JOIN (VALUES (1, 10), (1, 20)) u(c, k) ON u.k = r.k AND u.c = 1
 JOIN (VALUES (1, 10)) v(c, k) ON v.k = u.k AND v.c = 1
 ----
+-- `alias.*` on an UNNEST relation whose alias carries no column list.
+SELECT u.* FROM (VALUES (1, ARRAY[10, 20])) AS s(a, b) CROSS JOIN UNNEST(b) AS u
+----
 -- Chained LEFT JOINs with same-named columns and GROUP BY.
 -- a.ds must group by a's column, not c's.
 SELECT a.ds

--- a/axiom/optimizer/tests/sql/sort.sql
+++ b/axiom/optimizer/tests/sql/sort.sql
@@ -28,3 +28,11 @@ SELECT * FROM t ORDER BY b + c DESC
 -- ORDER BY an expression, descending on one key and ascending on another.
 -- ordered
 SELECT * FROM t ORDER BY a * -1 DESC, b + c ASC
+----
+-- ORDER BY a qualified key naming one side of a join, where both sides
+-- contribute a column of that name.
+-- ordered
+SELECT y.v AS v
+FROM (VALUES (1, 10), (2, 5)) x(k, v)
+JOIN (VALUES (1, 200), (2, 300)) y(k, v) ON x.k = y.k
+ORDER BY x.v DESC

--- a/axiom/optimizer/tests/sql/unionAll.sql
+++ b/axiom/optimizer/tests/sql/unionAll.sql
@@ -105,3 +105,10 @@ SELECT * FROM (
 )
 UNION ALL
 SELECT a, b, a AS r FROM t WHERE a = 999
+----
+-- A UNION ALL of a joined leg and a leg that unnests an array.
+SELECT u.a
+FROM (VALUES (1)) u(a)
+JOIN (VALUES (1)) v(b) ON u.a = v.b
+UNION ALL
+SELECT w.x FROM (VALUES (ARRAY[1])) v(arr) CROSS JOIN UNNEST(arr) AS w(x)

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -109,6 +109,24 @@ LocalPropertyVector retainedLocal(NodeCP input, const ColumnVector& columns) {
       input->physicalProperties().local, PlanObjectSet::fromObjects(columns));
 }
 
+// Keeps an input's partitioning when a node emits only a subset of its input:
+// the rows stay on the task they arrived on, so the distribution survives as
+// long as every partition key does. A dropped key leaves the output with no
+// expressible partitioning.
+Partitioning retainedGlobalPartition(
+    NodeCP input,
+    const ColumnVector& columns) {
+  Partitioning partition =
+      input->physicalProperties().globalPartition.dropOrder();
+  const auto columnSet = PlanObjectSet::fromObjects(columns);
+  for (ExprCP key : partition.keys) {
+    if (!key->columns().isSubset(columnSet)) {
+      return Partitioning{};
+    }
+  }
+  return partition;
+}
+
 // Keeps an input's unique key-sets whose columns all survive in `columns`, for
 // a node that emits only a subset of its input. A key-set with a dropped member
 // is no longer a key of the output, so it is removed whole.
@@ -1067,6 +1085,8 @@ Unnest::Unnest(Key key)
           NodeType::kUnnest,
           ColumnVector{key.outputColumns},
           PhysicalProperties{
+              .globalPartition =
+                  retainedGlobalPartition(key.input, key.replicatedColumns),
               .local = retainedLocal(key.input, key.replicatedColumns)}),
       input_(key.input),
       unnestExpressions_(std::move(key.unnestExpressions)),
@@ -1862,6 +1882,8 @@ AssignUniqueId::AssignUniqueId(Key key)
           NodeType::kAssignUniqueId,
           withIdColumn(key.input->outputColumns(), key.idColumn),
           PhysicalProperties{
+              .globalPartition =
+                  key.input->physicalProperties().globalPartition.dropOrder(),
               .local = groupedLocal(key.idColumn),
               .unique = globalUniqueKey(key.idColumn)}),
       input_(key.input),

--- a/axiom/sql/presto/SortProjection.cpp
+++ b/axiom/sql/presto/SortProjection.cpp
@@ -104,13 +104,19 @@ size_t lookupSortKey(
   if (preResolvedOrdinal != 0) {
     return preResolvedOrdinal;
   }
-  if (sortKey.alias().has_value()) {
+
+  // Only an unqualified name can match a SELECT output name. A qualified key
+  // (`t.a`) names a column of an input relation, so it resolves by expression
+  // below even when two inputs put that name in the output.
+  if (sortKey.alias().has_value() &&
+      core::FieldAccessExpr::tryAsRootColumn(sortKey.expr()) != nullptr) {
     auto it = index.byAlias.find(sortKey.alias().value());
     if (it != index.byAlias.end()) {
       VELOX_USER_CHECK_NE(it->second, 0, "Column is ambiguous: {}", it->first);
       return it->second;
     }
   }
+
   auto resolved = replaceAliases(sortKey.expr(), index.byAlias, projections);
   auto it = index.byExpr.find(resolved);
   return it != index.byExpr.end() ? it->second : 0;

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -95,6 +95,15 @@ TEST_F(PrestoParserTest, unnest) {
         "WITH a AS (SELECT array[1,2,3] as x) SELECT t.x + 1 FROM a, unnest(A.x) as T(X)",
         matcher);
   }
+
+  // A relation alias with no column list still names the unnested relation, so
+  // `alias.*` expands to the unnested column.
+  {
+    auto plan = parseSelect(
+        "SELECT u.* FROM (VALUES (1, ARRAY[10, 20])) AS t(a, b) "
+        "CROSS JOIN UNNEST(b) AS u");
+    EXPECT_EQ(1, plan->outputType()->size());
+  }
 }
 
 TEST_F(PrestoParserTest, lateralJoin) {

--- a/axiom/sql/presto/tests/SortParserTest.cpp
+++ b/axiom/sql/presto/tests/SortParserTest.cpp
@@ -295,6 +295,21 @@ TEST_F(SortParserTest, starWithHiddenColumn) {
       ::testing::Pointwise(::testing::Eq(), {"a", "b"}));
 }
 
+// A qualified sort key names one side of a join, so it resolves even when both
+// sides contribute an output column of that name.
+TEST_F(SortParserTest, qualifiedSortKeyWithDuplicateOutputNames) {
+  connector_->addTable("t", ROW({"k", "v"}, INTEGER()));
+
+  testSelect(
+      "SELECT x.*, y.* FROM t x JOIN t y ON x.k = y.k "
+      "ORDER BY x.v DESC",
+      matchScan()
+          .join(matchScan().build(), {"left_k", "left_v", "right_k", "right_v"})
+          .project({"left_k", "left_v", "right_k", "right_v"})
+          .sort({"left_v desc"})
+          .output({"k", "v", "k", "v"}));
+}
+
 TEST_F(SortParserTest, joinedTable) {
   testSelect(
       "SELECT n_name "


### PR DESCRIPTION
Summary:

This query failed to plan under `--v2`:

    SELECT u.a FROM (VALUES (1)) u(a) JOIN (VALUES (1)) v(b) ON u.a = v.b
    UNION ALL
    SELECT w.x FROM (VALUES (ARRAY[1])) v(arr) CROSS JOIN UNNEST(arr) AS w(x)

with:

    Incompatible fragment-type contributions in one fragment: FIXED + SINGLE

`Unnest` and `AssignUniqueId` never derived a global partitioning, so their output claimed no partitioning at all. Neither node moves rows between tasks, so both now inherit the input's partitioning without its merge order. `Unnest` emits only part of its input, so it keeps the partitioning only while every partition key survives.

The `AssignUniqueId` half also removes a shuffle. A correlated scalar subquery over a single-task input used to hash-partition on the generated row id before `EnforceDistinct`; that plan now runs in place, going from four fragments to two.

Reviewed By: amitkdutta

Differential Revision: D115824474


