### PR TITLE
feat(parser): Plan TIME literals (#1720)

### DIFF
--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -32,9 +32,11 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/functions/prestosql/types/BigintEnumType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/functions/prestosql/types/VarcharEnumType.h"
 #include "velox/parse/Expressions.h"
+#include "velox/type/Time.h"
 
 namespace axiom::sql::presto {
 
@@ -1374,6 +1376,31 @@ lp::ExprApi ExpressionPlanner::toExpr(
         return lp::Call("json_parse", lp::Lit(literal->value()));
       }
       return lp::Cast(type, lp::Lit(literal->value()));
+    }
+
+    case NodeType::kTimeLiteral: {
+      auto literal = node->as<TimeLiteral>();
+      const auto& value = literal->value();
+
+      // A fixed offset makes the literal TIME WITH TIME ZONE. A named zone,
+      // as in TIME '01:02:03 UTC', is not supported, matching Presto C++.
+      if (!util::fromTimeWithTimezoneString(value.data(), value.size())
+               .hasError()) {
+        return lp::Cast(TIME_WITH_TIME_ZONE(), lp::Lit(value));
+      }
+
+      // Without an offset the literal is a plain time. Parsing it here reports
+      // a malformed literal with its location.
+      const auto time = util::fromTimeString(value.data(), value.size());
+
+      AXIOM_PRESTO_SEMANTIC_CHECK(
+          !time.hasError(),
+          literal->location(),
+          value,
+          "Not a valid time literal: {}",
+          time.error().message());
+
+      return lp::Cast(TIME(), lp::Lit(value));
     }
 
     case NodeType::kTimestampLiteral: {

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -23,6 +23,7 @@
 #include "velox/functions/prestosql/types/QDigestType.h"
 #include "velox/functions/prestosql/types/TDigestRegistration.h"
 #include "velox/functions/prestosql/types/TDigestType.h"
+#include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/parse/ExpressionsParser.h"
 
@@ -580,6 +581,45 @@ TEST_F(ExpressionParserTest, timestampLiteral) {
 
   AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseExpr("TIMESTAMP 'foo'"), "Not a valid timestamp literal");
+}
+
+TEST_F(ExpressionParserTest, timeLiteral) {
+  auto test = [&](std::string_view sql) {
+    SCOPED_TRACE(sql);
+    VELOX_ASSERT_EQ_TYPES(parseExpr(sql)->type(), TIME());
+  };
+
+  test("TIME '00:00:00'");
+  test("TIME '23:59:59'");
+  test("TIME '01:02:03.456'");
+
+  // A fixed offset makes it TIME WITH TIME ZONE, written with or without a
+  // space. A named zone is not supported, as in Presto C++.
+  VELOX_ASSERT_EQ_TYPES(
+      parseExpr("TIME '01:02:03+00:00'")->type(), TIME_WITH_TIME_ZONE());
+  VELOX_ASSERT_EQ_TYPES(
+      parseExpr("TIME '01:02:03-07:00'")->type(), TIME_WITH_TIME_ZONE());
+  VELOX_ASSERT_EQ_TYPES(
+      parseExpr("TIME '01:02:03 +05:30'")->type(), TIME_WITH_TIME_ZONE());
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("TIME '01:02:03 UTC'"),
+      "Not a valid time literal: Invalid time format: unexpected trailing "
+      "characters");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("TIME 'foo'"),
+      "Not a valid time literal: Invalid time format: failed to parse hour");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("TIME '24:00:00'"),
+      "Not a valid time literal: Invalid hour value: 24");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("TIME '01:02:60'"),
+      "Not a valid time literal: Invalid second value: 60");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("TIME '01:02:03+99:00'"),
+      "Not a valid time literal: Invalid time format: unexpected trailing "
+      "characters");
 }
 
 // JSON literals (json '...') should be translated as json_parse('...'),


### PR DESCRIPTION
Summary:

A query using a TIME literal failed to plan:

    SELECT CAST(TIME '00:00:00' + SLAtime * INTERVAL '1' SECOND AS VARCHAR)

reported `Unsupported expression type: TimeLiteral`. The grammar produced the literal and nothing lowered it, which is how a production query that formats a duration as a clock time failed to plan.

A literal now lowers to a cast of its text, as the timestamp literal beside it does: `TIME '01:02:03'` to TIME, and `TIME '01:02:03+05:30'` to TIME WITH TIME ZONE. Reading the value in the planner reports a malformed literal with its location rather than leaving it to fail at evaluation, and the message names what is wrong with it: `TIME '24:00:00'` reports an invalid hour.

A named zone, as in `TIME '01:02:03 UTC'`, is rejected. Presto C++ removed IANA zone names from TIME and TIME WITH TIME ZONE to follow the SQL standard, and Velox encodes a fixed offset with no room for a zone.

Reviewed By: amitkdutta

Differential Revision: D115981938


