### PR TITLE
test(optimizer): Run OutputNode, TpchConnectorQuery and CsvReadWrite tests under both optimizers

### DIFF
--- a/axiom/optimizer/tests/CsvReadWriteTest.cpp
+++ b/axiom/optimizer/tests/CsvReadWriteTest.cpp
@@ -23,12 +23,14 @@ namespace {
 
 using namespace velox;
 
-class CsvReadWriteTest : public test::HiveQueriesTestBase {
+class CsvReadWriteTest : public test::HiveQueriesTestBase,
+                         public ::testing::WithParamInterface<bool> {
  protected:
   const std::string kDefaultSchema{
       connector::hive::LocalHiveConnectorMetadata::kDefaultSchema};
 
   void SetUp() override {
+    useV2_ = GetParam();
     HiveQueriesTestBase::SetUp();
     velox::text::registerTextReaderFactory();
     velox::text::registerTextWriterFactory();
@@ -55,7 +57,7 @@ class CsvReadWriteTest : public test::HiveQueriesTestBase {
 };
 
 // Create a TEXT table via SQL and verify SHOW CREATE TABLE output.
-TEST_F(CsvReadWriteTest, createTextTable) {
+TEST_P(CsvReadWriteTest, createTextTable) {
   SCOPE_EXIT {
     dropTableIfExists("text_test");
   };
@@ -79,7 +81,7 @@ TEST_F(CsvReadWriteTest, createTextTable) {
 
 // Create a CSV table (TEXT with comma delimiter) via SQL and verify
 // SHOW CREATE TABLE output includes field.delim and serialization.null.format.
-TEST_F(CsvReadWriteTest, createCsvTable) {
+TEST_P(CsvReadWriteTest, createCsvTable) {
   SCOPE_EXIT {
     dropTableIfExists("csv_test");
   };
@@ -103,7 +105,7 @@ TEST_F(CsvReadWriteTest, createCsvTable) {
       ")");
 }
 
-TEST_F(CsvReadWriteTest, validateSchemaFileProperties) {
+TEST_P(CsvReadWriteTest, validateSchemaFileProperties) {
   SCOPE_EXIT {
     dropTableIfExists("custom_delimiter_test");
   };
@@ -146,7 +148,7 @@ TEST_F(CsvReadWriteTest, validateSchemaFileProperties) {
 }
 
 // Test reading CSV with custom delimiter and representative data types.
-TEST_F(CsvReadWriteTest, readCustomDelimiterWithVariousTypes) {
+TEST_P(CsvReadWriteTest, readCustomDelimiterWithVariousTypes) {
   SCOPE_EXIT {
     dropTableIfExists("custom_delimiter_test");
   };
@@ -184,7 +186,7 @@ TEST_F(CsvReadWriteTest, readCustomDelimiterWithVariousTypes) {
 }
 
 // Test writing CSV using INSERT statement with various data types.
-TEST_F(CsvReadWriteTest, writeWithInsertStatement) {
+TEST_P(CsvReadWriteTest, writeWithInsertStatement) {
   SCOPE_EXIT {
     dropTableIfExists("csv_write_test");
   };
@@ -227,6 +229,8 @@ TEST_F(CsvReadWriteTest, writeWithInsertStatement) {
 
   checkTableData("csv_write_test", {expectedData});
 }
+
+AXIOM_INSTANTIATE_V1_V2(CsvReadWriteTest);
 
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/OutputNodeTest.cpp
+++ b/axiom/optimizer/tests/OutputNodeTest.cpp
@@ -25,8 +25,14 @@ namespace {
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class OutputNodeTest : public test::QueryTestBase {
+class OutputNodeTest : public test::QueryTestBase,
+                       public ::testing::WithParamInterface<bool> {
  protected:
+  void SetUp() override {
+    useV2_ = GetParam();
+    QueryTestBase::SetUp();
+  }
+
   lp::PlanBuilder::Context makeContext() const {
     return lp::PlanBuilder::Context{kTestConnectorId, kDefaultSchema};
   }
@@ -34,7 +40,7 @@ class OutputNodeTest : public test::QueryTestBase {
 
 // Verifies the optimizer honors OutputNode entry shapes documented in
 // OutputNode::Entry — drop, reorder, duplicate, identity.
-TEST_F(OutputNodeTest, entries) {
+TEST_P(OutputNodeTest, entries) {
   testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
 
   auto makePlan = [&](const std::vector<lp::OutputNode::Entry>& entries)
@@ -81,6 +87,8 @@ TEST_F(OutputNodeTest, entries) {
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
+
+AXIOM_INSTANTIATE_V1_V2(OutputNodeTest);
 
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/TpchConnectorQueryTest.cpp
+++ b/axiom/optimizer/tests/TpchConnectorQueryTest.cpp
@@ -27,11 +27,13 @@ namespace {
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class TpchConnectorQueryTest : public QueryTestBase {
+class TpchConnectorQueryTest : public QueryTestBase,
+                               public ::testing::WithParamInterface<bool> {
  protected:
   static constexpr auto kTpchConnectorId = "tpch";
 
   void SetUp() override {
+    useV2_ = GetParam();
     QueryTestBase::SetUp();
     connectors_ = std::make_unique<Connectors>();
     connectors_->registerTpchConnector(kTpchConnectorId);
@@ -66,7 +68,7 @@ class TpchConnectorQueryTest : public QueryTestBase {
   }
 };
 
-TEST_F(TpchConnectorQueryTest, lambda) {
+TEST_P(TpchConnectorQueryTest, lambda) {
   auto query =
       "SELECT n_regionkey, transform(array_agg(n_nationkey), x -> x * 2) FROM nation "
       "WHERE all_match(sequence(1, n_nationkey), x -> x < 3) "
@@ -79,7 +81,7 @@ TEST_F(TpchConnectorQueryTest, lambda) {
   checkSame(parseSql(query), {expected});
 }
 
-TEST_F(TpchConnectorQueryTest, scaleFactors) {
+TEST_P(TpchConnectorQueryTest, scaleFactors) {
   ASSERT_EQ(15'000, runCountStar("orders"));
   ASSERT_EQ(15'000, runCountStar("tiny.orders"));
   ASSERT_EQ(15'000, runCountStar("tpch.tiny.orders"));
@@ -87,6 +89,8 @@ TEST_F(TpchConnectorQueryTest, scaleFactors) {
   ASSERT_EQ(1'500'000, runCountStar("sf1.orders"));
   ASSERT_EQ(1'500'000, runCountStar("tpch.sf1.orders"));
 }
+
+AXIOM_INSTANTIATE_V1_V2(TpchConnectorQueryTest);
 
 } // namespace
 } // namespace facebook::axiom::optimizer::test


### PR DESCRIPTION
Summary: `OutputNodeTest`, `TpchConnectorQueryTest` and `CsvReadWriteTest` ran under v1 only; each already passes under v2. They are now `TEST_P` suites over both.

Differential Revision: D115793294


