### PR TITLE
fix(optimizer): Fold a single-value IN list to an equality in v1 (#1711)

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -776,10 +776,11 @@ class TableLayout {
   ///   constant the second, for eq, lt, lte, gt and gte. A connector never
   ///   sees the constant on the left (e.g. eq(constant, column)).
   /// - An IN list over constants is a single in() over the column and the
-  ///   constant values, with duplicate values removed. The values may be
-  ///   encoded either as a constant array, in(column, ARRAY[...]), or as
-  ///   variadic arguments, in(column, v1, v2, ...). A connector should handle
-  ///   both forms.
+  ///   constant values, with duplicate values removed. A list that reduces to a
+  ///   single value is folded to an equality, eq(column, value). The remaining
+  ///   multi-value form may be encoded either as a constant array,
+  ///   in(column, ARRAY[...]), or as variadic arguments, in(column, v1, v2,
+  ///   ...). A connector should handle both forms.
   ///
   /// Predicates are NOT combined across conjuncts: 'filters' may contain
   /// several predicates on the same column (e.g. a = 1 and a = 2), which the
@@ -788,8 +789,8 @@ class TableLayout {
   ///
   /// TODO: Unify the two IN encodings into the varargs form and remove the
   /// ARRAY encoding.
-  /// TODO: Fold a single-element IN list to an equality, and simplify
-  /// redundant or contradictory same-column predicates, before pushdown.
+  /// TODO: Simplify redundant or contradictory same-column predicates before
+  /// pushdown.
   virtual velox::connector::ConnectorTableHandlePtr createTableHandle(
       const ConnectorSessionPtr& session,
       std::vector<velox::connector::ColumnHandlePtr> columnHandles,

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -690,16 +690,17 @@ velox::core::TypedExprPtr ToVelox::toAnd(const ExprVector& exprs) {
 namespace {
 
 template <typename T>
-velox::core::TypedExprPtr makeKey(const velox::TypePtr& type, T v) {
+velox::core::TypedExprPtr makeConstant(const velox::TypePtr& type, T v) {
   return std::make_shared<velox::core::ConstantTypedExpr>(
-      type, velox::Variant(v));
+      type, velox::Variant(std::move(v)));
 }
 
-// Returns a constant array expression for the IN list if the call is an IN
-// expression with all-literal elements. Returns nullptr otherwise.
-velox::core::TypedExprPtr tryCreateConstantInList(const Call& call) {
+// Returns the deduplicated literal values of an IN list, or std::nullopt if
+// 'call' is not an IN over all-literal elements.
+std::optional<std::vector<velox::Variant>> tryConstantInValues(
+    const Call& call) {
   if (call.name() != SpecialFormCallNames::kIn) {
-    return nullptr;
+    return std::nullopt;
   }
 
   VELOX_USER_CHECK_GE(call.args().size(), 2);
@@ -708,13 +709,13 @@ velox::core::TypedExprPtr tryCreateConstantInList(const Call& call) {
   if (!std::all_of(args.begin() + 1, args.end(), [](const auto& arg) {
         return arg->is(PlanType::kLiteralExpr);
       })) {
-    return nullptr;
+    return std::nullopt;
   }
 
   auto elementType = toTypePtr(args[0]->value().type);
 
-  std::vector<velox::Variant> arrayElements;
-  arrayElements.reserve(args.size() - 1);
+  std::vector<velox::Variant> values;
+  values.reserve(args.size() - 1);
   folly::F14FastSet<velox::Variant, velox::Variant::Hasher> seen;
   seen.reserve(args.size() - 1);
   for (size_t i = 1; i < args.size(); ++i) {
@@ -726,14 +727,10 @@ velox::core::TypedExprPtr tryCreateConstantInList(const Call& call) {
         arg->value().type->toString());
     auto& literal = arg->as<Literal>()->literal();
     if (seen.insert(literal).second) {
-      arrayElements.push_back(literal);
+      values.push_back(literal);
     }
   }
-  auto arrayVector = variantToVector(
-      ARRAY(elementType),
-      velox::Variant::array(arrayElements),
-      queryCtx()->optimization()->evaluator()->pool());
-  return std::make_shared<velox::core::ConstantTypedExpr>(arrayVector);
+  return values;
 }
 
 velox::core::TypedExprPtr stepToMapSubscript(
@@ -744,19 +741,19 @@ velox::core::TypedExprPtr stepToMapSubscript(
   velox::core::TypedExprPtr key;
   switch (type->as<velox::TypeKind::MAP>().childAt(0)->kind()) {
     case velox::TypeKind::VARCHAR:
-      key = makeKey(velox::VARCHAR(), step.field);
+      key = makeConstant(velox::VARCHAR(), step.field);
       break;
     case velox::TypeKind::BIGINT:
-      key = makeKey(velox::BIGINT(), step.id);
+      key = makeConstant(velox::BIGINT(), step.id);
       break;
     case velox::TypeKind::INTEGER:
-      key = makeKey(velox::INTEGER(), static_cast<int32_t>(step.id));
+      key = makeConstant(velox::INTEGER(), static_cast<int32_t>(step.id));
       break;
     case velox::TypeKind::SMALLINT:
-      key = makeKey(velox::SMALLINT(), static_cast<int16_t>(step.id));
+      key = makeConstant(velox::SMALLINT(), static_cast<int16_t>(step.id));
       break;
     case velox::TypeKind::TINYINT:
-      key = makeKey(velox::TINYINT(), static_cast<int8_t>(step.id));
+      key = makeConstant(velox::TINYINT(), static_cast<int8_t>(step.id));
       break;
     default:
       VELOX_FAIL("Unsupported key type");
@@ -804,7 +801,7 @@ velox::core::TypedExprPtr stepToGetter(
           type->childAt(0),
           funcName,
           arg,
-          makeKey(velox::INTEGER(), static_cast<int32_t>(step.id)));
+          makeConstant(velox::INTEGER(), static_cast<int32_t>(step.id)));
     }
 
     default:
@@ -911,9 +908,35 @@ velox::core::TypedExprPtr ToVelox::toTypedExprUncached(
       std::vector<velox::core::TypedExprPtr> inputs;
       auto call = expr->as<Call>();
 
-      if (auto inList = tryCreateConstantInList(*call)) {
-        inputs.push_back(toTypedExpr(call->args()[0], cache));
-        inputs.push_back(std::move(inList));
+      std::optional<std::vector<velox::Variant>> values;
+      if (call->name() == SpecialFormCallNames::kIn) {
+        values = tryConstantInValues(*call);
+      }
+      if (values) {
+        auto elementType = toTypePtr(call->args()[0]->value().type);
+        auto column = toTypedExpr(call->args()[0], cache);
+
+        // A list that reduces to a single value folds to an equality, matching
+        // the v2 optimizer.
+        if (values->size() == 1) {
+          const auto& value = values->front();
+          return std::make_shared<velox::core::CallTypedExpr>(
+              velox::BOOLEAN(),
+              std::string{queryCtx()->functionNames().equality},
+              std::move(column),
+              makeConstant(elementType, value));
+        }
+
+        // Multiple deduplicated values lower to in(column, ARRAY[...]); the
+        // special-form handling below names the call.
+        inputs.push_back(std::move(column));
+        inputs.push_back(
+            std::make_shared<velox::core::ConstantTypedExpr>(
+                velox::BaseVector::createConstant(
+                    ARRAY(elementType),
+                    velox::Variant::array(*values),
+                    1,
+                    queryCtx()->optimization()->evaluator()->pool())));
       } else {
         for (auto arg : call->args()) {
           inputs.push_back(toTypedExpr(arg, cache));

--- a/axiom/optimizer/tests/ConnectorPushdownTest.cpp
+++ b/axiom/optimizer/tests/ConnectorPushdownTest.cpp
@@ -33,9 +33,11 @@ namespace lp = facebook::axiom::logical_plan;
 // a connector's createTableHandle for pushdown. This shape is the contract
 // documented on ConnectorMetadata::createTableHandle; connector authors rely on
 // it.
-class ConnectorPushdownTest : public QueryTestBase {
+class ConnectorPushdownTest : public QueryTestBase,
+                              public ::testing::WithParamInterface<bool> {
  protected:
   void SetUp() override {
+    useV2_ = GetParam();
     QueryTestBase::SetUp();
     testConnector_->addTable(
         "t",
@@ -85,7 +87,7 @@ class ConnectorPushdownTest : public QueryTestBase {
 
 // Equality is canonicalized with the column as the first argument, regardless
 // of how the predicate was written.
-TEST_F(ConnectorPushdownTest, equality) {
+TEST_P(ConnectorPushdownTest, equality) {
   expectPushed("a = 5", {"a = 5"});
   expectPushed("5 = a", {"a = 5"});
   expectPushed("s = 'x'", {"s = 'x'"});
@@ -93,7 +95,7 @@ TEST_F(ConnectorPushdownTest, equality) {
 
 // Reversible comparisons also put the column first, flipping the operator when
 // the constant was written on the left.
-TEST_F(ConnectorPushdownTest, comparison) {
+TEST_P(ConnectorPushdownTest, comparison) {
   expectPushed("a < 10", {"a < 10"});
   expectPushed("10 > a", {"a < 10"});
   expectPushed("a > 5", {"a > 5"});
@@ -104,27 +106,29 @@ TEST_F(ConnectorPushdownTest, comparison) {
   expectPushed("5 <= a", {"a >= 5"});
 }
 
-// An all-literal IN list is pushed as a deduplicated IN. v1 emits the constant
-// array form (the contract also permits varargs); a single-element list stays
-// an IN, not folded to an equality.
-TEST_F(ConnectorPushdownTest, inList) {
+// An all-literal IN list is pushed as a deduplicated IN; the multi-value form
+// may be a constant array (as v1 emits) or varargs. A list that dedups to a
+// single value folds to an equality.
+TEST_P(ConnectorPushdownTest, inList) {
   expectPushed("a in (1, 2, 3)", {"a in (1, 2, 3)"});
-  expectPushed("a in (5, 5)", {"a in (5)"});
+  expectPushed("a in (5, 5)", {"a = 5"});
 }
 
 // Predicates are not combined across conjuncts: a connector may receive several
 // predicates on the same column and must handle them.
-TEST_F(ConnectorPushdownTest, duplicateColumnPredicates) {
+TEST_P(ConnectorPushdownTest, duplicateColumnPredicates) {
   expectPushed("a = 1 and a = 2", {"a = 1", "a = 2"});
 }
 
 // A top-level conjunction is flattened: each leaf predicate is a separate
 // conjunct, even when nested.
-TEST_F(ConnectorPushdownTest, nestedAndFlattened) {
+TEST_P(ConnectorPushdownTest, nestedAndFlattened) {
   expectPushed(
       "a = 1 and (b = 2 and (c = 3 and s = 'x'))",
       {"a = 1", "b = 2", "c = 3", "s = 'x'"});
 }
+
+AXIOM_INSTANTIATE_V1_V2(ConnectorPushdownTest);
 
 } // namespace
 } // namespace facebook::axiom::optimizer::test


### PR DESCRIPTION
Summary:

An IN list over constants that reduces to one value, `a IN (5, 5)`, now lowers to `a = 5` in v1, as it already does in v2. The fold is sound in three-valued logic: `a IN (b)` and `a = b` agree on true, false and null.

Documents the folded form in the `createTableHandle` pushdown contract, and runs `ConnectorPushdownTest` under both optimizers.

Reviewed By: mbasmanova

Differential Revision: D115870503


