### PR TITLE
fix(optimizer): Close v2 plan gaps around window functions (#1715)

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1775,10 +1775,12 @@ WindowFunctionVector flattenWindowFunctions(
         func->args(), /*aliases=*/nullptr, /*preserveLiterals=*/true);
     Frame frame = func->frame();
     if (frame.startValue) {
-      frame.startValue = precompute.toColumn(frame.startValue);
+      frame.startValue = precompute.toColumn(
+          frame.startValue, /*alias=*/nullptr, /*preserveLiterals=*/true);
     }
     if (frame.endValue) {
-      frame.endValue = precompute.toColumn(frame.endValue);
+      frame.endValue = precompute.toColumn(
+          frame.endValue, /*alias=*/nullptr, /*preserveLiterals=*/true);
     }
     result.emplace_back(
         make<WindowFunction>(

--- a/axiom/optimizer/tests/SubqueryFoldTest.cpp
+++ b/axiom/optimizer/tests/SubqueryFoldTest.cpp
@@ -141,13 +141,11 @@ TEST_P(SubqueryFoldTest, foldable) {
         "SELECT * FROM t WHERE ds = (SELECT max(ds) FROM t WHERE a > 5)");
     auto plan = toSingleNodePlan(logicalPlan);
 
-    // v2 adds a top projection to drop the join's extra aggregate column.
     auto matcher = matchScan("t")
                        .hashJoinInner(matchScan("t")
                                           .aliases({"ds", "a"})
                                           .filter("a > 5")
                                           .aggregation())
-                       .projectIf(useV2_)
                        .build();
     AXIOM_ASSERT_PLAN(plan, matcher);
   }

--- a/axiom/optimizer/tests/WindowTest.cpp
+++ b/axiom/optimizer/tests/WindowTest.cpp
@@ -21,8 +21,14 @@ namespace {
 
 using namespace velox;
 
-class WindowTest : public test::QueryTestBase {
+class WindowTest : public test::QueryTestBase,
+                   public ::testing::WithParamInterface<bool> {
  protected:
+  void SetUp() override {
+    useV2_ = GetParam();
+    test::QueryTestBase::SetUp();
+  }
+
   velox::core::PlanNodePtr toSingleNodePlan(
       std::string_view sql,
       int32_t numDrivers = 1) {
@@ -36,7 +42,7 @@ class WindowTest : public test::QueryTestBase {
   }
 };
 
-TEST_F(WindowTest, singleFunction) {
+TEST_P(WindowTest, singleFunction) {
   // No extra columns to drop, so no final project.
   auto plan = toSingleNodePlan(
       "SELECT n_name, row_number() OVER (ORDER BY n_name) as rn "
@@ -48,7 +54,7 @@ TEST_F(WindowTest, singleFunction) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, partitionBy) {
+TEST_P(WindowTest, partitionBy) {
   // Project drops unused columns (n_nationkey).
   auto plan = toSingleNodePlan(
       "SELECT n_name, n_regionkey, "
@@ -64,7 +70,7 @@ TEST_F(WindowTest, partitionBy) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, multipleFunctionsSameSpec) {
+TEST_P(WindowTest, multipleFunctionsSameSpec) {
   // Multiple window functions with the same partition/order spec should be
   // grouped into a single Window operator.
   auto plan = toSingleNodePlan(
@@ -83,7 +89,7 @@ TEST_F(WindowTest, multipleFunctionsSameSpec) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, stackedWindows) {
+TEST_P(WindowTest, stackedWindows) {
   // Window functions from stacked projects (inner subquery + outer window)
   // merge into the same DT when the outer window doesn't reference the inner
   // window's output. The two windows have different specs (ORDER BY vs none),
@@ -104,7 +110,7 @@ TEST_F(WindowTest, stackedWindows) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, stackedWindowsSameSpec) {
+TEST_P(WindowTest, stackedWindowsSameSpec) {
   // Window functions from stacked projects with the same spec are combined
   // into a single Window operator.
   auto plan = toSingleNodePlan(
@@ -124,7 +130,7 @@ TEST_F(WindowTest, stackedWindowsSameSpec) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, differentPartitionKeys) {
+TEST_P(WindowTest, differentPartitionKeys) {
   // Window functions with different partition keys produce separate Window
   // operators.
   auto plan = toSingleNodePlan(
@@ -146,7 +152,7 @@ TEST_F(WindowTest, differentPartitionKeys) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, differentOrderTypes) {
+TEST_P(WindowTest, differentOrderTypes) {
   // Window functions with same order keys but different sort orders (ASC vs
   // DESC) must produce separate Window operators.
   auto plan = toSingleNodePlan(
@@ -166,8 +172,9 @@ TEST_F(WindowTest, differentOrderTypes) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, frameBounds) {
-  // Precompute projection materializes frame bound constant.
+TEST_P(WindowTest, frameBounds) {
+  // A constant frame bound stays a literal in the frame; nothing precomputes
+  // it into a column.
   auto plan = toSingleNodePlan(
       "SELECT n_name, "
       "sum(n_nationkey) OVER ("
@@ -176,25 +183,17 @@ TEST_F(WindowTest, frameBounds) {
       ") as s "
       "FROM nation");
 
-  // Precompute project materializes the constant frame bounds. Use aliases to
-  // capture the auto-generated column names for symbol propagation.
   auto matcher =
       matchScan("nation")
-          .project({
-              "n_nationkey",
-              "n_name",
-              "n_regionkey",
-              "1 as one",
-          })
           .window(
               {"sum(n_nationkey) OVER (PARTITION BY n_regionkey ORDER BY n_name "
-               "ROWS BETWEEN one PRECEDING AND one FOLLOWING)"})
+               "ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)"})
           .project()
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, expressionFrameBounds) {
+TEST_P(WindowTest, expressionFrameBounds) {
   // Precompute projection materializes expression frame bounds.
   auto plan = toSingleNodePlan(
       "SELECT n_name, "
@@ -222,7 +221,7 @@ TEST_F(WindowTest, expressionFrameBounds) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, expressionInputs) {
+TEST_P(WindowTest, expressionInputs) {
   // All inputs to window function are expressions: function args, partition
   // keys, sorting keys, frame start and end. Partition key and frame end share
   // the expression n_regionkey + 1 which is computed once.
@@ -237,16 +236,27 @@ TEST_F(WindowTest, expressionInputs) {
   // Precompute project has 6 outputs: 3 pass-through + 3 computed. The
   // expression n_regionkey + 1 appears once (shared by partition key and frame
   // end). Use aliases to capture auto-generated names for symbol propagation.
+  // The two optimizers materialize the window's inputs in different order.
+  const std::vector<std::string> precomputed = useV2_
+      ? std::vector<std::string>{
+            "n_nationkey",
+            "n_name",
+            "n_regionkey",
+            "n_regionkey + 1 as partKey",
+            "upper(n_name) as orderKey",
+            "n_nationkey * 2 as sumArg",
+        }
+      : std::vector<std::string>{
+            "n_nationkey",
+            "n_name",
+            "n_regionkey",
+            "n_nationkey * 2 as sumArg",
+            "n_regionkey + 1 as partKey",
+            "upper(n_name) as orderKey",
+        };
   auto matcher =
       matchScan("nation")
-          .project({
-              "n_nationkey",
-              "n_name",
-              "n_regionkey",
-              "n_nationkey * 2 as sumArg",
-              "n_regionkey + 1 as partKey",
-              "upper(n_name) as orderKey",
-          })
+          .project(precomputed)
           .window({"sum(sumArg) OVER (PARTITION BY partKey ORDER BY orderKey "
                    "ROWS BETWEEN n_regionkey PRECEDING AND partKey FOLLOWING)"})
           .project()
@@ -254,7 +264,7 @@ TEST_F(WindowTest, expressionInputs) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, windowAfterFilter) {
+TEST_P(WindowTest, windowAfterFilter) {
   auto plan = toSingleNodePlan(
       "SELECT n_name, "
       "row_number() OVER (ORDER BY n_name) as rn "
@@ -269,7 +279,7 @@ TEST_F(WindowTest, windowAfterFilter) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, filterOnWindowOutput) {
+TEST_P(WindowTest, filterOnWindowOutput) {
   // Filter on a non-ranking window function output forces a DT boundary.
   // The filter stays because sum() is not a ranking function.
   auto plan = toSingleNodePlan(
@@ -278,15 +288,18 @@ TEST_F(WindowTest, filterOnWindowOutput) {
       "  FROM nation"
       ") WHERE s > 10");
 
-  auto matcher = matchScan("nation")
-                     .window({"sum(n_regionkey) OVER (ORDER BY n_name) as s"})
-                     .project({"n_name", "s"})
-                     .filter("s > 10")
-                     .build();
+  // v1 prunes columns before the filter, v2 after.
+  auto window = [] {
+    return matchScan("nation").window(
+        {"sum(n_regionkey) OVER (ORDER BY n_name) as s"});
+  };
+  auto matcher = useV2_
+      ? window().filter("s > 10").project({"n_name", "s"}).build()
+      : window().project({"n_name", "s"}).filter("s > 10").build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, windowOnWindowInArgs) {
+TEST_P(WindowTest, windowOnWindowInArgs) {
   // Window function that references another window function's output in its
   // args forces a DT boundary.
   auto plan = toSingleNodePlan(
@@ -309,7 +322,7 @@ TEST_F(WindowTest, windowOnWindowInArgs) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, windowOnWindowInFrameBounds) {
+TEST_P(WindowTest, windowOnWindowInFrameBounds) {
   // Window function that references another window function's output in its
   // frame bounds forces a DT boundary.
   auto plan = toSingleNodePlan(
@@ -341,7 +354,7 @@ TEST_F(WindowTest, windowOnWindowInFrameBounds) {
 // Window subquery as a join input must be wrapped in a nested DT.
 // Without wrapping, the join and window end up in the same DT, and the
 // window computes over the joined result instead of the subquery's rows.
-TEST_F(WindowTest, underJoin) {
+TEST_P(WindowTest, underJoin) {
   auto plan = toSingleNodePlan(
       "SELECT n_name, dt.s "
       "FROM nation "
@@ -359,7 +372,7 @@ TEST_F(WindowTest, underJoin) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(WindowTest, distributed) {
+TEST_P(WindowTest, distributed) {
   // Distributed plan should have repartitioning for window.
   auto logicalPlan = parseSelect(
       "SELECT n_name, "
@@ -384,7 +397,7 @@ TEST_F(WindowTest, distributed) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
 }
 
-TEST_F(WindowTest, distributedMultipleShuffles) {
+TEST_P(WindowTest, distributedMultipleShuffles) {
   // Window functions with different partition keys require separate shuffles.
   auto logicalPlan = parseSelect(
       "SELECT n_name, "
@@ -411,7 +424,7 @@ TEST_F(WindowTest, distributedMultipleShuffles) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
 }
 
-TEST_F(WindowTest, nonRedundantOrderByWithPartitionKeys) {
+TEST_P(WindowTest, nonRedundantOrderByWithPartitionKeys) {
   // With partition keys, ORDER BY is NOT redundant because the window only
   // sorts within each partition, not globally.
   constexpr auto sql =
@@ -419,63 +432,82 @@ TEST_F(WindowTest, nonRedundantOrderByWithPartitionKeys) {
       "sum(n_regionkey) OVER (PARTITION BY n_regionkey ORDER BY n_name) as s "
       "FROM nation ORDER BY n_name LIMIT 10";
 
+  // v2 prunes columns before the TopN, v1 after.
   auto plan = toSingleNodePlan(sql);
-  auto matcher =
-      matchScan("nation")
-          .window(
-              {"sum(n_regionkey) OVER (PARTITION BY n_regionkey ORDER BY n_name)"})
-          .topN(10)
-          .project({"n_name", "s"})
-          .build();
+  auto window = [] {
+    return matchScan("nation").window(
+        {"sum(n_regionkey) OVER (PARTITION BY n_regionkey ORDER BY n_name)"});
+  };
+  auto matcher = useV2_ ? window().project({"n_name", "s"}).topN(10).build()
+                        : window().topN(10).project({"n_name", "s"}).build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   auto distributedPlan = toDistributedPlan(sql);
-  auto distributedMatcher =
-      matchScan("nation")
-          .shuffle({"n_regionkey"})
-          .localPartition({"n_regionkey"})
-          .window(
-              {"sum(n_regionkey) OVER (PARTITION BY n_regionkey ORDER BY n_name)"})
-          .topN(10)
-          .localMerge()
-          .shuffleMerge()
-          .finalLimit(0, 10)
-          .project({"n_name", "s"})
-          .build();
+  // v2 also limits per worker before the merge exchange.
+  auto distributedWindow = [] {
+    return matchScan("nation")
+        .shuffle({"n_regionkey"})
+        .localPartition({"n_regionkey"})
+        .window(
+            {"sum(n_regionkey) OVER (PARTITION BY n_regionkey ORDER BY n_name)"});
+  };
+  auto distributedMatcher = useV2_ ? distributedWindow()
+                                         .project({"n_name", "s"})
+                                         .topN(10)
+                                         .localMerge()
+                                         .finalLimit(0, 10)
+                                         .shuffleMerge()
+                                         .finalLimit(0, 10)
+                                         .build()
+                                   : distributedWindow()
+                                         .topN(10)
+                                         .localMerge()
+                                         .shuffleMerge()
+                                         .finalLimit(0, 10)
+                                         .project({"n_name", "s"})
+                                         .build();
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(WindowTest, nonRedundantOrderByWithDifferentKeys) {
+TEST_P(WindowTest, nonRedundantOrderByWithDifferentKeys) {
   // Query ORDER BY does not match window ORDER BY — ORDER BY is preserved.
   constexpr auto sql =
       "SELECT n_name, n_nationkey, sum(n_regionkey) OVER (ORDER BY n_name) "
       "FROM nation ORDER BY n_nationkey LIMIT 10";
 
+  // v2 prunes columns before the TopN, v1 after.
   auto plan = toSingleNodePlan(sql);
-  auto matcher = matchScan("nation")
-                     .window({"sum(n_regionkey) OVER (ORDER BY n_name)"})
-                     .topN(10)
-                     .project()
-                     .build();
+  auto window = [] {
+    return matchScan("nation").window(
+        {"sum(n_regionkey) OVER (ORDER BY n_name)"});
+  };
+  auto matcher = useV2_ ? window().project().topN(10).build()
+                        : window().topN(10).project().build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // No partition keys — gather, then Window + TopN + project, all on the one
   // task the gather already produced.
   auto distributedPlan = toDistributedPlan(sql);
-  auto distributedMatcher =
-      matchScan("nation")
-          .gather()
-          .localGather()
-          .window({"sum(n_regionkey) OVER (ORDER BY n_name)"})
-          .topN(10)
-          .localMerge()
-          .finalLimit(0, 10)
-          .project()
-          .build();
+  auto distributedWindow = [] {
+    return matchScan("nation").gather().localGather().window(
+        {"sum(n_regionkey) OVER (ORDER BY n_name)"});
+  };
+  auto distributedMatcher = useV2_ ? distributedWindow()
+                                         .project()
+                                         .topN(10)
+                                         .localMerge()
+                                         .finalLimit(0, 10)
+                                         .build()
+                                   : distributedWindow()
+                                         .topN(10)
+                                         .localMerge()
+                                         .finalLimit(0, 10)
+                                         .project()
+                                         .build();
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(WindowTest, redundantOrderByMultipleWindowsSameOrderBy) {
+TEST_P(WindowTest, redundantOrderByMultipleWindowsSameOrderBy) {
   // Multiple window functions with the same ORDER BY and no partition keys —
   // query ORDER BY is redundant.
   constexpr auto sql =
@@ -484,31 +516,32 @@ TEST_F(WindowTest, redundantOrderByMultipleWindowsSameOrderBy) {
       "avg(n_nationkey) OVER (ORDER BY n_name) as a "
       "FROM nation ORDER BY n_name LIMIT 10";
 
+  // The window already emits rows in n_name order, so the query ORDER BY needs
+  // no sort. v2 prunes columns before the limit, v1 after.
   auto plan = toSingleNodePlan(sql);
-  auto matcher = matchScan("nation")
-                     .window(
-                         {"sum(n_regionkey) OVER (ORDER BY n_name)",
-                          "avg(n_nationkey) OVER (ORDER BY n_name)"})
-                     .finalLimit(0, 10)
-                     .project()
-                     .build();
+  auto windows = [] {
+    return matchScan("nation").window(
+        {"sum(n_regionkey) OVER (ORDER BY n_name)",
+         "avg(n_nationkey) OVER (ORDER BY n_name)"});
+  };
+  auto matcher = useV2_ ? windows().project().finalLimit(0, 10).build()
+                        : windows().finalLimit(0, 10).project().build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // No partition keys — gather, then Window + limit + project.
   auto distributedPlan = toDistributedPlan(sql);
-  auto distributedMatcher = matchScan("nation")
-                                .gather()
-                                .localGather()
-                                .window(
-                                    {"sum(n_regionkey) OVER (ORDER BY n_name)",
-                                     "avg(n_nationkey) OVER (ORDER BY n_name)"})
-                                .localLimit(0, 10)
-                                .project()
-                                .build();
+  auto distributedWindows = [] {
+    return matchScan("nation").gather().localGather().window(
+        {"sum(n_regionkey) OVER (ORDER BY n_name)",
+         "avg(n_nationkey) OVER (ORDER BY n_name)"});
+  };
+  auto distributedMatcher = useV2_
+      ? distributedWindows().project().localLimit(0, 10).build()
+      : distributedWindows().localLimit(0, 10).project().build();
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(WindowTest, nonRedundantOrderByMultipleWindowsDifferentOrderBy) {
+TEST_P(WindowTest, nonRedundantOrderByMultipleWindowsDifferentOrderBy) {
   // Multiple window functions with different ORDER BY — query ORDER BY is NOT
   // redundant.
   constexpr auto sql =
@@ -517,36 +550,46 @@ TEST_F(WindowTest, nonRedundantOrderByMultipleWindowsDifferentOrderBy) {
       "avg(n_nationkey) OVER (ORDER BY n_nationkey) as a "
       "FROM nation ORDER BY n_name LIMIT 10";
 
+  // v2 prunes columns before the TopN, v1 after.
   auto plan = toSingleNodePlan(sql);
-  auto matcher = matchScan("nation")
-                     .window({"sum(n_regionkey) OVER (ORDER BY n_name)"})
-                     .project()
-                     .window({"avg(n_nationkey) OVER (ORDER BY n_nationkey)"})
-                     .topN(10)
-                     .project()
-                     .build();
+  auto windows = [] {
+    return matchScan("nation")
+        .window({"sum(n_regionkey) OVER (ORDER BY n_name)"})
+        .project()
+        .window({"avg(n_nationkey) OVER (ORDER BY n_nationkey)"});
+  };
+  auto matcher = useV2_ ? windows().project().topN(10).build()
+                        : windows().topN(10).project().build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   // No partition keys — gather, then two Windows + TopN + project, all on the
   // one task the gather already produced.
   auto distributedPlan = toDistributedPlan(sql);
-  auto distributedMatcher =
-      matchScan("nation")
-          .gather()
-          .localGather()
-          .window({"sum(n_regionkey) OVER (ORDER BY n_name)"})
-          .project()
-          .localGather()
-          .window({"avg(n_nationkey) OVER (ORDER BY n_nationkey)"})
-          .topN(10)
-          .localMerge()
-          .finalLimit(0, 10)
-          .project()
-          .build();
+  auto distributedWindows = [] {
+    return matchScan("nation")
+        .gather()
+        .localGather()
+        .window({"sum(n_regionkey) OVER (ORDER BY n_name)"})
+        .project()
+        .localGather()
+        .window({"avg(n_nationkey) OVER (ORDER BY n_nationkey)"});
+  };
+  auto distributedMatcher = useV2_ ? distributedWindows()
+                                         .project()
+                                         .topN(10)
+                                         .localMerge()
+                                         .finalLimit(0, 10)
+                                         .build()
+                                   : distributedWindows()
+                                         .topN(10)
+                                         .localMerge()
+                                         .finalLimit(0, 10)
+                                         .project()
+                                         .build();
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(WindowTest, windowOutputAsGroupByKey) {
+TEST_P(WindowTest, windowOutputAsGroupByKey) {
   // Window function output used as GROUP BY key in outer query. The window
   // must be computed before the aggregation.
   auto plan = toSingleNodePlan(
@@ -567,7 +610,7 @@ TEST_F(WindowTest, windowOutputAsGroupByKey) {
 // When a window function's input expression references another window
 // function's output, they cannot share a Window node — the referenced
 // output isn't available until its Window runs.
-TEST_F(WindowTest, dependentWindowFunctions) {
+TEST_P(WindowTest, dependentWindowFunctions) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
 
   {
@@ -666,7 +709,7 @@ TEST_F(WindowTest, dependentWindowFunctions) {
 
 // Window ORDER BY references a column from the right side of a LEFT JOIN
 // whose WHERE further filters the right side.
-TEST_F(WindowTest, leftJoinWithWindowOrderingByRightSideColumn) {
+TEST_P(WindowTest, leftJoinWithWindowOrderingByRightSideColumn) {
   testConnector_->addTable("t", ROW("x", BIGINT()));
   testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()));
 
@@ -683,6 +726,8 @@ TEST_F(WindowTest, leftJoinWithWindowOrderingByRightSideColumn) {
                      .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
+
+AXIOM_INSTANTIATE_V1_V2(WindowTest);
 
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -404,6 +404,12 @@ class Emitter {
       velox::core::PlanNodePtr right,
       velox::core::TypedExprPtr filter);
 
+  // Drops columns the emitted plan carries beyond what 'node' outputs. See
+  // the definition for why they can appear.
+  velox::core::PlanNodePtr trimToNodeColumns(
+      NodeCP node,
+      velox::core::PlanNodePtr input);
+
   // Wraps 'input' in a `ProjectNode` that keeps only 'keepColumns'.
   velox::core::PlanNodePtr projectToColumns(
       const ColumnVector& keepColumns,
@@ -555,6 +561,19 @@ class Emitter {
     return std::move(prediction_);
   }
 };
+
+// A scan whose filter the connector rejected emits the filter's columns, so
+// the emitted plan can be wider than 'node' says. A Velox window operator
+// passes its input through, so those columns would ride through it and be
+// dropped only at the root. Trims them off first.
+velox::core::PlanNodePtr Emitter::trimToNodeColumns(
+    NodeCP node,
+    velox::core::PlanNodePtr input) {
+  if (input->outputType()->size() <= node->outputColumns().size()) {
+    return input;
+  }
+  return projectToColumns(node->outputColumns(), std::move(input));
+}
 
 velox::core::PlanNodePtr Emitter::projectToColumns(
     const ColumnVector& keepColumns,
@@ -1481,7 +1500,8 @@ velox::core::PlanNodePtr Emitter::emitValues(const Values& values) {
 }
 
 velox::core::PlanNodePtr Emitter::emitWindow(const Window& window) {
-  velox::core::PlanNodePtr input = emit(window.input());
+  velox::core::PlanNodePtr input =
+      trimToNodeColumns(window.input(), emit(window.input()));
 
   auto partitionKeys =
       toFieldAccessList(window.partitionKeys(), "Window partition key");
@@ -1546,7 +1566,8 @@ velox::core::PlanNodePtr Emitter::emitWindow(const Window& window) {
 }
 
 velox::core::PlanNodePtr Emitter::emitRowNumber(const RowNumber& node) {
-  velox::core::PlanNodePtr input = emit(node.input());
+  velox::core::PlanNodePtr input =
+      trimToNodeColumns(node.input(), emit(node.input()));
   auto partitionKeys =
       toFieldAccessList(node.partitionKeys(), "RowNumber partition key");
   // At numDrivers > 1 each partition must be complete in one driver:
@@ -1567,7 +1588,8 @@ velox::core::PlanNodePtr Emitter::emitRowNumber(const RowNumber& node) {
 }
 
 velox::core::PlanNodePtr Emitter::emitTopNRowNumber(const TopNRowNumber& node) {
-  velox::core::PlanNodePtr input = emit(node.input());
+  velox::core::PlanNodePtr input =
+      trimToNodeColumns(node.input(), emit(node.input()));
   auto partitionKeys =
       toFieldAccessList(node.partitionKeys(), "TopNRowNumber partition key");
   // At numDrivers > 1 each partition must be complete in one driver:

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -55,7 +55,8 @@ FrontendResult translateAndPushdown(
       plan, schema, evaluator, builder, session, constantPlanRunner);
   NodeCP decorrelated = DecorrelatePass::run(translated.root, builder);
   NodeCP limited = LimitAndOrderPass::run(decorrelated, builder);
-  NodeCP pushed = PushdownAndPrunePass::run(limited, builder, evaluator);
+  NodeCP pushed = PushdownAndPrunePass::run(
+      limited, translated.outputColumns, builder, evaluator);
   return {std::move(translated), pushed};
 }
 

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -1128,6 +1128,38 @@ class Pushdown : public NodeRewriter<PushdownContext> {
         {newInput, node->orderKeys(), node->orderTypes()});
   }
 
+  // Returns true when 'node' already emits rows in the order 'keys' / 'types'
+  // ask for. A Window over a single partition sorts its output, and a
+  // pass-through Project above it keeps that order. Pass a rewritten node: a
+  // Window specialized into a ranking node does not order its output.
+  bool emitsInOrder(
+      NodeCP node,
+      const ExprVector& keys,
+      const OrderTypeVector& types) {
+    ExprVector mapped(keys);
+    while (node->is(NodeType::kProject)) {
+      const auto* project = node->as<Project>();
+      const auto& outputs = project->outputColumns();
+      for (ExprCP& key : mapped) {
+        const auto it = std::find(outputs.begin(), outputs.end(), key);
+        if (it == outputs.end()) {
+          return false;
+        }
+        key = project->exprs()[it - outputs.begin()];
+      }
+      node = project->input();
+    }
+
+    if (!node->is(NodeType::kWindow)) {
+      return false;
+    }
+    const auto* window = node->as<Window>();
+    return window->partitionKeys().empty() &&
+        window->orderKeys().size() >= mapped.size() &&
+        std::equal(mapped.begin(), mapped.end(), window->orderKeys().begin()) &&
+        std::equal(types.begin(), types.end(), window->orderTypes().begin());
+  }
+
   // TopN: a filter barrier like Limit (its bound depends on the row set), and
   // its order keys must survive in the child like Sort.
   NodeCP rewriteTopN(const TopN* node, PushdownContext& context) override {
@@ -1148,6 +1180,12 @@ class Pushdown : public NodeRewriter<PushdownContext> {
       }
 
       NodeCP newInput = rewrite(node->input(), empty);
+
+      // A Window over a single partition emits its rows in order-key order, so
+      // a TopN asking for that same order only has to count rows.
+      if (emitsInOrder(newInput, node->orderKeys(), node->orderTypes())) {
+        return builder().make<Limit>({newInput, node->offset(), node->count()});
+      }
 
       // The cap only reduces the rows the TopN sees; the TopN itself stays,
       // because a ranking node emits each partition greatest-rank first rather
@@ -1393,9 +1431,6 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     childContext.required = context.required;
     childContext.required.unionColumns(node->partitionKeys());
     childContext.required.unionColumns(node->orderKeys());
-    // Every ranking node emits all of its input's columns, so the child must
-    // keep producing them.
-    childContext.required.unionObjects(node->input()->outputColumns());
     childContext.required.unionColumns(blocked);
     childContext.nonNullColumns = context.nonNullColumns;
 
@@ -1418,7 +1453,8 @@ class Pushdown : public NodeRewriter<PushdownContext> {
       ExprVector blocked) {
     childContext.required.unionColumns(childContext.pending);
     childContext.requiredAbove = childContext.required;
-    NodeCP newInput = rewrite(node->input(), childContext);
+    NodeCP newInput = dropColumnsForWindow(
+        rewrite(node->input(), childContext), childContext.required);
 
     // Emit the rank column only when a consumer above still needs it.
     const ColumnCP rankColumn =
@@ -1458,6 +1494,27 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     return maybeWrapFilter(ranking, std::move(blocked));
   }
 
+  // Velox's window operators pass every input column through, so a column
+  // that only an operator below the window reads would ride through it. Adds
+  // a Project that keeps just 'required' when the input has more.
+  NodeCP dropColumnsForWindow(NodeCP input, const PlanObjectSet& required) {
+    ExprVector exprs;
+    ColumnVector columns;
+    for (ColumnCP column : input->outputColumns()) {
+      if (required.contains(column)) {
+        exprs.push_back(column);
+        columns.push_back(column);
+      }
+    }
+
+    if (columns.size() == input->outputColumns().size()) {
+      return input;
+    }
+
+    return builder().make<Project>(
+        {input, std::move(exprs), std::move(columns)});
+  }
+
   // Keeps the Window, dropping the functions no consumer reads.
   NodeCP pruneWindowFunctions(
       const Window* node,
@@ -1477,10 +1534,17 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     }
     for (const auto& function : survivingFunctions) {
       childContext.required.unionColumns(function.call);
+      if (function.frame.startValue != nullptr) {
+        childContext.required.unionColumns(function.frame.startValue);
+      }
+      if (function.frame.endValue != nullptr) {
+        childContext.required.unionColumns(function.frame.endValue);
+      }
     }
     childContext.required.unionColumns(childContext.pending);
     childContext.requiredAbove = childContext.required;
-    NodeCP newInput = rewrite(node->input(), childContext);
+    NodeCP newInput = dropColumnsForWindow(
+        rewrite(node->input(), childContext), childContext.required);
 
     // With every function pruned the node computes nothing and emits its
     // input's columns.
@@ -1649,6 +1713,19 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     return builder().makeEmptyValues(node->outputColumns());
   }
 
+  // Substituting a cross-side equality by the join's own equi-pair maps both
+  // of its arguments to the same expression, e.g. `t.x = u.x` becomes
+  // `t.x = t.x`. That says only that the key is not null, which an equi-join
+  // already guarantees, so it adds nothing.
+  bool isSelfEquality(ExprCP expr) {
+    if (!expr->is(PlanType::kCallExpr)) {
+      return false;
+    }
+    const auto* call = expr->as<Call>();
+    return call->name() == builder().functionNames().equality &&
+        call->args().size() == 2 && call->args()[0] == call->args()[1];
+  }
+
   // Derives new pending conjuncts via each cross-side
   // `Column == Column` equi-pair: a conjunct that references one side
   // gets duplicated with that side's column substituted for the other
@@ -1673,13 +1750,13 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     for (ExprCP conjunct : pending) {
       ExprCP leftSubstituted =
           exprs_.substitute(conjunct, rightKeys, leftAsExprs);
-      if (leftSubstituted != conjunct &&
+      if (leftSubstituted != conjunct && !isSelfEquality(leftSubstituted) &&
           simplifier_.simplifyFilter(leftSubstituted, derived)) {
         return true;
       }
       ExprCP rightSubstituted =
           exprs_.substitute(conjunct, leftKeys, rightAsExprs);
-      if (rightSubstituted != conjunct &&
+      if (rightSubstituted != conjunct && !isSelfEquality(rightSubstituted) &&
           simplifier_.simplifyFilter(rightSubstituted, derived)) {
         return true;
       }
@@ -1696,11 +1773,12 @@ class Pushdown : public NodeRewriter<PushdownContext> {
 
 NodeCP PushdownAndPrunePass::run(
     NodeCP root,
+    const ColumnVector& outputColumns,
     Builder& builder,
     velox::core::ExpressionEvaluator& evaluator) {
   Pushdown pass{builder, evaluator};
   PushdownContext context;
-  context.required = PlanObjectSet::fromObjects(root->outputColumns());
+  context.required = PlanObjectSet::fromObjects(outputColumns);
   context.requiredAbove = context.required;
   return pass.rewrite(root, context);
 }

--- a/axiom/optimizer/v2/PushdownAndPrunePass.h
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.h
@@ -67,8 +67,12 @@ class PushdownAndPrunePass {
   /// Returns `root` rewritten as described in the class doc. `evaluator` backs
   /// the expression simplifier used to fold conjuncts after substitution (and
   /// to detect ones that reduce to constant `false`).
+  /// @param outputColumns The user-visible output layout. `root` may produce
+  /// more columns than this -- Emit trims them -- and pruning uses this, not
+  /// `root`'s schema, to decide what the query actually needs.
   static NodeCP run(
       NodeCP root,
+      const ColumnVector& outputColumns,
       Builder& builder,
       velox::core::ExpressionEvaluator& evaluator);
 };

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -1184,6 +1184,26 @@ NodeCP Translator::maybeWrapInWindow(
     }
   }
 
+  // Evaluate groups sharing a partition adjacently so the physical plan
+  // shuffles once for them, longer ORDER BY first so a later group's sort is a
+  // prefix of an earlier one, and unpartitioned groups last so the gather they
+  // force happens after the partitioned groups have run distributed. Reordering
+  // is safe because the groups here come from one projection, where no window's
+  // input can be another's output -- that needs a nested query, hence a
+  // separate Window chain.
+  std::sort(
+      groups.begin(), groups.end(), [&](const auto& lhs, const auto& rhs) {
+        const Spec& lhsSpec = specs[lhs.front()];
+        const Spec& rhsSpec = specs[rhs.front()];
+        if (lhsSpec.partitionKeys.empty() != rhsSpec.partitionKeys.empty()) {
+          return !lhsSpec.partitionKeys.empty();
+        }
+        if (lhsSpec.partitionKeys != rhsSpec.partitionKeys) {
+          return lhsSpec.partitionKeys < rhsSpec.partitionKeys;
+        }
+        return lhsSpec.orderKeys.size() > rhsSpec.orderKeys.size();
+      });
+
   NodeCP current = input;
   for (const auto& group : groups) {
     const Spec& spec = specs[group.front()];

--- a/axiom/optimizer/v2/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/v2/tests/TpchPlanTest.cpp
@@ -430,7 +430,6 @@ TEST_F(TpchPlanTest, q11) {
                   .singleAggregation({}, {"sum(s) as totalSum"})
                   .project({"totalSum * 0.0001 as expr"}))
           .orderBy({"value DESC"})
-          .project()
           .build();
   AXIOM_ASSERT_PLAN(planTpch(11), matcher);
 


### PR DESCRIPTION
Summary:

Running `WindowTest` under both optimizers surfaced eleven queries where the two disagree. Five of those were v2 producing the worse plan. This fixes them and converts the suite to dual-run.

In v2:

- Nothing below a window could be pruned. The pruning pass demanded the window's whole input schema, so a column no consumer reads rode through the window. It now asks only for what the query, the window's keys, its arguments and its frame bounds need, and inserts a Project when the child cannot narrow itself.
- Pruning started from the root node's schema rather than the query's output columns. When the output projection is an identity the translator elides it, and the root is then wider than the query, so nothing was pruned. It now starts from the output columns, which is what Emit already trims to.
- A scan whose filter the connector rejects emits that filter's columns, and those rode through window operators to the root. Emit now trims them at the window, as v1 does.
- A WHERE equality that repeats a join's own equality derived `x = x` on each side and left it as a scan filter. An equi-join already rejects null keys, so the derivation is dropped.
- Window groups were evaluated in the order the functions appear in the SELECT list. They are now ordered as in v1: same partition keys adjacent so one shuffle serves both, longer ORDER BY first, and unpartitioned groups last so their gather happens after the partitioned ones.
- A query ORDER BY that a window's own ordering already satisfies produced a TopN. It becomes a Limit, but only when the child is still a Window after ranking specialization -- a `TopNRowNumber` does not order its output.

In v1, a constant frame bound was materialized into a column by the precompute projection. Literal bounds now stay inline, as they already did for window function arguments.

The remaining differences are v2 pruning columns earlier than v1 or ordering a projection differently. Those are conditional on the optimizer in the test.

Reviewed By: kKPulla

Differential Revision: D115943597
