### PR TITLE
fix(parser): Parse multi-part interval literals (#1719)

### DIFF
--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <limits>
 
 #include "axiom/common/SchemaTypeName.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
@@ -322,62 +323,235 @@ std::string toFunctionName(ArithmeticBinaryExpression::Operator op) {
   folly::assume_unreachable();
 }
 
-int32_t parseYearMonthInterval(
-    const std::string& value,
-    IntervalLiteral::IntervalField start,
-    std::optional<IntervalLiteral::IntervalField> end,
-    NodeLocation location) {
-  AXIOM_PRESTO_SEMANTIC_CHECK(
-      !end.has_value() || start == end.value(),
-      location,
-      value,
-      "Multi-part intervals are not supported yet");
+// Day-time fields in qualifier order, largest unit first.
+enum DayTimeField : int32_t {
+  kDayField = 0,
+  kHourField = 1,
+  kMinuteField = 2,
+  kSecondField = 3,
+};
 
-  if (value.empty()) {
-    return 0;
-  }
-
-  const auto n = atoi(value.c_str());
-
-  switch (start) {
-    case IntervalLiteral::IntervalField::kYear:
-      return n * 12;
-    case IntervalLiteral::IntervalField::kMonth:
-      return n;
+DayTimeField dayTimeField(IntervalLiteral::IntervalField field) {
+  switch (field) {
+    case IntervalLiteral::IntervalField::kDay:
+      return kDayField;
+    case IntervalLiteral::IntervalField::kHour:
+      return kHourField;
+    case IntervalLiteral::IntervalField::kMinute:
+      return kMinuteField;
+    case IntervalLiteral::IntervalField::kSecond:
+      return kSecondField;
     default:
       VELOX_UNREACHABLE();
   }
 }
 
+// Reads the digits at 'pos' as a non-negative number, advancing 'pos'.
+int64_t
+readNumber(const std::string& value, size_t& pos, NodeLocation location) {
+  const size_t start = pos;
+  while (pos < value.size() &&
+         std::isdigit(static_cast<unsigned char>(value[pos]))) {
+    ++pos;
+  }
+  AXIOM_PRESTO_SEMANTIC_CHECK_LT(
+      start, pos, location, value, "Interval value expects a number");
+  // Bound the digits so folly::to cannot overflow: 18 digits always fit.
+  AXIOM_PRESTO_SEMANTIC_CHECK_LE(
+      pos - start, 18UL, location, value, "Interval value is out of range");
+  return folly::to<int64_t>(value.substr(start, pos - start));
+}
+
+// Reads the fractional part of a seconds field as milliseconds, truncating
+// beyond three digits. Returns 0 when no fraction follows.
+int64_t
+readMillis(const std::string& value, size_t& pos, NodeLocation location) {
+  if (pos >= value.size() || value[pos] != '.') {
+    return 0;
+  }
+  ++pos;
+  const size_t firstDigit = pos;
+  int64_t millis = 0;
+  int32_t digits = 0;
+  while (pos < value.size() &&
+         std::isdigit(static_cast<unsigned char>(value[pos]))) {
+    if (digits < 3) {
+      millis = millis * 10 + (value[pos] - '0');
+      ++digits;
+    }
+    ++pos;
+  }
+  AXIOM_PRESTO_SEMANTIC_CHECK_LT(
+      firstDigit, pos, location, value, "Interval value expects a number");
+  while (digits < 3) {
+    millis *= 10;
+    ++digits;
+  }
+  return millis;
+}
+
+// Milliseconds one unit of 'field' contributes.
+int64_t dayTimeFieldMillis(DayTimeField field) {
+  static constexpr int64_t kMillis[] = {
+      24 * 60 * 60 * 1'000, 60 * 60 * 1'000, 60 * 1'000, 1'000};
+  return kMillis[field];
+}
+
+// Parses a day-time interval value as milliseconds. A single field is a plain
+// number; 'start TO end' spells every field in between, separated by a space
+// after the day and a colon elsewhere, as in '0 00:01:30' for DAY TO SECOND.
+// Seconds may carry a fraction.
 int64_t parseDayTimeInterval(
     const std::string& value,
     IntervalLiteral::IntervalField start,
     std::optional<IntervalLiteral::IntervalField> end,
     NodeLocation location) {
-  AXIOM_PRESTO_SEMANTIC_CHECK(
-      !end.has_value() || start == end.value(),
+  const DayTimeField first = dayTimeField(start);
+  const DayTimeField last = dayTimeField(end.value_or(start));
+  AXIOM_PRESTO_SEMANTIC_CHECK_LE(
+      static_cast<int32_t>(first),
+      static_cast<int32_t>(last),
       location,
       value,
-      "Multi-part intervals are not supported yet");
+      "Interval qualifier is out of order");
 
-  if (value.empty()) {
+  // An empty value is zero, as it has always been for a single field. A
+  // multi-field qualifier still has to spell every one of them.
+  if (value.empty() && first == last) {
     return 0;
   }
 
-  auto n = atol(value.c_str());
-
-  switch (start) {
-    case IntervalLiteral::IntervalField::kDay:
-      return n * 24 * 60 * 60;
-    case IntervalLiteral::IntervalField::kHour:
-      return n * 60 * 60;
-    case IntervalLiteral::IntervalField::kMinute:
-      return n * 60;
-    case IntervalLiteral::IntervalField::kSecond:
-      return n;
-    default:
-      VELOX_UNREACHABLE();
+  size_t pos = 0;
+  int64_t sign = 1;
+  if (value[pos] == '-' || value[pos] == '+') {
+    sign = value[pos] == '-' ? -1 : 1;
+    ++pos;
   }
+
+  int64_t millis = 0;
+  for (int32_t index = first; index <= last; ++index) {
+    const auto field = static_cast<DayTimeField>(index);
+    if (field > first) {
+      // A day is followed by a space, the smaller fields by a colon.
+      const char separator = field == kHourField ? ' ' : ':';
+      AXIOM_PRESTO_SEMANTIC_CHECK_LT(
+          pos, value.size(), location, value, "Interval value is too short");
+      AXIOM_PRESTO_SEMANTIC_CHECK_EQ(
+          value[pos],
+          separator,
+          location,
+          value,
+          "Interval value has the wrong separator");
+      ++pos;
+    }
+    const int64_t fieldValue = readNumber(value, pos, location);
+    if (field > first) {
+      // Only the leading field is unbounded: '100' HOUR is 100 hours, but
+      // '1 100:00:00' DAY TO SECOND names an hour that does not exist.
+      static constexpr int64_t kFieldLimit[] = {0, 24, 60, 60};
+      AXIOM_PRESTO_SEMANTIC_CHECK_LT(
+          fieldValue,
+          kFieldLimit[field],
+          location,
+          value,
+          "Interval field is out of range");
+    }
+    const int64_t unitMillis = dayTimeFieldMillis(field);
+    constexpr int64_t kMaxMillis = std::numeric_limits<int64_t>::max();
+    AXIOM_PRESTO_SEMANTIC_CHECK_LE(
+        fieldValue,
+        kMaxMillis / unitMillis,
+        location,
+        value,
+        "Interval value is out of range");
+    const int64_t fieldMillis = fieldValue * unitMillis;
+    AXIOM_PRESTO_SEMANTIC_CHECK_LE(
+        fieldMillis,
+        kMaxMillis - millis,
+        location,
+        value,
+        "Interval value is out of range");
+    millis += fieldMillis;
+  }
+
+  if (last == kSecondField) {
+    millis += readMillis(value, pos, location);
+  }
+
+  AXIOM_PRESTO_SEMANTIC_CHECK_EQ(
+      pos,
+      value.size(),
+      location,
+      value,
+      "Interval value has trailing characters");
+  return sign * millis;
+}
+
+// Parses a year-month interval value as months. A single field is a plain
+// number; YEAR TO MONTH spells both, as in '1-6'.
+int32_t parseYearMonthInterval(
+    const std::string& value,
+    IntervalLiteral::IntervalField start,
+    std::optional<IntervalLiteral::IntervalField> end,
+    NodeLocation location) {
+  const bool yearToMonth = end.has_value() && start != end.value();
+  AXIOM_PRESTO_SEMANTIC_CHECK(
+      !yearToMonth || start == IntervalLiteral::IntervalField::kYear,
+      location,
+      value,
+      "Interval qualifier is out of order");
+
+  // An empty value is zero, as it has always been for a single field. YEAR TO
+  // MONTH still has to spell both.
+  if (value.empty() && !yearToMonth) {
+    return 0;
+  }
+
+  size_t pos = 0;
+  int32_t sign = 1;
+  if (value[pos] == '-' || value[pos] == '+') {
+    sign = value[pos] == '-' ? -1 : 1;
+    ++pos;
+  }
+
+  constexpr int64_t kMaxMonths = std::numeric_limits<int32_t>::max();
+  int64_t months = readNumber(value, pos, location);
+  if (start == IntervalLiteral::IntervalField::kYear) {
+    AXIOM_PRESTO_SEMANTIC_CHECK_LE(
+        months,
+        kMaxMonths / 12,
+        location,
+        value,
+        "Interval value is out of range");
+    months *= 12;
+  }
+
+  if (yearToMonth) {
+    AXIOM_PRESTO_SEMANTIC_CHECK_LT(
+        pos, value.size(), location, value, "Interval value is too short");
+    AXIOM_PRESTO_SEMANTIC_CHECK_EQ(
+        value[pos],
+        '-',
+        location,
+        value,
+        "Interval value has the wrong separator");
+    ++pos;
+    const int64_t monthsOfYear = readNumber(value, pos, location);
+    AXIOM_PRESTO_SEMANTIC_CHECK_LT(
+        monthsOfYear, 12, location, value, "Interval field is out of range");
+    months += monthsOfYear;
+  }
+
+  AXIOM_PRESTO_SEMANTIC_CHECK_LE(
+      months, kMaxMonths, location, value, "Interval value is out of range");
+
+  AXIOM_PRESTO_SEMANTIC_CHECK_EQ(
+      pos,
+      value.size(),
+      location,
+      value,
+      "Interval value has trailing characters");
+  return static_cast<int32_t>(sign * months);
 }
 
 lp::ExprApi parseDecimal(std::string_view value, NodeLocation location) {
@@ -1181,12 +1355,12 @@ lp::ExprApi ExpressionPlanner::toExpr(
             interval->location());
         return lp::Lit(multiplier * months, INTERVAL_YEAR_MONTH());
       } else {
-        const auto seconds = parseDayTimeInterval(
+        const auto millis = parseDayTimeInterval(
             interval->value(),
             interval->startField(),
             interval->endField(),
             interval->location());
-        return lp::Lit(multiplier * seconds * 1'000, INTERVAL_DAY_TIME());
+        return lp::Lit(multiplier * millis, INTERVAL_DAY_TIME());
       }
     }
 

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -141,7 +141,7 @@ TEST_F(ExpressionParserTest, types) {
 }
 
 TEST_F(ExpressionParserTest, intervalDayTime) {
-  auto test = [&](std::string_view sql, int64_t expectedSeconds) {
+  auto test = [&](std::string_view sql, int64_t expectedMillis) {
     SCOPED_TRACE(sql);
     auto expr = parseExpr(sql);
 
@@ -150,21 +150,92 @@ TEST_F(ExpressionParserTest, intervalDayTime) {
 
     auto value = expr->as<lp::ConstantExpr>()->value();
     ASSERT_FALSE(value->isNull());
-    ASSERT_EQ(value->value<int64_t>(), expectedSeconds * 1'000);
+    ASSERT_EQ(value->value<int64_t>(), expectedMillis);
   };
 
-  test("INTERVAL '2' DAY", 2 * 24 * 60 * 60);
-  test("INTERVAL '3' HOUR", 3 * 60 * 60);
-  test("INTERVAL '4' MINUTE", 4 * 60);
-  test("INTERVAL '5' SECOND", 5);
+  constexpr int64_t kSecond = 1'000;
+  constexpr int64_t kMinute = 60 * kSecond;
+  constexpr int64_t kHour = 60 * kMinute;
+  constexpr int64_t kDay = 24 * kHour;
+
+  test("INTERVAL '2' DAY", 2 * kDay);
+  test("INTERVAL '3' HOUR", 3 * kHour);
+  test("INTERVAL '4' MINUTE", 4 * kMinute);
+  test("INTERVAL '5' SECOND", 5 * kSecond);
 
   test("INTERVAL '' DAY", 0);
   test("INTERVAL '0' HOUR", 0);
 
-  test("INTERVAL '-2' DAY", -2 * 24 * 60 * 60);
-  test("INTERVAL '-3' HOUR", -3 * 60 * 60);
-  test("INTERVAL '-4' MINUTE", -4 * 60);
-  test("INTERVAL '-5' SECOND", -5);
+  test("INTERVAL '-2' DAY", -2 * kDay);
+  test("INTERVAL '-3' HOUR", -3 * kHour);
+  test("INTERVAL '-4' MINUTE", -4 * kMinute);
+  test("INTERVAL '-5' SECOND", -5 * kSecond);
+
+  // A fraction of a second keeps its milliseconds.
+  test("INTERVAL '1.5' SECOND", kSecond + 500);
+  test("INTERVAL '0.001' SECOND", 1);
+  test("INTERVAL '0.00049' SECOND", 0);
+
+  // Every field between the two in the qualifier is spelled in the value.
+  test("INTERVAL '0 00:01:30' DAY TO SECOND", 90 * kSecond);
+  test(
+      "INTERVAL '1 02:03:04.5' DAY TO SECOND",
+      kDay + 2 * kHour + 3 * kMinute + 4 * kSecond + 500);
+  test("INTERVAL '1 02:03' DAY TO MINUTE", kDay + 2 * kHour + 3 * kMinute);
+  test("INTERVAL '1 02' DAY TO HOUR", kDay + 2 * kHour);
+  test(
+      "INTERVAL '02:03:04' HOUR TO SECOND",
+      2 * kHour + 3 * kMinute + 4 * kSecond);
+  test("INTERVAL '02:03' HOUR TO MINUTE", 2 * kHour + 3 * kMinute);
+  test("INTERVAL '03:04' MINUTE TO SECOND", 3 * kMinute + 4 * kSecond);
+  test(
+      "INTERVAL '-1 02:03:04' DAY TO SECOND",
+      -(kDay + 2 * kHour + 3 * kMinute + 4 * kSecond));
+
+  // The sign in the qualifier applies to the whole value.
+  test("INTERVAL -'1 00:00:01' DAY TO SECOND", -(kDay + kSecond));
+
+  // A value that does not spell every field of its qualifier, or spells more.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '1 02' DAY TO SECOND"),
+      "Interval value is too short");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '1:02:03' DAY TO SECOND"),
+      "Interval value has the wrong separator");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '1 02:03:04' SECOND"),
+      "Interval value has trailing characters");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL 'abc' SECOND"), "Interval value expects a number");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '1.' SECOND"), "Interval value expects a number");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '1' SECOND TO DAY"),
+      "Interval qualifier is out of order");
+
+  // Only the leading field is unbounded.
+  test("INTERVAL '100' HOUR", 100 * kHour);
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '1 24:00:00' DAY TO SECOND"),
+      "Interval field is out of range");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '1 00:60:00' DAY TO SECOND"),
+      "Interval field is out of range");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '1 00:00:60' DAY TO SECOND"),
+      "Interval field is out of range");
+
+  // An empty value is zero only when the qualifier names one field.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '' DAY TO SECOND"),
+      "Interval value expects a number");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '99999999999999999999' SECOND"),
+      "Interval value is out of range");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '999999999999999999' DAY"),
+      "Interval value is out of range");
 }
 
 TEST_F(ExpressionParserTest, decimal) {
@@ -239,6 +310,28 @@ TEST_F(ExpressionParserTest, intervalYearMonth) {
 
   test("INTERVAL '2' YEAR", 2 * 12);
   test("INTERVAL '3' MONTH", 3);
+
+  // YEAR TO MONTH spells both fields.
+  test("INTERVAL '1-6' YEAR TO MONTH", 12 + 6);
+  test("INTERVAL '0-11' YEAR TO MONTH", 11);
+  test("INTERVAL '-1-6' YEAR TO MONTH", -(12 + 6));
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '1-6' MONTH TO YEAR"),
+      "Interval qualifier is out of order");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '1' YEAR TO MONTH"), "Interval value is too short");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '1-6-9' YEAR TO MONTH"),
+      "Interval value has trailing characters");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '1-12' YEAR TO MONTH"),
+      "Interval field is out of range");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '' YEAR TO MONTH"),
+      "Interval value expects a number");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("INTERVAL '999999999' YEAR"), "Interval value is out of range");
 
   test("INTERVAL '' YEAR", 0);
   test("INTERVAL '0' MONTH", 0);


### PR DESCRIPTION
Summary:

An interval literal that names two fields failed to parse:

    SELECT * FROM t WHERE time_diff < INTERVAL '0 00:01:30' DAY TO SECOND

reported `Multi-part intervals are not supported yet`, which is how a production query comparing a duration against 90 seconds failed to plan. Only a single-field literal, `INTERVAL '90' SECOND`, was accepted.

A day-time value now spells every field from the qualifier's first to its last, separated by a space after the day and a colon elsewhere, and its seconds may carry a fraction. A year-month value spells years and months around a dash. The single-field forms are unchanged.

`parseDayTimeInterval` returns milliseconds rather than whole seconds, so `INTERVAL '1.5' SECOND` keeps its half second instead of truncating to one. The value is also read one character at a time rather than through `atol`, so a value that does not match its qualifier fails instead of silently becoming zero: `INTERVAL 'abc' SECOND` was 0.

Fractional digits past the third truncate, and a leading `+` is accepted.

Reviewed By: amitkdutta

Differential Revision: D115976054
