### PR TITLE
fix(v2): Demote a FULL join to preserve the filtered input (#1710)

### DIFF
--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -130,6 +130,32 @@ RIGHT JOIN (
 ) AS u ON a.a = u.a0 AND a.b = u.b0
 WHERE a.b = 10
 ----
+-- FULL JOIN with a null-rejecting conjunct on the right input demotes to RIGHT,
+-- so the right input keeps its unmatched rows.
+SELECT a, b, x, y
+FROM (VALUES (1, 10), (2, 20)) t(a, b)
+FULL JOIN (VALUES (1, 1), (3, 3)) u(x, y) ON a = x
+WHERE y > 0
+----
+-- FULL JOIN with a null-rejecting conjunct on the left input demotes to LEFT,
+-- so the left input keeps its unmatched rows.
+SELECT a, b, x, y
+FROM (VALUES (1, 10), (2, 20)) t(a, b)
+FULL JOIN (VALUES (1, 1), (3, 3)) u(x, y) ON a = x
+WHERE a > 0
+----
+-- FULL JOIN with null-rejecting conjuncts on both inputs demotes to INNER.
+SELECT a, b, x, y
+FROM (VALUES (1, 10), (2, 20)) t(a, b)
+FULL JOIN (VALUES (1, 1), (3, 3)) u(x, y) ON a = x
+WHERE a > 0 AND y > 0
+----
+-- FULL JOIN whose only conjunct does not reject nulls stays FULL.
+SELECT a, b, x, y
+FROM (VALUES (1, 10), (2, 20)) t(a, b)
+FULL JOIN (VALUES (1, 1), (3, 3)) u(x, y) ON a = x
+WHERE coalesce(y, 1) > 0
+----
 -- 8-way self-join hitting the greedy join-enumeration cutoff.
 SELECT count(*)
 FROM t t1

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -97,16 +97,20 @@ velox::core::JoinType demoteOuterToInner(
     case velox::core::JoinType::kRight:
       return anyRejects(leftColumns) ? velox::core::JoinType::kInner : joinType;
     case velox::core::JoinType::kFull: {
+      // A predicate that rejects nulls on one input eliminates the rows in
+      // which that input is null-padded, i.e. the other input's unmatched
+      // rows. So only the referenced input stays row-preserving: left ->
+      // LEFT, right -> RIGHT, both -> INNER.
       const bool rejectsLeft = anyRejects(leftColumns);
       const bool rejectsRight = anyRejects(rightColumns);
       if (rejectsLeft && rejectsRight) {
         return velox::core::JoinType::kInner;
       }
       if (rejectsLeft) {
-        return velox::core::JoinType::kRight;
+        return velox::core::JoinType::kLeft;
       }
       if (rejectsRight) {
-        return velox::core::JoinType::kLeft;
+        return velox::core::JoinType::kRight;
       }
       return joinType;
     }


### PR DESCRIPTION
Summary:

When a `FULL` join's ancestor predicate rejects nulls on one input,
`demoteOuterToInner` must demote to the outer join that keeps THAT input
row-preserving (a left-input predicate -> `LEFT`, a right-input predicate ->
`RIGHT`, predicates on both -> `INNER`), because the predicate eliminates the
rows in which that input is null-padded. It was selecting the opposite side, so
the referenced input's unmatched rows were dropped. This aligns v2 with the v1
optimizer (`DerivedTable::tryConvertOuterJoins`) and Prestissimo.

Reviewed By: kagamiori

Differential Revision: D115499009


