### PR TITLE
fix: Correct joins with UNNEST over a constant (#1722)

### DIFF
--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -936,6 +936,55 @@ TEST_P(UnnestTest, manyUnnestsCardinalityOverflow) {
   ASSERT_NO_THROW(toSingleNodePlan(logicalPlan));
 }
 
+// A join whose other side unnests a constant array, which reads no columns of
+// the query. The unnest stays on its own side of the join.
+TEST_P(UnnestTest, joinWithConstantUnnest) {
+  const parse::ParseOptions options = {.parseIntegerAsBigint = false};
+
+  auto query =
+      "SELECT a FROM (VALUES 1, 2) AS t(a) "
+      "JOIN (SELECT s FROM UNNEST(ARRAY[1, 2]) AS u(s)) ON a = s";
+  SCOPED_TRACE(query);
+
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(logicalPlan),
+      matchValues()
+          .project({"array[1, 2] as arr"}, options)
+          .unnest({}, {"arr"}, std::nullopt)
+          .aliases({"e"})
+          .hashJoinInner(matchValues().aliases({"k"}), {.keys = {{"e = k"}}})
+          .project({"k as a"})
+          .build());
+}
+
+// A join between two constant unnests, where no table or values relation takes
+// part.
+TEST_P(UnnestTest, joinOfConstantUnnests) {
+  const parse::ParseOptions options = {.parseIntegerAsBigint = false};
+
+  auto query =
+      "SELECT e FROM (SELECT s AS e FROM UNNEST(ARRAY[1, 2]) AS u(s)) "
+      "JOIN (SELECT s AS f FROM UNNEST(ARRAY[2, 3]) AS v(s)) ON e = f";
+  SCOPED_TRACE(query);
+
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(logicalPlan),
+      matchValues()
+          .project({"array[1, 2] as arr"}, options)
+          .unnest({}, {"arr"}, std::nullopt)
+          .hashJoinInner(
+              matchValues()
+                  .project({"array[2, 3] as arr2"}, options)
+                  .unnest({}, {"arr2"}, std::nullopt)
+                  .aliases({"f"}),
+              {.keys = {{"e = f"}}})
+          .build());
+}
+
 AXIOM_INSTANTIATE_V1_V2(UnnestTest);
 
 } // namespace

--- a/axiom/optimizer/tests/sql/unnest.sql
+++ b/axiom/optimizer/tests/sql/unnest.sql
@@ -65,3 +65,13 @@ JOIN (VALUES (10), (40)) AS u(k) ON u.k = y
 ----
 -- `alias.*` on an UNNEST relation whose alias carries no column list.
 SELECT u.* FROM (VALUES (1, ARRAY[10, 20])) AS s(a, b) CROSS JOIN UNNEST(b) AS u
+----
+-- Join whose other side unnests a constant array.
+SELECT a.x, s
+FROM arrays a
+JOIN (SELECT s FROM UNNEST(ARRAY[7, 8]) AS u(s)) ON a.x = s
+----
+-- The same, with the unnest on the null-padded side of an outer join.
+SELECT a.x, s
+FROM arrays a
+LEFT JOIN (SELECT s FROM UNNEST(ARRAY[7, 8]) AS u(s)) ON a.x = s

--- a/axiom/optimizer/v2/HypergraphBuilder.cpp
+++ b/axiom/optimizer/v2/HypergraphBuilder.cpp
@@ -82,7 +82,12 @@ RelationSet populateJoinLeaves(
     return RelationSet::singleton(it->second);
   }
   if (node->is(NodeType::kUnnest)) {
-    return populateJoinLeaves(node->as<Unnest>()->input(), leafIds, leaves);
+    // The cluster does not contain the input of an Unnest of a constant.
+    NodeCP input = node->onlyInput();
+    if (input->outputColumns().empty()) {
+      return RelationSet{};
+    }
+    return populateJoinLeaves(input, leafIds, leaves);
   }
   const auto* join = node->as<Join>();
   const RelationSet leftLeaves =
@@ -139,13 +144,13 @@ RelationSet tesExpansion(
     return RelationSet{};
   }
   if (node->is(NodeType::kUnnest)) {
+    // The cluster does not contain the input of an Unnest of a constant.
+    NodeCP input = node->onlyInput();
+    if (input->outputColumns().empty()) {
+      return RelationSet{};
+    }
     return tesExpansion(
-        node->as<Unnest>()->input(),
-        parentType,
-        parentSes,
-        leftSide,
-        leafIds,
-        leaves);
+        input, parentType, parentSes, leftSide, leafIds, leaves);
   }
 
   const auto* childJoin = node->as<Join>();
@@ -383,10 +388,10 @@ JoinHypergraph HypergraphBuilder::build(
     }
   }
 
-  // Build the directed cross-join-unnest edge for each Unnest, and record
-  // its input relations (the relation ids its input subtree contributes,
-  // resolved via the now-complete columnToLeaf) for the outer-join barrier
-  // applied in the cluster-join loop.
+  // Build the directed cross-join-unnest edge for each Unnest that depends on
+  // a relation of the cluster, and record every Unnest's input relations (the
+  // relation ids its input subtree contributes, resolved via the now-complete
+  // columnToLeaf) for the outer-join barrier applied in the cluster-join loop.
   folly::F14FastMap<int8_t, RelationSet> unnestInputRelations;
   for (UnnestCP unnest : cluster.unnests) {
     const int8_t id = unnestIds.at(unnest);
@@ -397,10 +402,17 @@ JoinHypergraph HypergraphBuilder::build(
         inputRelations.add(it->second);
       }
     }
+    unnestInputRelations.emplace(id, inputRelations);
+
+    // Nothing of the cluster precedes an Unnest of a constant, so it has no
+    // edge; the cluster's own joins connect it.
+    if (unnest->input()->outputColumns().empty()) {
+      continue;
+    }
+
     VELOX_CHECK(
         !inputRelations.empty(),
         "Unnest input subtree must contribute at least one cluster relation");
-    unnestInputRelations.emplace(id, inputRelations);
 
     RelationSet tes{inputRelations};
     tes.add(id);

--- a/axiom/optimizer/v2/JoinHypergraph.cpp
+++ b/axiom/optimizer/v2/JoinHypergraph.cpp
@@ -93,6 +93,11 @@ void JoinHypergraph::checkConsistency() const {
   // Every Unnest relation must be reachable through its cross-join-unnest
   // edge; otherwise the directed-edge connectivity was never built.
   unnestRelationIds_.forEach([&](int32_t id) {
+    // An Unnest of a constant has no input in the cluster and so no edge; the
+    // connectivity check above covers it.
+    if (relation(id).node()->onlyInput()->outputColumns().empty()) {
+      return;
+    }
     bool found = false;
     for (const auto& edge : edges_) {
       if (edge.isUnnest() && edge.right().contains(id)) {

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -128,6 +128,13 @@ class Node : public PlanObject {
   /// lifetime.
   virtual std::span<const NodeCP> inputs() const = 0;
 
+  /// Returns the only input. Throws if there is not exactly one.
+  NodeCP onlyInput() const {
+    const auto nodeInputs = inputs();
+    VELOX_CHECK_EQ(1, nodeInputs.size());
+    return nodeInputs[0];
+  }
+
   /// Double-dispatch hook for `NodeVisitor`.
   virtual void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const = 0;

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -97,7 +97,13 @@ void collectCluster(
   if (node->is(NodeType::kUnnest)) {
     const auto* unnest = node->as<Unnest>();
     cluster.unnests.push_back(unnest);
-    collectCluster(unnest->input(), cluster, dissolveCrossJoins);
+    // An Unnest of a constant, as in UNNEST(ARRAY[1, 2]), reads a subtree that
+    // produces no columns. No predicate can reference it, so it is not a
+    // relation of the cluster; the Unnest emits it as its own input.
+    NodeCP input = unnest->input();
+    if (!input->outputColumns().empty()) {
+      collectCluster(input, cluster, dissolveCrossJoins);
+    }
     return;
   }
   cluster.leaves.push_back(node);

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -822,6 +822,16 @@ class RelationPlanner : public AstVisitor {
     processFrom(join.left());
 
     if (auto unnest = tryGetUnnest(join.right())) {
+      // The unnest is applied to every row of the left side, which is what a
+      // CROSS or comma join means; there is no join node to carry an ON
+      // condition. Presto rejects every other join type here, whatever the
+      // condition says.
+      AXIOM_PRESTO_SEMANTIC_CHECK(
+          join.joinType() == Join::Type::kCross ||
+              join.joinType() == Join::Type::kImplicit,
+          join.location(),
+          "UNNEST",
+          "UNNEST on other than the right side of CROSS JOIN is not supported");
       addCrossJoinUnnest(*unnest->first, unnest->second);
       return;
     }

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1414,6 +1414,29 @@ TEST_F(PrestoParserTest, duplicateAliases) {
       "Cannot resolve column: u");
 }
 
+// An UNNEST is applied to every row of the other side, which only a CROSS or
+// comma join expresses. Any other join type is rejected whatever its ON clause
+// says, matching Presto.
+TEST_F(PrestoParserTest, unnestJoin) {
+  testSelect(
+      "SELECT a FROM (VALUES 1) AS t(a), UNNEST(ARRAY[1, 2]) AS u(s) "
+      "WHERE a = s",
+      matchValues().project().unnest().filter("a = s").project().output({"a"}));
+
+  for (
+      const auto* query : {
+          "SELECT a FROM (VALUES 1) AS t(a) JOIN UNNEST(ARRAY[1, 2]) AS u(s) ON a = s",
+          "SELECT a FROM (VALUES 1) AS t(a) JOIN UNNEST(ARRAY[1, 2]) AS u(s) ON TRUE",
+          "SELECT a FROM (VALUES 1) AS t(a) LEFT JOIN UNNEST(ARRAY[1, 2]) AS u(s) ON TRUE",
+          "SELECT a FROM (VALUES 1) AS t(a) FULL JOIN UNNEST(ARRAY[1, 2]) AS u(s) ON TRUE",
+      }) {
+    SCOPED_TRACE(query);
+    AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+        parseSql(query),
+        "UNNEST on other than the right side of CROSS JOIN is not supported");
+  }
+}
+
 TEST_F(PrestoParserTest, outputNames) {
   auto test = [&](const std::string& sql,
                   const std::vector<std::string>& expectedNames) {


### PR DESCRIPTION
Summary:

A join whose other side unnests a constant failed to plan under v2:

    SELECT a FROM (VALUES 1, 2) AS t(a)
    JOIN (SELECT s FROM UNNEST(ARRAY[1, 2]) AS u(s)) ON a = s

reported `Unnest input subtree must contribute at least one cluster relation`. v1 plans it.

An UNNEST of a constant reads a subtree that produces no columns. Join clustering collected that subtree as a relation of the cluster, but no predicate can reference a relation without columns, so nothing connected it: join enumeration cross-joined it, and the Unnest emitted the same rows a second time as its own input. The cluster now leaves such a subtree out, walks over the cluster stop at the Unnest, and no cross-join-unnest edge is built for it. The plan matches v1's. `Node::onlyInput()` is added along the way, mirroring `LogicalPlanNode::onlyInput()`.

Writing the join with an ON condition instead exposed a second defect, in the parser:

    SELECT e FROM UNNEST(ARRAY[1, 2]) AS u(e)
    JOIN UNNEST(ARRAY[2, 3]) AS v(f) ON e = f

returned four rows, the cross product, where one row matches `e = f`. An UNNEST on the right of a join is applied to every row of the left side and produces no join node, so the ON condition had nothing to hang on and was read by nothing. Presto rejects this query, and Axiom now reports the same error: an UNNEST may be joined only as the right side of a CROSS or comma join. The comma spelling keeps working, since its predicate is a WHERE and is planned separately.

Reviewed By: amitkdutta

Differential Revision: D116059248
