### PR TITLE
fix(parser): Match qualified ORDER BY keys of DISTINCT (#1721)

### DIFF
--- a/axiom/optimizer/tests/sql/sort.sql
+++ b/axiom/optimizer/tests/sql/sort.sql
@@ -36,3 +36,19 @@ SELECT y.v AS v
 FROM (VALUES (1, 10), (2, 5)) x(k, v)
 JOIN (VALUES (1, 200), (2, 300)) y(k, v) ON x.k = y.k
 ORDER BY x.v DESC
+----
+-- SELECT DISTINCT ordered by a qualified key.
+-- ordered
+SELECT DISTINCT t.a FROM t ORDER BY t.a DESC
+----
+-- SELECT DISTINCT ordered by a qualified key naming one side of a join, where
+-- both sides contribute a column of that name.
+-- ordered
+SELECT DISTINCT x.v AS xv, y.v AS yv
+FROM (VALUES (1, 10), (2, 5), (1, 10)) x(k, v)
+JOIN (VALUES (1, 200), (2, 300)) y(k, v) ON x.k = y.k
+ORDER BY y.v DESC
+----
+-- SELECT DISTINCT with GROUP BY, ordered by a qualified key.
+-- ordered
+SELECT DISTINCT t.a, count(1) FROM t GROUP BY t.a ORDER BY t.a DESC

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -32,9 +32,11 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/functions/prestosql/types/BigintEnumType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/functions/prestosql/types/VarcharEnumType.h"
 #include "velox/parse/Expressions.h"
+#include "velox/type/Time.h"
 
 namespace axiom::sql::presto {
 
@@ -1374,6 +1376,31 @@ lp::ExprApi ExpressionPlanner::toExpr(
         return lp::Call("json_parse", lp::Lit(literal->value()));
       }
       return lp::Cast(type, lp::Lit(literal->value()));
+    }
+
+    case NodeType::kTimeLiteral: {
+      auto literal = node->as<TimeLiteral>();
+      const auto& value = literal->value();
+
+      // A fixed offset makes the literal TIME WITH TIME ZONE. A named zone,
+      // as in TIME '01:02:03 UTC', is not supported, matching Presto C++.
+      if (!util::fromTimeWithTimezoneString(value.data(), value.size())
+               .hasError()) {
+        return lp::Cast(TIME_WITH_TIME_ZONE(), lp::Lit(value));
+      }
+
+      // Without an offset the literal is a plain time. Parsing it here reports
+      // a malformed literal with its location.
+      const auto time = util::fromTimeString(value.data(), value.size());
+
+      AXIOM_PRESTO_SEMANTIC_CHECK(
+          !time.hasError(),
+          literal->location(),
+          value,
+          "Not a valid time literal: {}",
+          time.error().message());
+
+      return lp::Cast(TIME(), lp::Lit(value));
     }
 
     case NodeType::kTimestampLiteral: {

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1318,30 +1318,41 @@ class RelationPlanner : public AstVisitor {
       addOrderBy(orderBy);
       return;
     }
+
     // Match ORDER BY against the SELECT list before extractNestedWindows
     // rewrites nested windows to column references; otherwise a sort key that
     // repeats a SELECT window (e.g. `x / sum(x) OVER ()`) would not match its
     // SELECT item. The matched ordinals index the projected output
     // positionally.
     auto selectExprs = projections.value();
-    extractNestedWindows(projections.value());
-    builder_->project(projections.value());
-    addDistinctAndOrderByOnProjection(selectExprs, orderBy);
-  }
 
-  // Adds DISTINCT and (optional) ORDER BY assuming the SELECT list has
-  // already been projected. 'projectedExprs' are the SELECT-list expressions
-  // currently produced by the builder. Validates that every ORDER BY key
-  // matches a SELECT-list expression (SELECT DISTINCT semantics).
-  void addDistinctAndOrderByOnProjection(
-      const std::vector<lp::ExprApi>& projectedExprs,
-      const OrderByPtr& orderBy) {
-    if (orderBy == nullptr) {
-      builder_->distinct();
-      return;
+    std::optional<SortKeyExpansion> sortKeys;
+    if (orderBy != nullptr) {
+      sortKeys = buildSortKeyExprs(orderBy, selectExprs);
     }
 
-    auto expansion = buildSortKeyExprs(orderBy, projectedExprs);
+    extractNestedWindows(projections.value());
+    builder_->project(projections.value());
+
+    if (sortKeys.has_value()) {
+      addDistinctAndSortOnProjection(
+          selectExprs, orderBy, std::move(sortKeys.value()));
+    } else {
+      builder_->distinct();
+    }
+  }
+
+  // Adds DISTINCT and ORDER BY assuming the SELECT list has already been
+  // projected. 'projectedExprs' are the SELECT-list expressions currently
+  // produced by the builder and 'expansion' the sort keys built from them.
+  // Sort keys must be built before the projection: a qualified key like `t.a`
+  // names a column of the relation the SELECT list reads from, which the
+  // projection replaces. Validates that every ORDER BY key matches a
+  // SELECT-list expression (SELECT DISTINCT semantics).
+  void addDistinctAndSortOnProjection(
+      const std::vector<lp::ExprApi>& projectedExprs,
+      const OrderByPtr& orderBy,
+      SortKeyExpansion expansion) {
     auto ordinals = SortProjection::resolveSortKeys(
         expansion.sortKeyExprs,
         expansion.preResolved,
@@ -1597,6 +1608,14 @@ class RelationPlanner : public AstVisitor {
       auto selectExprs =
           expandSelectExprs(selectItems, {.allowGrouping = true});
 
+      // Sort keys of a DISTINCT are built here, before GroupByPlanner
+      // projects and aggregates: a qualified key like `t.a` names a column of
+      // the relation the SELECT list reads from.
+      std::optional<SortKeyExpansion> sortKeys;
+      if (distinct && orderBy != nullptr) {
+        sortKeys = buildSortKeyExprs(orderBy, selectExprs);
+      }
+
       // When DISTINCT is also present, skip ORDER BY in the GROUP BY
       // planner so the Sort lands ABOVE the DISTINCT aggregate.
       const OrderByPtr noOrderBy;
@@ -1608,7 +1627,12 @@ class RelationPlanner : public AstVisitor {
           distinct ? noOrderBy : orderBy);
 
       if (distinct) {
-        addDistinctAndOrderByOnProjection(selectExprs, orderBy);
+        if (sortKeys.has_value()) {
+          addDistinctAndSortOnProjection(
+              selectExprs, orderBy, std::move(sortKeys.value()));
+        } else {
+          builder_->distinct();
+        }
       }
     } else {
       if (GroupByPlanner{builder_, exprPlanner_}.tryPlanGlobalAgg(

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -23,6 +23,7 @@
 #include "velox/functions/prestosql/types/QDigestType.h"
 #include "velox/functions/prestosql/types/TDigestRegistration.h"
 #include "velox/functions/prestosql/types/TDigestType.h"
+#include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/parse/ExpressionsParser.h"
 
@@ -580,6 +581,45 @@ TEST_F(ExpressionParserTest, timestampLiteral) {
 
   AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseExpr("TIMESTAMP 'foo'"), "Not a valid timestamp literal");
+}
+
+TEST_F(ExpressionParserTest, timeLiteral) {
+  auto test = [&](std::string_view sql) {
+    SCOPED_TRACE(sql);
+    VELOX_ASSERT_EQ_TYPES(parseExpr(sql)->type(), TIME());
+  };
+
+  test("TIME '00:00:00'");
+  test("TIME '23:59:59'");
+  test("TIME '01:02:03.456'");
+
+  // A fixed offset makes it TIME WITH TIME ZONE, written with or without a
+  // space. A named zone is not supported, as in Presto C++.
+  VELOX_ASSERT_EQ_TYPES(
+      parseExpr("TIME '01:02:03+00:00'")->type(), TIME_WITH_TIME_ZONE());
+  VELOX_ASSERT_EQ_TYPES(
+      parseExpr("TIME '01:02:03-07:00'")->type(), TIME_WITH_TIME_ZONE());
+  VELOX_ASSERT_EQ_TYPES(
+      parseExpr("TIME '01:02:03 +05:30'")->type(), TIME_WITH_TIME_ZONE());
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("TIME '01:02:03 UTC'"),
+      "Not a valid time literal: Invalid time format: unexpected trailing "
+      "characters");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("TIME 'foo'"),
+      "Not a valid time literal: Invalid time format: failed to parse hour");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("TIME '24:00:00'"),
+      "Not a valid time literal: Invalid hour value: 24");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("TIME '01:02:60'"),
+      "Not a valid time literal: Invalid second value: 60");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("TIME '01:02:03+99:00'"),
+      "Not a valid time literal: Invalid time format: unexpected trailing "
+      "characters");
 }
 
 // JSON literals (json '...') should be translated as json_parse('...'),

--- a/axiom/sql/presto/tests/SortParserTest.cpp
+++ b/axiom/sql/presto/tests/SortParserTest.cpp
@@ -310,6 +310,22 @@ TEST_F(SortParserTest, qualifiedSortKeyWithDuplicateOutputNames) {
           .output({"k", "v", "k", "v"}));
 }
 
+// Under SELECT DISTINCT a qualified sort key picks the side of the join it
+// names, even though both sides contribute an output column of that name.
+TEST_F(SortParserTest, distinctQualifiedSortKeyOnJoin) {
+  connector_->addTable("t", ROW({"k", "v"}, INTEGER()));
+
+  testSelect(
+      "SELECT DISTINCT x.v AS xv, y.v AS yv FROM t x JOIN t y ON x.k = y.k "
+      "ORDER BY y.v DESC",
+      matchScan()
+          .join(matchScan().build(), {"left_k", "left_v", "right_k", "right_v"})
+          .project({"left_v as xv", "right_v as yv"})
+          .aggregate({"xv", "yv"}, {})
+          .sort({"yv desc"})
+          .output({"xv", "yv"}));
+}
+
 TEST_F(SortParserTest, joinedTable) {
   testSelect(
       "SELECT n_name "
@@ -332,6 +348,16 @@ TEST_F(SortParserTest, distinct) {
 
   testSelect("SELECT DISTINCT a FROM t ORDER BY a", matcher);
   testSelect("SELECT DISTINCT a FROM t ORDER BY 1", matcher);
+
+  // A qualified sort key names a column of the relation the SELECT list reads
+  // from, and matches the SELECT item whichever way that item is written.
+  testSelect("SELECT DISTINCT t.a FROM t ORDER BY t.a", matcher);
+  testSelect("SELECT DISTINCT a FROM t ORDER BY t.a", matcher);
+  testSelect("SELECT DISTINCT t.a FROM t ORDER BY a", matcher);
+  testSelect(
+      "SELECT DISTINCT t.a AS z FROM t ORDER BY t.a",
+      matchScan().project({"a"}).aggregate({"z"}, {}).sort({"z"}).output(
+          {"z"}));
 
   AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql(
@@ -381,6 +407,9 @@ TEST_F(SortParserTest, distinctWithGroupBy) {
         "SELECT DISTINCT a, COUNT(1) FROM t GROUP BY a ORDER BY a", matcher);
     testSelect(
         "SELECT DISTINCT a, COUNT(1) FROM t GROUP BY a ORDER BY 1", matcher);
+    testSelect(
+        "SELECT DISTINCT t.a, COUNT(1) FROM t GROUP BY t.a ORDER BY t.a",
+        matcher);
   }
 
   // ORDER BY a column that is in GROUP BY but not in the SELECT list — must


### PR DESCRIPTION
Summary:

A SELECT DISTINCT ordered by a qualified column failed to plan:

    SELECT DISTINCT t.a, t.b FROM t ORDER BY t.a

reported `For SELECT DISTINCT, ORDER BY expressions must be output expressions`, though both sort keys are in the SELECT list. Presto runs the query. Writing the key as `a` worked, so any query naming its sort key by table hit this, with or without GROUP BY.

A sort key is matched to a SELECT item by comparing expressions, and the two were built in different scopes. The SELECT items were converted while the relation they read from was still in scope; the sort keys only after the SELECT list had been projected, where `t` names nothing. Sort keys are now converted alongside the SELECT items, before the projection and before a GROUP BY aggregates, so `t.a` means the same column on both sides.

Differential Revision: D115985498


