### PR TITLE
fix(optimizer): Report the fixed-point NYI error from v2 as well

### DIFF
--- a/axiom/optimizer/tests/FixedPointTest.cpp
+++ b/axiom/optimizer/tests/FixedPointTest.cpp
@@ -24,10 +24,17 @@ using namespace facebook::velox;
 namespace facebook::axiom::optimizer {
 namespace {
 
-class FixedPointTest : public test::QueryTestBase {};
+class FixedPointTest : public test::QueryTestBase,
+                       public ::testing::WithParamInterface<bool> {
+ protected:
+  void SetUp() override {
+    useV2_ = GetParam();
+    test::QueryTestBase::SetUp();
+  }
+};
 
 // Attempting to execute a recursive plan must fail with a clear NYI error.
-TEST_F(FixedPointTest, withRecursiveThrowsNyi) {
+TEST_P(FixedPointTest, withRecursiveThrowsNyi) {
   auto rowType = ROW("n", BIGINT());
   logical_plan::PlanBuilder::Context context;
 
@@ -45,6 +52,8 @@ TEST_F(FixedPointTest, withRecursiveThrowsNyi) {
       toSingleNodePlan(plan),
       "Fixed-point (recursive) plan execution is not yet implemented");
 }
+
+AXIOM_INSTANTIATE_V1_V2(FixedPointTest);
 
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -733,6 +733,10 @@ Translated Translator::translateNode(
       return translateTableWrite(*node.as<lp::TableWriteNode>(), required);
     case lp::NodeKind::kOutput:
       VELOX_UNREACHABLE();
+    case lp::NodeKind::kFixedPoint:
+    case lp::NodeKind::kRecursiveReference:
+      VELOX_NYI(
+          "Fixed-point (recursive) plan execution is not yet implemented");
     default:
       VELOX_NYI(
           "Unsupported logical plan node kind: {}",


### PR DESCRIPTION
Summary:
A recursive plan reaching v2 raised the generic "Unsupported logical plan node
kind: FIXED_POINT". Report the same "not yet implemented" error v1 does, since
fixed point is a known unimplemented feature rather than an unrecognized node.
Runs `FixedPointTest` under both optimizers.

Differential Revision: D115871526


