### PR TITLE
test(optimizer): Take child matchers as builders in PlanMatcher

### DIFF
--- a/axiom/connectors/system/tests/CoordinatorSchedulingTest.cpp
+++ b/axiom/connectors/system/tests/CoordinatorSchedulingTest.cpp
@@ -131,7 +131,7 @@ TEST_F(CoordinatorSchedulingTest, unionWithValues) {
 
   auto matcher = PlanMatcherBuilder()
                      .tableScan("runtime.queries")
-                     .localPartition(matchValues().project().build())
+                     .localPartition(matchValues().project())
                      .output(FragmentType::kCoordinator)
                      .build();
   AXIOM_ASSERT_DISTRIBUTED_PLAN(plan, matcher);
@@ -152,8 +152,7 @@ TEST_F(CoordinatorSchedulingTest, unionWithRegular) {
                      .localPartition(
                          PlanMatcherBuilder()
                              .tableScan("runtime.queries")
-                             .arbitrary(FragmentType::kCoordinator)
-                             .build())
+                             .arbitrary(FragmentType::kCoordinator))
                      .gather(FragmentType::kSource)
                      .build();
   AXIOM_ASSERT_DISTRIBUTED_PLAN(plan, matcher);

--- a/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
@@ -185,8 +185,7 @@ TEST_P(BucketedExecutionTest, semijoin) {
           plan.plan,
           matchScan("sj_orders")
               .hashJoin(
-                  matchScan("sj_customers").build(),
-                  core::JoinType::kLeftSemiFilter)
+                  matchScan("sj_customers"), core::JoinType::kLeftSemiFilter)
               .bucketed()
               .fragmentWidth(4)
               .gather()
@@ -211,7 +210,7 @@ TEST_P(BucketedExecutionTest, semijoin) {
           plan.plan,
           matchScan("sj_orders")
               .hashJoin(
-                  matchScan("sj_customers").build(),
+                  matchScan("sj_customers"),
                   core::JoinType::kAnti,
                   {.nullAware = true})
               .bucketed()
@@ -645,9 +644,7 @@ TEST_P(BucketedExecutionTest, innerJoinChainFuses) {
       syntacticPlan,
       matchScan("t")
           .hashJoin(
-              matchScan("u")
-                  .hashJoin(matchScan("v").build(), core::JoinType::kInner)
-                  .build(),
+              matchScan("u").hashJoin(matchScan("v"), core::JoinType::kInner),
               core::JoinType::kInner)
           .bucketed()
           .bucketedScans(3)
@@ -664,8 +661,8 @@ TEST_P(BucketedExecutionTest, innerJoinChainFuses) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         reorderedPlan,
         matchScan("u")
-            .hashJoin(matchScan("v").build(), core::JoinType::kInner)
-            .hashJoin(matchScan("t").build(), core::JoinType::kInner)
+            .hashJoin(matchScan("v"), core::JoinType::kInner)
+            .hashJoin(matchScan("t"), core::JoinType::kInner)
             .bucketed()
             .bucketedScans(3)
             .fragmentWidth(4)
@@ -675,8 +672,8 @@ TEST_P(BucketedExecutionTest, innerJoinChainFuses) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         reorderedPlan,
         matchScan("t")
-            .hashJoin(matchScan("u").build(), core::JoinType::kInner)
-            .hashJoin(matchScan("v").build(), core::JoinType::kInner)
+            .hashJoin(matchScan("u"), core::JoinType::kInner)
+            .hashJoin(matchScan("v"), core::JoinType::kInner)
             .bucketed()
             .bucketedScans(3)
             .fragmentWidth(4)
@@ -712,9 +709,8 @@ TEST_P(BucketedExecutionTest, leftJoinChainDoesNotFuse) {
         matchScan("t")
             .hashJoin(
                 matchScan("u")
-                    .hashJoin(matchScan("v").build(), core::JoinType::kLeft)
-                    .shuffle()
-                    .build(),
+                    .hashJoin(matchScan("v"), core::JoinType::kLeft)
+                    .shuffle(),
                 core::JoinType::kInner)
             .gather()
             .build());
@@ -723,9 +719,7 @@ TEST_P(BucketedExecutionTest, leftJoinChainDoesNotFuse) {
         syntacticPlan,
         matchScan("t")
             .hashJoin(
-                matchScan("u")
-                    .hashJoin(matchScan("v").build(), core::JoinType::kInner)
-                    .build(),
+                matchScan("u").hashJoin(matchScan("v"), core::JoinType::kInner),
                 core::JoinType::kInner)
             .bucketed()
             .bucketedScans(3)
@@ -742,17 +736,16 @@ TEST_P(BucketedExecutionTest, leftJoinChainDoesNotFuse) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         reorderedPlan,
         matchScan("u")
-            .hashJoin(matchScan("v").build(), core::JoinType::kLeft)
-            .hashJoin(
-                matchScan("t").broadcast().build(), core::JoinType::kInner)
+            .hashJoin(matchScan("v"), core::JoinType::kLeft)
+            .hashJoin(matchScan("t").broadcast(), core::JoinType::kInner)
             .gather()
             .build());
   } else {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         reorderedPlan,
         matchScan("t")
-            .hashJoin(matchScan("u").build(), core::JoinType::kInner)
-            .hashJoin(matchScan("v").build(), core::JoinType::kInner)
+            .hashJoin(matchScan("u"), core::JoinType::kInner)
+            .hashJoin(matchScan("v"), core::JoinType::kInner)
             .bucketed()
             .bucketedScans(3)
             .fragmentWidth(4)

--- a/axiom/optimizer/tests/ConnectorSubtreePushdownTest.cpp
+++ b/axiom/optimizer/tests/ConnectorSubtreePushdownTest.cpp
@@ -100,7 +100,7 @@ TEST_F(ConnectorSubtreePushdownTest, absorbsProbeSideOfJoin) {
       });
 
   auto plan = toSingleNodePlan(logicalPlan);
-  auto buildMatcher = matchScan("u").build();
+  auto buildMatcher = matchScan("u");
   auto matcher = matchScan("v").hashJoin(buildMatcher).build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }

--- a/axiom/optimizer/tests/ExistencePushdownTest.cpp
+++ b/axiom/optimizer/tests/ExistencePushdownTest.cpp
@@ -92,11 +92,9 @@ TEST_F(ExistencePushdownTest, innerJoinGroupBy) {
   auto matcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("b < 100").build(),
-              core::JoinType::kLeftSemiFilter)
+              matchScan("t").filter("b < 100"), core::JoinType::kLeftSemiFilter)
           .singleAggregation({"x"}, {"count(*) as cnt"})
-          .hashJoin(
-              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
+          .hashJoin(matchScan("t").filter("b < 100"), core::JoinType::kInner)
           .project()
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -110,13 +108,13 @@ TEST_F(ExistencePushdownTest, innerJoinGroupBy) {
   auto distributedMatcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("b < 100").broadcast().build(),
+              matchScan("t").filter("b < 100").broadcast(),
               core::JoinType::kLeftSemiFilter)
           .shuffle({"x"})
           .localPartition({"x"})
           .singleAggregation({"x"}, {"count(*) as cnt"})
           .hashJoin(
-              matchScan("t").filter("b < 100").shuffle({"a"}).build(),
+              matchScan("t").filter("b < 100").shuffle({"a"}),
               core::JoinType::kInner)
           .project()
           .gather()
@@ -140,12 +138,11 @@ TEST_F(ExistencePushdownTest, semiJoin) {
                      .hashJoin(
                          matchScan("u")
                              .hashJoin(
-                                 matchScan("t").filter("b < 100").build(),
+                                 matchScan("t").filter("b < 100"),
                                  core::JoinType::kLeftSemiFilter)
                              .singleAggregation({"x"}, {"count(*) as cnt"})
                              .filter("cnt > 1")
-                             .project()
-                             .build(),
+                             .project(),
                          core::JoinType::kLeftSemiFilter)
                      .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -165,15 +162,14 @@ TEST_F(ExistencePushdownTest, semiJoin) {
           .hashJoin(
               matchScan("u")
                   .hashJoin(
-                      matchScan("t").filter("b < 100").broadcast().build(),
+                      matchScan("t").filter("b < 100").broadcast(),
                       core::JoinType::kLeftSemiFilter)
                   .shuffle({"x"})
                   .localPartition({"x"})
                   .singleAggregation({"x"}, {"count(*) as cnt"})
                   .filter("cnt > 1")
                   .project()
-                  .broadcast()
-                  .build(),
+                  .broadcast(),
               core::JoinType::kLeftSemiFilter)
           .gather()
           .build();
@@ -196,11 +192,9 @@ TEST_F(ExistencePushdownTest, leftJoinDtIsOptional) {
   auto matcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("b < 100").build(),
-              core::JoinType::kLeftSemiFilter)
+              matchScan("t").filter("b < 100"), core::JoinType::kLeftSemiFilter)
           .singleAggregation({"x"}, {"count(*) as cnt"})
-          .hashJoin(
-              matchScan("t").filter("b < 100").build(), core::JoinType::kRight)
+          .hashJoin(matchScan("t").filter("b < 100"), core::JoinType::kRight)
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
@@ -210,13 +204,13 @@ TEST_F(ExistencePushdownTest, leftJoinDtIsOptional) {
   auto distributedMatcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("b < 100").broadcast().build(),
+              matchScan("t").filter("b < 100").broadcast(),
               core::JoinType::kLeftSemiFilter)
           .shuffle({"x"})
           .localPartition({"x"})
           .singleAggregation({"x"}, {"count(*) as cnt"})
           .hashJoin(
-              matchScan("t").filter("b < 100").shuffle({"a"}).build(),
+              matchScan("t").filter("b < 100").shuffle({"a"}),
               core::JoinType::kRight)
           .gather()
           .build();
@@ -236,17 +230,15 @@ TEST_F(ExistencePushdownTest, otherIsDerivedTable) {
   // Single-node plan.
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher = matchScan("u")
-                     .filter("x < 10")
-                     .singleAggregation({"x"}, {"count(*) as cnt"})
-                     .hashJoin(
-                         matchScan("v")
-                             .filter("a < 10")
-                             .singleAggregation({"a"}, {})
-                             .build(),
-                         core::JoinType::kInner)
-                     .project()
-                     .build();
+  auto matcher =
+      matchScan("u")
+          .filter("x < 10")
+          .singleAggregation({"x"}, {"count(*) as cnt"})
+          .hashJoin(
+              matchScan("v").filter("a < 10").singleAggregation({"a"}, {}),
+              core::JoinType::kInner)
+          .project()
+          .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
@@ -262,8 +254,7 @@ TEST_F(ExistencePushdownTest, otherIsDerivedTable) {
                                         .filter("a < 10")
                                         .shuffle({"a"})
                                         .localPartition({"a"})
-                                        .singleAggregation({"a"}, {})
-                                        .build(),
+                                        .singleAggregation({"a"}, {}),
                                     core::JoinType::kInner)
                                 .project()
                                 .gather()
@@ -290,19 +281,14 @@ TEST_F(ExistencePushdownTest, chainJoin) {
               matchScan("r")
                   .filter("b < 100")
                   .hashJoin(
-                      matchScan("s")
-                          .aliases({"s_a"})
-                          .filter("s_a < 100")
-                          .build(),
+                      matchScan("s").aliases({"s_a"}).filter("s_a < 100"),
                       core::JoinType::kInner)
-                  .project()
-                  .build(),
+                  .project(),
               core::JoinType::kLeftSemiFilter)
           .singleAggregation({"x"}, {"count(*) as cnt"})
+          .hashJoin(matchScan("r").filter("b < 100"), core::JoinType::kInner)
           .hashJoin(
-              matchScan("r").filter("b < 100").build(), core::JoinType::kInner)
-          .hashJoin(
-              matchScan("s").aliases({"s_a"}).filter("s_a < 100").build(),
+              matchScan("s").aliases({"s_a"}).filter("s_a < 100"),
               core::JoinType::kInner)
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -319,25 +305,19 @@ TEST_F(ExistencePushdownTest, chainJoin) {
                       matchScan("s")
                           .aliases({"s_a"})
                           .filter("s_a < 100")
-                          .broadcast()
-                          .build(),
+                          .broadcast(),
                       core::JoinType::kInner)
                   .project()
-                  .broadcast()
-                  .build(),
+                  .broadcast(),
               core::JoinType::kLeftSemiFilter)
           .shuffle({"x"})
           .localPartition({"x"})
           .singleAggregation({"x"}, {"count(*) as cnt"})
           .hashJoin(
-              matchScan("r").filter("b < 100").shuffle({"a"}).build(),
+              matchScan("r").filter("b < 100").shuffle({"a"}),
               core::JoinType::kInner)
           .hashJoin(
-              matchScan("s")
-                  .aliases({"s_a"})
-                  .filter("s_a < 100")
-                  .broadcast()
-                  .build(),
+              matchScan("s").aliases({"s_a"}).filter("s_a < 100").broadcast(),
               core::JoinType::kInner)
           .gather()
           .build();
@@ -363,15 +343,12 @@ TEST_F(ExistencePushdownTest, multipleTables) {
           .hashJoin(
               matchScan("u")
                   .hashJoin(
-                      matchScan("r").filter("b < 100").build(),
+                      matchScan("r").filter("b < 100"),
                       core::JoinType::kLeftSemiFilter)
-                  .hashJoin(
-                      matchScan("s").build(), core::JoinType::kLeftSemiFilter)
-                  .singleAggregation({"x", "y"}, {})
-                  .build(),
+                  .hashJoin(matchScan("s"), core::JoinType::kLeftSemiFilter)
+                  .singleAggregation({"x", "y"}, {}),
               core::JoinType::kInner)
-          .hashJoin(
-              matchScan("r").filter("b < 100").build(), core::JoinType::kInner)
+          .hashJoin(matchScan("r").filter("b < 100"), core::JoinType::kInner)
           .project()
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -387,22 +364,17 @@ TEST_F(ExistencePushdownTest, multipleTables) {
                   .hashJoin(
                       matchScan("u")
                           .hashJoin(
-                              matchScan("r")
-                                  .filter("b < 100")
-                                  .broadcast()
-                                  .build(),
+                              matchScan("r").filter("b < 100").broadcast(),
                               core::JoinType::kLeftSemiFilter)
-                          .shuffle({"y"})
-                          .build(),
+                          .shuffle({"y"}),
                       core::JoinType::kRightSemiFilter)
                   .shuffle({"x", "y"})
                   .localPartition({"x", "y"})
                   .singleAggregation({"x", "y"}, {})
-                  .broadcast()
-                  .build(),
+                  .broadcast(),
               core::JoinType::kInner)
           .hashJoin(
-              matchScan("r").filter("b < 100").broadcast().build(),
+              matchScan("r").filter("b < 100").broadcast(),
               core::JoinType::kInner)
           .project()
           .gather()
@@ -429,9 +401,8 @@ TEST_F(ExistencePushdownTest, partialPush) {
   auto matcher =
       matchScan("u")
           .singleAggregation({"x"}, {"count(*) as cnt"})
-          .hashJoin(
-              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
-          .hashJoin(matchScan("r").build(), core::JoinType::kInner)
+          .hashJoin(matchScan("t").filter("b < 100"), core::JoinType::kInner)
+          .hashJoin(matchScan("r"), core::JoinType::kInner)
           .project()
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -445,9 +416,9 @@ TEST_F(ExistencePushdownTest, partialPush) {
           .localPartition({"x"})
           .singleAggregation({"x"}, {"count(*) as cnt"})
           .hashJoin(
-              matchScan("t").filter("b < 100").shuffle({"a"}).build(),
+              matchScan("t").filter("b < 100").shuffle({"a"}),
               core::JoinType::kInner)
-          .hashJoin(matchScan("r").broadcast().build(), core::JoinType::kInner)
+          .hashJoin(matchScan("r").broadcast(), core::JoinType::kInner)
           .project()
           .gather()
           .project()
@@ -470,11 +441,9 @@ TEST_F(ExistencePushdownTest, distinctSubquery) {
   auto matcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("b < 100").build(),
-              core::JoinType::kLeftSemiFilter)
+              matchScan("t").filter("b < 100"), core::JoinType::kLeftSemiFilter)
           .singleAggregation({"x"}, {})
-          .hashJoin(
-              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
+          .hashJoin(matchScan("t").filter("b < 100"), core::JoinType::kInner)
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
@@ -487,13 +456,13 @@ TEST_F(ExistencePushdownTest, distinctSubquery) {
   auto distributedMatcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("b < 100").broadcast().build(),
+              matchScan("t").filter("b < 100").broadcast(),
               core::JoinType::kLeftSemiFilter)
           .shuffle({"x"})
           .localPartition({"x"})
           .singleAggregation({"x"}, {})
           .hashJoin(
-              matchScan("t").filter("b < 100").shuffle({"a"}).build(),
+              matchScan("t").filter("b < 100").shuffle({"a"}),
               core::JoinType::kInner)
           .gather()
           .build();
@@ -516,11 +485,9 @@ TEST_F(ExistencePushdownTest, multiKeyJoin) {
   auto matcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("c < 100").build(),
-              core::JoinType::kLeftSemiFilter)
+              matchScan("t").filter("c < 100"), core::JoinType::kLeftSemiFilter)
           .singleAggregation({"x", "y"}, {"count(*) as cnt"})
-          .hashJoin(
-              matchScan("t").filter("c < 100").build(), core::JoinType::kInner)
+          .hashJoin(matchScan("t").filter("c < 100"), core::JoinType::kInner)
           .project()
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -531,13 +498,13 @@ TEST_F(ExistencePushdownTest, multiKeyJoin) {
   auto distributedMatcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("c < 100").broadcast().build(),
+              matchScan("t").filter("c < 100").broadcast(),
               core::JoinType::kLeftSemiFilter)
           .shuffle({"x", "y"})
           .localPartition({"x", "y"})
           .singleAggregation({"x", "y"}, {"count(*) as cnt"})
           .hashJoin(
-              matchScan("t").filter("c < 100").shuffle({"a", "b"}).build(),
+              matchScan("t").filter("c < 100").shuffle({"a", "b"}),
               core::JoinType::kInner)
           .project()
           .gather()
@@ -562,11 +529,9 @@ TEST_F(ExistencePushdownTest, joinWithFilter) {
   auto matcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("c < 100").build(),
-              core::JoinType::kLeftSemiFilter)
+              matchScan("t").filter("c < 100"), core::JoinType::kLeftSemiFilter)
           .singleAggregation({"x"}, {"count(*) as cnt"})
-          .hashJoin(
-              matchScan("t").filter("c < 100").build(), core::JoinType::kInner)
+          .hashJoin(matchScan("t").filter("c < 100"), core::JoinType::kInner)
           .filter("b < x")
           .project()
           .build();
@@ -578,13 +543,13 @@ TEST_F(ExistencePushdownTest, joinWithFilter) {
   auto distributedMatcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("c < 100").broadcast().build(),
+              matchScan("t").filter("c < 100").broadcast(),
               core::JoinType::kLeftSemiFilter)
           .shuffle({"x"})
           .localPartition({"x"})
           .singleAggregation({"x"}, {"count(*) as cnt"})
           .hashJoin(
-              matchScan("t").filter("c < 100").shuffle({"a"}).build(),
+              matchScan("t").filter("c < 100").shuffle({"a"}),
               core::JoinType::kInner)
           .filter("b < x")
           .project()
@@ -606,7 +571,7 @@ TEST_F(ExistencePushdownTest, leftJoinDtIsPreserved) {
 
   auto matcher = matchScan("u")
                      .singleAggregation({"x"}, {"count(*) as cnt"})
-                     .hashJoin(matchScan("t").build(), core::JoinType::kLeft)
+                     .hashJoin(matchScan("t"), core::JoinType::kLeft)
                      .project()
                      .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -619,8 +584,7 @@ TEST_F(ExistencePushdownTest, leftJoinDtIsPreserved) {
           .shuffle({"x"})
           .localPartition({"x"})
           .singleAggregation({"x"}, {"count(*) as cnt"})
-          .hashJoin(
-              matchScan("t").shuffle({"a"}).build(), core::JoinType::kLeft)
+          .hashJoin(matchScan("t").shuffle({"a"}), core::JoinType::kLeft)
           .project()
           .gather()
           .build();
@@ -645,12 +609,10 @@ TEST_F(ExistencePushdownTest, windowSubquery) {
   auto matcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("b < 100").build(),
-              core::JoinType::kLeftSemiFilter)
+              matchScan("t").filter("b < 100"), core::JoinType::kLeftSemiFilter)
           .window({"row_number() OVER (PARTITION BY x ORDER BY y)"})
           .project()
-          .hashJoin(
-              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
+          .hashJoin(matchScan("t").filter("b < 100"), core::JoinType::kInner)
           .project()
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -661,14 +623,14 @@ TEST_F(ExistencePushdownTest, windowSubquery) {
   auto distributedMatcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("b < 100").broadcast().build(),
+              matchScan("t").filter("b < 100").broadcast(),
               core::JoinType::kLeftSemiFilter)
           .shuffle({"x"})
           .localPartition({"x"})
           .window({"row_number() OVER (PARTITION BY x ORDER BY y)"})
           .project()
           .hashJoin(
-              matchScan("t").filter("b < 100").shuffle({"a"}).build(),
+              matchScan("t").filter("b < 100").shuffle({"a"}),
               core::JoinType::kInner)
           .project()
           .gather()
@@ -689,15 +651,13 @@ TEST_F(ExistencePushdownTest, limitOnFirstDt) {
   // Single-node plan.
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher = matchScan("t")
-                     .filter("b < 100")
-                     .hashJoin(
-                         matchScan("u")
-                             .singleAggregation({"x"}, {})
-                             .finalLimit(0, 10)
-                             .build(),
-                         core::JoinType::kInner)
-                     .build();
+  auto matcher =
+      matchScan("t")
+          .filter("b < 100")
+          .hashJoin(
+              matchScan("u").singleAggregation({"x"}, {}).finalLimit(0, 10),
+              core::JoinType::kInner)
+          .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // Distributed plan.
@@ -711,8 +671,7 @@ TEST_F(ExistencePushdownTest, limitOnFirstDt) {
                                         .localPartition({"x"})
                                         .singleAggregation({"x"}, {})
                                         .distributedLimit(0, 10)
-                                        .broadcast()
-                                        .build(),
+                                        .broadcast(),
                                     core::JoinType::kInner)
                                 .gather()
                                 .build();
@@ -737,12 +696,10 @@ TEST_F(ExistencePushdownTest, orderByOnFirstDt) {
   auto matcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("b < 100").build(),
-              core::JoinType::kLeftSemiFilter)
+              matchScan("t").filter("b < 100"), core::JoinType::kLeftSemiFilter)
           .singleAggregation({"x"}, {"count(*) as cnt"})
           .project()
-          .hashJoin(
-              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
+          .hashJoin(matchScan("t").filter("b < 100"), core::JoinType::kInner)
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
@@ -752,14 +709,14 @@ TEST_F(ExistencePushdownTest, orderByOnFirstDt) {
   auto distributedMatcher =
       matchScan("u")
           .hashJoin(
-              matchScan("t").filter("b < 100").broadcast().build(),
+              matchScan("t").filter("b < 100").broadcast(),
               core::JoinType::kLeftSemiFilter)
           .shuffle({"x"})
           .localPartition({"x"})
           .singleAggregation({"x"}, {"count(*) as cnt"})
           .project()
           .hashJoin(
-              matchScan("t").filter("b < 100").shuffle({"a"}).build(),
+              matchScan("t").filter("b < 100").shuffle({"a"}),
               core::JoinType::kInner)
           .gather()
           .build();
@@ -782,8 +739,7 @@ TEST_F(ExistencePushdownTest, aggregateKey) {
       matchScan("u")
           .singleAggregation({"x"}, {"count(*) as cnt"})
           .project()
-          .hashJoin(
-              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
+          .hashJoin(matchScan("t").filter("b < 100"), core::JoinType::kInner)
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
@@ -797,7 +753,7 @@ TEST_F(ExistencePushdownTest, aggregateKey) {
           .singleAggregation({"x"}, {"count(*) as cnt"})
           .project()
           .hashJoin(
-              matchScan("t").filter("b < 100").broadcast().build(),
+              matchScan("t").filter("b < 100").broadcast(),
               core::JoinType::kInner)
           .gather()
           .build();
@@ -826,8 +782,7 @@ TEST_F(ExistencePushdownTest, otherIsUnnestDerivedTable) {
                          matchScan("t")
                              .project({"array[a, b] as a"})
                              .unnest({}, {"a"})
-                             .singleAggregation({"n"}, {})
-                             .build(),
+                             .singleAggregation({"n"}, {}),
                          core::JoinType::kInner)
                      .project()
                      .build();
@@ -847,8 +802,7 @@ TEST_F(ExistencePushdownTest, otherIsUnnestDerivedTable) {
                                         .partialAggregation({"n"}, {})
                                         .shuffle({"n"})
                                         .localPartition({"n"})
-                                        .finalAggregation({"n"}, {})
-                                        .build(),
+                                        .finalAggregation({"n"}, {}),
                                     core::JoinType::kInner)
                                 .project()
                                 .gather()
@@ -878,11 +832,8 @@ TEST_F(ExistencePushdownTest, unnestGroupBy) {
   auto matcher = matchScan("r")
                      .filter("b < 100")
                      .hashJoin(
-                         matchScan("t")
-                             .project()
-                             .unnest()
-                             .singleAggregation({"n"}, {"count(*) as cnt"})
-                             .build(),
+                         matchScan("t").project().unnest().singleAggregation(
+                             {"n"}, {"count(*) as cnt"}),
                          core::JoinType::kInner)
                      .project()
                      .build();
@@ -902,8 +853,7 @@ TEST_F(ExistencePushdownTest, unnestGroupBy) {
                   .shuffle({"n"})
                   .localPartition({"n"})
                   .finalAggregation({"n"}, {"count(cnt) as cnt"})
-                  .broadcast()
-                  .build(),
+                  .broadcast(),
               core::JoinType::kInner)
           .project()
           .gather()
@@ -928,7 +878,7 @@ TEST_F(ExistencePushdownTest, unnestKey) {
   // The plan has a semi-join between t_no_stats and the unnest output.
   auto matcher = matchScan("t_no_stats")
                      .hashJoin(
-                         core::PlanMatcherBuilder{}.values().unnest().build(),
+                         core::PlanMatcherBuilder{}.values().unnest(),
                          core::JoinType::kLeftSemiFilter)
                      .project()
                      .build();
@@ -954,8 +904,7 @@ TEST_F(ExistencePushdownTest, windowNonPartitionKey) {
       matchScan("u")
           .window({"row_number() OVER (ORDER BY y)"})
           .project()
-          .hashJoin(
-              matchScan("t").filter("b < 100").build(), core::JoinType::kInner)
+          .hashJoin(matchScan("t").filter("b < 100"), core::JoinType::kInner)
           .project()
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -973,7 +922,7 @@ TEST_F(ExistencePushdownTest, windowNonPartitionKey) {
           .window({"row_number() OVER (ORDER BY y)"})
           .project()
           .hashJoin(
-              matchScan("t").filter("b < 100").broadcast().build(),
+              matchScan("t").filter("b < 100").broadcast(),
               core::JoinType::kInner)
           .project()
           .build();
@@ -998,12 +947,11 @@ TEST_F(ExistencePushdownTest, functionOfGroupingKey) {
                            matchScan("u")
                                .project()
                                .hashJoin(
-                                   matchScan("t").project().build(),
+                                   matchScan("t").project(),
                                    core::JoinType::kLeftSemiFilter)
                                .singleAggregation({"x", "y"}, {})
                                .project()
-                               .project()
-                               .build(),
+                               .project(),
                            core::JoinType::kLeft)
                        .project()
                        .build();
@@ -1020,16 +968,16 @@ TEST_F(ExistencePushdownTest, functionOfGroupingKey) {
         ") dt ON abs(dt.x) = abs(t.a)");
 
     // No semi-join — reversed LEFT JOIN (RIGHT JOIN with u as probe).
-    auto matcher = matchScan("u")
-                       .project({"x + 2 as p", "y"})
-                       .singleAggregation({"p", "y"}, {})
-                       .project()
-                       .project()
-                       .hashJoin(
-                           matchScan("t").project({"abs(a)"}).build(),
-                           core::JoinType::kRight)
-                       .project()
-                       .build();
+    auto matcher =
+        matchScan("u")
+            .project({"x + 2 as p", "y"})
+            .singleAggregation({"p", "y"}, {})
+            .project()
+            .project()
+            .hashJoin(
+                matchScan("t").project({"abs(a)"}), core::JoinType::kRight)
+            .project()
+            .build();
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
@@ -1047,14 +995,13 @@ TEST_F(ExistencePushdownTest, functionOfAggregate) {
       ") dt ON abs(dt.cnt) = abs(t.a)");
 
   // No semi-join pushdown — reversed LEFT JOIN (RIGHT JOIN with u as probe).
-  auto matcher =
-      matchScan("u")
-          .singleAggregation({"x"}, {"count(*) as cnt"})
-          .project()
-          .project()
-          .hashJoin(matchScan("t").project().build(), core::JoinType::kRight)
-          .project()
-          .build();
+  auto matcher = matchScan("u")
+                     .singleAggregation({"x"}, {"count(*) as cnt"})
+                     .project()
+                     .project()
+                     .hashJoin(matchScan("t").project(), core::JoinType::kRight)
+                     .project()
+                     .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 

--- a/axiom/optimizer/tests/FilterPushdownTest.cpp
+++ b/axiom/optimizer/tests/FilterPushdownTest.cpp
@@ -130,8 +130,7 @@ TEST_F(FilterPushdownTest, throughJoin) {
 
     auto matcher =
         startMatcher("nation")
-            .hashJoin(
-                startMatcher("region").build(), velox::core::JoinType::kInner)
+            .hashJoin(startMatcher("region"), velox::core::JoinType::kInner)
             .filter()
             .aggregation()
             .build();
@@ -155,8 +154,7 @@ TEST_F(FilterPushdownTest, throughJoin) {
     auto matcher =
         core::PlanMatcherBuilder()
             .hiveScan("nation", test::lt("n_nationkey", (int64_t)10))
-            .hashJoin(
-                startMatcher("region").build(), velox::core::JoinType::kInner)
+            .hashJoin(startMatcher("region"), velox::core::JoinType::kInner)
             .aggregation()
             .build();
 
@@ -174,15 +172,13 @@ TEST_F(FilterPushdownTest, throughJoin) {
 
     auto plan = toSingleNodePlan(logicalPlan);
 
-    auto matcher =
-        startMatcher("nation")
-            .hashJoin(
-                core::PlanMatcherBuilder()
-                    .hiveScan("region", test::lt("r_regionkey", (int64_t)10))
-                    .build(),
-                velox::core::JoinType::kInner)
-            .aggregation()
-            .build();
+    auto matcher = startMatcher("nation")
+                       .hashJoin(
+                           core::PlanMatcherBuilder().hiveScan(
+                               "region", test::lt("r_regionkey", (int64_t)10)),
+                           velox::core::JoinType::kInner)
+                       .aggregation()
+                       .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -199,16 +195,14 @@ TEST_F(FilterPushdownTest, throughJoin) {
 
     auto plan = toSingleNodePlan(logicalPlan);
 
-    auto matcher =
-        core::PlanMatcherBuilder()
-            .hiveScan("nation", test::eq("n_regionkey", (int64_t)1))
-            .hashJoin(
-                core::PlanMatcherBuilder()
-                    .hiveScan("region", test::eq("r_regionkey", (int64_t)1))
-                    .build(),
-                velox::core::JoinType::kInner)
-            .aggregation()
-            .build();
+    auto matcher = core::PlanMatcherBuilder()
+                       .hiveScan("nation", test::eq("n_regionkey", (int64_t)1))
+                       .hashJoin(
+                           core::PlanMatcherBuilder().hiveScan(
+                               "region", test::eq("r_regionkey", (int64_t)1)),
+                           velox::core::JoinType::kInner)
+                       .aggregation()
+                       .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -263,9 +257,8 @@ TEST_F(FilterPushdownTest, multiTableOrFilter) {
       core::PlanMatcherBuilder()
           .hiveScan("nation", test::in("n_name", {"FRANCE", "JAPAN"}))
           .hashJoin(
-              core::PlanMatcherBuilder()
-                  .hiveScan("region", test::in("r_name", {"ASIA", "EUROPE"}))
-                  .build(),
+              core::PlanMatcherBuilder().hiveScan(
+                  "region", test::in("r_name", {"ASIA", "EUROPE"})),
               velox::core::JoinType::kInner)
           .filter(
               "(n_name = 'FRANCE' AND r_name = 'EUROPE') OR "
@@ -287,7 +280,7 @@ TEST_F(FilterPushdownTest, belowSingleRowSubqueryCrossJoin) {
 
   auto matcher = matchValues()
                      .filter("neq(c0, 0) AND eq(c1, 5)")
-                     .nestedLoopJoin(matchValues().singleAggregation().build())
+                     .nestedLoopJoin(matchValues().singleAggregation())
                      .filter()
                      .project()
                      .singleAggregation()

--- a/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
@@ -120,7 +120,7 @@ TEST_P(HiveBucketedExecutionTest, join) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchHiveScan("t")
-            .hashJoinInner(matchHiveScan("u").build())
+            .hashJoinInner(matchHiveScan("u"))
             .bucketed()
             .fragmentWidth(4)
             .gather()
@@ -142,8 +142,7 @@ TEST_P(HiveBucketedExecutionTest, join) {
           matchHiveScan("t")
               .hashJoinRight(matchHiveScan("u")
                                  .aliases({"u_nationkey"})
-                                 .shuffle({"u_nationkey"})
-                                 .build())
+                                 .shuffle({"u_nationkey"}))
               .project()
               .bucketed()
               .fragmentWidth(4)
@@ -162,7 +161,7 @@ TEST_P(HiveBucketedExecutionTest, join) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchHiveScan("t")
-            .hashJoinFull(matchHiveScan("u").build())
+            .hashJoinFull(matchHiveScan("u"))
             .bucketed()
             .fragmentWidth(4)
             .gather()
@@ -179,7 +178,7 @@ TEST_P(HiveBucketedExecutionTest, join) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchHiveScan("t")
-            .hashJoinLeft(matchHiveScan("u").build())
+            .hashJoinLeft(matchHiveScan("u"))
             .bucketed()
             .fragmentWidth(4)
             .gather()
@@ -200,8 +199,7 @@ TEST_P(HiveBucketedExecutionTest, join) {
       matchHiveScan("t")
           .hashJoinInner(matchHiveScan("w")
                              .aliases({"w_nationkey"})
-                             .shuffle({"w_nationkey"})
-                             .build())
+                             .shuffle({"w_nationkey"}))
           .bucketed()
           .fragmentWidth(4)
           .gather()
@@ -231,7 +229,7 @@ TEST_P(HiveBucketedExecutionTest, semijoin) {
       AXIOM_ASSERT_DISTRIBUTED_PLAN(
           plan.plan,
           matchHiveScan("t")
-              .hashJoinLeftSemiFilter(matchHiveScan("u").build())
+              .hashJoinLeftSemiFilter(matchHiveScan("u"))
               .bucketed()
               .fragmentWidth(4)
               .gather()
@@ -252,7 +250,7 @@ TEST_P(HiveBucketedExecutionTest, semijoin) {
       AXIOM_ASSERT_DISTRIBUTED_PLAN(
           plan.plan,
           matchHiveScan("t")
-              .hashJoinAnti(matchHiveScan("u").build())
+              .hashJoinAnti(matchHiveScan("u"))
               .bucketed()
               .fragmentWidth(4)
               .gather()
@@ -432,7 +430,7 @@ TEST_P(HiveBucketedExecutionTest, joinDifferentBucketCounts) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(
       plan.plan,
       matchHiveScan("t16")
-          .hashJoinInner(matchHiveScan("t8").build())
+          .hashJoinInner(matchHiveScan("t8"))
           .bucketed()
           .fragmentWidth(4)
           .gather()
@@ -521,8 +519,7 @@ TEST_P(HiveBucketedExecutionTest, widthClampsToNumWorkers) {
         matchHiveScan("t")
             .hashJoinInner(matchHiveScan("u")
                                .aliases({"u_nationkey"})
-                               .shuffle({"u_nationkey"})
-                               .build())
+                               .shuffle({"u_nationkey"}))
             .bucketed()
             .fragmentWidth(5)
             .gather()
@@ -549,7 +546,7 @@ TEST_P(HiveBucketedExecutionTest, copartitionedJoinIndivisibleWorkers) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(
       plan.plan,
       matchHiveScan("t")
-          .hashJoinInner(matchHiveScan("u").build())
+          .hashJoinInner(matchHiveScan("u"))
           .bucketed()
           .fragmentWidth(3)
           .gather()
@@ -581,7 +578,7 @@ TEST_P(HiveBucketedExecutionTest, unionall) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchHiveScan("t")
-            .localPartition(matchHiveScan("u").project().build())
+            .localPartition(matchHiveScan("u").project())
             .bucketed()
             .fragmentWidth(4)
             .shuffle({"c_nationkey"})

--- a/axiom/optimizer/tests/JoinFilterProjectionTest.cpp
+++ b/axiom/optimizer/tests/JoinFilterProjectionTest.cpp
@@ -48,14 +48,13 @@ class JoinFilterProjectionTest : public test::QueryTestBase {
 // arguments moved. The inputs project only what the join needs, dropping the
 // columns that fed the moved expressions.
 TEST_F(JoinFilterProjectionTest, basic) {
-  auto matcher =
-      matchScan("t")
-          .project({"a", "length(b) as pt"})
-          .nestedLoopJoin(
-              matchScan("u").project({"x", "length(y) as pu"}).build(),
-              core::JoinType::kInner,
-              "\"and\"(pt < pu, pt + pu > 10, a < x)")
-          .build();
+  auto matcher = matchScan("t")
+                     .project({"a", "length(b) as pt"})
+                     .nestedLoopJoin(
+                         matchScan("u").project({"x", "length(y) as pu"}),
+                         core::JoinType::kInner,
+                         "\"and\"(pt < pu, pt + pu > 10, a < x)")
+                     .build();
 
   AXIOM_ASSERT_PLAN(
       plan(
@@ -71,7 +70,7 @@ TEST_F(JoinFilterProjectionTest, lambdaReadingBothSides) {
   auto matcher = matchScan("t")
                      .project({"a", "sequence(1, a + 10) as arr"})
                      .nestedLoopJoin(
-                         matchScan("u").build(),
+                         matchScan("u"),
                          core::JoinType::kInner,
                          "cardinality(filter(arr, z -> x < z)) > 0")
                      .build();
@@ -91,8 +90,7 @@ TEST_F(JoinFilterProjectionTest, lambdaReadingOneSide) {
           .project(
               {"a",
                "cardinality(filter(sequence(1, a + 10), z -> a < z)) as c"})
-          .nestedLoopJoin(
-              matchScan("u").build(), core::JoinType::kInner, "x < c")
+          .nestedLoopJoin(matchScan("u"), core::JoinType::kInner, "x < c")
           .build();
 
   AXIOM_ASSERT_PLAN(
@@ -106,15 +104,14 @@ TEST_F(JoinFilterProjectionTest, lambdaReadingOneSide) {
 // out of the filter would change results. It stays, while the deterministic
 // operands around it move.
 TEST_F(JoinFilterProjectionTest, nonDeterministic) {
-  auto matcher = matchScan("t")
-                     .project({"a", "cast(length(b) as DOUBLE) as pt"})
-                     .nestedLoopJoin(
-                         matchScan("u")
-                             .project({"x", "cast(length(y) as DOUBLE) as pu"})
-                             .build(),
-                         core::JoinType::kInner,
-                         "pt + random() < pu")
-                     .build();
+  auto matcher =
+      matchScan("t")
+          .project({"a", "cast(length(b) as DOUBLE) as pt"})
+          .nestedLoopJoin(
+              matchScan("u").project({"x", "cast(length(y) as DOUBLE) as pu"}),
+              core::JoinType::kInner,
+              "pt + random() < pu")
+          .build();
 
   AXIOM_ASSERT_PLAN(
       plan("SELECT a, x FROM t, u WHERE length(b) + random() < length(y)"),

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -48,12 +48,12 @@ TEST_F(JoinTest, pushdownFilterThroughJoin) {
   {
     SCOPED_TRACE("Inner Join");
     auto logicalPlan = makePlan(lp::JoinType::kInner);
-    auto matcher = matchScan("t")
-                       .filter("t_data IS NULL")
-                       .hashJoin(
-                           matchScan("u").filter("u_data IS NULL").build(),
-                           core::JoinType::kInner)
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .filter("t_data IS NULL")
+            .hashJoin(
+                matchScan("u").filter("u_data IS NULL"), core::JoinType::kInner)
+            .build();
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -63,7 +63,7 @@ TEST_F(JoinTest, pushdownFilterThroughJoin) {
     auto logicalPlan = makePlan(lp::JoinType::kLeft);
     auto matcher = matchScan("t")
                        .filter("t_data IS NULL")
-                       .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
+                       .hashJoin(matchScan("u"), core::JoinType::kLeft)
                        .filter("u_data IS NULL")
                        .build();
     auto plan = toSingleNodePlan(logicalPlan);
@@ -73,13 +73,13 @@ TEST_F(JoinTest, pushdownFilterThroughJoin) {
   {
     SCOPED_TRACE("Right Join");
     auto logicalPlan = makePlan(lp::JoinType::kRight);
-    auto matcher = matchScan("t")
-                       .hashJoin(
-                           matchScan("u").filter("u_data IS NULL").build(),
-                           core::JoinType::kRight)
-                       .filter("t_data IS NULL")
-                       .project()
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .hashJoin(
+                matchScan("u").filter("u_data IS NULL"), core::JoinType::kRight)
+            .filter("t_data IS NULL")
+            .project()
+            .build();
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -88,7 +88,7 @@ TEST_F(JoinTest, pushdownFilterThroughJoin) {
     SCOPED_TRACE("Full Join");
     auto logicalPlan = makePlan(lp::JoinType::kFull);
     auto matcher = matchScan("t")
-                       .hashJoin(matchScan("u").build(), core::JoinType::kFull)
+                       .hashJoin(matchScan("u"), core::JoinType::kFull)
                        .filter("t_data IS NULL AND u_data IS NULL")
                        .build();
     auto plan = toSingleNodePlan(logicalPlan);
@@ -112,8 +112,8 @@ TEST_F(JoinTest, hyperEdge) {
                          .build();
 
   auto matcher = matchScan("t")
-                     .hashJoin(matchScan("u").build(), core::JoinType::kInner)
-                     .hashJoin(matchScan("v").build(), core::JoinType::kLeft)
+                     .hashJoin(matchScan("u"), core::JoinType::kInner)
+                     .hashJoin(matchScan("v"), core::JoinType::kLeft)
                      .build();
   auto plan = toSingleNodePlan(logicalPlan);
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -141,8 +141,7 @@ TEST_F(JoinTest, joinWithFilterOverLimit) {
         matchScan("t")
             .finalLimit(0, 100)
             .filter("b > 50")
-            .hashJoin(
-                matchScan("u").finalLimit(0, 50).filter("y < 100").build())
+            .hashJoin(matchScan("u").finalLimit(0, 50).filter("y < 100"))
             .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -165,11 +164,10 @@ TEST_F(JoinTest, joinWithTopNOnBothSides) {
               lp::JoinType::kInner)
           .build();
 
-  auto matcher =
-      matchScan("t")
-          .topN(10)
-          .hashJoin(matchScan("u").topN(5).build(), core::JoinType::kInner)
-          .build();
+  auto matcher = matchScan("t")
+                     .topN(10)
+                     .hashJoin(matchScan("u").topN(5), core::JoinType::kInner)
+                     .build();
 
   AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
 }
@@ -201,15 +199,13 @@ TEST_F(JoinTest, outerJoinWithInnerJoin) {
 
     auto plan = toSingleNodePlan(logicalPlan);
 
-    auto matcher =
-        startMatcher("t")
-            .filter("b > 50")
-            .hashJoin(
-                startMatcher("u")
-                    .hashJoin(startMatcher("v").build(), core::JoinType::kInner)
-                    .build(),
-                core::JoinType::kLeft)
-            .build();
+    auto matcher = startMatcher("t")
+                       .filter("b > 50")
+                       .hashJoin(
+                           startMatcher("u").hashJoin(
+                               startMatcher("v"), core::JoinType::kInner),
+                           core::JoinType::kLeft)
+                       .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -235,17 +231,15 @@ TEST_F(JoinTest, outerJoinWithInnerJoin) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = startMatcher("t")
-                       .filter()
-                       .aggregation()
-                       .hashJoin(
-                           startMatcher("u")
-                               .hashJoin(startMatcher("v").build())
-                               .filter()
-                               .build(),
-                           core::JoinType::kLeft)
-                       .project()
-                       .build();
+    auto matcher =
+        startMatcher("t")
+            .filter()
+            .aggregation()
+            .hashJoin(
+                startMatcher("u").hashJoin(startMatcher("v")).filter(),
+                core::JoinType::kLeft)
+            .project()
+            .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -262,13 +256,12 @@ TEST_F(JoinTest, nestedOuterJoins) {
   auto logicalPlan = parseSelect(sql, kTestConnectorId);
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher =
-      matchScan("nation")
-          .hashJoin(matchScan("region").build(), core::JoinType::kFull)
-          .hashJoin(matchScan("region").build(), core::JoinType::kRight)
-          .aggregation()
-          .project()
-          .build();
+  auto matcher = matchScan("nation")
+                     .hashJoin(matchScan("region"), core::JoinType::kFull)
+                     .hashJoin(matchScan("region"), core::JoinType::kRight)
+                     .aggregation()
+                     .project()
+                     .build();
 
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
@@ -281,12 +274,11 @@ TEST_F(JoinTest, joinWithComputedKeys) {
   {
     auto plan = toSingleNodePlan(logicalPlan);
 
-    auto matcher =
-        matchScan("nation")
-            .project({"coalesce(n_regionkey, 1)"})
-            .hashJoin(matchScan("region").build(), core::JoinType::kRight)
-            .aggregation()
-            .build();
+    auto matcher = matchScan("nation")
+                       .project({"coalesce(n_regionkey, 1)"})
+                       .hashJoin(matchScan("region"), core::JoinType::kRight)
+                       .aggregation()
+                       .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -294,7 +286,7 @@ TEST_F(JoinTest, joinWithComputedKeys) {
   {
     auto distributedPlan = planVelox(logicalPlan);
 
-    auto rightSideMatcher = matchScan("region").shuffle().build();
+    auto rightSideMatcher = matchScan("region").shuffle();
 
     auto matcher = matchScan("nation")
                        .project({"coalesce(n_regionkey, 1)"})
@@ -335,8 +327,7 @@ TEST_F(JoinTest, broadcastSizeLimitGatesBroadcast) {
         planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 1}, options);
     auto matcher =
         matchScan("probe")
-            .hashJoin(
-                matchScan("build").broadcast().build(), core::JoinType::kInner)
+            .hashJoin(matchScan("build").broadcast(), core::JoinType::kInner)
             .gather()
             .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
@@ -348,13 +339,13 @@ TEST_F(JoinTest, broadcastSizeLimitGatesBroadcast) {
     options.broadcastSizeLimit = 1024;
     auto distributedPlan =
         planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 1}, options);
-    auto matcher = matchScan("probe")
-                       .shuffle({"p_key"})
-                       .hashJoin(
-                           matchScan("build").shuffle({"b_key"}).build(),
-                           core::JoinType::kInner)
-                       .gather()
-                       .build();
+    auto matcher =
+        matchScan("probe")
+            .shuffle({"p_key"})
+            .hashJoin(
+                matchScan("build").shuffle({"b_key"}), core::JoinType::kInner)
+            .gather()
+            .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
   }
 }
@@ -370,7 +361,7 @@ TEST_F(JoinTest, crossJoin) {
         lp::PlanBuilder{ctx}.from({"t", "u"}).project({"a + x"}).build();
 
     auto matcher = matchScan("t")
-                       .nestedLoopJoin(matchScan("u").build())
+                       .nestedLoopJoin(matchScan("u"))
                        .project({"a + x"})
                        .build();
 
@@ -385,10 +376,8 @@ TEST_F(JoinTest, crossJoin) {
     auto logicalPlan =
         lp::PlanBuilder{ctx}.from({"t", "u"}).filter("a > x").build();
 
-    auto matcher = matchScan("t")
-                       .nestedLoopJoin(matchScan("u").build())
-                       .filter("a > x")
-                       .build();
+    auto matcher =
+        matchScan("t").nestedLoopJoin(matchScan("u")).filter("a > x").build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -403,10 +392,8 @@ TEST_F(JoinTest, crossJoin) {
                            .aggregate({}, {"count(1)"})
                            .build();
 
-    auto matcher = matchScan("t")
-                       .nestedLoopJoin(matchScan("u").build())
-                       .aggregation()
-                       .build();
+    auto matcher =
+        matchScan("t").nestedLoopJoin(matchScan("u")).aggregation().build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -419,8 +406,8 @@ TEST_F(JoinTest, crossJoin) {
         parseSelect("SELECT * FROM t, u, v WHERE a = x", kTestConnectorId);
 
     auto matcher = matchScan("t")
-                       .hashJoin(matchScan("u").build())
-                       .nestedLoopJoin(matchScan("v").build())
+                       .hashJoin(matchScan("u"))
+                       .nestedLoopJoin(matchScan("v"))
                        .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
@@ -449,9 +436,8 @@ TEST_F(JoinTest, crossJoin) {
     auto logicalPlan = parseSelect(
         "SELECT * FROM t, (SELECT count(*) FROM u)", kTestConnectorId);
 
-    auto matcher = matchScan("t")
-                       .nestedLoopJoin(matchScan("u").aggregation().build())
-                       .build();
+    auto matcher =
+        matchScan("t").nestedLoopJoin(matchScan("u").aggregation()).build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -467,7 +453,7 @@ TEST_F(JoinTest, crossJoin) {
         "SELECT a FROM t, (SELECT * FROM u LIMIT 1)", kTestConnectorId);
 
     auto matcher =
-        matchScan("t").nestedLoopJoin(matchScan("u").limit().build()).build();
+        matchScan("t").nestedLoopJoin(matchScan("u").limit()).build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -487,8 +473,7 @@ TEST_F(JoinTest, leftCrossJoin) {
 
     auto matcher =
         matchScan("t")
-            .nestedLoopJoin(
-                matchScan("u").aggregation().build(), core::JoinType::kLeft)
+            .nestedLoopJoin(matchScan("u").aggregation(), core::JoinType::kLeft)
             .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
@@ -505,8 +490,7 @@ TEST_F(JoinTest, leftCrossJoin) {
     auto matcher =
         matchScan("t")
             .aggregation()
-            .nestedLoopJoin(
-                matchScan("u").aggregation().build(), core::JoinType::kLeft)
+            .nestedLoopJoin(matchScan("u").aggregation(), core::JoinType::kLeft)
             .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
@@ -520,12 +504,11 @@ TEST_F(JoinTest, leftCrossJoin) {
         "SELECT a FROM t LEFT JOIN u ON 1 = 1 WHERE coalesce(x, 1) > 0",
         kTestConnectorId);
 
-    auto matcher =
-        matchScan("t")
-            .nestedLoopJoin(matchScan("u").build(), core::JoinType::kLeft)
-            .filter()
-            .project()
-            .build();
+    auto matcher = matchScan("t")
+                       .nestedLoopJoin(matchScan("u"), core::JoinType::kLeft)
+                       .filter()
+                       .project()
+                       .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -542,12 +525,12 @@ TEST_F(JoinTest, leftCrossJoin) {
 
     auto logicalPlan = parseSelect(query, kTestConnectorId);
 
-    auto matcher = matchScan("t")
-                       .nestedLoopJoin(
-                           matchScan("u").project({"x", "y + 1"}).build(),
-                           core::JoinType::kLeft)
-                       .project()
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .nestedLoopJoin(
+                matchScan("u").project({"x", "y + 1"}), core::JoinType::kLeft)
+            .project()
+            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -573,7 +556,7 @@ TEST_F(JoinTest, rightJoin) {
 
     auto matcher = matchScan("u")
                        .project({"x", "y + 1"})
-                       .hashJoin(matchScan("t").build(), core::JoinType::kRight)
+                       .hashJoin(matchScan("t"), core::JoinType::kRight)
                        .project()
                        .build();
 
@@ -594,9 +577,8 @@ TEST_F(JoinTest, crossThenLeft) {
 
   auto matcher =
       matchScan("u")
-          .nestedLoopJoin(matchScan("t").build())
-          .hashJoin(
-              matchValues().aggregation().build(), velox::core::JoinType::kLeft)
+          .nestedLoopJoin(matchScan("t"))
+          .hashJoin(matchValues().aggregation(), velox::core::JoinType::kLeft)
           .aggregation()
           .build();
 
@@ -613,11 +595,10 @@ TEST_F(JoinTest, joinWithComputedAndProjectedKeys) {
       "SELECT * FROM u LEFT JOIN v ON u0 = v0";
   SCOPED_TRACE(query);
 
-  auto matcher =
-      matchScan("u")
-          .hashJoin(matchScan("t").project({"coalesce(t0, 0)"}).build())
-          .project()
-          .build();
+  auto matcher = matchScan("u")
+                     .hashJoin(matchScan("t").project({"coalesce(t0, 0)"}))
+                     .project()
+                     .build();
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -628,7 +609,7 @@ TEST_F(JoinTest, crossThanOrderBy) {
   SCOPED_TRACE(query);
 
   auto matcher = matchScan("nation")
-                     .nestedLoopJoin(matchScan("region").build())
+                     .nestedLoopJoin(matchScan("region"))
                      .project({"length(n_name) as l"})
                      .orderBy({"l"})
                      .project()
@@ -675,10 +656,8 @@ TEST_F(JoinTest, joinOnClause) {
     auto query = "SELECT * FROM t JOIN u ON t0.a = u0.a";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .project()
-                       .hashJoin(matchScan("u").project().build())
-                       .build();
+    auto matcher =
+        matchScan("t").project().hashJoin(matchScan("u").project()).build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -690,7 +669,7 @@ TEST_F(JoinTest, joinOnClause) {
 
     auto matcher = matchScan("t")
                        .project()
-                       .hashJoin(matchScan("u").project().build())
+                       .hashJoin(matchScan("u").project())
                        .project()
                        .build();
 
@@ -705,7 +684,7 @@ TEST_F(JoinTest, leftJoinOverValues) {
   SCOPED_TRACE(query);
 
   auto matcher = matchValues()
-                     .hashJoin(matchValues().build(), core::JoinType::kLeft)
+                     .hashJoin(matchValues(), core::JoinType::kLeft)
                      .project()
                      .build();
 
@@ -737,13 +716,13 @@ TEST_F(JoinTest, leftThenFilter) {
         "WHERE coalesce(z, 1) > 0";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .hashJoin(
-                           matchScan("u").project({"x", "y + 1"}).build(),
-                           core::JoinType::kLeft)
-                       .filter()
-                       .project()
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .hashJoin(
+                matchScan("u").project({"x", "y + 1"}), core::JoinType::kLeft)
+            .filter()
+            .project()
+            .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -756,12 +735,12 @@ TEST_F(JoinTest, leftThenFilter) {
         "WHERE z > 0";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .hashJoin(
-                           matchScan("u").filter("y + 1 > 0").build(),
-                           core::JoinType::kInner)
-                       .project()
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .hashJoin(
+                matchScan("u").filter("y + 1 > 0"), core::JoinType::kInner)
+            .project()
+            .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -774,14 +753,13 @@ TEST_F(JoinTest, leftThenFilter) {
         "WHERE coalesce(z, 1) > 0 AND z > 0";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .hashJoin(
-                           matchScan("u")
-                               .filter("coalesce(y + 1, 1) > 0 AND y + 1 > 0")
-                               .build(),
-                           core::JoinType::kInner)
-                       .project()
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .hashJoin(
+                matchScan("u").filter("coalesce(y + 1, 1) > 0 AND y + 1 > 0"),
+                core::JoinType::kInner)
+            .project()
+            .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -802,12 +780,12 @@ TEST_F(JoinTest, leftThenFilter) {
         "WHERE z > 0";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .hashJoin(
-                           matchScan("u").filter("y + 1 > 0").build(),
-                           core::JoinType::kInner)
-                       .project()
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .hashJoin(
+                matchScan("u").filter("y + 1 > 0"), core::JoinType::kInner)
+            .project()
+            .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -820,13 +798,13 @@ TEST_F(JoinTest, leftThenFilter) {
         "WHERE z > 0";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .hashJoin(
-                           matchScan("u").filter("y + 1 > 0").build(),
-                           core::JoinType::kInner)
-                       .project()
-                       .aggregation()
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .hashJoin(
+                matchScan("u").filter("y + 1 > 0"), core::JoinType::kInner)
+            .project()
+            .aggregation()
+            .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -840,14 +818,14 @@ TEST_F(JoinTest, leftThenFilter) {
         "ORDER BY z DESC";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .hashJoin(
-                           matchScan("u").filter("y + 1 > 0").build(),
-                           core::JoinType::kInner)
-                       .project()
-                       .orderBy()
-                       .project()
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .hashJoin(
+                matchScan("u").filter("y + 1 > 0"), core::JoinType::kInner)
+            .project()
+            .orderBy()
+            .project()
+            .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -864,7 +842,7 @@ TEST_F(JoinTest, leftThenFilter) {
     SCOPED_TRACE(query);
 
     auto matcher = matchScan("t")
-                       .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                       .hashJoin(matchScan("u"), core::JoinType::kInner)
                        .filter("a > y")
                        .build();
 
@@ -887,11 +865,10 @@ TEST_F(JoinTest, leftThenFilter) {
         "WHERE cardinality(coalesce(y, b)) > 0";
     SCOPED_TRACE(query);
 
-    auto matcher =
-        matchScan("card_t")
-            .hashJoin(matchScan("card_u").build(), core::JoinType::kLeft)
-            .filter("cardinality(coalesce(y, b)) > 0")
-            .build();
+    auto matcher = matchScan("card_t")
+                       .hashJoin(matchScan("card_u"), core::JoinType::kLeft)
+                       .filter("cardinality(coalesce(y, b)) > 0")
+                       .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -911,10 +888,10 @@ TEST_F(JoinTest, leftThenFilter) {
     SCOPED_TRACE(query);
 
     auto matcher = matchScan("t")
-                       .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
+                       .hashJoin(matchScan("u"), core::JoinType::kLeft)
                        .filter("not(is_null(coalesce(b, y)))")
                        .project()
-                       .hashJoin(matchScan("v").build(), core::JoinType::kLeft)
+                       .hashJoin(matchScan("v"), core::JoinType::kLeft)
                        .project()
                        .build();
 
@@ -937,7 +914,7 @@ TEST_F(JoinTest, fullThenFilter) {
 
     auto matcher = matchScan("t")
                        .hashJoin(
-                           matchScan("u").project({"x", "y + 1 as z"}).build(),
+                           matchScan("u").project({"x", "y + 1 as z"}),
                            core::JoinType::kFull)
                        .filter("coalesce(z, 1) > 0 AND is_null(a)")
                        .project()
@@ -955,13 +932,13 @@ TEST_F(JoinTest, fullThenFilter) {
         "WHERE z > 0 AND is_null(a)";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .hashJoin(
-                           matchScan("u").filter("y + 1 > 0").build(),
-                           core::JoinType::kRight)
-                       .filter("is_null(a)")
-                       .project()
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .hashJoin(
+                matchScan("u").filter("y + 1 > 0"), core::JoinType::kRight)
+            .filter("is_null(a)")
+            .project()
+            .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -976,7 +953,7 @@ TEST_F(JoinTest, fullThenFilter) {
     auto matcher = matchScan("t")
                        .filter("a > 0")
                        .hashJoin(
-                           matchScan("u").project({"x", "y + 1 as z"}).build(),
+                           matchScan("u").project({"x", "y + 1 as z"}),
                            core::JoinType::kLeft)
                        .filter("coalesce(z, 1) > 0")
                        .project()
@@ -994,13 +971,13 @@ TEST_F(JoinTest, fullThenFilter) {
         "WHERE z > 0 AND a > 0";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .filter("a > 0")
-                       .hashJoin(
-                           matchScan("u").filter("y + 1 > 0").build(),
-                           core::JoinType::kInner)
-                       .project()
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .filter("a > 0")
+            .hashJoin(
+                matchScan("u").filter("y + 1 > 0"), core::JoinType::kInner)
+            .project()
+            .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1016,7 +993,7 @@ TEST_F(JoinTest, fullThenFilter) {
     SCOPED_TRACE(query);
 
     auto matcher = matchScan("t")
-                       .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                       .hashJoin(matchScan("u"), core::JoinType::kInner)
                        .filter("a > y")
                        .build();
 
@@ -1038,8 +1015,7 @@ TEST_F(JoinTest, leftJoinOnClausePushdown) {
 
     auto matcher =
         matchScan("t")
-            .hashJoin(
-                matchScan("u").filter("y > 0").build(), core::JoinType::kLeft)
+            .hashJoin(matchScan("u").filter("y > 0"), core::JoinType::kLeft)
             .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
@@ -1052,9 +1028,8 @@ TEST_F(JoinTest, leftJoinOnClausePushdown) {
     auto query = "SELECT * FROM t LEFT JOIN u ON a = x AND b > 0";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
-                       .build();
+    auto matcher =
+        matchScan("t").hashJoin(matchScan("u"), core::JoinType::kLeft).build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1065,9 +1040,8 @@ TEST_F(JoinTest, leftJoinOnClausePushdown) {
     auto query = "SELECT * FROM t LEFT JOIN u ON a = x AND b > y";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
-                       .build();
+    auto matcher =
+        matchScan("t").hashJoin(matchScan("u"), core::JoinType::kLeft).build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1080,15 +1054,13 @@ TEST_F(JoinTest, leftJoinOnClausePushdown) {
         "ON a = x AND z > 0";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .hashJoin(
-                           matchScan("u")
-                               .filter("y + 1 > 0")
-                               .project({"x", "y + 1"})
-                               .build(),
-                           core::JoinType::kLeft)
-                       .project()
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .hashJoin(
+                matchScan("u").filter("y + 1 > 0").project({"x", "y + 1"}),
+                core::JoinType::kLeft)
+            .project()
+            .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1105,8 +1077,7 @@ TEST_F(JoinTest, leftJoinOnClausePushdown) {
                        .hashJoin(
                            matchScan("u")
                                .singleAggregation({"x"}, {"sum(y) as s"})
-                               .filter("s > 10")
-                               .build(),
+                               .filter("s > 10"),
                            core::JoinType::kLeft)
                        .build();
 
@@ -1123,10 +1094,8 @@ TEST_F(JoinTest, leftJoinOnClausePushdown) {
 
     auto matcher = matchScan("t")
                        .hashJoin(
-                           matchScan("u")
-                               .filter("x > 0")
-                               .singleAggregation({"x"}, {"sum(y)"})
-                               .build(),
+                           matchScan("u").filter("x > 0").singleAggregation(
+                               {"x"}, {"sum(y)"}),
                            core::JoinType::kLeft)
                        .build();
 
@@ -1143,10 +1112,9 @@ TEST_F(JoinTest, leftJoinOnClausePushdown) {
         " ON a = x AND y > 0";
     SCOPED_TRACE(query);
 
-    auto matcher =
-        matchScan("t")
-            .hashJoin(matchScan("u").limit().build(), core::JoinType::kLeft)
-            .build();
+    auto matcher = matchScan("t")
+                       .hashJoin(matchScan("u").limit(), core::JoinType::kLeft)
+                       .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1202,8 +1170,8 @@ TEST_F(JoinTest, impliedJoins) {
     SCOPED_TRACE(query);
 
     auto matcher = matchScan("t")
-                       .hashJoin(matchScan("v").build(), core::JoinType::kInner)
-                       .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                       .hashJoin(matchScan("v"), core::JoinType::kInner)
+                       .hashJoin(matchScan("u"), core::JoinType::kInner)
                        .aggregation()
                        .build();
 
@@ -1221,8 +1189,7 @@ TEST_F(JoinTest, impliedJoins) {
 
     auto matcher =
         matchScan("u")
-            .hashJoin(
-                matchScan("t").filter("a = b").build(), core::JoinType::kInner)
+            .hashJoin(matchScan("t").filter("a = b"), core::JoinType::kInner)
             .aggregation()
             .build();
 
@@ -1240,8 +1207,7 @@ TEST_F(JoinTest, impliedJoins) {
 
     auto matcher =
         matchScan("u")
-            .hashJoin(
-                matchScan("t").filter("a = b").build(), core::JoinType::kInner)
+            .hashJoin(matchScan("t").filter("a = b"), core::JoinType::kInner)
             .aggregation()
             .build();
 
@@ -1255,8 +1221,7 @@ TEST_F(JoinTest, impliedJoins) {
 
     auto matcher =
         matchScan("u")
-            .hashJoin(
-                matchScan("t").filter("a = b").build(), core::JoinType::kInner)
+            .hashJoin(matchScan("t").filter("a = b"), core::JoinType::kInner)
             .aggregation()
             .build();
 
@@ -1270,7 +1235,7 @@ TEST_F(JoinTest, impliedJoins) {
     SCOPED_TRACE(query);
 
     auto matcher = matchScan("t")
-                       .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                       .hashJoin(matchScan("u"), core::JoinType::kInner)
                        .aggregation()
                        .build();
 
@@ -1285,7 +1250,7 @@ TEST_F(JoinTest, impliedJoins) {
     SCOPED_TRACE(query);
 
     auto matcher = matchScan("t")
-                       .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
+                       .hashJoin(matchScan("u"), core::JoinType::kLeft)
                        .aggregation()
                        .build();
 
@@ -1301,16 +1266,14 @@ TEST_F(JoinTest, impliedJoins) {
         "JOIN v ON u.x = v.n";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("u")
-                       .hashJoin(
-                           matchScan("v")
-                               .hashJoin(
-                                   matchScan("t").filter("a = b").build(),
-                                   core::JoinType::kInner)
-                               .build(),
-                           core::JoinType::kInner)
-                       .aggregation()
-                       .build();
+    auto matcher =
+        matchScan("u")
+            .hashJoin(
+                matchScan("v").hashJoin(
+                    matchScan("t").filter("a = b"), core::JoinType::kInner),
+                core::JoinType::kInner)
+            .aggregation()
+            .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1328,8 +1291,8 @@ TEST_F(JoinTest, impliedJoins) {
 
     auto matcher =
         matchScan("t")
-            .hashJoin(matchScan("v").build(), core::JoinType::kLeftSemiFilter)
-            .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+            .hashJoin(matchScan("v"), core::JoinType::kLeftSemiFilter)
+            .hashJoin(matchScan("u"), core::JoinType::kInner)
             .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
@@ -1346,8 +1309,8 @@ TEST_F(JoinTest, impliedJoins) {
 
     auto matcher =
         matchScan("t")
-            .hashJoin(matchScan("u").build(), core::JoinType::kInner)
-            .hashJoin(matchScan("v").build(), core::JoinType::kLeftSemiFilter)
+            .hashJoin(matchScan("u"), core::JoinType::kInner)
+            .hashJoin(matchScan("v"), core::JoinType::kLeftSemiFilter)
             .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
@@ -1388,9 +1351,8 @@ TEST_F(JoinTest, impliedJoinChain) {
 
   auto matcher = matchScan("t3")
                      .hashJoin(matchScan("t1")
-                                   .hashJoin(matchScan("t2").build())
-                                   .hashJoin(matchScan("t4").build())
-                                   .build())
+                                   .hashJoin(matchScan("t2"))
+                                   .hashJoin(matchScan("t4")))
                      .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
@@ -1411,8 +1373,7 @@ TEST_F(JoinTest, impliedFilters) {
     auto matcher =
         matchScan("u")
             .filter("x = 5")
-            .hashJoin(
-                matchScan("t").filter("a = 5").build(), core::JoinType::kInner)
+            .hashJoin(matchScan("t").filter("a = 5"), core::JoinType::kInner)
             .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
@@ -1424,12 +1385,11 @@ TEST_F(JoinTest, impliedFilters) {
     auto query = "SELECT * FROM t, u WHERE t.a = u.x AND t.a > 100";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .filter("a > 100")
-                       .hashJoin(
-                           matchScan("u").filter("x > 100").build(),
-                           core::JoinType::kInner)
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .filter("a > 100")
+            .hashJoin(matchScan("u").filter("x > 100"), core::JoinType::kInner)
+            .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1440,12 +1400,12 @@ TEST_F(JoinTest, impliedFilters) {
     auto query = "SELECT * FROM t, u WHERE t.a = u.x AND t.a IN (1, 2, 3)";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("u")
-                       .filter("x IN (1, 2, 3)")
-                       .hashJoin(
-                           matchScan("t").filter("a IN (1, 2, 3)").build(),
-                           core::JoinType::kInner)
-                       .build();
+    auto matcher =
+        matchScan("u")
+            .filter("x IN (1, 2, 3)")
+            .hashJoin(
+                matchScan("t").filter("a IN (1, 2, 3)"), core::JoinType::kInner)
+            .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1459,12 +1419,12 @@ TEST_F(JoinTest, impliedFilters) {
     auto query = "SELECT * FROM t, u WHERE t.a = u.x AND t.a IS NULL";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .filter("a IS NULL")
-                       .hashJoin(
-                           matchScan("u").filter("x IS NULL").build(),
-                           core::JoinType::kInner)
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .filter("a IS NULL")
+            .hashJoin(
+                matchScan("u").filter("x IS NULL"), core::JoinType::kInner)
+            .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1475,12 +1435,12 @@ TEST_F(JoinTest, impliedFilters) {
     auto query = "SELECT * FROM t, u WHERE t.a = u.x AND t.a IS NOT NULL";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .filter("a IS NOT NULL")
-                       .hashJoin(
-                           matchScan("u").filter("x IS NOT NULL").build(),
-                           core::JoinType::kInner)
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .filter("a IS NOT NULL")
+            .hashJoin(
+                matchScan("u").filter("x IS NOT NULL"), core::JoinType::kInner)
+            .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1494,7 +1454,7 @@ TEST_F(JoinTest, impliedFilters) {
     SCOPED_TRACE(query);
 
     auto matcher = matchScan("t")
-                       .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                       .hashJoin(matchScan("u"), core::JoinType::kInner)
                        .filter("a = cast(random() * 100.0 as bigint)")
                        .build();
 
@@ -1513,8 +1473,7 @@ TEST_F(JoinTest, impliedFilters) {
     auto matcher =
         matchScan("u")
             .filter("x = 5")
-            .hashJoin(
-                matchScan("t").filter("a = 5").build(), core::JoinType::kInner)
+            .hashJoin(matchScan("t").filter("a = 5"), core::JoinType::kInner)
             .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
@@ -1532,10 +1491,8 @@ TEST_F(JoinTest, impliedFilters) {
     auto matcher =
         matchScan("u")
             .filter("x = 5")
-            .hashJoin(
-                matchScan("t").filter("a = 5").build(), core::JoinType::kInner)
-            .hashJoin(
-                matchScan("v").filter("k = 5").build(), core::JoinType::kInner)
+            .hashJoin(matchScan("t").filter("a = 5"), core::JoinType::kInner)
+            .hashJoin(matchScan("v").filter("k = 5"), core::JoinType::kInner)
             .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
@@ -1557,7 +1514,7 @@ TEST_F(JoinTest, impliedSameTableEquality) {
 
     auto matcher = matchScan("t")
                        .filter("a = b AND a = c")
-                       .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                       .hashJoin(matchScan("u"), core::JoinType::kInner)
                        .aggregation()
                        .build();
 
@@ -1584,8 +1541,7 @@ TEST_F(JoinTest, impliedSameTableEqualityBothSides) {
     auto matcher =
         matchScan("t")
             .filter("a = b")
-            .hashJoin(
-                matchScan("u").filter("x = y").build(), core::JoinType::kInner)
+            .hashJoin(matchScan("u").filter("x = y"), core::JoinType::kInner)
             .aggregation()
             .build();
 
@@ -1609,7 +1565,7 @@ TEST_F(JoinTest, impliedSameTableEqualityBelowAggregation) {
                      .filter("a = b")
                      .singleAggregation({"a", "b"}, {})
                      .project()
-                     .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                     .hashJoin(matchScan("u"), core::JoinType::kInner)
                      .aggregation()
                      .build();
 
@@ -1636,8 +1592,7 @@ TEST_F(JoinTest, impliedSameTableEqualityInHaving) {
                          matchScan("t")
                              .singleAggregation({"k"}, {"count(*) as c"})
                              .filter("k = c")
-                             .project()
-                             .build(),
+                             .project(),
                          core::JoinType::kInner)
                      .aggregation()
                      .build();
@@ -1660,7 +1615,7 @@ TEST_F(JoinTest, impliedSameTableEqualityBlockedByLimit) {
   auto matcher = matchScan("t")
                      .limit()
                      .filter("a = b")
-                     .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                     .hashJoin(matchScan("u"), core::JoinType::kInner)
                      .aggregation()
                      .build();
 
@@ -1683,7 +1638,7 @@ TEST_F(JoinTest, impliedSameTableEqualityBlockedByLimitDedup) {
   auto matcher = matchScan("t")
                      .limit()
                      .filter("a = b")
-                     .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                     .hashJoin(matchScan("u"), core::JoinType::kInner)
                      .aggregation()
                      .build();
 
@@ -1709,8 +1664,7 @@ TEST_F(JoinTest, impliedSameTableEqualityOuterJoin) {
 
   auto matcher =
       matchScan("t")
-          .hashJoin(
-              matchScan("u").filter("x = y").build(), core::JoinType::kLeft)
+          .hashJoin(matchScan("u").filter("x = y"), core::JoinType::kLeft)
           .aggregation()
           .build();
 
@@ -1732,12 +1686,12 @@ TEST_F(JoinTest, impliedSameTableEqualitySemiJoin) {
       "  SELECT 1 FROM u WHERE u.x = t.a AND u.y = t.a)";
   SCOPED_TRACE(query);
 
-  auto matcher = matchScan("t")
-                     .hashJoin(
-                         matchScan("u").filter("x = y").build(),
-                         core::JoinType::kLeftSemiFilter)
-                     .aggregation()
-                     .build();
+  auto matcher =
+      matchScan("t")
+          .hashJoin(
+              matchScan("u").filter("x = y"), core::JoinType::kLeftSemiFilter)
+          .aggregation()
+          .build();
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1757,8 +1711,7 @@ TEST_F(JoinTest, impliedSameTableEqualityRightJoinNormalized) {
 
   auto matcher =
       matchScan("t")
-          .hashJoin(
-              matchScan("u").filter("x = y").build(), core::JoinType::kLeft)
+          .hashJoin(matchScan("u").filter("x = y"), core::JoinType::kLeft)
           .aggregation()
           .build();
 
@@ -1781,7 +1734,7 @@ TEST_F(JoinTest, impliedSameTableEqualityFullOuterJoinSkipped) {
 
   // u must have no filter — slot synthesis is unsound for FULL OUTER.
   auto matcher = matchScan("t")
-                     .hashJoin(matchScan("u").build(), core::JoinType::kFull)
+                     .hashJoin(matchScan("u"), core::JoinType::kFull)
                      .aggregation()
                      .build();
 
@@ -1804,7 +1757,7 @@ TEST_F(JoinTest, impliedSameTableEqualityMismatchedLeftKeys) {
 
   // u must have no filter — u.x = u.y must not be inferred.
   auto matcher = matchScan("t")
-                     .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
+                     .hashJoin(matchScan("u"), core::JoinType::kLeft)
                      .aggregation()
                      .build();
 
@@ -1826,7 +1779,7 @@ TEST_F(JoinTest, impliedSameTableEqualityPreservedSide) {
 
   // t must have no filter — t.a = t.b must not be inferred.
   auto matcher = matchScan("t")
-                     .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
+                     .hashJoin(matchScan("u"), core::JoinType::kLeft)
                      .aggregation()
                      .build();
 
@@ -1857,13 +1810,13 @@ TEST_F(JoinTest, leftJoinNoEqualitiesMultipleTables) {
 
   auto matcher =
       matchScan("nation")
-          .hashJoin(matchScan("region").build(), core::JoinType::kInner)
+          .hashJoin(matchScan("region"), core::JoinType::kInner)
           .hashJoin(
-              matchScan("customer").build(),
+              matchScan("customer"),
               core::JoinType::kLeftSemiProject,
               {.nullAware = false})
           .project()
-          .nestedLoopJoin(matchScan("supplier").build(), core::JoinType::kLeft)
+          .nestedLoopJoin(matchScan("supplier"), core::JoinType::kLeft)
           .build();
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
@@ -1892,19 +1845,15 @@ TEST_F(JoinTest, leftToInnerWithAggregation) {
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
 
-  auto matcher = matchScan("t")
-                     .hashJoin(
-                         matchScan("u")
-                             .filter("x > 0")
-                             .project()
-                             .unnest()
-                             .project()
-                             .build(),
-                         core::JoinType::kInner)
-                     .project({"cast(y as REAL) as c"})
-                     .distinct()
-                     .project()
-                     .build();
+  auto matcher =
+      matchScan("t")
+          .hashJoin(
+              matchScan("u").filter("x > 0").project().unnest().project(),
+              core::JoinType::kInner)
+          .project({"cast(y as REAL) as c"})
+          .distinct()
+          .project()
+          .build();
 
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
@@ -1929,7 +1878,7 @@ TEST_F(JoinTest, duplicateJoinOutputColumns) {
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
 
     auto matcher = matchScan("t")
-                       .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
+                       .hashJoin(matchScan("u"), core::JoinType::kLeft)
                        .project({"b as x", "b as y"})
                        .build();
 
@@ -1949,7 +1898,7 @@ TEST_F(JoinTest, duplicateJoinOutputColumns) {
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
 
     auto matcher = matchScan("t")
-                       .hashJoin(matchScan("u").build(), core::JoinType::kLeft)
+                       .hashJoin(matchScan("u"), core::JoinType::kLeft)
                        .distinct()
                        .project({"b as x", "b as y"})
                        .build();
@@ -1972,8 +1921,7 @@ TEST_F(JoinTest, duplicateJoinOutputColumns) {
 
     auto matcher =
         matchScan("t")
-            .hashJoin(
-                matchScan("u").filter("a = 1").build(), core::JoinType::kInner)
+            .hashJoin(matchScan("u").filter("a = 1"), core::JoinType::kInner)
             .distinct()
             .project({"b as x", "b as y"})
             .build();
@@ -2015,9 +1963,9 @@ TEST_F(JoinTest, greedyJoinOrder) {
     auto plan = toSingleNodePlan(logicalPlan);
 
     auto matcher = matchScan("t4")
-                       .hashJoin(matchScan("t1").build())
-                       .hashJoin(matchScan("t2").build())
-                       .hashJoin(matchScan("t3").build())
+                       .hashJoin(matchScan("t1"))
+                       .hashJoin(matchScan("t2"))
+                       .hashJoin(matchScan("t3"))
                        .build();
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -2027,14 +1975,10 @@ TEST_F(JoinTest, greedyJoinOrder) {
     optimizerOptions_.greedyJoinThreshold = 100;
     auto plan = toSingleNodePlan(logicalPlan);
 
-    auto matcher =
-        matchScan("t4")
-            .hashJoin(matchScan("t3")
-                          .hashJoin(matchScan("t2")
-                                        .hashJoin(matchScan("t1").build())
-                                        .build())
-                          .build())
-            .build();
+    auto matcher = matchScan("t4")
+                       .hashJoin(matchScan("t3").hashJoin(
+                           matchScan("t2").hashJoin(matchScan("t1"))))
+                       .build();
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
@@ -2058,12 +2002,11 @@ TEST_F(JoinTest, greedyDtStart) {
   optimizerOptions_.greedyJoinThreshold = 2;
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher =
-      matchScan("t")
-          .singleAggregation({"a"}, {"sum(b) as s"})
-          .hashJoin(matchScan("base1").build(), core::JoinType::kLeft)
-          .project()
-          .build();
+  auto matcher = matchScan("t")
+                     .singleAggregation({"a"}, {"sum(b) as s"})
+                     .hashJoin(matchScan("base1"), core::JoinType::kLeft)
+                     .project()
+                     .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
@@ -2110,10 +2053,10 @@ TEST_F(JoinTest, greedySnowflakeLeftDeep) {
   auto plan = toSingleNodePlan(logicalPlan);
 
   auto matcher = matchScan("fact")
-                     .hashJoin(matchScan("dim_a").build())
-                     .hashJoin(matchScan("sub_a").build())
-                     .hashJoin(matchScan("dim_b").build())
-                     .hashJoin(matchScan("sub_b").build())
+                     .hashJoin(matchScan("dim_a"))
+                     .hashJoin(matchScan("sub_a"))
+                     .hashJoin(matchScan("dim_b"))
+                     .hashJoin(matchScan("sub_b"))
                      .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
@@ -2149,9 +2092,9 @@ TEST_F(JoinTest, greedyValuesStart) {
   auto plan = toSingleNodePlan(logicalPlan);
 
   auto matcher = matchScan("v_t3")
-                     .hashJoin(core::PlanMatcherBuilder{}.values().build())
-                     .hashJoin(matchScan("v_t1").build())
-                     .hashJoin(matchScan("v_t2").build())
+                     .hashJoin(core::PlanMatcherBuilder{}.values())
+                     .hashJoin(matchScan("v_t1"))
+                     .hashJoin(matchScan("v_t2"))
                      .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }

--- a/axiom/optimizer/tests/LimitTest.cpp
+++ b/axiom/optimizer/tests/LimitTest.cpp
@@ -297,9 +297,7 @@ TEST_P(LimitTest, zeroLimit) {
   AXIOM_ASSERT_PLAN(
       toSingleNodePlan(
           "SELECT * FROM t, (SELECT * FROM u LIMIT 0) s WHERE a = x"),
-      matchScan("t")
-          .hashJoin(matchValues().build(), core::JoinType::kInner)
-          .build());
+      matchScan("t").hashJoin(matchValues(), core::JoinType::kInner).build());
 }
 
 AXIOM_INSTANTIATE_V1_V2(LimitTest);

--- a/axiom/optimizer/tests/MetadataCountsTest.cpp
+++ b/axiom/optimizer/tests/MetadataCountsTest.cpp
@@ -177,8 +177,7 @@ TEST_F(MetadataCountsTest, unionAll) {
               matchHiveScan("t")
                   .aliases({"a"})
                   .singleAggregation({}, {"sum(a)"})
-                  .project()
-                  .build(),
+                  .project(),
           })
           .build());
 }

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -2112,29 +2112,29 @@ PlanMatcherBuilder& PlanMatcherBuilder::streamingAggregation(
 }
 
 PlanMatcherBuilder& PlanMatcherBuilder::hashJoin(
-    const std::shared_ptr<PlanMatcher>& rightMatcher) {
+    PlanMatcherBuilder rightMatcher) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
-  matcher_ = std::make_shared<HashJoinMatcher>(matcher_, rightMatcher);
+  matcher_ = std::make_shared<HashJoinMatcher>(matcher_, rightMatcher.build());
   return *this;
 }
 
 PlanMatcherBuilder& PlanMatcherBuilder::hashJoin(
-    const std::shared_ptr<PlanMatcher>& rightMatcher,
+    PlanMatcherBuilder rightMatcher,
     JoinType joinType,
     const HashJoinDetails& details) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<HashJoinMatcher>(
-      matcher_, rightMatcher, joinType, details);
+      matcher_, rightMatcher.build(), joinType, details);
   return *this;
 }
 
 PlanMatcherBuilder& PlanMatcherBuilder::nestedLoopJoin(
-    const std::shared_ptr<PlanMatcher>& rightMatcher,
+    PlanMatcherBuilder rightMatcher,
     JoinType joinType,
     std::optional<std::string> joinCondition) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<NestedLoopJoinMatcher>(
-      matcher_, rightMatcher, joinType, std::move(joinCondition));
+      matcher_, rightMatcher.build(), joinType, std::move(joinCondition));
   return *this;
 }
 
@@ -2160,12 +2160,14 @@ PlanMatcherBuilder& PlanMatcherBuilder::localPartition(
 }
 
 PlanMatcherBuilder& PlanMatcherBuilder::localPartition(
-    std::initializer_list<std::shared_ptr<PlanMatcher>> matcher) {
+    std::initializer_list<PlanMatcherBuilder> sources) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
-  std::vector<std::shared_ptr<PlanMatcher>> matchers{matcher_};
-  matchers.insert(matchers.end(), matcher);
+  std::vector<std::shared_ptr<PlanMatcher>> sourceMatchers{matcher_};
+  for (const auto& source : sources) {
+    sourceMatchers.push_back(source.build());
+  }
   matcher_ = std::make_shared<PlanMatcherImpl<LocalPartitionNode>>(
-      std::move(matchers));
+      std::move(sourceMatchers));
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -382,8 +382,7 @@ class PlanMatcherBuilder {
 
   /// Matches a HashJoin node with the specified right side matcher.
   /// @param rightMatcher Matcher for the right (build) side of the join.
-  PlanMatcherBuilder& hashJoin(
-      const std::shared_ptr<PlanMatcher>& rightMatcher);
+  PlanMatcherBuilder& hashJoin(PlanMatcherBuilder rightMatcher);
 
   /// Matches a HashJoin node with the specified right side matcher, join type,
   /// and optional details. Supports symbol rewriting from child matchers.
@@ -391,63 +390,67 @@ class PlanMatcherBuilder {
   /// @param joinType Type of join.
   /// @param details Join details. See HashJoinDetails.
   PlanMatcherBuilder& hashJoin(
-      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      PlanMatcherBuilder rightMatcher,
       JoinType joinType,
       const HashJoinDetails& details = {});
 
   /// Typed shortcuts for `hashJoin` with a fixed `JoinType`.
   PlanMatcherBuilder& hashJoinInner(
-      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      PlanMatcherBuilder rightMatcher,
       const HashJoinDetails& details = {}) {
-    return hashJoin(rightMatcher, JoinType::kInner, details);
+    return hashJoin(std::move(rightMatcher), JoinType::kInner, details);
   }
 
   PlanMatcherBuilder& hashJoinLeft(
-      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      PlanMatcherBuilder rightMatcher,
       const HashJoinDetails& details = {}) {
-    return hashJoin(rightMatcher, JoinType::kLeft, details);
+    return hashJoin(std::move(rightMatcher), JoinType::kLeft, details);
   }
 
   PlanMatcherBuilder& hashJoinRight(
-      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      PlanMatcherBuilder rightMatcher,
       const HashJoinDetails& details = {}) {
-    return hashJoin(rightMatcher, JoinType::kRight, details);
+    return hashJoin(std::move(rightMatcher), JoinType::kRight, details);
   }
 
   PlanMatcherBuilder& hashJoinFull(
-      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      PlanMatcherBuilder rightMatcher,
       const HashJoinDetails& details = {}) {
-    return hashJoin(rightMatcher, JoinType::kFull, details);
+    return hashJoin(std::move(rightMatcher), JoinType::kFull, details);
   }
 
   PlanMatcherBuilder& hashJoinLeftSemiFilter(
-      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      PlanMatcherBuilder rightMatcher,
       const HashJoinDetails& details = {}) {
-    return hashJoin(rightMatcher, JoinType::kLeftSemiFilter, details);
+    return hashJoin(
+        std::move(rightMatcher), JoinType::kLeftSemiFilter, details);
   }
 
   PlanMatcherBuilder& hashJoinLeftSemiProject(
-      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      PlanMatcherBuilder rightMatcher,
       const HashJoinDetails& details = {}) {
-    return hashJoin(rightMatcher, JoinType::kLeftSemiProject, details);
+    return hashJoin(
+        std::move(rightMatcher), JoinType::kLeftSemiProject, details);
   }
 
   PlanMatcherBuilder& hashJoinRightSemiFilter(
-      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      PlanMatcherBuilder rightMatcher,
       const HashJoinDetails& details = {}) {
-    return hashJoin(rightMatcher, JoinType::kRightSemiFilter, details);
+    return hashJoin(
+        std::move(rightMatcher), JoinType::kRightSemiFilter, details);
   }
 
   PlanMatcherBuilder& hashJoinRightSemiProject(
-      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      PlanMatcherBuilder rightMatcher,
       const HashJoinDetails& details = {}) {
-    return hashJoin(rightMatcher, JoinType::kRightSemiProject, details);
+    return hashJoin(
+        std::move(rightMatcher), JoinType::kRightSemiProject, details);
   }
 
   PlanMatcherBuilder& hashJoinAnti(
-      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      PlanMatcherBuilder rightMatcher,
       const HashJoinDetails& details = {}) {
-    return hashJoin(rightMatcher, JoinType::kAnti, details);
+    return hashJoin(std::move(rightMatcher), JoinType::kAnti, details);
   }
 
   /// Matches a NestedLoopJoin node with the specified right side matcher and
@@ -457,7 +460,7 @@ class PlanMatcherBuilder {
   /// @param joinCondition When set, asserts the join condition (e.g., "a > b").
   /// Empty string asserts no join condition, i.e. a plain cross join.
   PlanMatcherBuilder& nestedLoopJoin(
-      const std::shared_ptr<PlanMatcher>& rightMatcher,
+      PlanMatcherBuilder rightMatcher,
       JoinType joinType = JoinType::kInner,
       std::optional<std::string> joinCondition = std::nullopt);
 
@@ -470,15 +473,14 @@ class PlanMatcherBuilder {
       const std::vector<std::string>& partitionKeys);
 
   /// Matches a LocalPartition node with the specified source matchers.
-  /// @param matcher Matchers for the partition sources.
+  /// @param sources Matchers for the partition sources.
   PlanMatcherBuilder& localPartition(
-      std::initializer_list<std::shared_ptr<PlanMatcher>> matcher);
+      std::initializer_list<PlanMatcherBuilder> sources);
 
   /// Matches a LocalPartition node with a single source matcher.
   /// @param matcher Matcher for the partition source.
-  PlanMatcherBuilder& localPartition(
-      const std::shared_ptr<PlanMatcher>& matcher) {
-    return localPartition({matcher});
+  PlanMatcherBuilder& localPartition(PlanMatcherBuilder matcher) {
+    return localPartition({std::move(matcher)});
   }
 
   /// Matches a LocalPartition node with gather type (N-to-1, empty partition
@@ -811,7 +813,7 @@ class PlanMatcherBuilder {
 
   /// Builds and returns the constructed PlanMatcher.
   /// @throws VeloxUserError if matcher is empty.
-  std::shared_ptr<PlanMatcher> build() {
+  std::shared_ptr<PlanMatcher> build() const {
     VELOX_USER_CHECK_NOT_NULL(matcher_, "Cannot build an empty PlanMatcher.");
     return matcher_;
   }

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -392,8 +392,7 @@ TEST_F(PlanTest, multipleConnectors) {
           .build();
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher =
-      matchScan("table1").hashJoin(matchScan("table2").build()).build();
+  auto matcher = matchScan("table1").hashJoin(matchScan("table2")).build();
 
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
@@ -412,15 +411,12 @@ TEST_F(PlanTest, filterToJoinEdge) {
 
   {
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder()
-                       .tableScan("nation")
-                       .project()
-                       .hashJoin(
-                           core::PlanMatcherBuilder()
-                               .tableScan("region")
-                               .project()
-                               .build())
-                       .build();
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .tableScan("nation")
+            .project()
+            .hashJoin(core::PlanMatcherBuilder().tableScan("region").project())
+            .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -463,8 +459,7 @@ TEST_F(PlanTest, filterToJoinEdge) {
                            core::PlanMatcherBuilder()
                                .tableScan("region")
                                .filter("rand() < 3.0")
-                               .project()
-                               .build())
+                               .project())
                        .filter("rand() < 4.0")
                        .project()
                        .build();
@@ -533,14 +528,12 @@ TEST_F(PlanTest, filterBreakup) {
         core::PlanMatcherBuilder()
             .hiveScan("lineitem", std::move(lineitemFilters))
             .hashJoin(
-                core::PlanMatcherBuilder()
-                    .hiveScan(
-                        "part",
-                        {},
-                        "\"or\"(\"and\"(p_size between 1 and 15, (p_brand = 'Brand#34' AND p_container LIKE 'LG%')), "
-                        "   \"or\"(\"and\"(p_size between 1 and 5, (p_brand = 'Brand#12' AND p_container LIKE 'SM%')), "
-                        "          \"and\"(p_size between 1 and 10, (p_brand = 'Brand#23' AND p_container LIKE 'MED%'))))")
-                    .build())
+                core::PlanMatcherBuilder().hiveScan(
+                    "part",
+                    {},
+                    "\"or\"(\"and\"(p_size between 1 and 15, (p_brand = 'Brand#34' AND p_container LIKE 'LG%')), "
+                    "   \"or\"(\"and\"(p_size between 1 and 5, (p_brand = 'Brand#12' AND p_container LIKE 'SM%')), "
+                    "          \"and\"(p_size between 1 and 10, (p_brand = 'Brand#23' AND p_container LIKE 'MED%'))))"))
             .filter()
             .project()
             .singleAggregation()

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -65,12 +65,11 @@ TEST_F(SetTest, unionAll) {
         .filter(filter)
         .project();
   };
-  auto matcher =
-      matchLeg("nationkey < 11 and (regionkey + 1) % 3 = 1")
-          .localPartition(
-              matchLeg("nationkey > 13 and (regionkey + 1) % 3 = 1").build())
-          .project()
-          .build();
+  auto matcher = matchLeg("nationkey < 11 and (regionkey + 1) % 3 = 1")
+                     .localPartition(
+                         matchLeg("nationkey > 13 and (regionkey + 1) % 3 = 1"))
+                     .project()
+                     .build();
 
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
@@ -90,7 +89,7 @@ TEST_F(SetTest, lambdaFilterPushdownThroughUnionAll) {
 
   auto matcher = matchScan("t")
                      .filter()
-                     .localPartition(matchScan("u").filter().project().build())
+                     .localPartition(matchScan("u").filter().project())
                      .build();
 
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -145,16 +144,14 @@ TEST_F(SetTest, unionJoin) {
   auto matcher =
       matchLeg("partsupp", "availqty", "availqty < 1000")
           .localPartition({
-              matchLeg("partsupp", "availqty", "availqty > 2000").build(),
-              matchLeg("partsupp", "availqty", "availqty between 1200 and 1400")
-                  .build(),
+              matchLeg("partsupp", "availqty", "availqty > 2000"),
+              matchLeg(
+                  "partsupp", "availqty", "availqty between 1200 and 1400"),
           })
           .hashJoin(
               matchLeg("part", "retailprice", "retailprice < 1100.0")
                   .localPartition(
-                      matchLeg("part", "retailprice", "retailprice > 1200.0")
-                          .build())
-                  .build(),
+                      matchLeg("part", "retailprice", "retailprice > 1200.0")),
               core::JoinType::kInner)
           .singleAggregation({}, {"sum(1)"})
           .build();
@@ -220,7 +217,7 @@ TEST_F(SetTest, unionFlatten) {
     // first child of a LocalPartition has no rename Project; non-first children
     // do.
     auto nonFirstChildMatcher =
-        core::PlanMatcherBuilder().tableScan().filter().project().build();
+        core::PlanMatcherBuilder().tableScan().filter().project();
     if (rootType == lp::SetOperation::kUnion) {
       auto matcher = core::PlanMatcherBuilder()
                          .tableScan()
@@ -262,8 +259,7 @@ TEST_F(SetTest, unionFlatten) {
                                  .filter()
                                  .localPartition(nonFirstChildMatcher)
                                  .aggregation()
-                                 .project()
-                                 .build())
+                                 .project())
                          .build();
 
       AXIOM_ASSERT_PLAN(plan, matcher);
@@ -311,10 +307,8 @@ TEST_F(SetTest, intersect) {
             .hashJoin(
                 matchLeg("nationkey > 11")
                     .hashJoin(
-                        matchLeg("nationkey < 21 and (regionkey + 1) % 3 = 1")
-                            .build(),
-                        core::JoinType::kRightSemiFilter)
-                    .build(),
+                        matchLeg("nationkey < 21 and (regionkey + 1) % 3 = 1"),
+                        core::JoinType::kRightSemiFilter),
                 core::JoinType::kRightSemiFilter)
             .singleAggregation()
             .project()
@@ -359,11 +353,11 @@ TEST_F(SetTest, except) {
   };
   auto matcher = matchLeg("nationkey < 21 and (regionkey + 1) % 3 = 1")
                      .hashJoin(
-                         matchLeg("nationkey > 16").build(),
+                         matchLeg("nationkey > 16"),
                          core::JoinType::kAnti,
                          {.nullAware = false})
                      .hashJoin(
-                         matchLeg("nationkey <= 5").build(),
+                         matchLeg("nationkey <= 5"),
                          core::JoinType::kAnti,
                          {.nullAware = false})
                      .singleAggregation()
@@ -386,8 +380,7 @@ TEST_F(SetTest, exceptAll) {
   auto matchBuild = [](const std::string& filter) {
     return matchScan("nation")
         .aliases({"nationkey", "regionkey"})
-        .filter(filter)
-        .build();
+        .filter(filter);
   };
 
   {
@@ -424,8 +417,7 @@ TEST_F(SetTest, exceptAll) {
     return matchScan("nation")
         .aliases({"nationkey", "regionkey"})
         .filter(filter)
-        .shuffle()
-        .build();
+        .shuffle();
   };
 
   {
@@ -461,9 +453,7 @@ TEST_F(SetTest, intersectAll) {
       "INTERSECT ALL SELECT a FROM t2 "
       "INTERSECT ALL SELECT a FROM t3");
 
-  auto matchBuild = [](const std::string& table) {
-    return matchScan(table).build();
-  };
+  auto matchBuild = [](const std::string& table) { return matchScan(table); };
   {
     // Single-driver: counting left semi filter joins, no aggregation.
     auto plan = toSingleNodePlan(logicalPlan);
@@ -490,7 +480,7 @@ TEST_F(SetTest, intersectAll) {
   }
 
   auto matchPartitionedBuild = [](const std::string& table) {
-    return matchScan(table).shuffle().build();
+    return matchScan(table).shuffle();
   };
 
   {
@@ -521,13 +511,12 @@ TEST_F(SetTest, intersectAllSideSwap) {
 
   auto startMatcher = [&]() {
     return matchScan("big").hashJoin(
-        matchScan("small").build(), core::JoinType::kCountingLeftSemiFilter);
+        matchScan("small"), core::JoinType::kCountingLeftSemiFilter);
   };
 
   auto startDistributedMatcher = [&]() {
     return matchScan("big").shuffle({"a"}).localPartition({"a"}).hashJoin(
-        matchScan("small").shuffle().build(),
-        core::JoinType::kCountingLeftSemiFilter);
+        matchScan("small").shuffle(), core::JoinType::kCountingLeftSemiFilter);
   };
 
   // big INTERSECT ALL small: 'big' is probe, 'small' is build.
@@ -573,13 +562,12 @@ TEST_F(SetTest, joinWithUnionAll) {
   auto logicalPlan = parseSelect(sql);
   auto plan = toSingleNodePlan(logicalPlan);
 
-  auto matcher = matchScan("t")
-                     .hashJoin(
-                         matchScan("u")
-                             .localPartition(matchScan("v").project().build())
-                             .build(),
-                         core::JoinType::kInner)
-                     .build();
+  auto matcher =
+      matchScan("t")
+          .hashJoin(
+              matchScan("u").localPartition(matchScan("v").project()),
+              core::JoinType::kInner)
+          .build();
 
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
@@ -598,8 +586,7 @@ TEST_F(SetTest, filterOnDuplicateConstantInUnionAll) {
 
   // Constant filters ('x' <> '' and 'y' <> '') are folded and eliminated.
   auto buildMatcher = [&] {
-    return matchValues().project().localPartition(
-        matchValues().project().build());
+    return matchValues().project().localPartition(matchValues().project());
   };
 
   auto plan = toSingleNodePlan(logicalPlan);
@@ -621,7 +608,7 @@ TEST_F(SetTest, unionDistinctOverGatherInputs) {
       toSingleNodePlan(logicalPlan),
       matchValues()
           .project()
-          .localPartition(matchValues().project().build())
+          .localPartition(matchValues().project())
           .singleAggregation({"k"}, {})
           .build());
 
@@ -634,7 +621,7 @@ TEST_F(SetTest, unionDistinctOverGatherInputs) {
       planVelox(logicalPlan).plan,
       matchValues()
           .project()
-          .localPartition(matchValues().project().build())
+          .localPartition(matchValues().project())
           .localPartition({"k"})
           .singleAggregation({"k"}, {})
           .build());
@@ -662,8 +649,7 @@ TEST_F(SetTest, nondeterministicFilterAboveUnion) {
           .project()
           .localPartition(matchScan("region")
                               .filter("rand() < cast(r_regionkey as double)")
-                              .project()
-                              .build());
+                              .project());
     };
 
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), buildMatcher().build());
@@ -682,7 +668,7 @@ TEST_F(SetTest, nondeterministicFilterAboveUnion) {
         toSingleNodePlan(logicalPlan),
         matchScan("nation")
             .project()
-            .localPartition(matchScan("region").project().build())
+            .localPartition(matchScan("region").project())
             .singleAggregation({"k"}, {})
             .filter("cast(k as double) > rand()")
             .build());
@@ -691,7 +677,7 @@ TEST_F(SetTest, nondeterministicFilterAboveUnion) {
         planVelox(logicalPlan).plan,
         matchScan("nation")
             .project()
-            .localPartition(matchScan("region").project().build())
+            .localPartition(matchScan("region").project())
             .distributedSingleAggregation({"k"}, {})
             .filter("cast(k as double) > rand()")
             .gather()
@@ -719,20 +705,19 @@ TEST_F(SetTest, filterOnDuplicateColumnInUnionAll) {
     auto matcher = matchScan("t")
                        .filter("x > 0")
                        .project()
-                       .localPartition(matchValues().project().build())
+                       .localPartition(matchValues().project())
                        .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
 
   {
     // Values is isolated behind an arbitrary exchange.
-    auto matcher =
-        matchScan("t")
-            .filter("x > 0")
-            .project()
-            .localPartition(matchValues().project().arbitrary().build())
-            .gather()
-            .build();
+    auto matcher = matchScan("t")
+                       .filter("x > 0")
+                       .project()
+                       .localPartition(matchValues().project().arbitrary())
+                       .gather()
+                       .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -762,7 +747,7 @@ TEST_F(SetTest, filterOnDuplicateExpressionInUnionAll) {
   {
     auto matcher = matchLeg("x + 1 > 0")
                        .project()
-                       .localPartition(matchLeg("x + 2 > 0").project().build())
+                       .localPartition(matchLeg("x + 2 > 0").project())
                        .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
@@ -770,7 +755,7 @@ TEST_F(SetTest, filterOnDuplicateExpressionInUnionAll) {
   {
     auto matcher = matchLeg("x + 1 > 0")
                        .project()
-                       .localPartition(matchLeg("x + 2 > 0").project().build())
+                       .localPartition(matchLeg("x + 2 > 0").project())
                        .gather()
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
@@ -798,16 +783,13 @@ TEST_F(SetTest, filterColumnPruningInUnionAll) {
   };
 
   {
-    auto matcher =
-        matchLeg("x > 0").localPartition(matchLeg("x > 0").build()).build();
+    auto matcher = matchLeg("x > 0").localPartition(matchLeg("x > 0")).build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
 
   {
-    auto matcher = matchLeg("x > 0")
-                       .localPartition(matchLeg("x > 0").build())
-                       .gather()
-                       .build();
+    auto matcher =
+        matchLeg("x > 0").localPartition(matchLeg("x > 0")).gather().build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -866,7 +848,7 @@ TEST_F(SetTest, constantFalseFilterInUnionAll) {
         plan,
         matchValues()
             .project()
-            .localPartition(matchValues().project().build())
+            .localPartition(matchValues().project())
             .build());
   }
 }
@@ -887,12 +869,11 @@ TEST_F(SetTest, filterOnUnionWithWindow) {
         ") WHERE r > 1");
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher =
-        matchScan("t")
-            .window({"row_number() OVER (ORDER BY a) AS r"})
-            .filter("r > 1")
-            .localPartition(matchScan("u").filter("y > 1").project().build())
-            .build();
+    auto matcher = matchScan("t")
+                       .window({"row_number() OVER (ORDER BY a) AS r"})
+                       .filter("r > 1")
+                       .localPartition(matchScan("u").filter("y > 1").project())
+                       .build();
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -906,13 +887,12 @@ TEST_F(SetTest, filterOnUnionWithWindow) {
         ") WHERE r > 1");
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher =
-        matchScan("t")
-            .window({"row_number() OVER (ORDER BY a) AS r"})
-            .filter("r > 1")
-            .localPartition(matchScan("u").filter("y > 1").project().build())
-            .distinct()
-            .build();
+    auto matcher = matchScan("t")
+                       .window({"row_number() OVER (ORDER BY a) AS r"})
+                       .filter("r > 1")
+                       .localPartition(matchScan("u").filter("y > 1").project())
+                       .distinct()
+                       .build();
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
@@ -935,16 +915,13 @@ TEST_F(SetTest, exceptUnionAll) {
   // rename project to align column names through LocalPartition.
   auto matchExcept = [](const std::string& left, const std::string& right) {
     return matchScan(left)
-        .hashJoin(
-            matchScan(right).build(),
-            core::JoinType::kAnti,
-            {.nullAware = false})
+        .hashJoin(matchScan(right), core::JoinType::kAnti, {.nullAware = false})
         .singleAggregation()
         .project();
   };
 
   auto matcher = matchExcept("t", "u")
-                     .localPartition(matchExcept("u", "t").build())
+                     .localPartition(matchExcept("u", "t"))
                      .singleAggregation()
                      .build();
 
@@ -974,10 +951,9 @@ TEST_F(SetTest, unionDistinctWithUnnestMultipleReferences) {
           .nestedLoopJoin(matchScan("t")
                               .unnest()
                               .project()
-                              .localPartition(matchScan("t").project().build())
+                              .localPartition(matchScan("t").project())
                               .distinct()
-                              .singleAggregation({}, {"count(*) as cnt"})
-                              .build())
+                              .singleAggregation({}, {"count(*) as cnt"}))
           .project({"cnt", "cnt"})
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -999,7 +975,7 @@ TEST_F(SetTest, unionAllWithDistinctAndCountStar) {
         matchScan("t")
             .singleAggregation({"a"}, {})
             .project({})
-            .localPartition(core::PlanMatcherBuilder().values(ROW({})).build())
+            .localPartition(core::PlanMatcherBuilder().values(ROW({})))
             .singleAggregation({}, {"count(*) as c"})
             .build());
   }
@@ -1020,8 +996,8 @@ TEST_F(SetTest, unionAllWithDistinctAndCountStar) {
             .singleAggregation({"a"}, {})
             .project({})
             .localPartition(
-                {core::PlanMatcherBuilder().values(ROW({})).build(),
-                 core::PlanMatcherBuilder().values(ROW({})).build()})
+                {core::PlanMatcherBuilder().values(ROW({})),
+                 core::PlanMatcherBuilder().values(ROW({}))})
             .singleAggregation({}, {"count(*) as c"})
             .build());
   }
@@ -1041,7 +1017,7 @@ TEST_F(SetTest, unionAllWithDistinctAndCountStar) {
         matchScan("t")
             .singleAggregation({"a"}, {})
             .project({})
-            .localPartition(core::PlanMatcherBuilder().values(ROW({})).build())
+            .localPartition(core::PlanMatcherBuilder().values(ROW({})))
             .singleAggregation({}, {"count(*) as cnt"})
             .filter("cnt > 0")
             .build());
@@ -1062,9 +1038,8 @@ TEST_F(SetTest, rowSubfieldAccessInUnionAll) {
         plan,
         matchValues(ROW({}))
             .project({"row_constructor(1, null)"})
-            .localPartition(matchValues(ROW({}))
-                                .project({"row_constructor(3, null)"})
-                                .build())
+            .localPartition(
+                matchValues(ROW({})).project({"row_constructor(3, null)"}))
             .project({"x.a"})
             .build());
   }
@@ -1083,10 +1058,8 @@ TEST_F(SetTest, rowSubfieldAccessInUnionAll) {
         matchValues(ROW({}))
             .filter()
             .project({"row_constructor(1, null)"})
-            .localPartition(matchValues(ROW({}))
-                                .filter()
-                                .project({"row_constructor(3, null)"})
-                                .build())
+            .localPartition(matchValues(ROW({})).filter().project(
+                {"row_constructor(3, null)"}))
             .project({"x[1]"})
             .build());
   }
@@ -1108,11 +1081,10 @@ TEST_F(SetTest, rowSubfieldAccessInUnionAll) {
         plan,
         matchValues(ROW({}))
             .project({"row_constructor(1, null)"})
-            .localPartition(matchValues(ROW({}))
-                                .project({"row_constructor(3, null)"})
-                                .build())
+            .localPartition(
+                matchValues(ROW({})).project({"row_constructor(3, null)"}))
             .project({"x[1]"})
-            .localPartition(matchValues(ROW({})).project({"5 as y"}).build())
+            .localPartition(matchValues(ROW({})).project({"5 as y"}))
             .build());
   }
 }

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -300,8 +300,7 @@ class SubfieldTest : public HiveQueriesTestBase,
                 core::PlanMatcherBuilder()
                     .hiveScan(
                         "features", {}, "float_features[10010] + 1 < 10000")
-                    .project()
-                    .build())
+                    .project())
             .project()
             .build();
 
@@ -877,7 +876,7 @@ TEST_P(SubfieldTest, subquery) {
     auto matcher = core::PlanMatcherBuilder()
                        .tableScan("t_subquery")
                        .project()
-                       .hashJoin(matchValues().project().build())
+                       .hashJoin(matchValues().project())
                        .project()
                        .build();
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -894,7 +893,7 @@ TEST_P(SubfieldTest, subquery) {
     auto matcher = core::PlanMatcherBuilder()
                        .tableScan()
                        .project()
-                       .hashJoin(matchValues().aggregation().project().build())
+                       .hashJoin(matchValues().aggregation().project())
                        .filter()
                        .project()
                        .build();

--- a/axiom/optimizer/tests/SubqueryFoldTest.cpp
+++ b/axiom/optimizer/tests/SubqueryFoldTest.cpp
@@ -146,8 +146,7 @@ TEST_P(SubqueryFoldTest, foldable) {
                        .hashJoinInner(matchScan("t")
                                           .aliases({"ds", "a"})
                                           .filter("a > 5")
-                                          .aggregation()
-                                          .build())
+                                          .aggregation())
                        .projectIf(useV2_)
                        .build();
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -201,9 +200,8 @@ TEST_P(SubqueryFoldTest, foldableHivePartitions) {
         "SELECT x FROM pt WHERE ds = (SELECT max(ds) FROM pt WHERE x > 0)");
     auto matcher =
         matchHiveScan("pt")
-            .hashJoinInner(matchHiveScan("pt", test::gt("x", int64_t{0}))
-                               .aggregation()
-                               .build())
+            .hashJoinInner(
+                matchHiveScan("pt", test::gt("x", int64_t{0})).aggregation())
             .build();
     AXIOM_ASSERT_PLAN(plan, matcher);
   }

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -53,8 +53,7 @@ TEST_F(SubqueryTest, uncorrelatedScalar) {
                        .hashJoin(
                            core::PlanMatcherBuilder()
                                .hiveScan("region", {}, "r_name like 'AF%'")
-                               .enforceSingleRow()
-                               .build(),
+                               .enforceSingleRow(),
                            velox::core::JoinType::kInner)
                        .build();
 
@@ -71,9 +70,8 @@ TEST_F(SubqueryTest, uncorrelatedScalar) {
     auto plan = toSingleNodePlan(query);
     auto matcher = matchHiveScan("nation")
                        .hashJoin(
-                           core::PlanMatcherBuilder()
-                               .hiveScan("region", test::gt("r_name", "ASIA"))
-                               .build(),
+                           core::PlanMatcherBuilder().hiveScan(
+                               "region", test::gt("r_name", "ASIA")),
                            velox::core::JoinType::kLeftSemiFilter)
                        .build();
 
@@ -94,8 +92,7 @@ TEST_F(SubqueryTest, uncorrelatedScalar) {
             .hashJoin(
                 core::PlanMatcherBuilder()
                     .hiveScan("region", test::gt("r_name", "ASIA"))
-                    .project({"cast(cast(r_regionkey as tinyint) as bigint)"})
-                    .build(),
+                    .project({"cast(cast(r_regionkey as tinyint) as bigint)"}),
                 velox::core::JoinType::kLeftSemiFilter)
             .build();
 
@@ -112,9 +109,8 @@ TEST_F(SubqueryTest, uncorrelatedScalar) {
     auto plan = toSingleNodePlan(query);
     auto matcher = matchHiveScan("nation")
                        .hashJoin(
-                           core::PlanMatcherBuilder()
-                               .hiveScan("region", test::gt("r_name", "ASIA"))
-                               .build(),
+                           core::PlanMatcherBuilder().hiveScan(
+                               "region", test::gt("r_name", "ASIA")),
                            velox::core::JoinType::kAnti,
                            {.nullAware = true})
                        .build();
@@ -136,10 +132,8 @@ TEST_F(SubqueryTest, inListWithMixedSubqueries) {
     auto plan = toSingleNodePlan(query);
     auto matcher =
         matchHiveScan("nation")
-            .nestedLoopJoin(
-                matchHiveScan("region")
-                    .singleAggregation({}, {"max(r_regionkey) as max_key"})
-                    .build())
+            .nestedLoopJoin(matchHiveScan("region").singleAggregation(
+                {}, {"max(r_regionkey) as max_key"}))
             .filter("\"in\"(n_regionkey, max_key, 2)")
             .project()
             .build();
@@ -159,14 +153,10 @@ TEST_F(SubqueryTest, inListWithMixedSubqueries) {
     auto plan = toSingleNodePlan(query);
     auto matcher =
         matchHiveScan("nation")
-            .nestedLoopJoin(
-                matchHiveScan("region")
-                    .singleAggregation({}, {"max(r_regionkey) as max_key"})
-                    .build())
-            .nestedLoopJoin(
-                matchHiveScan("region")
-                    .singleAggregation({}, {"min(r_regionkey_2) as min_key"})
-                    .build())
+            .nestedLoopJoin(matchHiveScan("region").singleAggregation(
+                {}, {"max(r_regionkey) as max_key"}))
+            .nestedLoopJoin(matchHiveScan("region").singleAggregation(
+                {}, {"min(r_regionkey_2) as min_key"}))
             .filter("\"in\"(n_regionkey, max_key, min_key)")
             .project()
             .build();
@@ -182,14 +172,13 @@ TEST_F(SubqueryTest, uncorrelatedInConstantLeftSide) {
   auto query = "SELECT 1 IN (SELECT r_regionkey FROM region)";
   SCOPED_TRACE(query);
 
-  auto matcher =
-      matchHiveScan("region")
-          .hashJoin(
-              matchValues().nestedLoopJoin(matchValues().build()).build(),
-              velox::core::JoinType::kRightSemiProject,
-              {.nullAware = true})
-          .project()
-          .build();
+  auto matcher = matchHiveScan("region")
+                     .hashJoin(
+                         matchValues().nestedLoopJoin(matchValues()),
+                         velox::core::JoinType::kRightSemiProject,
+                         {.nullAware = true})
+                     .project()
+                     .build();
 
   auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -201,12 +190,11 @@ TEST_F(SubqueryTest, correlatedExists) {
         "SELECT * FROM nation WHERE "
         "EXISTS (SELECT * FROM region WHERE r_regionkey = n_regionkey)";
 
-    auto matcher =
-        matchHiveScan("nation")
-            .hashJoin(
-                core::PlanMatcherBuilder().hiveScan("region", {}).build(),
-                velox::core::JoinType::kLeftSemiFilter)
-            .build();
+    auto matcher = matchHiveScan("nation")
+                       .hashJoin(
+                           core::PlanMatcherBuilder().hiveScan("region", {}),
+                           velox::core::JoinType::kLeftSemiFilter)
+                       .build();
 
     {
       SCOPED_TRACE(query);
@@ -245,7 +233,7 @@ TEST_F(SubqueryTest, correlatedExists) {
 
     auto matcher = matchHiveScan("nation")
                        .nestedLoopJoin(
-                           matchHiveScan("region").build(),
+                           matchHiveScan("region"),
                            velox::core::JoinType::kLeftSemiProject)
                        .filter()
                        .project()
@@ -263,11 +251,9 @@ TEST_F(SubqueryTest, correlatedExists) {
 
     auto matcher =
         matchHiveScan("nation")
+            .hashJoin(matchHiveScan("region"), velox::core::JoinType::kFull)
             .hashJoin(
-                matchHiveScan("region").build(), velox::core::JoinType::kFull)
-            .hashJoin(
-                matchValues().project().build(),
-                velox::core::JoinType::kLeftSemiFilter)
+                matchValues().project(), velox::core::JoinType::kLeftSemiFilter)
             .build();
 
     SCOPED_TRACE(query);
@@ -283,11 +269,9 @@ TEST_F(SubqueryTest, correlatedExists) {
 
     auto matcher =
         matchHiveScan("nation")
+            .hashJoin(matchHiveScan("region"), velox::core::JoinType::kInner)
             .hashJoin(
-                matchHiveScan("region").build(), velox::core::JoinType::kInner)
-            .hashJoin(
-                matchHiveScan("nation").build(),
-                velox::core::JoinType::kLeftSemiFilter)
+                matchHiveScan("nation"), velox::core::JoinType::kLeftSemiFilter)
             .project()
             .build();
 
@@ -307,14 +291,13 @@ TEST_F(SubqueryTest, uncorrelatedProject) {
         "FROM region";
 
     // Uncorrelated subquery is cross-joined.
-    auto matcher = matchHiveScan("region")
-                       .nestedLoopJoin(
-                           matchHiveScan("nation")
-                               .singleAggregation({}, {"count(*)"})
-                               .build(),
-                           velox::core::JoinType::kInner)
-                       .project()
-                       .build();
+    auto matcher =
+        matchHiveScan("region")
+            .nestedLoopJoin(
+                matchHiveScan("nation").singleAggregation({}, {"count(*)"}),
+                velox::core::JoinType::kInner)
+            .project()
+            .build();
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
@@ -330,15 +313,14 @@ TEST_F(SubqueryTest, uncorrelatedProject) {
         "FROM region";
 
     // The scalar subquery must be cross-joined AFTER the aggregation.
-    auto matcher = matchHiveScan("region")
-                       .singleAggregation({}, {"array_agg(r_name)"})
-                       .nestedLoopJoin(
-                           matchHiveScan("nation")
-                               .singleAggregation({}, {"count(*)"})
-                               .build(),
-                           velox::core::JoinType::kInner)
-                       .project()
-                       .build();
+    auto matcher =
+        matchHiveScan("region")
+            .singleAggregation({}, {"array_agg(r_name)"})
+            .nestedLoopJoin(
+                matchHiveScan("nation").singleAggregation({}, {"count(*)"}),
+                velox::core::JoinType::kInner)
+            .project()
+            .build();
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
@@ -359,9 +341,7 @@ TEST_F(SubqueryTest, uncorrelatedProject) {
         matchHiveScan("nation")
             .singleAggregation({"n_regionkey"}, {"array_agg(n_name)"})
             .nestedLoopJoin(
-                matchHiveScan("region")
-                    .singleAggregation({}, {"count(*)"})
-                    .build(),
+                matchHiveScan("region").singleAggregation({}, {"count(*)"}),
                 velox::core::JoinType::kInner)
             .project()
             .build();
@@ -382,9 +362,8 @@ TEST_F(SubqueryTest, uncorrelatedProject) {
     // with a mark column. nullAware is true for IN semantics.
     auto matcher = matchHiveScan("nation")
                        .hashJoin(
-                           core::PlanMatcherBuilder()
-                               .hiveScan("region", test::gt("r_name", "ASIA"))
-                               .build(),
+                           core::PlanMatcherBuilder().hiveScan(
+                               "region", test::gt("r_name", "ASIA")),
                            velox::core::JoinType::kLeftSemiProject,
                            {.nullAware = true})
                        .project()
@@ -406,9 +385,8 @@ TEST_F(SubqueryTest, uncorrelatedProject) {
     // join with a mark column and NOT applied to the result. nullAware is true.
     auto matcher = matchHiveScan("nation")
                        .hashJoin(
-                           core::PlanMatcherBuilder()
-                               .hiveScan("region", test::gt("r_name", "ASIA"))
-                               .build(),
+                           core::PlanMatcherBuilder().hiveScan(
+                               "region", test::gt("r_name", "ASIA")),
                            velox::core::JoinType::kLeftSemiProject,
                            {.nullAware = true})
                        .project()
@@ -427,13 +405,12 @@ TEST_F(SubqueryTest, uncorrelatedProject) {
         "FROM region";
 
     // Uncorrelated EXISTS in projection uses cross join with count check.
-    auto matcher =
-        matchHiveScan("region")
-            .nestedLoopJoin(
-                matchHiveScan("nation").limit().singleAggregation().build(),
-                velox::core::JoinType::kInner)
-            .project()
-            .build();
+    auto matcher = matchHiveScan("region")
+                       .nestedLoopJoin(
+                           matchHiveScan("nation").limit().singleAggregation(),
+                           velox::core::JoinType::kInner)
+                       .project()
+                       .build();
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
@@ -449,13 +426,12 @@ TEST_F(SubqueryTest, uncorrelatedProject) {
 
     // Uncorrelated NOT EXISTS in projection uses cross join with count = 0
     // check.
-    auto matcher =
-        matchHiveScan("region")
-            .nestedLoopJoin(
-                matchHiveScan("nation").limit().singleAggregation().build(),
-                velox::core::JoinType::kInner)
-            .project()
-            .build();
+    auto matcher = matchHiveScan("region")
+                       .nestedLoopJoin(
+                           matchHiveScan("nation").limit().singleAggregation(),
+                           velox::core::JoinType::kInner)
+                       .project()
+                       .build();
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
@@ -474,11 +450,11 @@ TEST_F(SubqueryTest, correlatedIn) {
 
     // Correlated IN subquery creates a semi-join. The optimizer may flip
     // the join order and use RIGHT SEMI.
-    auto matcher = matchHiveScan("orders")
-                       .hashJoin(
-                           matchHiveScan("customer").build(),
-                           core::JoinType::kRightSemiFilter)
-                       .build();
+    auto matcher =
+        matchHiveScan("orders")
+            .hashJoin(
+                matchHiveScan("customer"), core::JoinType::kRightSemiFilter)
+            .build();
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
@@ -497,7 +473,7 @@ TEST_F(SubqueryTest, correlatedIn) {
     // mark column, then filters and projects.
     auto matcher = matchHiveScan("orders")
                        .hashJoin(
-                           matchHiveScan("customer").build(),
+                           matchHiveScan("customer"),
                            core::JoinType::kRightSemiProject,
                            {.nullAware = true})
                        .filter()
@@ -528,17 +504,14 @@ TEST_F(SubqueryTest, correlatedIn) {
         "  SELECT u.x FROM u "
         "  WHERE u.y < t.b"
         ") FROM t";
-    auto matcher =
-        matchScan("t")
-            .hashJoin(
-                matchScan("u")
-                    .hashJoin(
-                        matchScan("t").build(), core::JoinType::kLeftSemiFilter)
-                    .build(),
-                core::JoinType::kLeftSemiProject,
-                {.nullAware = true})
-            .project()
-            .build();
+    auto matcher = matchScan("t")
+                       .hashJoin(
+                           matchScan("u").hashJoin(
+                               matchScan("t"), core::JoinType::kLeftSemiFilter),
+                           core::JoinType::kLeftSemiProject,
+                           {.nullAware = true})
+                       .project()
+                       .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -562,7 +535,7 @@ TEST_F(SubqueryTest, correlatedInWithCorrelationFilter) {
     auto matcher =
         matchScan("t")
             .hashJoin(
-                matchScan("u").build(),
+                matchScan("u"),
                 core::JoinType::kLeftSemiProject,
                 {.nullAware = true, .keys = {{"a = x"}}, .filter = "b = y"})
             .project()
@@ -581,7 +554,7 @@ TEST_F(SubqueryTest, correlatedInWithCorrelationFilter) {
 
     auto matcher = matchScan("t")
                        .hashJoin(
-                           matchScan("u").build(),
+                           matchScan("u"),
                            core::JoinType::kLeftSemiProject,
                            {.nullAware = true,
                             .keys = {{"a = x"}},
@@ -607,7 +580,7 @@ TEST_F(SubqueryTest, correlatedInWithMixedCorrelationFilter) {
 
   auto matcher = matchScan("t")
                      .hashJoin(
-                         matchScan("u").build(),
+                         matchScan("u"),
                          core::JoinType::kLeftSemiProject,
                          {.nullAware = true,
                           .keys = {{"a = x"}},
@@ -631,7 +604,7 @@ TEST_F(SubqueryTest, correlatedInWithRedundantCorrelationFilter) {
 
   auto matcher = matchScan("t")
                      .hashJoin(
-                         matchScan("u").build(),
+                         matchScan("u"),
                          core::JoinType::kLeftSemiProject,
                          {.nullAware = true, .keys = {{"a = x"}}, .filter = ""})
                      .project()
@@ -653,9 +626,8 @@ TEST_F(SubqueryTest, correlatedInOnSibling) {
 
   auto matcher =
       matchScan("t")
-          .nestedLoopJoin(matchScan("u").build(), core::JoinType::kInner)
-          .hashJoin(
-              matchScan("v").project().build(), core::JoinType::kLeftSemiFilter)
+          .nestedLoopJoin(matchScan("u"), core::JoinType::kInner)
+          .hashJoin(matchScan("v").project(), core::JoinType::kLeftSemiFilter)
           .build();
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -675,11 +647,10 @@ TEST_F(SubqueryTest, multiTableInSubquery) {
   // The inner join is computed first, then the semi-join filters rows.
   auto matcher =
       matchScan("t")
-          .hashJoin(matchScan("u").build(), velox::core::JoinType::kInner)
+          .hashJoin(matchScan("u"), velox::core::JoinType::kInner)
           .project()
           .hashJoin(
-              matchScan("v").project().build(),
-              velox::core::JoinType::kLeftSemiFilter)
+              matchScan("v").project(), velox::core::JoinType::kLeftSemiFilter)
           .build();
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
@@ -700,8 +671,7 @@ TEST_F(SubqueryTest, correlatedScalar) {
             .hashJoin(
                 matchHiveScan("nation")
                     .singleAggregation({"n_regionkey"}, {"min(n_nationkey)"})
-                    .project()
-                    .build(),
+                    .project(),
                 velox::core::JoinType::kLeft)
             .filter("r_regionkey = min")
             .project()
@@ -725,8 +695,7 @@ TEST_F(SubqueryTest, correlatedScalar) {
                        .hashJoin(
                            matchHiveScan("nation")
                                .singleAggregation({"n_regionkey"}, {"count(*)"})
-                               .project()
-                               .build(),
+                               .project(),
                            velox::core::JoinType::kLeft)
                        .filter("r_regionkey = coalesce(count, 0)")
                        .project()
@@ -747,8 +716,7 @@ TEST_F(SubqueryTest, correlatedScalar) {
                            matchHiveScan("nation")
                                .singleAggregation(
                                    {"n_regionkey"}, {"approx_distinct(n_name)"})
-                               .project()
-                               .build(),
+                               .project(),
                            velox::core::JoinType::kLeft)
                        .filter("r_regionkey = coalesce(approx_distinct, 0)")
                        .project()
@@ -762,7 +730,7 @@ TEST_F(SubqueryTest, correlatedScalar) {
 
 TEST_F(SubqueryTest, correlatedProject) {
   auto matchAggNation = [&]() {
-    return matchHiveScan("nation").singleAggregation().project().build();
+    return matchHiveScan("nation").singleAggregation().project();
   };
 
   // Correlated scalar subquery in projection with COUNT aggregation.
@@ -831,14 +799,13 @@ TEST_F(SubqueryTest, correlatedProject) {
 
     // EXISTS subquery in projection is transformed into a LEFT SEMI PROJECT
     // join with a mark column. nullAware is false for EXISTS semantics.
-    auto matcher =
-        matchHiveScan("nation")
-            .hashJoin(
-                core::PlanMatcherBuilder().hiveScan("region", {}).build(),
-                velox::core::JoinType::kLeftSemiProject,
-                {.nullAware = false})
-            .project()
-            .build();
+    auto matcher = matchHiveScan("nation")
+                       .hashJoin(
+                           core::PlanMatcherBuilder().hiveScan("region", {}),
+                           velox::core::JoinType::kLeftSemiProject,
+                           {.nullAware = false})
+                       .project()
+                       .build();
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
@@ -854,14 +821,13 @@ TEST_F(SubqueryTest, correlatedProject) {
 
     // Correlated IN subquery in projection is transformed into a LEFT SEMI
     // PROJECT join with a mark column.
-    auto matcher =
-        matchHiveScan("nation")
-            .hashJoin(
-                core::PlanMatcherBuilder().hiveScan("region", {}).build(),
-                velox::core::JoinType::kLeftSemiProject,
-                {.nullAware = true})
-            .project()
-            .build();
+    auto matcher = matchHiveScan("nation")
+                       .hashJoin(
+                           core::PlanMatcherBuilder().hiveScan("region", {}),
+                           velox::core::JoinType::kLeftSemiProject,
+                           {.nullAware = true})
+                       .project()
+                       .build();
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
@@ -877,14 +843,13 @@ TEST_F(SubqueryTest, correlatedProject) {
 
     // Correlated NOT IN subquery in projection is transformed into a LEFT SEMI
     // PROJECT join with a mark column and NOT applied.
-    auto matcher =
-        matchHiveScan("nation")
-            .hashJoin(
-                core::PlanMatcherBuilder().hiveScan("region", {}).build(),
-                velox::core::JoinType::kLeftSemiProject,
-                {.nullAware = true})
-            .project()
-            .build();
+    auto matcher = matchHiveScan("nation")
+                       .hashJoin(
+                           core::PlanMatcherBuilder().hiveScan("region", {}),
+                           velox::core::JoinType::kLeftSemiProject,
+                           {.nullAware = true})
+                       .project()
+                       .build();
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
@@ -903,8 +868,7 @@ TEST_F(SubqueryTest, uncorrelatedExists) {
                            matchHiveScan("nation")
                                .finalLimit(0, 1)
                                .singleAggregation({}, {"count(*) as c"})
-                               .filter("not(eq(c, 0))")
-                               .build(),
+                               .filter("not(eq(c, 0))"),
                            velox::core::JoinType::kInner)
                        .build();
 
@@ -923,8 +887,7 @@ TEST_F(SubqueryTest, uncorrelatedExists) {
                            matchHiveScan("nation")
                                .finalLimit(0, 1)
                                .singleAggregation({}, {"count(*) as c"})
-                               .filter("not(not(eq(c, 0)))")
-                               .build(),
+                               .filter("not(not(eq(c, 0)))"),
                            velox::core::JoinType::kInner)
                        .build();
 
@@ -941,13 +904,12 @@ TEST_F(SubqueryTest, correlatedNotExists) {
         "SELECT * FROM nation WHERE "
         "NOT EXISTS (SELECT * FROM region WHERE r_regionkey = n_regionkey)";
 
-    auto matcher =
-        matchHiveScan("nation")
-            .hashJoin(
-                core::PlanMatcherBuilder().hiveScan("region", {}).build(),
-                velox::core::JoinType::kAnti,
-                {.nullAware = false})
-            .build();
+    auto matcher = matchHiveScan("nation")
+                       .hashJoin(
+                           core::PlanMatcherBuilder().hiveScan("region", {}),
+                           velox::core::JoinType::kAnti,
+                           {.nullAware = false})
+                       .build();
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
@@ -964,7 +926,7 @@ TEST_F(SubqueryTest, correlatedNotExists) {
     // LEFT SEMI PROJECT, then filters and negates the result.
     auto matcher = matchHiveScan("nation")
                        .nestedLoopJoin(
-                           matchHiveScan("region").build(),
+                           matchHiveScan("region"),
                            velox::core::JoinType::kLeftSemiProject)
                        .filter()
                        .project()
@@ -984,14 +946,13 @@ TEST_F(SubqueryTest, correlatedNotExists) {
 
     // NOT EXISTS subquery in projection is transformed into a LEFT SEMI PROJECT
     // join with a mark column and NOT applied.
-    auto matcher =
-        matchHiveScan("nation")
-            .hashJoin(
-                core::PlanMatcherBuilder().hiveScan("region", {}).build(),
-                velox::core::JoinType::kLeftSemiProject,
-                {.nullAware = false})
-            .project()
-            .build();
+    auto matcher = matchHiveScan("nation")
+                       .hashJoin(
+                           core::PlanMatcherBuilder().hiveScan("region", {}),
+                           velox::core::JoinType::kLeftSemiProject,
+                           {.nullAware = false})
+                       .project()
+                       .build();
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
@@ -1009,8 +970,7 @@ TEST_F(SubqueryTest, unnest) {
         "select * from t, unnest(a) as v(n) where n in (SELECT x FROM u) ";
 
     auto logicalPlan = parseSelect(query, kTestConnectorId);
-    auto matcher =
-        matchScan("t").unnest().hashJoin(matchScan("u").build()).build();
+    auto matcher = matchScan("t").unnest().hashJoin(matchScan("u")).build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1021,8 +981,7 @@ TEST_F(SubqueryTest, unnest) {
         "select * from t, unnest(a) as v(n) where EXISTS (SELECT * FROM u WHERE x = n) ";
 
     auto logicalPlan = parseSelect(query, kTestConnectorId);
-    auto matcher =
-        matchScan("t").unnest().hashJoin(matchScan("u").build()).build();
+    auto matcher = matchScan("t").unnest().hashJoin(matchScan("u")).build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1033,12 +992,12 @@ TEST_F(SubqueryTest, unnest) {
         "select (SELECT sum(y) FROM u WHERE x = n) from t, unnest(a) as v(n)";
 
     auto logicalPlan = parseSelect(query, kTestConnectorId);
-    auto matcher = matchScan("t")
-                       .unnest()
-                       .hashJoin(
-                           matchScan("u").aggregation().project().build(),
-                           core::JoinType::kLeft)
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .unnest()
+            .hashJoin(
+                matchScan("u").aggregation().project(), core::JoinType::kLeft)
+            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1054,7 +1013,7 @@ TEST_F(SubqueryTest, enforceSingleRow) {
   {
     auto matcher =
         matchHiveScan("region")
-            .nestedLoopJoin(matchHiveScan("nation").enforceSingleRow().build())
+            .nestedLoopJoin(matchHiveScan("nation").enforceSingleRow())
             .filter()
             .project()
             .build();
@@ -1066,16 +1025,14 @@ TEST_F(SubqueryTest, enforceSingleRow) {
   }
 
   {
-    auto matcher = matchHiveScan("region")
-                       .nestedLoopJoin(matchHiveScan("nation")
-                                           .gather()
-                                           .enforceSingleRow()
-                                           .broadcast()
-                                           .build())
-                       .filter()
-                       .project()
-                       .gather()
-                       .build();
+    auto matcher =
+        matchHiveScan("region")
+            .nestedLoopJoin(
+                matchHiveScan("nation").gather().enforceSingleRow().broadcast())
+            .filter()
+            .project()
+            .gather()
+            .build();
 
     auto distributedPlan = planVelox(logicalPlan);
     AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
@@ -1092,7 +1049,7 @@ TEST_F(SubqueryTest, enforceSingleRowInProjection) {
     auto matcher = core::PlanMatcherBuilder()
                        .hiveScan("region", test::eq("r_name", "AFRICA"))
                        .enforceSingleRow()
-                       .nestedLoopJoin(matchHiveScan("nation").build())
+                       .nestedLoopJoin(matchHiveScan("nation"))
                        .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
@@ -1104,16 +1061,14 @@ TEST_F(SubqueryTest, enforceSingleRowInProjection) {
     // broadcast-then-EnforceSingleRow shape would collapse the gather
     // + broadcast pair into a single broadcast with EnforceSingleRow
     // running on each consumer.
-    auto matcher = core::PlanMatcherBuilder()
-                       .hiveScan("region", test::eq("r_name", "AFRICA"))
-                       .gather()
-                       .enforceSingleRow()
-                       .nestedLoopJoin(
-                           core::PlanMatcherBuilder()
-                               .tableScan("nation")
-                               .broadcast()
-                               .build())
-                       .build();
+    auto matcher =
+        core::PlanMatcherBuilder()
+            .hiveScan("region", test::eq("r_name", "AFRICA"))
+            .gather()
+            .enforceSingleRow()
+            .nestedLoopJoin(
+                core::PlanMatcherBuilder().tableScan("nation").broadcast())
+            .build();
 
     auto distributedPlan = planVelox(logicalPlan);
     AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
@@ -1125,11 +1080,10 @@ TEST_F(SubqueryTest, uncorrelatedGroupingKey) {
       "SELECT r_name, (SELECT count(*) FROM nation) FROM region GROUP BY 1, 2";
   SCOPED_TRACE(query);
 
-  auto matcher =
-      matchHiveScan("region")
-          .nestedLoopJoin(matchHiveScan("nation").aggregation().build())
-          .aggregation()
-          .build();
+  auto matcher = matchHiveScan("region")
+                     .nestedLoopJoin(matchHiveScan("nation").aggregation())
+                     .aggregation()
+                     .build();
 
   auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1141,14 +1095,13 @@ TEST_F(SubqueryTest, correlatedGroupingKey) {
       "FROM region GROUP BY 1, 2";
   SCOPED_TRACE(query);
 
-  auto matcher =
-      matchHiveScan("region")
-          .hashJoin(
-              matchHiveScan("nation").aggregation().project().build(),
-              core::JoinType::kLeft)
-          .project()
-          .aggregation()
-          .build();
+  auto matcher = matchHiveScan("region")
+                     .hashJoin(
+                         matchHiveScan("nation").aggregation().project(),
+                         core::JoinType::kLeft)
+                     .project()
+                     .aggregation()
+                     .build();
 
   auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1168,9 +1121,8 @@ TEST_F(SubqueryTest, nonEquiCorrelatedScalar) {
       auto matcher = matchHiveScan("region")
                          .assignUniqueId("unique_id")
                          .nestedLoopJoin(
-                             matchHiveScan("nation")
-                                 .project({"true as marker", "n_regionkey"})
-                                 .build(),
+                             matchHiveScan("nation").project(
+                                 {"true as marker", "n_regionkey"}),
                              velox::core::JoinType::kLeft)
                          .streamingAggregation(
                              {"unique_id"},
@@ -1194,8 +1146,7 @@ TEST_F(SubqueryTest, nonEquiCorrelatedScalar) {
                          .nestedLoopJoin(
                              matchHiveScan("nation")
                                  .project({"true as marker", "n_regionkey"})
-                                 .broadcast()
-                                 .build(),
+                                 .broadcast(),
                              velox::core::JoinType::kLeft)
                          .streamingAggregation(
                              {"unique_id"},
@@ -1227,24 +1178,22 @@ TEST_F(SubqueryTest, nonEquiCorrelatedScalar) {
     auto logicalPlan = parseSelect(query);
 
     {
-      auto matcher =
-          matchHiveScan("region")
-              .assignUniqueId("unique_id")
-              .hashJoin(
-                  matchHiveScan("nation")
-                      .project({"true as marker", "n_name", "n_regionkey"})
-                      .build(),
-                  velox::core::JoinType::kLeft)
-              .streamingAggregation(
-                  {"unique_id"},
-                  {
-                      "count(*) filter (where marker) as cnt",
-                      "arbitrary(r_regionkey)",
-                      "arbitrary(r_name)",
-                  })
-              .filter("cnt > 3")
-              .project()
-              .build();
+      auto matcher = matchHiveScan("region")
+                         .assignUniqueId("unique_id")
+                         .hashJoin(
+                             matchHiveScan("nation").project(
+                                 {"true as marker", "n_name", "n_regionkey"}),
+                             velox::core::JoinType::kLeft)
+                         .streamingAggregation(
+                             {"unique_id"},
+                             {
+                                 "count(*) filter (where marker) as cnt",
+                                 "arbitrary(r_regionkey)",
+                                 "arbitrary(r_name)",
+                             })
+                         .filter("cnt > 3")
+                         .project()
+                         .build();
 
       auto plan = toSingleNodePlan(logicalPlan);
       AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1276,8 +1225,7 @@ TEST_F(SubqueryTest, nonEquiCorrelatedScalarWithNestedAggregation) {
           .hashJoin(
               matchScan("u")
                   .singleAggregation({"c"}, {"count(*) as inner_cnt"})
-                  .project({"true as marker", "inner_cnt", "c"})
-                  .build(),
+                  .project({"true as marker", "inner_cnt", "c"}),
               velox::core::JoinType::kLeft)
           .streamingAggregation(
               {"unique_id"},
@@ -1307,9 +1255,8 @@ TEST_F(SubqueryTest, nonEquiCorrelatedProject) {
       auto matcher = matchHiveScan("region")
                          .assignUniqueId("unique_id")
                          .nestedLoopJoin(
-                             matchHiveScan("nation")
-                                 .project({"true as marker", "n_regionkey"})
-                                 .build(),
+                             matchHiveScan("nation").project(
+                                 {"true as marker", "n_regionkey"}),
                              velox::core::JoinType::kLeft)
                          .streamingAggregation(
                              {"unique_id"},
@@ -1332,8 +1279,7 @@ TEST_F(SubqueryTest, nonEquiCorrelatedProject) {
                          .nestedLoopJoin(
                              matchHiveScan("nation")
                                  .project({"true as marker", "n_regionkey"})
-                                 .broadcast()
-                                 .build(),
+                                 .broadcast(),
                              velox::core::JoinType::kLeft)
                          .streamingAggregation(
                              {"unique_id"},
@@ -1371,9 +1317,8 @@ TEST_F(SubqueryTest, multipleNonEquiCorrelatedScalars) {
     auto matcher = matchHiveScan("region")
                        .assignUniqueId("unique_id")
                        .nestedLoopJoin(
-                           matchHiveScan("nation")
-                               .project({"true as marker1", "n_regionkey"})
-                               .build(),
+                           matchHiveScan("nation").project(
+                               {"true as marker1", "n_regionkey"}),
                            velox::core::JoinType::kLeft)
                        .streamingAggregation(
                            {"unique_id"},
@@ -1384,8 +1329,7 @@ TEST_F(SubqueryTest, multipleNonEquiCorrelatedScalars) {
                        .project()
                        .nestedLoopJoin(
                            matchHiveScan("supplier")
-                               .project({"true as marker2", "s_suppkey"})
-                               .build(),
+                               .project({"true as marker2", "s_suppkey"}),
                            velox::core::JoinType::kLeft)
                        .streamingAggregation(
                            {"unique_id"},
@@ -1415,9 +1359,8 @@ TEST_F(SubqueryTest, multipleNonEquiCorrelatedScalars) {
     auto matcher = matchHiveScan("region")
                        .assignUniqueId("unique_id")
                        .nestedLoopJoin(
-                           matchHiveScan("nation")
-                               .project({"true as marker1", "n_regionkey"})
-                               .build(),
+                           matchHiveScan("nation").project(
+                               {"true as marker1", "n_regionkey"}),
                            velox::core::JoinType::kLeft)
                        .streamingAggregation(
                            {"unique_id"},
@@ -1428,8 +1371,7 @@ TEST_F(SubqueryTest, multipleNonEquiCorrelatedScalars) {
                        .project()
                        .nestedLoopJoin(
                            matchHiveScan("supplier")
-                               .project({"true as marker2", "s_suppkey"})
-                               .build(),
+                               .project({"true as marker2", "s_suppkey"}),
                            velox::core::JoinType::kLeft)
                        .streamingAggregation(
                            {"unique_id"},
@@ -1441,8 +1383,7 @@ TEST_F(SubqueryTest, multipleNonEquiCorrelatedScalars) {
                        .project()
                        .nestedLoopJoin(
                            matchHiveScan("customer")
-                               .project({"true as marker3", "c_custkey"})
-                               .build(),
+                               .project({"true as marker3", "c_custkey"}),
                            velox::core::JoinType::kLeft)
                        .streamingAggregation(
                            {"unique_id"},
@@ -1473,14 +1414,12 @@ TEST_F(SubqueryTest, uncorrelatedThenNonEquiCorrelatedScalar) {
   auto matcher = matchHiveScan("region")
                      .assignUniqueId("unique_id")
                      .nestedLoopJoin(
-                         matchHiveScan("nation")
-                             .project({"true as marker", "n_regionkey"})
-                             .build(),
+                         matchHiveScan("nation").project(
+                             {"true as marker", "n_regionkey"}),
                          velox::core::JoinType::kLeft)
                      .nestedLoopJoin(matchHiveScan("supplier")
                                          .singleAggregation(
-                                             {}, {"max(s_suppkey) as max_key"})
-                                         .build())
+                                             {}, {"max(s_suppkey) as max_key"}))
                      .streamingAggregation(
                          {"unique_id"},
                          {
@@ -1508,9 +1447,8 @@ TEST_F(SubqueryTest, nonEquiCorrelatedScalarThenCorrelatedExists) {
   auto matcher = matchHiveScan("region")
                      .assignUniqueId("unique_id")
                      .nestedLoopJoin(
-                         matchHiveScan("nation")
-                             .project({"true as marker", "n_regionkey"})
-                             .build(),
+                         matchHiveScan("nation").project(
+                             {"true as marker", "n_regionkey"}),
                          velox::core::JoinType::kLeft)
                      .streamingAggregation(
                          {"unique_id"},
@@ -1520,7 +1458,7 @@ TEST_F(SubqueryTest, nonEquiCorrelatedScalarThenCorrelatedExists) {
                          })
                      .project()
                      .nestedLoopJoin(
-                         matchHiveScan("supplier").build(),
+                         matchHiveScan("supplier"),
                          velox::core::JoinType::kLeftSemiProject)
                      .project()
                      .build();
@@ -1542,9 +1480,8 @@ TEST_F(SubqueryTest, nonEquiCorrelatedThenUncorrelatedScalar) {
   auto matcher = matchHiveScan("region")
                      .assignUniqueId("unique_id")
                      .nestedLoopJoin(
-                         matchHiveScan("nation")
-                             .project({"true as marker", "n_regionkey"})
-                             .build(),
+                         matchHiveScan("nation").project(
+                             {"true as marker", "n_regionkey"}),
                          velox::core::JoinType::kLeft)
                      .streamingAggregation(
                          {"unique_id"},
@@ -1555,8 +1492,7 @@ TEST_F(SubqueryTest, nonEquiCorrelatedThenUncorrelatedScalar) {
                      .project()
                      .nestedLoopJoin(matchHiveScan("supplier")
                                          .singleAggregation(
-                                             {}, {"max(s_suppkey) as max_key"})
-                                         .build())
+                                             {}, {"max(s_suppkey) as max_key"}))
                      .project({"cnt as x", "max_key as y"})
                      .build();
 
@@ -1573,16 +1509,16 @@ TEST_F(SubqueryTest, correlatedExistsThenUncorrelatedIn) {
       "FROM region";
   SCOPED_TRACE(query);
 
-  auto matcher = matchHiveScan("supplier")
-                     .hashJoin(
-                         matchHiveScan("region").build(),
-                         velox::core::JoinType::kRightSemiProject,
-                         {.nullAware = true})
-                     .nestedLoopJoin(
-                         matchHiveScan("nation").build(),
-                         velox::core::JoinType::kLeftSemiProject)
-                     .project()
-                     .build();
+  auto matcher =
+      matchHiveScan("supplier")
+          .hashJoin(
+              matchHiveScan("region"),
+              velox::core::JoinType::kRightSemiProject,
+              {.nullAware = true})
+          .nestedLoopJoin(
+              matchHiveScan("nation"), velox::core::JoinType::kLeftSemiProject)
+          .project()
+          .build();
 
   auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1599,14 +1535,13 @@ TEST_F(SubqueryTest, correlatedScalarWithoutAggregation) {
     auto query = "SELECT * FROM t WHERE a > (SELECT c FROM u WHERE d = b)";
     SCOPED_TRACE(query);
 
-    auto matcher =
-        matchScan("t")
-            .assignUniqueId("unique_id")
-            .hashJoin(matchScan("u").build(), velox::core::JoinType::kLeft)
-            .enforceDistinct({"unique_id"})
-            .filter("a > c")
-            .project()
-            .build();
+    auto matcher = matchScan("t")
+                       .assignUniqueId("unique_id")
+                       .hashJoin(matchScan("u"), velox::core::JoinType::kLeft)
+                       .enforceDistinct({"unique_id"})
+                       .filter("a > c")
+                       .project()
+                       .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1616,13 +1551,12 @@ TEST_F(SubqueryTest, correlatedScalarWithoutAggregation) {
     auto query = "SELECT a + (SELECT c FROM u WHERE d = b) FROM t";
     SCOPED_TRACE(query);
 
-    auto matcher =
-        matchScan("t")
-            .assignUniqueId("unique_id")
-            .hashJoin(matchScan("u").build(), velox::core::JoinType::kLeft)
-            .enforceDistinct({"unique_id"})
-            .project({"a + c"})
-            .build();
+    auto matcher = matchScan("t")
+                       .assignUniqueId("unique_id")
+                       .hashJoin(matchScan("u"), velox::core::JoinType::kLeft)
+                       .enforceDistinct({"unique_id"})
+                       .project({"a + c"})
+                       .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1636,7 +1570,7 @@ TEST_F(SubqueryTest, correlatedScalarWithoutAggregation) {
     auto matcher = matchScan("t")
                        .assignUniqueId("unique_id")
                        .nestedLoopJoin(
-                           matchScan("u").project({"c + d as cd", "d"}).build(),
+                           matchScan("u").project({"c + d as cd", "d"}),
                            velox::core::JoinType::kLeft)
                        .enforceDistinct({"unique_id"})
                        .filter("a > cd")
@@ -1654,7 +1588,7 @@ TEST_F(SubqueryTest, correlatedScalarWithoutAggregation) {
     auto matcher = matchScan("t")
                        .assignUniqueId("unique_id")
                        .nestedLoopJoin(
-                           matchScan("u").project({"c + d as cd", "d"}).build(),
+                           matchScan("u").project({"c + d as cd", "d"}),
                            velox::core::JoinType::kLeft)
                        .enforceDistinct({"unique_id"})
                        .project({"a + cd"})
@@ -1681,11 +1615,9 @@ TEST_F(SubqueryTest, innerJoinOnSubquery) {
         matchHiveScan("nation")
             .hashJoin(
                 matchHiveScan("supplier")
-                    .singleAggregation({}, {"min(s_nationkey)"})
-                    .build(),
+                    .singleAggregation({}, {"min(s_nationkey)"}),
                 velox::core::JoinType::kInner)
-            .hashJoin(
-                matchHiveScan("region").build(), velox::core::JoinType::kInner)
+            .hashJoin(matchHiveScan("region"), velox::core::JoinType::kInner)
             .build();
 
     auto plan = toSingleNodePlan(query);
@@ -1701,10 +1633,9 @@ TEST_F(SubqueryTest, innerJoinOnSubquery) {
     auto matcher =
         matchHiveScan("supplier")
             .hashJoin(
-                matchHiveScan("nation").build(),
+                matchHiveScan("nation"),
                 velox::core::JoinType::kRightSemiFilter)
-            .hashJoin(
-                matchHiveScan("region").build(), velox::core::JoinType::kInner)
+            .hashJoin(matchHiveScan("region"), velox::core::JoinType::kInner)
             .build();
 
     auto plan = toSingleNodePlan(query);
@@ -1720,12 +1651,11 @@ TEST_F(SubqueryTest, innerJoinOnSubquery) {
     auto matcher =
         matchHiveScan("supplier")
             .hashJoin(
-                matchHiveScan("nation").build(),
+                matchHiveScan("nation"),
                 velox::core::JoinType::kRightSemiProject,
                 {.nullAware = true})
             .filter()
-            .hashJoin(
-                matchHiveScan("region").build(), velox::core::JoinType::kInner)
+            .hashJoin(matchHiveScan("region"), velox::core::JoinType::kInner)
             .build();
 
     auto plan = toSingleNodePlan(query);
@@ -1742,10 +1672,9 @@ TEST_F(SubqueryTest, innerJoinOnSubquery) {
     auto matcher =
         matchHiveScan("supplier")
             .hashJoin(
-                matchHiveScan("nation").build(),
+                matchHiveScan("nation"),
                 velox::core::JoinType::kRightSemiFilter)
-            .hashJoin(
-                matchHiveScan("region").build(), velox::core::JoinType::kInner)
+            .hashJoin(matchHiveScan("region"), velox::core::JoinType::kInner)
             .build();
 
     auto plan = toSingleNodePlan(query);
@@ -1762,12 +1691,11 @@ TEST_F(SubqueryTest, innerJoinOnSubquery) {
     auto matcher =
         matchHiveScan("supplier")
             .hashJoin(
-                matchHiveScan("nation").build(),
+                matchHiveScan("nation"),
                 velox::core::JoinType::kRightSemiProject,
                 {.nullAware = false})
             .filter()
-            .hashJoin(
-                matchHiveScan("region").build(), velox::core::JoinType::kInner)
+            .hashJoin(matchHiveScan("region"), velox::core::JoinType::kInner)
             .build();
 
     auto plan = toSingleNodePlan(query);
@@ -1786,12 +1714,10 @@ TEST_F(SubqueryTest, innerJoinOnSubquery) {
             .hashJoin(
                 matchHiveScan("supplier")
                     .singleAggregation({"s_nationkey"}, {"count(*) as cnt"})
-                    .project()
-                    .build(),
+                    .project(),
                 velox::core::JoinType::kLeft)
             .filter("n_nationkey > coalesce(cnt, 0)")
-            .hashJoin(
-                matchHiveScan("region").build(), velox::core::JoinType::kInner)
+            .hashJoin(matchHiveScan("region"), velox::core::JoinType::kInner)
             .build();
 
     auto plan = toSingleNodePlan(query);
@@ -1807,12 +1733,10 @@ TEST_F(SubqueryTest, innerJoinOnSubquery) {
 
     auto matcher =
         matchHiveScan("nation")
-            .hashJoin(
-                matchHiveScan("region").build(), velox::core::JoinType::kInner)
+            .hashJoin(matchHiveScan("region"), velox::core::JoinType::kInner)
             .nestedLoopJoin(
                 matchHiveScan("supplier")
-                    .singleAggregation({}, {"min(s_nationkey)"})
-                    .build(),
+                    .singleAggregation({}, {"min(s_nationkey)"}),
                 velox::core::JoinType::kInner)
             .filter()
             .project()
@@ -1838,9 +1762,8 @@ TEST_F(SubqueryTest, leftJoinOnSubquery) {
                        .hashJoin(
                            matchHiveScan("supplier")
                                .hashJoin(
-                                   matchHiveScan("region").build(),
-                                   core::JoinType::kRightSemiFilter)
-                               .build(),
+                                   matchHiveScan("region"),
+                                   core::JoinType::kRightSemiFilter),
                            core::JoinType::kLeft)
                        .build();
 
@@ -1860,12 +1783,10 @@ TEST_F(SubqueryTest, leftJoinOnSubquery) {
                 matchHiveScan("region")
                     .nestedLoopJoin(
                         matchHiveScan("supplier")
-                            .singleAggregation({}, {"min(s_nationkey) as m"})
-                            .build(),
+                            .singleAggregation({}, {"min(s_nationkey) as m"}),
                         core::JoinType::kInner)
                     .filter("r_regionkey > m")
-                    .project()
-                    .build(),
+                    .project(),
                 core::JoinType::kLeft)
             .build();
 
@@ -1885,12 +1806,11 @@ TEST_F(SubqueryTest, leftJoinOnSubquery) {
                        .hashJoin(
                            matchHiveScan("supplier")
                                .hashJoin(
-                                   matchHiveScan("region").build(),
+                                   matchHiveScan("region"),
                                    core::JoinType::kRightSemiProject,
                                    {.nullAware = true})
                                .filter()
-                               .project()
-                               .build(),
+                               .project(),
                            core::JoinType::kLeft)
                        .build();
 
@@ -1909,9 +1829,8 @@ TEST_F(SubqueryTest, leftJoinOnSubquery) {
                        .nestedLoopJoin(
                            matchHiveScan("supplier")
                                .hashJoin(
-                                   matchHiveScan("region").build(),
-                                   core::JoinType::kRightSemiFilter)
-                               .build(),
+                                   matchHiveScan("region"),
+                                   core::JoinType::kRightSemiFilter),
                            core::JoinType::kLeft)
                        .build();
 
@@ -1930,9 +1849,8 @@ TEST_F(SubqueryTest, leftJoinOnSubquery) {
                        .hashJoin(
                            matchHiveScan("supplier")
                                .hashJoin(
-                                   matchHiveScan("region").build(),
-                                   core::JoinType::kRightSemiFilter)
-                               .build(),
+                                   matchHiveScan("region"),
+                                   core::JoinType::kRightSemiFilter),
                            core::JoinType::kLeft)
                        .build();
 
@@ -1951,12 +1869,11 @@ TEST_F(SubqueryTest, leftJoinOnSubquery) {
                        .hashJoin(
                            matchHiveScan("supplier")
                                .hashJoin(
-                                   matchHiveScan("region").build(),
+                                   matchHiveScan("region"),
                                    core::JoinType::kRightSemiProject,
                                    {.nullAware = false})
                                .filter()
-                               .project()
-                               .build(),
+                               .project(),
                            core::JoinType::kLeft)
                        .build();
 
@@ -1981,15 +1898,13 @@ TEST_F(SubqueryTest, leftJoinOnSubquery) {
                     .hashJoin(
                         matchHiveScan("supplier")
                             .hashJoin(
-                                matchHiveScan("region").build(),
+                                matchHiveScan("region"),
                                 core::JoinType::kLeftSemiFilter)
                             .singleAggregation({"s_nationkey"}, {"count(*)"})
-                            .project()
-                            .build(),
+                            .project(),
                         core::JoinType::kLeft)
                     .filter()
-                    .project()
-                    .build(),
+                    .project(),
                 core::JoinType::kLeft)
             .build();
 
@@ -2019,8 +1934,8 @@ TEST_F(SubqueryTest, nonEquiLeftJoinWithScalarSubquery) {
   // nested-loop join.
   auto matcher =
       matchScan("t")
-          .nestedLoopJoin(matchScan("u").build(), velox::core::JoinType::kLeft)
-          .nestedLoopJoin(matchScan("v").enforceSingleRow().build())
+          .nestedLoopJoin(matchScan("u"), velox::core::JoinType::kLeft)
+          .nestedLoopJoin(matchScan("v").enforceSingleRow())
           .project()
           .build();
 
@@ -2041,7 +1956,7 @@ TEST_F(SubqueryTest, leftJoinFilterWithNonDefaultNullEquality) {
   auto matcher = matchValues()
                      .aliases({"x"})
                      .hashJoin(
-                         matchValues().aliases({"y"}).build(),
+                         matchValues().aliases({"y"}),
                          core::JoinType::kLeft,
                          {.keys = {{"x = y"}}})
                      .filter("eq(y, try(x))")
@@ -2068,9 +1983,8 @@ TEST_F(SubqueryTest, rightJoinOnSubquery) {
                        .hashJoin(
                            matchHiveScan("supplier")
                                .hashJoin(
-                                   matchHiveScan("region").build(),
-                                   core::JoinType::kRightSemiFilter)
-                               .build(),
+                                   matchHiveScan("region"),
+                                   core::JoinType::kRightSemiFilter),
                            core::JoinType::kLeft)
                        .project()
                        .build();
@@ -2090,9 +2004,8 @@ TEST_F(SubqueryTest, rightJoinOnSubquery) {
                        .hashJoin(
                            matchHiveScan("supplier")
                                .hashJoin(
-                                   matchHiveScan("region").build(),
-                                   core::JoinType::kRightSemiFilter)
-                               .build(),
+                                   matchHiveScan("region"),
+                                   core::JoinType::kRightSemiFilter),
                            core::JoinType::kLeft)
                        .project()
                        .build();
@@ -2131,7 +2044,7 @@ TEST_F(SubqueryTest, unsupportedSubqueryInJoin) {
 TEST_F(SubqueryTest, inSubqueryInsideAggregate) {
   auto matchJoin = [&]() {
     return matchHiveScan("nation").hashJoin(
-        matchHiveScan("region").build(),
+        matchHiveScan("region"),
         core::JoinType::kLeftSemiProject,
         {.nullAware = true});
   };
@@ -2177,12 +2090,12 @@ TEST_F(SubqueryTest, nestedInSubqueries) {
 
   auto matcher = matchHiveScan("nation")
                      .hashJoin(
-                         matchHiveScan("region").build(),
+                         matchHiveScan("region"),
                          velox::core::JoinType::kLeftSemiProject,
                          {.nullAware = true})
                      .project()
                      .hashJoin(
-                         matchValues().project().build(),
+                         matchValues().project(),
                          velox::core::JoinType::kLeftSemiProject,
                          {.nullAware = true})
                      .project()
@@ -2209,11 +2122,9 @@ TEST_F(SubqueryTest, existsWithNoFromClause) {
 
   auto matcher =
       matchScan("t")
-          .nestedLoopJoin(
-              matchScan("t")
-                  .hashJoin(matchScan("u").build(), core::JoinType::kInner)
-                  .aggregation()
-                  .build())
+          .nestedLoopJoin(matchScan("t")
+                              .hashJoin(matchScan("u"), core::JoinType::kInner)
+                              .aggregation())
           .build();
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
@@ -2249,21 +2160,18 @@ TEST_F(SubqueryTest, inSubqueryWithCorrelatedNotExists) {
   // The IN subquery becomes a LEFT SEMI PROJECT (mark) join with v, wrapped
   // in its own DT. The inner join combines u's projection with t. The NOT
   // EXISTS becomes an anti-join with v.
-  auto matcher = matchScan("t")
-                     .hashJoin(
-                         matchScan("u")
-                             .hashJoin(
-                                 matchScan("v").build(),
-                                 core::JoinType::kLeftSemiProject,
-                                 {.nullAware = true})
-                             .project()
-                             .build(),
-                         core::JoinType::kInner)
-                     .hashJoin(
-                         matchScan("v").build(),
-                         core::JoinType::kAnti,
-                         {.nullAware = false})
-                     .build();
+  auto matcher =
+      matchScan("t")
+          .hashJoin(
+              matchScan("u")
+                  .hashJoin(
+                      matchScan("v"),
+                      core::JoinType::kLeftSemiProject,
+                      {.nullAware = true})
+                  .project(),
+              core::JoinType::kInner)
+          .hashJoin(matchScan("v"), core::JoinType::kAnti, {.nullAware = false})
+          .build();
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -2297,16 +2205,15 @@ TEST_F(SubqueryTest, inReplicateNullsAndAny) {
     auto query = "SELECT * FROM t WHERE a NOT IN (SELECT c FROM u)";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .shuffle({"a"})
-                       .hashJoin(
-                           matchScan("u")
-                               .shuffle({"c"}, /*replicateNullsAndAny=*/true)
-                               .build(),
-                           velox::core::JoinType::kAnti,
-                           {.nullAware = true})
-                       .gather()
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .shuffle({"a"})
+            .hashJoin(
+                matchScan("u").shuffle({"c"}, /*replicateNullsAndAny=*/true),
+                velox::core::JoinType::kAnti,
+                {.nullAware = true})
+            .gather()
+            .build();
 
     auto distributedPlan = planVelox(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
@@ -2319,17 +2226,16 @@ TEST_F(SubqueryTest, inReplicateNullsAndAny) {
     auto query = "SELECT a, a IN (SELECT c FROM u) AS flag FROM t";
     SCOPED_TRACE(query);
 
-    auto matcher = matchScan("t")
-                       .shuffle({"a"})
-                       .hashJoin(
-                           matchScan("u")
-                               .shuffle({"c"}, /*replicateNullsAndAny=*/true)
-                               .build(),
-                           velox::core::JoinType::kLeftSemiProject,
-                           {.nullAware = true})
-                       .project()
-                       .gather()
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .shuffle({"a"})
+            .hashJoin(
+                matchScan("u").shuffle({"c"}, /*replicateNullsAndAny=*/true),
+                velox::core::JoinType::kLeftSemiProject,
+                {.nullAware = true})
+            .project()
+            .gather()
+            .build();
 
     auto distributedPlan = planVelox(parseSelect(query, kTestConnectorId));
     AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
@@ -2343,7 +2249,7 @@ TEST_F(SubqueryTest, inReplicateNullsAndAny) {
     auto matcher = matchScan("t")
                        .shuffle({"a"}, /*replicateNullsAndAny=*/true)
                        .hashJoin(
-                           matchScan("u").shuffle({"c"}).build(),
+                           matchScan("u").shuffle({"c"}),
                            velox::core::JoinType::kRightSemiProject,
                            {.nullAware = true})
                        .project()

--- a/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
+++ b/axiom/optimizer/tests/SyntacticJoinOrderTest.cpp
@@ -62,9 +62,7 @@ TEST_F(SyntacticJoinOrderTest, innerJoins) {
   // Optimized join order: lineitem x (orders x customer).
   auto optimizedMatcher =
       matchHiveScan("lineitem")
-          .hashJoin(matchHiveScan("orders")
-                        .hashJoin(matchHiveScan("customer").build())
-                        .build())
+          .hashJoin(matchHiveScan("orders").hashJoin(matchHiveScan("customer")))
           .aggregation()
           .build();
 
@@ -140,8 +138,8 @@ TEST_F(SyntacticJoinOrderTest, innerJoins) {
         auto plan = toSingleNodePlan(logicalPlan);
 
         auto matcher = matchHiveScan(order[0])
-                           .hashJoin(matchHiveScan(order[1]).build())
-                           .hashJoin(matchHiveScan(order[2]).build())
+                           .hashJoin(matchHiveScan(order[1]))
+                           .hashJoin(matchHiveScan(order[2]))
                            .aggregation()
                            .build();
         AXIOM_ASSERT_PLAN(plan, matcher);
@@ -197,13 +195,11 @@ TEST_F(SyntacticJoinOrderTest, innerJoins) {
         optimizerOptions_.syntacticJoinOrder = true;
         auto plan = toSingleNodePlan(logicalPlan);
 
-        auto matcher =
-            matchHiveScan(order[0])
-                .hashJoin(matchHiveScan(order[1])
-                              .hashJoin(matchHiveScan(order[2]).build())
-                              .build())
-                .aggregation()
-                .build();
+        auto matcher = matchHiveScan(order[0])
+                           .hashJoin(matchHiveScan(order[1]).hashJoin(
+                               matchHiveScan(order[2])))
+                           .aggregation()
+                           .build();
         AXIOM_ASSERT_PLAN(plan, matcher);
 
         checkSame(logicalPlan, referenceResults);
@@ -218,7 +214,7 @@ TEST_F(SyntacticJoinOrderTest, outerJoins) {
   // Optimized join order: lineitem x orders.
   auto optimizedMatcher =
       matchHiveScan("lineitem")
-          .hashJoin(matchHiveScan("orders").build(), core::JoinType::kLeft)
+          .hashJoin(matchHiveScan("orders"), core::JoinType::kLeft)
           .aggregation()
           .build();
 
@@ -286,8 +282,7 @@ TEST_F(SyntacticJoinOrderTest, outerJoins) {
 
       auto matcher =
           matchHiveScan("orders")
-              .hashJoin(
-                  matchHiveScan("lineitem").build(), core::JoinType::kRight)
+              .hashJoin(matchHiveScan("lineitem"), core::JoinType::kRight)
               .aggregation()
               .build();
       AXIOM_ASSERT_PLAN(plan, matcher);
@@ -317,12 +312,10 @@ TEST_F(SyntacticJoinOrderTest, crossJoinStartsWithSingleRowSubqueries) {
           .aliases({"status"})
           .singleAggregation({"status"}, {"count(*) as s"})
           .project()
-          .nestedLoopJoin(matchHiveScan("orders")
-                              .singleAggregation({}, {"count(*) as c"})
-                              .build())
+          .nestedLoopJoin(
+              matchHiveScan("orders").singleAggregation({}, {"count(*) as c"}))
           .nestedLoopJoin(matchHiveScan("lineitem")
-                              .singleAggregation({}, {"count(*) as c"})
-                              .build())
+                              .singleAggregation({}, {"count(*) as c"}))
           .project()
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -349,11 +342,10 @@ TEST_F(SyntacticJoinOrderTest, singleRowSubqueryInMiddleOfJoinOrder) {
   auto matcher =
       matchHiveScan("region")
           .hashJoin(
-              matchHiveScan("nation").singleAggregation().project().build(),
+              matchHiveScan("nation").singleAggregation().project(),
               core::JoinType::kLeft)
           .nestedLoopJoin(matchHiveScan("lineitem")
-                              .singleAggregation({}, {"max(l_quantity)"})
-                              .build())
+                              .singleAggregation({}, {"max(l_quantity)"}))
           .project()
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);

--- a/axiom/optimizer/tests/TableSampleTest.cpp
+++ b/axiom/optimizer/tests/TableSampleTest.cpp
@@ -140,7 +140,7 @@ TEST_P(TableSampleTest, sampledCardinality) {
   };
 
   auto matchJoin = [&](const std::string& probe, const std::string& build) {
-    return matchScan(probe).hashJoinInner(matchScan(build).build()).build();
+    return matchScan(probe).hashJoinInner(matchScan(build)).build();
   };
 
   // Unsampled, 'small' (1K rows) is the smaller side.

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -158,39 +158,24 @@ TEST_F(TpchPlanTest, q02) {
   // )
   auto matcher =
       matchScan("partsupp")
-          .hashJoinInner(matchScan("part")
-                             .filter("p_size = 15 and p_type like '%BRASS'")
-                             .build())
+          .hashJoinInner(
+              matchScan("part").filter("p_size = 15 and p_type like '%BRASS'"))
           .hashJoinInner(
               matchScan("supplier")
-                  .hashJoinInner(
-                      matchScan("nation")
-                          .hashJoinInner(matchScan("region")
-                                             .filter("r_name = 'EUROPE'")
-                                             .build())
-                          .build())
-                  .build())
+                  .hashJoinInner(matchScan("nation").hashJoinInner(
+                      matchScan("region").filter("r_name = 'EUROPE'"))))
           .hashJoinInner(
               matchScan("partsupp")
-                  .hashJoinLeftSemiFilter(
-                      matchScan("part")
-                          .filter("p_size = 15 and p_type like '%BRASS'")
-                          .build())
+                  .hashJoinLeftSemiFilter(matchScan("part").filter(
+                      "p_size = 15 and p_type like '%BRASS'"))
                   .hashJoinInner(
                       matchScan("supplier")
-                          .hashJoinInner(
-                              matchScan("nation")
-                                  .hashJoinInner(
-                                      matchScan("region")
-                                          .aliases(
-                                              {std::nullopt, "region_name"})
-                                          .filter("region_name = 'EUROPE'")
-                                          .build())
-                                  .build())
-                          .build())
+                          .hashJoinInner(matchScan("nation").hashJoinInner(
+                              matchScan("region")
+                                  .aliases({std::nullopt, "region_name"})
+                                  .filter("region_name = 'EUROPE'"))))
                   .aggregation()
-                  .project()
-                  .build())
+                  .project())
           .topN()
           .project()
           .build();
@@ -206,9 +191,7 @@ TEST_F(TpchPlanTest, q03) {
               matchScan("orders")
                   .filter("o_orderdate < date '1995-03-15'")
                   .hashJoinInner(matchScan("customer")
-                                     .filter("c_mktsegment = 'BUILDING'")
-                                     .build())
-                  .build())
+                                     .filter("c_mktsegment = 'BUILDING'")))
           .project()
           .aggregation()
           .topN()
@@ -222,11 +205,8 @@ TEST_F(TpchPlanTest, q04) {
   auto matcher =
       matchScan("lineitem")
           .filter("l_commitdate < l_receiptdate")
-          .hashJoinRightSemiFilter(
-              matchScan("orders")
-                  .filter(
-                      "o_orderdate >= date '1993-07-01' and o_orderdate < date '1993-10-01'")
-                  .build())
+          .hashJoinRightSemiFilter(matchScan("orders").filter(
+              "o_orderdate >= date '1993-07-01' and o_orderdate < date '1993-10-01'"))
           .aggregation()
           .orderBy()
           .build();
@@ -247,24 +227,14 @@ TEST_F(TpchPlanTest, q05) {
                       "o_orderdate >= date '1994-01-01' and o_orderdate < date '1995-01-01'")
                   .hashJoinInner(
                       matchScan("customer")
-                          .hashJoinInner(
-                              matchScan("nation")
-                                  .hashJoinInner(matchScan("region")
-                                                     .filter("r_name = 'ASIA'")
-                                                     .build())
-                                  .build())
-                          .build())
-                  .build())
-          .hashJoinInner(
-              matchScan("supplier")
-                  .hashJoinLeftSemiFilter(
-                      matchScan("nation")
-                          .hashJoinInner(matchScan("region")
-                                             .filter("r_name = 'ASIA'")
-                                             .build())
-                          .project()
-                          .build())
-                  .build())
+                          .hashJoinInner(matchScan("nation").hashJoinInner(
+                              matchScan("region").filter("r_name = 'ASIA'")))))
+          .hashJoinInner(matchScan("supplier")
+                             .hashJoinLeftSemiFilter(
+                                 matchScan("nation")
+                                     .hashJoinInner(matchScan("region").filter(
+                                         "r_name = 'ASIA'"))
+                                     .project()))
           .project()
           .aggregation()
           .orderBy()
@@ -310,21 +280,14 @@ TEST_F(TpchPlanTest, q07) {
                       matchScan("nation")
                           .aliases({std::nullopt, "supp_nation"})
                           .filter(
-                              "supp_nation = 'FRANCE' or supp_nation = 'GERMANY'")
-                          .build())
-                  .build())
-          .hashJoinInner(
-              matchScan("orders")
+                              "supp_nation = 'FRANCE' or supp_nation = 'GERMANY'")))
+          .hashJoinInner(matchScan("orders").hashJoinInner(
+              matchScan("customer")
                   .hashJoinInner(
-                      matchScan("customer")
-                          .hashJoinInner(
-                              matchScan("nation")
-                                  .aliases({std::nullopt, "cust_nation"})
-                                  .filter(
-                                      "cust_nation = 'GERMANY' or cust_nation = 'FRANCE'")
-                                  .build())
-                          .build())
-                  .build())
+                      matchScan("nation")
+                          .aliases({std::nullopt, "cust_nation"})
+                          .filter(
+                              "cust_nation = 'GERMANY' or cust_nation = 'FRANCE'"))))
           .filter(
               "(supp_nation = 'FRANCE' and cust_nation = 'GERMANY') or "
               "(supp_nation = 'GERMANY' and cust_nation = 'FRANCE')")
@@ -354,10 +317,8 @@ TEST_F(TpchPlanTest, q08) {
       matchScan("supplier")
           .hashJoinInner(
               matchScan("lineitem")
-                  .hashJoinInner(
-                      matchScan("part")
-                          .filter("p_type = 'ECONOMY ANODIZED STEEL'")
-                          .build())
+                  .hashJoinInner(matchScan("part").filter(
+                      "p_type = 'ECONOMY ANODIZED STEEL'"))
                   .hashJoinInner(
                       matchScan("orders")
                           .filter(
@@ -365,16 +326,10 @@ TEST_F(TpchPlanTest, q08) {
                           .hashJoinInner(
                               matchScan("customer")
                                   .hashJoinInner(
-                                      matchScan("nation")
-                                          .hashJoinInner(
-                                              matchScan("region")
-                                                  .filter("r_name = 'AMERICA'")
-                                                  .build())
-                                          .build())
-                                  .build())
-                          .build())
-                  .build())
-          .hashJoinInner(matchScan("nation").build())
+                                      matchScan("nation").hashJoinInner(
+                                          matchScan("region").filter(
+                                              "r_name = 'AMERICA'"))))))
+          .hashJoinInner(matchScan("nation"))
           .project()
           .aggregation()
           .orderBy()
@@ -404,14 +359,11 @@ TEST_F(TpchPlanTest, q09Alt) {
       matchScan("orders")
           .hashJoinInner(
               matchScan("lineitem")
-                  .hashJoinInner(
-                      matchScan("partsupp")
-                          .hashJoinInner(
-                              matchScan("part").filter("p_size <= 3").build())
-                          .build())
-                  .build())
-          .hashJoinInner(matchScan("supplier").build())
-          .hashJoinInner(matchScan("nation").build())
+                  .hashJoinInner(matchScan("partsupp")
+                                     .hashJoinInner(matchScan("part").filter(
+                                         "p_size <= 3"))))
+          .hashJoinInner(matchScan("supplier"))
+          .hashJoinInner(matchScan("nation"))
           .project()
           .aggregation()
           .orderBy()
@@ -430,26 +382,18 @@ TEST_F(TpchPlanTest, q10) {
   // ))
   auto matcher =
       matchScan("customer")
-          .hashJoinInner(
-              matchScan("orders")
-                  .filter(
-                      "o_orderdate >= date '1993-10-01' and o_orderdate < date '1994-01-01'")
-                  .build())
-          .hashJoinInner(matchScan("nation").build())
+          .hashJoinInner(matchScan("orders").filter(
+              "o_orderdate >= date '1993-10-01' and o_orderdate < date '1994-01-01'"))
+          .hashJoinInner(matchScan("nation"))
           .hashJoinInner(
               matchScan("lineitem")
                   .filter("l_returnflag = 'R'")
                   .hashJoinLeftSemiFilter(
                       matchScan("customer")
-                          .hashJoinInner(
-                              matchScan("orders")
-                                  .filter(
-                                      "o_orderdate >= date '1993-10-01' and o_orderdate < date '1994-01-01'")
-                                  .build())
-                          .hashJoinInner(matchScan("nation").build())
-                          .project()
-                          .build())
-                  .build())
+                          .hashJoinInner(matchScan("orders").filter(
+                              "o_orderdate >= date '1993-10-01' and o_orderdate < date '1994-01-01'"))
+                          .hashJoinInner(matchScan("nation"))
+                          .project()))
           .project()
           .aggregation()
           .topN()
@@ -466,11 +410,9 @@ TEST_F(TpchPlanTest, q11) {
   // )
   auto matcher =
       matchScan("partsupp")
-          .hashJoinInner(
-              matchScan("supplier")
-                  .hashJoinInner(
-                      matchScan("nation").filter("n_name = 'GERMANY'").build())
-                  .build())
+          .hashJoinInner(matchScan("supplier")
+                             .hashJoinInner(matchScan("nation").filter(
+                                 "n_name = 'GERMANY'")))
           .project()
           .aggregation()
           .nestedLoopJoin(
@@ -480,13 +422,10 @@ TEST_F(TpchPlanTest, q11) {
                           .hashJoinInner(
                               matchScan("nation")
                                   .aliases({std::nullopt, "nation_name"})
-                                  .filter("nation_name = 'GERMANY'")
-                                  .build())
-                          .build())
+                                  .filter("nation_name = 'GERMANY'")))
                   .project()
                   .aggregation()
-                  .project()
-                  .build())
+                  .project())
           .filter("value > expr")
           .orderBy()
           .project()
@@ -500,19 +439,18 @@ TEST_F(TpchPlanTest, q12) {
       "\"and\"(l_shipmode in ('MAIL', 'SHIP'), l_receiptdate >= date '1994-01-01', "
       "         l_receiptdate < date '1995-01-01', l_commitdate < l_receiptdate, "
       "         l_shipdate < l_commitdate)";
-  auto matcher =
-      matchScan("orders")
-          .hashJoinInner(matchScan("lineitem").filter(filter).build())
-          .project()
-          .aggregation()
-          .orderBy()
-          .build();
+  auto matcher = matchScan("orders")
+                     .hashJoinInner(matchScan("lineitem").filter(filter))
+                     .project()
+                     .aggregation()
+                     .orderBy()
+                     .build();
   AXIOM_ASSERT_PLAN(planTpch(12), matcher);
 
   auto distributed = [&](bool isMultiThreaded) {
     return matchScan("orders")
         .multiThreaded(isMultiThreaded)
-        .hashJoinInner(matchScan("lineitem").filter(filter).broadcast().build())
+        .hashJoinInner(matchScan("lineitem").filter(filter).broadcast())
         .project(
             {"l_shipmode",
              "if(o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH', 1, 0) as high_line_count",
@@ -532,7 +470,7 @@ TEST_F(TpchPlanTest, q13) {
   // agg(agg((orders RIGHT customer)))
   auto matcher = matchScan("orders")
                      .filter("o_comment not like '%special%requests%'")
-                     .hashJoinRight(matchScan("customer").build())
+                     .hashJoinRight(matchScan("customer"))
                      .aggregation()
                      .project()
                      .aggregation()
@@ -545,19 +483,18 @@ TEST_F(TpchPlanTest, q14) {
   // agg((part INNER lineitem))
   const auto filter =
       "l_shipdate >= date '1995-09-01' and l_shipdate < date '1995-10-01'";
-  auto matcher =
-      matchScan("part")
-          .hashJoinInner(matchScan("lineitem").filter(filter).build())
-          .project()
-          .aggregation()
-          .project()
-          .build();
+  auto matcher = matchScan("part")
+                     .hashJoinInner(matchScan("lineitem").filter(filter))
+                     .project()
+                     .aggregation()
+                     .project()
+                     .build();
   AXIOM_ASSERT_PLAN(planTpch(14), matcher);
 
   auto distributed = [&](bool isMultiThreaded) {
     return matchScan("part")
         .multiThreaded(isMultiThreaded)
-        .hashJoinInner(matchScan("lineitem").filter(filter).broadcast().build())
+        .hashJoinInner(matchScan("lineitem").filter(filter).broadcast())
         .project(
             {"if(p_type like 'PROMO%', l_extendedprice * (1.0 - l_discount), 0.0) as promo",
              "l_extendedprice * (1.0 - l_discount) as disc_price"})
@@ -589,12 +526,11 @@ TEST_F(TpchPlanTest, q15) {
 
   auto matcher =
       matchScan("supplier")
-          .hashJoinInner(matchCte().build())
+          .hashJoinInner(matchCte())
           .hashJoinInner(
               matchCte()
                   .project({"total_revenue as revenue"})
-                  .singleAggregation({}, {"max(revenue) as max_revenue"})
-                  .build())
+                  .singleAggregation({}, {"max(revenue) as max_revenue"}))
           .orderBy()
           .build();
   AXIOM_ASSERT_PLAN(planTpch(15), matcher);
@@ -605,19 +541,17 @@ TEST_F(TpchPlanTest, q16) {
       "\"and\"(p_brand <> 'Brand#45', p_type not like 'MEDIUM POLISHED%', "
       "         p_size in (49, 14, 23, 45, 19, 3, 36, 9))";
   // agg(((partsupp INNER part) ANTI supplier))
-  auto matcher =
-      matchScan("partsupp")
-          .hashJoinInner(matchScan("part").filter(partFilter).build())
-          .hashJoinAnti(
-              matchScan("supplier")
-                  .filter("s_comment like '%Customer%Complaints%'")
-                  .build(),
-              {.nullAware = true})
-          .singleAggregation(
-              {"p_brand", "p_type", "p_size"},
-              {"count(distinct ps_suppkey) as supplier_cnt"})
-          .orderBy()
-          .build();
+  auto matcher = matchScan("partsupp")
+                     .hashJoinInner(matchScan("part").filter(partFilter))
+                     .hashJoinAnti(
+                         matchScan("supplier")
+                             .filter("s_comment like '%Customer%Complaints%'"),
+                         {.nullAware = true})
+                     .singleAggregation(
+                         {"p_brand", "p_type", "p_size"},
+                         {"count(distinct ps_suppkey) as supplier_cnt"})
+                     .orderBy()
+                     .build();
   AXIOM_ASSERT_PLAN(planTpch(16), matcher);
 
   // Distributed: part and supplier broadcast to the partsupp probe (INNER then
@@ -626,12 +560,11 @@ TEST_F(TpchPlanTest, q16) {
   auto distributed = [&](bool isMultiThreaded) {
     return matchScan("partsupp")
         .multiThreaded(isMultiThreaded)
-        .hashJoinInner(matchScan("part").filter(partFilter).broadcast().build())
+        .hashJoinInner(matchScan("part").filter(partFilter).broadcast())
         .hashJoinAnti(
             matchScan("supplier")
                 .filter("s_comment like '%Customer%Complaints%'")
-                .broadcast()
-                .build(),
+                .broadcast(),
             {.nullAware = true})
         .distributedSingleAggregation(
             {"p_brand", "p_type", "p_size", "ps_suppkey"}, {})
@@ -652,21 +585,15 @@ TEST_F(TpchPlanTest, q17) {
   // agg(((lineitem INNER part) LEFT agg((lineitem LEFT SEMI (FILTER) part))))
   auto matcher =
       matchScan("lineitem")
-          .hashJoinInner(
-              matchScan("part")
-                  .filter("p_brand = 'Brand#23' and p_container = 'MED BOX'")
-                  .build())
+          .hashJoinInner(matchScan("part").filter(
+              "p_brand = 'Brand#23' and p_container = 'MED BOX'"))
           .hashJoinLeft(
               matchScan("lineitem")
-                  .hashJoinLeftSemiFilter(
-                      matchScan("part")
-                          .filter(
-                              "p_brand = 'Brand#23' and p_container = 'MED BOX'")
-                          .build())
+                  .hashJoinLeftSemiFilter(matchScan("part").filter(
+                      "p_brand = 'Brand#23' and p_container = 'MED BOX'"))
                   .aggregation()
                   .project()
-                  .aliases({std::nullopt, "quantity_limit"})
-                  .build())
+                  .aliases({std::nullopt, "quantity_limit"}))
           .filter("l_quantity < quantity_limit")
           .aggregation()
           .project()
@@ -684,10 +611,9 @@ TEST_F(TpchPlanTest, q18) {
                      .hashJoinLeftSemiFilter(matchScan("lineitem")
                                                  .aggregation()
                                                  .filter("\"sum\" > 300.0")
-                                                 .project()
-                                                 .build())
-                     .hashJoinInner(matchScan("orders").build())
-                     .hashJoinInner(matchScan("customer").build())
+                                                 .project())
+                     .hashJoinInner(matchScan("orders"))
+                     .hashJoinInner(matchScan("customer"))
                      .aggregation()
                      .topN()
                      .build();
@@ -703,13 +629,10 @@ TEST_F(TpchPlanTest, q19) {
               "       \"or\"(\"and\"(l_quantity >= 20.0, l_quantity <= 30.0), "
               "             \"or\"(\"and\"(l_quantity >= 1.0, l_quantity <= 11.0), "
               "                   \"and\"(l_quantity >= 10.0, l_quantity <= 20.0))))")
-          .hashJoinInner(
-              matchScan("part")
-                  .filter(
-                      "\"or\"(\"and\"(p_size between 1 and 15, \"and\"(p_brand = 'Brand#34', p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'))), "
-                      "      \"or\"(\"and\"(p_size between 1 and 5, \"and\"(p_brand = 'Brand#12', p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG'))), "
-                      "            \"and\"(p_size between 1 and 10, \"and\"(p_brand = 'Brand#23', p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')))))")
-                  .build())
+          .hashJoinInner(matchScan("part").filter(
+              "\"or\"(\"and\"(p_size between 1 and 15, \"and\"(p_brand = 'Brand#34', p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'))), "
+              "      \"or\"(\"and\"(p_size between 1 and 5, \"and\"(p_brand = 'Brand#12', p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG'))), "
+              "            \"and\"(p_size between 1 and 10, \"and\"(p_brand = 'Brand#23', p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')))))"))
           .filter(
               "\"or\"(\"and\"(p_size between 1 and 15, \"and\"(l_quantity <= 30.0, \"and\"(l_quantity >= 20.0, \"and\"(p_brand = 'Brand#34', p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'))))), "
               "      \"or\"(\"and\"(p_size between 1 and 5, \"and\"(l_quantity <= 11.0, \"and\"(l_quantity >= 1.0, \"and\"(p_brand = 'Brand#12', p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG'))))), "
@@ -747,21 +670,15 @@ TEST_F(TpchPlanTest, q20) {
                       matchScan("partsupp")
                           .hashJoinLeftSemiFilter(
                               matchScan("supplier")
-                                  .hashJoinInner(
-                                      matchScan("nation")
-                                          .filter("n_name = 'CANADA'")
-                                          .build())
-                                  .project()
-                                  .build())
-                          .build())
-                  .build())
+                                  .hashJoinInner(matchScan("nation").filter(
+                                      "n_name = 'CANADA'"))
+                                  .project())))
           .filter("expr < cast(ps_availqty as double)")
           .project()
           .hashJoinRightSemiFilter(
               matchScan("supplier")
                   .hashJoinInner(
-                      matchScan("nation").filter("n_name = 'CANADA'").build())
-                  .build())
+                      matchScan("nation").filter("n_name = 'CANADA'")))
           .orderBy()
           .build();
   AXIOM_ASSERT_PLAN(planTpch(20), matcher);
@@ -794,19 +711,13 @@ TEST_F(TpchPlanTest, q21) {
                           .filter("commitdate < receiptdate")
                           .hashJoinInner(
                               matchScan("supplier")
-                                  .hashJoinInner(
-                                      matchScan("nation")
-                                          .filter("n_name = 'SAUDI ARABIA'")
-                                          .build())
-                                  .build())
-                          .hashJoinInner(matchScan("orders")
-                                             .filter("o_orderstatus = 'F'")
-                                             .build())
-                          .build(),
+                                  .hashJoinInner(matchScan("nation").filter(
+                                      "n_name = 'SAUDI ARABIA'")))
+                          .hashJoinInner(matchScan("orders").filter(
+                              "o_orderstatus = 'F'")),
                       {.nullAware = false})
                   .aliases({std::nullopt, std::nullopt, std::nullopt, "mark"})
-                  .filter("not(mark)")
-                  .build())
+                  .filter("not(mark)"))
           .singleAggregation({"s_name"}, {"count(*)"})
           .topN()
           .build();
@@ -827,10 +738,8 @@ TEST_F(TpchPlanTest, q22) {
                           .filter(
                               "acctbal > 0.0 and substr(phone, 1, 2) in ('13', '31', '23', '29', '30', '18', '17')")
                           .singleAggregation(
-                              {}, {"avg(acctbal) as avg_acctbal"})
-                          .build())
-                  .filter("c_acctbal > avg_acctbal")
-                  .build(),
+                              {}, {"avg(acctbal) as avg_acctbal"}))
+                  .filter("c_acctbal > avg_acctbal"),
               {.nullAware = false})
           .aliases({std::nullopt, std::nullopt, "exists_mark"})
           .filter("not(exists_mark)")

--- a/axiom/optimizer/tests/UnionAllTest.cpp
+++ b/axiom/optimizer/tests/UnionAllTest.cpp
@@ -58,13 +58,13 @@ TEST_P(UnionAllTest, twoScans) {
 
   {
     auto matcher =
-        matchScan("t").localPartition(matchScan("u").project().build()).build();
+        matchScan("t").localPartition(matchScan("u").project()).build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
 
   {
     auto matcher = matchScan("t")
-                       .localPartition(matchScan("u").project().build())
+                       .localPartition(matchScan("u").project())
                        .gather(FragmentType::kSource)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
@@ -83,20 +83,19 @@ TEST_P(UnionAllTest, twoDistincts) {
         matchScan("t")
             .singleAggregation({"a"}, {})
             .localPartition(
-                matchScan("u").singleAggregation({"b"}, {}).project().build())
+                matchScan("u").singleAggregation({"b"}, {}).project())
             .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
 
   {
-    auto matcher = matchScan("t")
-                       .distributedAggregation({"a"}, {})
-                       .localPartition(matchScan("u")
-                                           .distributedAggregation({"b"}, {})
-                                           .project()
-                                           .build())
-                       .gather(FragmentType::kFixed)
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .distributedAggregation({"a"}, {})
+            .localPartition(
+                matchScan("u").distributedAggregation({"b"}, {}).project())
+            .gather(FragmentType::kFixed)
+            .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -109,7 +108,7 @@ TEST_P(UnionAllTest, twoValues) {
 
   {
     auto matcher =
-        matchValues().localPartition(matchValues().project().build()).build();
+        matchValues().localPartition(matchValues().project()).build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
 
@@ -117,7 +116,7 @@ TEST_P(UnionAllTest, twoValues) {
     // All-gather UnionAll output stays gather; no extra gather Repartition
     // needed.
     auto matcher = matchValues()
-                       .localPartition(matchValues().project().build())
+                       .localPartition(matchValues().project())
                        .output(FragmentType::kSingle)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
@@ -131,7 +130,7 @@ TEST_P(UnionAllTest, scanAndValues) {
 
   {
     auto matcher =
-        matchScan("t").localPartition(matchValues().project().build()).build();
+        matchScan("t").localPartition(matchValues().project()).build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
 
@@ -144,8 +143,7 @@ TEST_P(UnionAllTest, scanAndValues) {
                            matchValues()
                                .project()
                                .arbitrary(FragmentType::kSingle)
-                               .projectIf(useV2_)
-                               .build())
+                               .projectIf(useV2_))
                        .gather(FragmentType::kSource)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
@@ -160,11 +158,10 @@ TEST_P(UnionAllTest, scanAndTwoValues) {
       "FROM t UNION ALL VALUES 1 UNION ALL VALUES 2", kTestConnectorId);
 
   {
-    auto matcher = matchScan("t")
-                       .localPartition(
-                           {matchValues().project().build(),
-                            matchValues().project().build()})
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .localPartition({matchValues().project(), matchValues().project()})
+            .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
 
@@ -173,9 +170,8 @@ TEST_P(UnionAllTest, scanAndTwoValues) {
                        .localPartition(
                            matchValues()
                                .project()
-                               .localPartition(matchValues().project().build())
-                               .arbitrary(FragmentType::kSingle)
-                               .build())
+                               .localPartition(matchValues().project())
+                               .arbitrary(FragmentType::kSingle))
                        .gather(FragmentType::kSource)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
@@ -191,7 +187,7 @@ TEST_P(UnionAllTest, distinctAndValues) {
   {
     auto matcher = matchScan("t")
                        .singleAggregation({"a"}, {})
-                       .localPartition(matchValues().project().build())
+                       .localPartition(matchValues().project())
                        .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
@@ -203,8 +199,7 @@ TEST_P(UnionAllTest, distinctAndValues) {
                            matchValues()
                                .project()
                                .arbitrary(FragmentType::kSingle)
-                               .projectIf(useV2_)
-                               .build())
+                               .projectIf(useV2_))
                        .gather(FragmentType::kFixed)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
@@ -221,7 +216,7 @@ TEST_P(UnionAllTest, scanAndDistinct) {
   {
     auto matcher = matchScan("t")
                        .singleAggregation({"a"}, {})
-                       .localPartition(matchScan("u").project().build())
+                       .localPartition(matchScan("u").project())
                        .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
@@ -229,7 +224,7 @@ TEST_P(UnionAllTest, scanAndDistinct) {
   {
     auto matcher = matchScan("t")
                        .distributedAggregation({"a"}, {})
-                       .localPartition(matchScan("u").project().build())
+                       .localPartition(matchScan("u").project())
                        .gather(FragmentType::kFixed)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
@@ -250,26 +245,23 @@ TEST_P(UnionAllTest, scanAndDistinctAndValues) {
     auto matcher =
         matchScan("t")
             .localPartition(
-                {matchScan("u").singleAggregation({"b"}, {}).project().build(),
-                 matchValues().project().build()})
+                {matchScan("u").singleAggregation({"b"}, {}).project(),
+                 matchValues().project()})
             .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
 
   {
-    auto matcher = matchScan("t")
-                       .localPartition(
-                           {matchScan("u")
-                                .distributedAggregation({"b"}, {})
-                                .project()
-                                .build(),
-                            matchValues()
-                                .project()
-                                .arbitrary(FragmentType::kSingle)
-                                .projectIf(useV2_)
-                                .build()})
-                       .gather(FragmentType::kFixed)
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .localPartition(
+                {matchScan("u").distributedAggregation({"b"}, {}).project(),
+                 matchValues()
+                     .project()
+                     .arbitrary(FragmentType::kSingle)
+                     .projectIf(useV2_)})
+            .gather(FragmentType::kFixed)
+            .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -291,7 +283,7 @@ TEST_P(UnionAllTest, groupByOverTwoScans) {
 
   {
     auto matcher = matchScan("t")
-                       .localPartition(matchScan("u").project().build())
+                       .localPartition(matchScan("u").project())
                        .singleAggregation({"a"}, {"count(*)"})
                        .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
@@ -299,7 +291,7 @@ TEST_P(UnionAllTest, groupByOverTwoScans) {
 
   {
     auto matcher = matchScan("t")
-                       .localPartition(matchScan("u").project().build())
+                       .localPartition(matchScan("u").project())
                        .distributedAggregation({"a"}, {"count(*)"})
                        .gather(FragmentType::kFixed)
                        .build();
@@ -329,7 +321,7 @@ TEST_P(UnionAllTest, groupByOverTwoDistincts) {
         matchScan("t")
             .singleAggregation({"a"}, {})
             .localPartition(
-                matchScan("u").singleAggregation({"b"}, {}).project().build())
+                matchScan("u").singleAggregation({"b"}, {}).project())
             .singleAggregation({"a"}, {"count(*)"})
             .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
@@ -342,7 +334,7 @@ TEST_P(UnionAllTest, groupByOverTwoDistincts) {
     // aggregation after the hash.
     auto builder =
         matchScan("t").distributedAggregation({"a"}, {}).localPartition(
-            matchScan("u").distributedAggregation({"b"}, {}).project().build());
+            matchScan("u").distributedAggregation({"b"}, {}).project());
     if (useV2_) {
       builder.partialAggregation({"a"}, {"count(*)"})
           .localPartition({"a"})
@@ -368,7 +360,7 @@ TEST_P(UnionAllTest, groupByOverTwoValues) {
 
   {
     auto matcher = matchValues()
-                       .localPartition(matchValues().project().build())
+                       .localPartition(matchValues().project())
                        .singleAggregation({"c0"}, {"count(*)"})
                        .project()
                        .build();
@@ -380,8 +372,7 @@ TEST_P(UnionAllTest, groupByOverTwoValues) {
     // in that fragment with no remote shuffle. v2 does a local two-stage
     // aggregation (partial → local HASH → final) to pre-aggregate before the
     // intra-fragment exchange; v1 does a single aggregation after the hash.
-    auto builder =
-        matchValues().localPartition(matchValues().project().build());
+    auto builder = matchValues().localPartition(matchValues().project());
     if (useV2_) {
       builder.partialAggregation({"c0"}, {"count(*)"})
           .localPartition({"c0"})
@@ -406,7 +397,7 @@ TEST_P(UnionAllTest, groupByOverScanAndValues) {
 
   {
     auto matcher = matchScan("t")
-                       .localPartition(matchValues().project().build())
+                       .localPartition(matchValues().project())
                        .singleAggregation({"a"}, {"count(*)"})
                        .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
@@ -418,8 +409,7 @@ TEST_P(UnionAllTest, groupByOverScanAndValues) {
                            matchValues()
                                .project()
                                .arbitrary(FragmentType::kSingle)
-                               .projectIf(useV2_)
-                               .build())
+                               .projectIf(useV2_))
                        .distributedAggregation({"a"}, {"count(*)"})
                        .gather(FragmentType::kFixed)
                        .build();
@@ -446,7 +436,7 @@ TEST_P(UnionAllTest, groupByOverDistinctAndValues) {
   {
     auto matcher = matchScan("t")
                        .singleAggregation({"a"}, {})
-                       .localPartition(matchValues().project().build())
+                       .localPartition(matchValues().project())
                        .singleAggregation({"a"}, {"count(*)"})
                        .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
@@ -462,8 +452,7 @@ TEST_P(UnionAllTest, groupByOverDistinctAndValues) {
             matchValues()
                 .project()
                 .arbitrary(FragmentType::kSingle)
-                .projectIf(useV2_)
-                .build());
+                .projectIf(useV2_));
     if (useV2_) {
       builder.distributedAggregation({"a"}, {"count(*)"});
     } else {
@@ -489,21 +478,20 @@ TEST_P(UnionAllTest, groupByOverScanAndDistinct) {
     auto matcher =
         matchScan("t")
             .localPartition(
-                matchScan("u").singleAggregation({"b"}, {}).project().build())
+                matchScan("u").singleAggregation({"b"}, {}).project())
             .singleAggregation({"a"}, {"count(*)"})
             .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
 
   {
-    auto matcher = matchScan("t")
-                       .localPartition(matchScan("u")
-                                           .distributedAggregation({"b"}, {})
-                                           .project()
-                                           .build())
-                       .distributedAggregation({"a"}, {"count(*)"})
-                       .gather(FragmentType::kFixed)
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .localPartition(
+                matchScan("u").distributedAggregation({"b"}, {}).project())
+            .distributedAggregation({"a"}, {"count(*)"})
+            .gather(FragmentType::kFixed)
+            .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -524,28 +512,25 @@ TEST_P(UnionAllTest, groupByOverScanAndDistinctAndValues) {
     auto matcher =
         matchScan("t")
             .localPartition(
-                {matchScan("u").singleAggregation({"b"}, {}).project().build(),
-                 matchValues().project().build()})
+                {matchScan("u").singleAggregation({"b"}, {}).project(),
+                 matchValues().project()})
             .singleAggregation({"a"}, {"count(*)"})
             .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
 
   {
-    auto matcher = matchScan("t")
-                       .localPartition(
-                           {matchScan("u")
-                                .distributedAggregation({"b"}, {})
-                                .project()
-                                .build(),
-                            matchValues()
-                                .project()
-                                .arbitrary(FragmentType::kSingle)
-                                .projectIf(useV2_)
-                                .build()})
-                       .distributedAggregation({"a"}, {"count(*)"})
-                       .gather(FragmentType::kFixed)
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .localPartition(
+                {matchScan("u").distributedAggregation({"b"}, {}).project(),
+                 matchValues()
+                     .project()
+                     .arbitrary(FragmentType::kSingle)
+                     .projectIf(useV2_)})
+            .distributedAggregation({"a"}, {"count(*)"})
+            .gather(FragmentType::kFixed)
+            .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -572,7 +557,7 @@ TEST_P(UnionAllTest, orderByOverTwoScans) {
 
   {
     auto matcher = matchScan("t")
-                       .localPartition(matchScan("u").project().build())
+                       .localPartition(matchScan("u").project())
                        .orderBy({"a ASC NULLS LAST"})
                        .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
@@ -580,7 +565,7 @@ TEST_P(UnionAllTest, orderByOverTwoScans) {
 
   {
     auto matcher = matchScan("t")
-                       .localPartition(matchScan("u").project().build())
+                       .localPartition(matchScan("u").project())
                        .orderBy({"a ASC NULLS LAST"})
                        .localMerge()
                        .shuffleMerge(FragmentType::kSource)
@@ -600,7 +585,7 @@ TEST_P(UnionAllTest, orderByOverTwoValues) {
 
   {
     auto matcher = matchValues()
-                       .localPartition(matchValues().project().build())
+                       .localPartition(matchValues().project())
                        .orderBy({"c0 ASC NULLS LAST"})
                        .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
@@ -609,7 +594,7 @@ TEST_P(UnionAllTest, orderByOverTwoValues) {
   {
     // The union is kSingle, so the sort runs in that fragment: no gather.
     auto matcher = matchValues()
-                       .localPartition(matchValues().project().build())
+                       .localPartition(matchValues().project())
                        .orderBy({"c0 ASC NULLS LAST"})
                        .localMerge()
                        .output(FragmentType::kSingle)
@@ -633,23 +618,22 @@ TEST_P(UnionAllTest, orderByOverTwoDistincts) {
         matchScan("t")
             .singleAggregation({"a"}, {})
             .localPartition(
-                matchScan("u").singleAggregation({"b"}, {}).project().build())
+                matchScan("u").singleAggregation({"b"}, {}).project())
             .orderBy({"a ASC NULLS LAST"})
             .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
 
   {
-    auto matcher = matchScan("t")
-                       .distributedAggregation({"a"}, {})
-                       .localPartition(matchScan("u")
-                                           .distributedAggregation({"b"}, {})
-                                           .project()
-                                           .build())
-                       .orderBy({"a ASC NULLS LAST"})
-                       .localMerge()
-                       .shuffleMerge(FragmentType::kFixed)
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .distributedAggregation({"a"}, {})
+            .localPartition(
+                matchScan("u").distributedAggregation({"b"}, {}).project())
+            .orderBy({"a ASC NULLS LAST"})
+            .localMerge()
+            .shuffleMerge(FragmentType::kFixed)
+            .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -669,7 +653,7 @@ TEST_P(UnionAllTest, orderByOverScanAndValues) {
 
   {
     auto matcher = matchScan("t")
-                       .localPartition(matchValues().project().build())
+                       .localPartition(matchValues().project())
                        .orderBy({"a ASC NULLS LAST"})
                        .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
@@ -681,8 +665,7 @@ TEST_P(UnionAllTest, orderByOverScanAndValues) {
                            matchValues()
                                .project()
                                .arbitrary(FragmentType::kSingle)
-                               .projectIf(useV2_)
-                               .build())
+                               .projectIf(useV2_))
                        .orderBy({"a ASC NULLS LAST"})
                        .localMerge()
                        .shuffleMerge(FragmentType::kSource)
@@ -702,7 +685,7 @@ TEST_P(UnionAllTest, orderByOverDistinctAndValues) {
   {
     auto matcher = matchScan("t")
                        .singleAggregation({"a"}, {})
-                       .localPartition(matchValues().project().build())
+                       .localPartition(matchValues().project())
                        .orderBy({"a ASC NULLS LAST"})
                        .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
@@ -715,8 +698,7 @@ TEST_P(UnionAllTest, orderByOverDistinctAndValues) {
                            matchValues()
                                .project()
                                .arbitrary(FragmentType::kSingle)
-                               .projectIf(useV2_)
-                               .build())
+                               .projectIf(useV2_))
                        .orderBy({"a ASC NULLS LAST"})
                        .localMerge()
                        .shuffleMerge(FragmentType::kFixed)
@@ -736,22 +718,21 @@ TEST_P(UnionAllTest, orderByOverScanAndDistinct) {
     auto matcher =
         matchScan("t")
             .localPartition(
-                matchScan("u").singleAggregation({"b"}, {}).project().build())
+                matchScan("u").singleAggregation({"b"}, {}).project())
             .orderBy({"a ASC NULLS LAST"})
             .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
 
   {
-    auto matcher = matchScan("t")
-                       .localPartition(matchScan("u")
-                                           .distributedAggregation({"b"}, {})
-                                           .project()
-                                           .build())
-                       .orderBy({"a ASC NULLS LAST"})
-                       .localMerge()
-                       .shuffleMerge(FragmentType::kFixed)
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .localPartition(
+                matchScan("u").distributedAggregation({"b"}, {}).project())
+            .orderBy({"a ASC NULLS LAST"})
+            .localMerge()
+            .shuffleMerge(FragmentType::kFixed)
+            .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -775,29 +756,26 @@ TEST_P(UnionAllTest, orderByOverScanAndDistinctAndValues) {
     auto matcher =
         matchScan("t")
             .localPartition(
-                {matchScan("u").singleAggregation({"b"}, {}).project().build(),
-                 matchValues().project().build()})
+                {matchScan("u").singleAggregation({"b"}, {}).project(),
+                 matchValues().project()})
             .orderBy({"a ASC NULLS LAST"})
             .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
 
   {
-    auto matcher = matchScan("t")
-                       .localPartition(
-                           {matchScan("u")
-                                .distributedAggregation({"b"}, {})
-                                .project()
-                                .build(),
-                            matchValues()
-                                .project()
-                                .arbitrary(FragmentType::kSingle)
-                                .projectIf(useV2_)
-                                .build()})
-                       .orderBy({"a ASC NULLS LAST"})
-                       .localMerge()
-                       .shuffleMerge(FragmentType::kFixed)
-                       .build();
+    auto matcher =
+        matchScan("t")
+            .localPartition(
+                {matchScan("u").distributedAggregation({"b"}, {}).project(),
+                 matchValues()
+                     .project()
+                     .arbitrary(FragmentType::kSingle)
+                     .projectIf(useV2_)})
+            .orderBy({"a ASC NULLS LAST"})
+            .localMerge()
+            .shuffleMerge(FragmentType::kFixed)
+            .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -830,25 +808,21 @@ TEST_P(UnionAllTest, broadcastJoinBuildOverUnion) {
     // v2 merges the equi-join keys (a = c) into one equivalence column, so the
     // join outputs only `a` and a project reconstructs `c` (= a) for the
     // output; v1 keeps both keys in the join output.
-    auto matcher =
-        matchScan("t")
-            .hashJoin(matchScan("v")
-                          .localPartition(
-                              matchScan("u").filter("b < 0").project().build())
-                          .build())
-            .projectIf(useV2_)
-            .build();
+    auto matcher = matchScan("t")
+                       .hashJoin(matchScan("v").localPartition(
+                           matchScan("u").filter("b < 0").project()))
+                       .projectIf(useV2_)
+                       .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
 
   {
     auto matcher =
         matchScan("t")
-            .hashJoin(matchScan("v")
-                          .localPartition(
-                              matchScan("u").filter("b < 0").project().build())
-                          .broadcast(FragmentType::kSource)
-                          .build())
+            .hashJoin(
+                matchScan("v")
+                    .localPartition(matchScan("u").filter("b < 0").project())
+                    .broadcast(FragmentType::kSource))
             .projectIf(useV2_)
             .gather(FragmentType::kSource)
             .build();
@@ -870,8 +844,8 @@ TEST_P(UnionAllTest, shuffledJoinBuildOverUnion) {
 
   {
     auto matcher = matchScan("v")
-                       .localPartition(matchScan("u").project().build())
-                       .hashJoin(matchScan("t").build())
+                       .localPartition(matchScan("u").project())
+                       .hashJoin(matchScan("t"))
                        .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
@@ -879,10 +853,9 @@ TEST_P(UnionAllTest, shuffledJoinBuildOverUnion) {
   {
     auto matcher =
         matchScan("v")
-            .localPartition(matchScan("u").project().build())
+            .localPartition(matchScan("u").project())
             .shuffle({"c"}, FragmentType::kSource)
-            .hashJoin(
-                matchScan("t").shuffle({"a"}, FragmentType::kSource).build())
+            .hashJoin(matchScan("t").shuffle({"a"}, FragmentType::kSource))
             .gather(FragmentType::kFixed)
             .build();
     // Cap the broadcast size limit low so the union build stays hash
@@ -917,7 +890,7 @@ TEST_P(UnionAllTest, groupByOverUnionAllWithOrderedLegs) {
 
   {
     auto matcher = matchScan("t")
-                       .localPartition(matchScan("u").project().build())
+                       .localPartition(matchScan("u").project())
                        .singleAggregation({"a"}, {"count(*)"})
                        .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
@@ -925,7 +898,7 @@ TEST_P(UnionAllTest, groupByOverUnionAllWithOrderedLegs) {
 
   {
     auto matcher = matchScan("t")
-                       .localPartition(matchScan("u").project().build())
+                       .localPartition(matchScan("u").project())
                        .distributedAggregation({"a"}, {"count(*)"})
                        .gather(FragmentType::kFixed)
                        .build();

--- a/axiom/optimizer/tests/UnknownStatsJoinTest.cpp
+++ b/axiom/optimizer/tests/UnknownStatsJoinTest.cpp
@@ -51,7 +51,7 @@ TEST_F(UnknownStatsJoinTest, singleJoin) {
 
   auto matchJoin = [&](const std::string& probe, const std::string& build) {
     return matchScan(probe)
-        .hashJoinInner(matchScan(build).build())
+        .hashJoinInner(matchScan(build))
         .aggregation()
         .build();
   };
@@ -92,9 +92,9 @@ TEST_F(UnknownStatsJoinTest, twoJoins) {
   auto matchPlan = [&](const std::string& innerProbe,
                        const std::string& innerBuild) {
     return matchScan(innerProbe)
-        .hashJoinInner(matchScan(innerBuild).build())
+        .hashJoinInner(matchScan(innerBuild))
         .filter()
-        .hashJoinInner(matchScan("v").build())
+        .hashJoinInner(matchScan("v"))
         .aggregation()
         .build();
   };
@@ -126,7 +126,7 @@ TEST_F(UnknownStatsJoinTest, joinWithUnknownTableCardinality) {
 
   auto matchJoin = [&](const std::string& probe, const std::string& build) {
     return matchScan(probe)
-        .hashJoinInner(matchScan(build).build())
+        .hashJoinInner(matchScan(build))
         .aggregation()
         .build();
   };
@@ -151,8 +151,8 @@ TEST_F(UnknownStatsJoinTest, sharedTableJoinAvoidsCrossJoin) {
   AXIOM_ASSERT_PLAN(
       plan(query),
       matchScan("t")
-          .hashJoinInner(matchScan("v").build())
-          .hashJoinInner(matchScan("u").build())
+          .hashJoinInner(matchScan("v"))
+          .hashJoinInner(matchScan("u"))
           .aggregation()
           .build());
 
@@ -161,8 +161,8 @@ TEST_F(UnknownStatsJoinTest, sharedTableJoinAvoidsCrossJoin) {
   AXIOM_ASSERT_PLAN(
       plan(query),
       matchScan("t")
-          .nestedLoopJoin(matchScan("u").build())
-          .hashJoinInner(matchScan("v").build())
+          .nestedLoopJoin(matchScan("u"))
+          .hashJoinInner(matchScan("v"))
           .aggregation()
           .build());
 }
@@ -180,8 +180,8 @@ TEST_F(UnknownStatsJoinTest, sharedTableJoinAvoidsCrossJoinExpressionKey) {
       plan(query),
       matchScan("t")
           .project()
-          .hashJoinInner(matchScan("v").build())
-          .hashJoinInner(matchScan("u").build())
+          .hashJoinInner(matchScan("v"))
+          .hashJoinInner(matchScan("u"))
           .aggregation()
           .build());
 
@@ -190,9 +190,9 @@ TEST_F(UnknownStatsJoinTest, sharedTableJoinAvoidsCrossJoinExpressionKey) {
   AXIOM_ASSERT_PLAN(
       plan(query),
       matchScan("t")
-          .nestedLoopJoin(matchScan("u").build())
+          .nestedLoopJoin(matchScan("u"))
           .project()
-          .hashJoinInner(matchScan("v").build())
+          .hashJoinInner(matchScan("v"))
           .aggregation()
           .build());
 }
@@ -212,9 +212,9 @@ TEST_F(UnknownStatsJoinTest, crossJoinWhenNoEquiPartner) {
   AXIOM_ASSERT_PLAN(
       plan(query),
       matchScan("t")
-          .hashJoinInner(matchScan("v").build())
-          .hashJoinInner(matchScan("u").build())
-          .nestedLoopJoin(matchScan("w").build())
+          .hashJoinInner(matchScan("v"))
+          .hashJoinInner(matchScan("u"))
+          .nestedLoopJoin(matchScan("w"))
           .aggregation()
           .build());
 
@@ -223,9 +223,9 @@ TEST_F(UnknownStatsJoinTest, crossJoinWhenNoEquiPartner) {
   AXIOM_ASSERT_PLAN(
       plan(query),
       matchScan("t")
-          .nestedLoopJoin(matchScan("u").build())
-          .hashJoinInner(matchScan("v").build())
-          .nestedLoopJoin(matchScan("w").build())
+          .nestedLoopJoin(matchScan("u"))
+          .hashJoinInner(matchScan("v"))
+          .nestedLoopJoin(matchScan("w"))
           .aggregation()
           .build());
 }
@@ -240,7 +240,7 @@ TEST_F(UnknownStatsJoinTest, sampledJoinWithUnknownCardinality) {
 
   auto matchJoin = [&](const std::string& probe, const std::string& build) {
     return matchScan(probe)
-        .hashJoinInner(matchScan(build).build())
+        .hashJoinInner(matchScan(build))
         .aggregation()
         .build();
   };
@@ -258,7 +258,7 @@ TEST_F(UnknownStatsJoinTest, sampledJoinMatchesUnsampledOnUnknownCardinality) {
 
   auto matchJoin = [&](const std::string& probe, const std::string& build) {
     return matchScan(probe)
-        .hashJoinInner(matchScan(build).build())
+        .hashJoinInner(matchScan(build))
         .aggregation()
         .build();
   };

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -554,7 +554,7 @@ TEST_P(UnnestTest, join) {
 
     auto plan = toSingleNodePlan(logicalPlan);
     auto matcher = matchValues()
-                       .hashJoin(matchValues().build())
+                       .hashJoin(matchValues())
                        .project()
                        .unnest()
                        .project()
@@ -591,7 +591,7 @@ TEST_P(UnnestTest, join) {
 
     auto plan = toSingleNodePlan(logicalPlan);
     auto matcher = matchValues()
-                       .hashJoin(matchValues().build())
+                       .hashJoin(matchValues())
                        .project()
                        .unnest()
                        .project()
@@ -632,7 +632,7 @@ TEST_P(UnnestTest, join) {
     // join; v1 keeps the query's unnest-then-join order.
     auto matcher = useV2_
         ? matchValues()
-              .hashJoin(matchValues().build())
+              .hashJoin(matchValues())
               .project()
               .unnest()
               .project()
@@ -643,7 +643,7 @@ TEST_P(UnnestTest, join) {
               .project()
               .unnest()
               .project()
-              .hashJoin(matchValues().project().unnest().project().build())
+              .hashJoin(matchValues().project().unnest().project())
               .project() // TODO Fix the Optimizer to remove this project.
               .build();
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -680,8 +680,7 @@ TEST_P(UnnestTest, join) {
         matchValues()
             .project()
             .unnest()
-            .hashJoin(
-                matchValues().project().unnest().projectIf(!useV2_).build())
+            .hashJoin(matchValues().project().unnest().projectIf(!useV2_))
             .project()
             .build();
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -791,7 +790,7 @@ TEST_P(UnnestTest, unnestWithJoinAndFilter) {
   // cross join.
   auto matchJoin = [&](const std::pair<std::string, std::string>& sides) {
     return matchScan(sides.first)
-        .nestedLoopJoin(matchScan(sides.second).build())
+        .nestedLoopJoin(matchScan(sides.second))
         .unnest()
         .filter("x = n")
         .project({"1"})
@@ -829,7 +828,7 @@ TEST_P(UnnestTest, crossJoinSingleRowAggregateAndUnnest) {
       matchScan("t")
           .projectIf(useV2_, {"a", "ids", "a::BIGINT"})
           .nestedLoopJoin(
-              matchScan("u").singleAggregation({}, {"count(*) as c"}).build())
+              matchScan("u").singleAggregation({}, {"count(*) as c"}))
           .filterIf(!useV2_, "c > a::BIGINT")
           .unnest({"c"}, {"ids"})
           .project({"n", "c"})
@@ -856,15 +855,13 @@ TEST_P(UnnestTest, leftJoinFilterOnSingleRowSubquery) {
   auto plan = toSingleNodePlan(logicalPlan);
   // v2 materializes y = x + count in a Project before the join; v1 inlines it
   // into the join filter.
-  auto matcher =
-      matchScan("t")
-          .unnest({"a"}, {"b"})
-          .nestedLoopJoin(matchScan("u")
-                              .singleAggregation({}, {"count(*) as count"})
-                              .build())
-          .projectIf(useV2_, {"a", "cast(x as bigint) + count as y"})
-          .hashJoin(matchScan("v").build(), core::JoinType::kLeft)
-          .build();
+  auto matcher = matchScan("t")
+                     .unnest({"a"}, {"b"})
+                     .nestedLoopJoin(matchScan("u").singleAggregation(
+                         {}, {"count(*) as count"}))
+                     .projectIf(useV2_, {"a", "cast(x as bigint) + count as y"})
+                     .hashJoin(matchScan("v"), core::JoinType::kLeft)
+                     .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
@@ -896,12 +893,9 @@ TEST_P(UnnestTest, leftJoinFilterOnSingleRowSubquerySmallPreservedSide) {
           .hashJoin(
               matchScan("t")
                   .unnest({"a"}, {"b"})
-                  .nestedLoopJoin(
-                      matchScan("u")
-                          .singleAggregation({}, {"count(*) as count"})
-                          .build())
-                  .projectIf(useV2_, {"a", "cast(x as bigint) + count as y"})
-                  .build(),
+                  .nestedLoopJoin(matchScan("u").singleAggregation(
+                      {}, {"count(*) as count"}))
+                  .projectIf(useV2_, {"a", "cast(x as bigint) + count as y"}),
               core::JoinType::kRight)
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);

--- a/axiom/optimizer/tests/WindowTest.cpp
+++ b/axiom/optimizer/tests/WindowTest.cpp
@@ -351,11 +351,11 @@ TEST_F(WindowTest, underJoin) {
       ") dt ON nation.n_regionkey = dt.n_regionkey");
 
   // The window must be inside a nested DT (below the join), not above it.
-  auto matcher = matchScan("nation")
-                     .hashJoin(
-                         matchScan("nation").window().project().build(),
-                         core::JoinType::kInner)
-                     .build();
+  auto matcher =
+      matchScan("nation")
+          .hashJoin(
+              matchScan("nation").window().project(), core::JoinType::kInner)
+          .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
@@ -677,7 +677,7 @@ TEST_F(WindowTest, leftJoinWithWindowOrderingByRightSideColumn) {
       "WHERE t.x = u.x");
 
   auto matcher = matchScan("t")
-                     .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+                     .hashJoin(matchScan("u"), core::JoinType::kInner)
                      .window({"row_number() OVER (ORDER BY y)"})
                      .project()
                      .build();

--- a/axiom/optimizer/v2/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/v2/tests/TpchPlanTest.cpp
@@ -127,29 +127,23 @@ TEST_F(TpchPlanTest, q02) {
   // a stable alias rather than the per-side disambiguated name.
   auto supplierInEurope = [](const std::string& regionName) {
     return matchScan("supplier")
-        .hashJoinInner(
-            matchScan("nation")
-                .hashJoinInner(matchScan("region")
-                                   .aliases({std::nullopt, regionName})
-                                   .filter(regionName + " = 'EUROPE'")
-                                   .build())
-                .build());
+        .hashJoinInner(matchScan("nation").hashJoinInner(
+            matchScan("region")
+                .aliases({std::nullopt, regionName})
+                .filter(regionName + " = 'EUROPE'")));
   };
 
   // The outer query's table tree: partsupp joined to the filtered part and to
   // supplier in Europe.
-  auto outerTables =
-      matchScan("partsupp")
-          .hashJoinInner(matchScan("part")
-                             .filter("p_size = 15 and p_type like '%BRASS'")
-                             .build())
-          .hashJoinInner(supplierInEurope("r_name_outer").build())
-          .build();
+  auto outerTables = matchScan("partsupp")
+                         .hashJoinInner(matchScan("part").filter(
+                             "p_size = 15 and p_type like '%BRASS'"))
+                         .hashJoinInner(supplierInEurope("r_name_outer"));
 
   // The aggregated subquery min(ps_supplycost) per ps_partkey, joined back to
   // the outer table tree.
   auto matcher = matchScan("partsupp")
-                     .hashJoinInner(supplierInEurope("r_name_sub").build())
+                     .hashJoinInner(supplierInEurope("r_name_sub"))
                      .aggregation()
                      .hashJoinInner(outerTables)
                      .project()
@@ -169,9 +163,7 @@ TEST_F(TpchPlanTest, q03) {
               matchScan("orders")
                   .filter("o_orderdate < date '1995-03-15'")
                   .hashJoinInner(matchScan("customer")
-                                     .filter("c_mktsegment = 'BUILDING'")
-                                     .build())
-                  .build())
+                                     .filter("c_mktsegment = 'BUILDING'")))
           .project()
           .aggregation()
           .project()
@@ -187,11 +179,8 @@ TEST_F(TpchPlanTest, q04) {
   auto matcher =
       matchScan("lineitem")
           .filter("l_commitdate < l_receiptdate")
-          .hashJoinRightSemiFilter(
-              matchScan("orders")
-                  .filter(
-                      "o_orderdate >= date '1993-07-01' and o_orderdate < date '1993-10-01'")
-                  .build())
+          .hashJoinRightSemiFilter(matchScan("orders").filter(
+              "o_orderdate >= date '1993-07-01' and o_orderdate < date '1993-10-01'"))
           .aggregation()
           .orderBy()
           .build();
@@ -216,15 +205,9 @@ TEST_F(TpchPlanTest, q05) {
                       "and o_orderdate < date '1995-01-01'")
                   .hashJoinInner(
                       matchScan("customer")
-                          .hashJoinInner(
-                              matchScan("nation")
-                                  .hashJoinInner(matchScan("region")
-                                                     .filter("r_name = 'ASIA'")
-                                                     .build())
-                                  .build())
-                          .build())
-                  .build())
-          .hashJoinInner(matchScan("supplier").build())
+                          .hashJoinInner(matchScan("nation").hashJoinInner(
+                              matchScan("region").filter("r_name = 'ASIA'")))))
+          .hashJoinInner(matchScan("supplier"))
           .project()
           .aggregation()
           .orderBy()
@@ -280,21 +263,14 @@ TEST_F(TpchPlanTest, q07) {
                       matchScan("nation")
                           .aliases({std::nullopt, "supp_nation"})
                           .filter(
-                              "supp_nation = 'FRANCE' or supp_nation = 'GERMANY'")
-                          .build())
-                  .build())
-          .hashJoinInner(
-              matchScan("orders")
+                              "supp_nation = 'FRANCE' or supp_nation = 'GERMANY'")))
+          .hashJoinInner(matchScan("orders").hashJoinInner(
+              matchScan("customer")
                   .hashJoinInner(
-                      matchScan("customer")
-                          .hashJoinInner(
-                              matchScan("nation")
-                                  .aliases({std::nullopt, "cust_nation"})
-                                  .filter(
-                                      "cust_nation = 'GERMANY' or cust_nation = 'FRANCE'")
-                                  .build())
-                          .build())
-                  .build())
+                      matchScan("nation")
+                          .aliases({std::nullopt, "cust_nation"})
+                          .filter(
+                              "cust_nation = 'GERMANY' or cust_nation = 'FRANCE'"))))
           .project()
           .aggregation()
           .orderBy()
@@ -323,25 +299,15 @@ TEST_F(TpchPlanTest, q08) {
               matchScan("orders")
                   .filter(
                       "o_orderdate between date '1995-01-01' and date '1996-12-31'")
-                  .hashJoinInner(
-                      matchScan("lineitem")
-                          .hashJoinInner(
-                              matchScan("part")
-                                  .filter("p_type = 'ECONOMY ANODIZED STEEL'")
-                                  .build())
-                          .build())
+                  .hashJoinInner(matchScan("lineitem")
+                                     .hashJoinInner(matchScan("part").filter(
+                                         "p_type = 'ECONOMY ANODIZED STEEL'")))
                   .hashJoinInner(
                       matchScan("customer")
-                          .hashJoinInner(
-                              matchScan("nation")
-                                  .hashJoinInner(
-                                      matchScan("region")
-                                          .filter("r_name = 'AMERICA'")
-                                          .build())
-                                  .build())
-                          .build())
-                  .build())
-          .hashJoinInner(matchScan("nation").build())
+                          .hashJoinInner(matchScan("nation").hashJoinInner(
+                              matchScan("region").filter(
+                                  "r_name = 'AMERICA'")))))
+          .hashJoinInner(matchScan("nation"))
           .project()
           .aggregation()
           .project()
@@ -374,15 +340,11 @@ TEST_F(TpchPlanTest, q09Alt) {
       matchScan("orders")
           .hashJoinInner(
               matchScan("lineitem")
-                  .hashJoinInner(
-                      matchScan("partsupp")
-                          .hashJoinInner(
-                              matchScan("part").filter("p_size <= 3").build())
-                          .build())
-                  .build())
-          .hashJoinInner(matchScan("supplier")
-                             .hashJoinInner(matchScan("nation").build())
-                             .build())
+                  .hashJoinInner(matchScan("partsupp")
+                                     .hashJoinInner(matchScan("part").filter(
+                                         "p_size <= 3"))))
+          .hashJoinInner(
+              matchScan("supplier").hashJoinInner(matchScan("nation")))
           .project()
           .singleAggregation({"n_name", "o_year"}, {"sum(amount)"})
           .orderBy({"n_name", "o_year DESC"})
@@ -402,16 +364,12 @@ TEST_F(TpchPlanTest, q10) {
   // joins last.
   auto matcher =
       matchScan("customer")
-          .hashJoinInner(
-              matchScan("lineitem")
-                  .filter("l_returnflag = 'R'")
-                  .hashJoinInner(matchScan("orders")
-                                     .filter(
-                                         "o_orderdate >= date '1993-10-01' "
-                                         "and o_orderdate < date '1994-01-01'")
-                                     .build())
-                  .build())
-          .hashJoinInner(matchScan("nation").build())
+          .hashJoinInner(matchScan("lineitem")
+                             .filter("l_returnflag = 'R'")
+                             .hashJoinInner(matchScan("orders").filter(
+                                 "o_orderdate >= date '1993-10-01' "
+                                 "and o_orderdate < date '1994-01-01'")))
+          .hashJoinInner(matchScan("nation"))
           .project(
               {"c_custkey",
                "c_name",
@@ -457,9 +415,7 @@ TEST_F(TpchPlanTest, q11) {
             matchScan("supplier")
                 .hashJoinInner(matchScan("nation")
                                    .aliases({std::nullopt, nationName})
-                                   .filter(nationName + " = 'GERMANY'")
-                                   .build())
-                .build());
+                                   .filter(nationName + " = 'GERMANY'")));
       };
 
   auto matcher =
@@ -472,8 +428,7 @@ TEST_F(TpchPlanTest, q11) {
               germanyPartsupp("n_name_sub", {std::nullopt, "aq", "sc"})
                   .project({"sc * cast(aq as double) as s"})
                   .singleAggregation({}, {"sum(s) as totalSum"})
-                  .project({"totalSum * 0.0001 as expr"})
-                  .build())
+                  .project({"totalSum * 0.0001 as expr"}))
           .orderBy({"value DESC"})
           .project()
           .build();
@@ -489,19 +444,18 @@ TEST_F(TpchPlanTest, q12) {
       "         l_shipdate < l_commitdate, l_receiptdate >= date '1994-01-01', "
       "         l_receiptdate < date '1995-01-01')";
 
-  auto matcher =
-      matchScan("orders")
-          .hashJoinInner(matchScan("lineitem").filter(filter).build())
-          .project()
-          .aggregation()
-          .orderBy()
-          .build();
+  auto matcher = matchScan("orders")
+                     .hashJoinInner(matchScan("lineitem").filter(filter))
+                     .project()
+                     .aggregation()
+                     .orderBy()
+                     .build();
   AXIOM_ASSERT_PLAN(planTpch(12), matcher);
 
   auto distributed = [&](bool isMultiThreaded) {
     return matchScan("orders")
         .multiThreaded(isMultiThreaded)
-        .hashJoinInner(matchScan("lineitem").filter(filter).broadcast().build())
+        .hashJoinInner(matchScan("lineitem").filter(filter).broadcast())
         .project({
             "l_shipmode",
             "if(o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH', 1, 0) as high_line_count",
@@ -534,7 +488,7 @@ TEST_F(TpchPlanTest, q13) {
   auto matcher =
       matchScan("orders")
           .filter("o_comment not like '%special%requests%'")
-          .hashJoinRight(matchScan("customer").build())
+          .hashJoinRight(matchScan("customer"))
           .singleAggregation({"c_custkey"}, {"count(o_orderkey) as cnt"})
           .project()
           .singleAggregation({"cnt"}, {"count() as custdist"})
@@ -550,19 +504,18 @@ TEST_F(TpchPlanTest, q13) {
 TEST_F(TpchPlanTest, q14) {
   const auto filter =
       "l_shipdate >= date '1995-09-01' and l_shipdate < date '1995-10-01'";
-  auto matcher =
-      matchScan("part")
-          .hashJoinInner(matchScan("lineitem").filter(filter).build())
-          .project()
-          .aggregation()
-          .project()
-          .build();
+  auto matcher = matchScan("part")
+                     .hashJoinInner(matchScan("lineitem").filter(filter))
+                     .project()
+                     .aggregation()
+                     .project()
+                     .build();
   AXIOM_ASSERT_PLAN(planTpch(14), matcher);
 
   auto distributed = [&](bool isMultiThreaded) {
     return matchScan("part")
         .multiThreaded(isMultiThreaded)
-        .hashJoinInner(matchScan("lineitem").filter(filter).broadcast().build())
+        .hashJoinInner(matchScan("lineitem").filter(filter).broadcast())
         .project({
             "if(p_type like 'PROMO%', l_extendedprice * (1.0 - l_discount), 0.0) as promo",
             "l_extendedprice * (1.0 - l_discount) as disc_price",
@@ -600,16 +553,13 @@ TEST_F(TpchPlanTest, q15) {
   auto matcher =
       matchScan("supplier")
           .hashJoinInner(
-              revenueAgg()
-                  .hashJoinInner(revenueAgg({"l_suppkey",
-                                             "l_extendedprice",
-                                             "l_discount",
-                                             std::nullopt})
-                                     .project()
-                                     .singleAggregation(
-                                         {}, {"max(total_revenue) as maxRev"})
-                                     .build())
-                  .build())
+              revenueAgg().hashJoinInner(
+                  revenueAgg({"l_suppkey",
+                              "l_extendedprice",
+                              "l_discount",
+                              std::nullopt})
+                      .project()
+                      .singleAggregation({}, {"max(total_revenue) as maxRev"})))
           .orderBy({"s_suppkey"})
           .build();
   AXIOM_ASSERT_PLAN(planTpch(15), matcher);
@@ -623,32 +573,28 @@ TEST_F(TpchPlanTest, q16) {
       "\"and\"(p_brand <> 'Brand#45', p_type not like 'MEDIUM POLISHED%', "
       "         p_size in (49, 14, 23, 45, 19, 3, 36, 9))";
 
-  auto matcher =
-      matchScan("partsupp")
-          .hashJoinInner(matchScan("part").filter(partFilter).build())
-          .hashJoinAnti(
-              matchScan("supplier")
-                  .filter("s_comment like '%Customer%Complaints%'")
-                  .build(),
-              {.nullAware = true})
-          .singleAggregation(
-              {"p_brand", "p_type", "p_size"},
-              {"count(distinct ps_suppkey) as supplier_cnt"})
-          .orderBy()
-          .build();
+  auto matcher = matchScan("partsupp")
+                     .hashJoinInner(matchScan("part").filter(partFilter))
+                     .hashJoinAnti(
+                         matchScan("supplier")
+                             .filter("s_comment like '%Customer%Complaints%'"),
+                         {.nullAware = true})
+                     .singleAggregation(
+                         {"p_brand", "p_type", "p_size"},
+                         {"count(distinct ps_suppkey) as supplier_cnt"})
+                     .orderBy()
+                     .build();
   AXIOM_ASSERT_PLAN(planTpch(16), matcher);
 
   auto distributed = [&](bool isMultiThreaded) {
     auto builder =
         matchScan("partsupp")
             .multiThreaded(isMultiThreaded)
-            .hashJoinInner(
-                matchScan("part").filter(partFilter).broadcast().build())
+            .hashJoinInner(matchScan("part").filter(partFilter).broadcast())
             .hashJoinAnti(
                 matchScan("supplier")
                     .filter("s_comment like '%Customer%Complaints%'")
-                    .broadcast()
-                    .build(),
+                    .broadcast(),
                 {.nullAware = true})
             .shuffle({"p_brand", "p_type", "p_size"});
     if (isMultiThreaded) {
@@ -679,12 +625,8 @@ TEST_F(TpchPlanTest, q17) {
           .hashJoinInner(
               matchScan("lineitem")
                   .aggregation()
-                  .hashJoinRight(
-                      matchScan("part")
-                          .filter(
-                              "p_brand = 'Brand#23' and p_container = 'MED BOX'")
-                          .build())
-                  .build())
+                  .hashJoinRight(matchScan("part").filter(
+                      "p_brand = 'Brand#23' and p_container = 'MED BOX'")))
           .filter()
           .project()
           .aggregation()
@@ -706,16 +648,14 @@ TEST_F(TpchPlanTest, q18) {
       matchScan("lineitem")
           .hashJoinInner(
               matchScan("orders")
-                  .hashJoinInner(matchScan("customer").build())
+                  .hashJoinInner(matchScan("customer"))
                   .hashJoinLeftSemiFilter(
                       matchScan("lineitem")
                           .aliases({"l_orderkey", "l_quantity"})
                           .singleAggregation(
                               {"l_orderkey"}, {"sum(l_quantity) as s"})
                           .filter("s > 300.0")
-                          .project()
-                          .build())
-                  .build())
+                          .project()))
           .aggregation()
           .topN()
           .build();
@@ -739,16 +679,13 @@ TEST_F(TpchPlanTest, q19) {
               "(l_quantity >= 1.0 and l_quantity <= 11.0) or "
               "(l_quantity >= 10.0 and l_quantity <= 20.0) or "
               "(l_quantity >= 20.0 and l_quantity <= 30.0))")
-          .hashJoinInner(
-              matchScan("part")
-                  .filter(
-                      "(p_brand = 'Brand#12' and p_container in ('SM CASE', "
-                      "'SM BOX', 'SM PACK', 'SM PKG') and p_size between 1 and 5) or "
-                      "(p_brand = 'Brand#23' and p_container in ('MED BAG', "
-                      "'MED BOX', 'MED PKG', 'MED PACK') and p_size between 1 and 10) or "
-                      "(p_brand = 'Brand#34' and p_container in ('LG CASE', "
-                      "'LG BOX', 'LG PACK', 'LG PKG') and p_size between 1 and 15)")
-                  .build())
+          .hashJoinInner(matchScan("part").filter(
+              "(p_brand = 'Brand#12' and p_container in ('SM CASE', "
+              "'SM BOX', 'SM PACK', 'SM PKG') and p_size between 1 and 5) or "
+              "(p_brand = 'Brand#23' and p_container in ('MED BAG', "
+              "'MED BOX', 'MED PKG', 'MED PACK') and p_size between 1 and 10) or "
+              "(p_brand = 'Brand#34' and p_container in ('LG CASE', "
+              "'LG BOX', 'LG PACK', 'LG PKG') and p_size between 1 and 15)"))
           .project()
           .aggregation()
           .build();
@@ -771,20 +708,16 @@ TEST_F(TpchPlanTest, q20) {
               "l_shipdate >= date '1994-01-01' and l_shipdate < date '1995-01-01'")
           .aggregation()
           .hashJoinRight(matchScan("partsupp")
-                             .hashJoinLeftSemiProject(
-                                 matchScan("part")
-                                     .filter("like(p_name, 'forest%')")
-                                     .build())
-                             .filter("mark1")
-                             .build())
+                             .hashJoinLeftSemiProject(matchScan("part").filter(
+                                 "like(p_name, 'forest%')"))
+                             .filter("mark1"))
           // TODO Optimize if(true, sum * 0.5, null) to sum * 0.5.
           .filter("cast(ps_availqty as double) > if(true, sum * 0.5, null)")
           .project()
           .hashJoinRightSemiFilter(
               matchScan("supplier")
                   .hashJoinInner(
-                      matchScan("nation").filter("n_name = 'CANADA'").build())
-                  .build())
+                      matchScan("nation").filter("n_name = 'CANADA'")))
           .orderBy()
           .project()
           .build();
@@ -818,19 +751,13 @@ TEST_F(TpchPlanTest, q21) {
                                   .hashJoinInner(
                                       matchScan("supplier")
                                           .hashJoinInner(
-                                              matchScan("nation")
-                                                  .filter(
-                                                      "n_name = 'SAUDI ARABIA'")
-                                                  .build())
-                                          .build())
-                                  .build())
-                          .build())
+                                              matchScan("nation").filter(
+                                                  "n_name = 'SAUDI ARABIA'")))))
                   // Bind the semijoin's trailing mark column by position rather
                   // than its internal name.
                   .aliases({std::nullopt, std::nullopt, std::nullopt, "mark"})
                   .filter("not(mark)")
-                  .project()
-                  .build())
+                  .project())
           .aggregation()
           .topN()
           .build();
@@ -856,9 +783,7 @@ TEST_F(TpchPlanTest, q22) {
                       matchScan("customer")
                           .aliases({"c_acctbal", std::nullopt})
                           .filter("c_acctbal > 0.0 and " + countryFilter)
-                          .aggregation()
-                          .build())
-                  .build())
+                          .aggregation()))
           .aliases({std::nullopt, std::nullopt, std::nullopt, "mark"})
           .filter("not(mark)")
           .project()


### PR DESCRIPTION
Summary:
Every nested matcher had to be finished with `.build()` before it could be passed to its parent:

    matchScan("t").hashJoinInner(matchScan("u").filter("b > 0").build())

`hashJoin`, its typed shortcuts, `nestedLoopJoin` and `localPartition` now take a `PlanMatcherBuilder` and build it themselves, so the same line reads:

    matchScan("t").hashJoinInner(matchScan("u").filter("b > 0"))

`.build()` is left only where a matcher is actually finished — at the end of the outermost chain, on its way into `AXIOM_ASSERT_PLAN`.

`localPartition`'s source list stays an `initializer_list`. As a `std::vector`, `localPartition({"a", "b"})` becomes ambiguous: two string literals also match vector's iterator-pair constructor, so the partition-keys overload and the sources overload both apply.

A few tests built a matcher into a local or returned one from a helper lambda before passing it in. Those now hold builders.

bypass-github-export-checks

___

Reviewed By: max-hoffman

Differential Revision: D115905467
