### PR TITLE
fix(optimizer/v2): Group by an expression with DISTINCT

### DIFF
--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -936,6 +936,55 @@ TEST_P(UnnestTest, manyUnnestsCardinalityOverflow) {
   ASSERT_NO_THROW(toSingleNodePlan(logicalPlan));
 }
 
+// A join whose other side unnests a constant array, which reads no columns of
+// the query. The unnest stays on its own side of the join.
+TEST_P(UnnestTest, joinWithConstantUnnest) {
+  const parse::ParseOptions options = {.parseIntegerAsBigint = false};
+
+  auto query =
+      "SELECT a FROM (VALUES 1, 2) AS t(a) "
+      "JOIN (SELECT s FROM UNNEST(ARRAY[1, 2]) AS u(s)) ON a = s";
+  SCOPED_TRACE(query);
+
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(logicalPlan),
+      matchValues()
+          .project({"array[1, 2] as arr"}, options)
+          .unnest({}, {"arr"}, std::nullopt)
+          .aliases({"e"})
+          .hashJoinInner(matchValues().aliases({"k"}), {.keys = {{"e = k"}}})
+          .project({"k as a"})
+          .build());
+}
+
+// A join between two constant unnests, where no table or values relation takes
+// part.
+TEST_P(UnnestTest, joinOfConstantUnnests) {
+  const parse::ParseOptions options = {.parseIntegerAsBigint = false};
+
+  auto query =
+      "SELECT e FROM (SELECT s AS e FROM UNNEST(ARRAY[1, 2]) AS u(s)) "
+      "JOIN (SELECT s AS f FROM UNNEST(ARRAY[2, 3]) AS v(s)) ON e = f";
+  SCOPED_TRACE(query);
+
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(logicalPlan),
+      matchValues()
+          .project({"array[1, 2] as arr"}, options)
+          .unnest({}, {"arr"}, std::nullopt)
+          .hashJoinInner(
+              matchValues()
+                  .project({"array[2, 3] as arr2"}, options)
+                  .unnest({}, {"arr2"}, std::nullopt)
+                  .aliases({"f"}),
+              {.keys = {{"e = f"}}})
+          .build());
+}
+
 AXIOM_INSTANTIATE_V1_V2(UnnestTest);
 
 } // namespace

--- a/axiom/optimizer/tests/sql/distinctAggregation.sql
+++ b/axiom/optimizer/tests/sql/distinctAggregation.sql
@@ -146,3 +146,13 @@ SELECT
   bool_and(a % 2 = 0),
   bool_and(DISTINCT a % 2 = 0) FILTER (WHERE b > 50)
 FROM t
+----
+-- DISTINCT: grouped by an expression that the SELECT list repeats.
+SELECT a % 2, count(DISTINCT c) FROM t GROUP BY a % 2
+----
+-- DISTINCT: the same, with a second aggregate and a wider expression.
+SELECT CAST(a AS VARCHAR), count(*), count(DISTINCT c) FROM t GROUP BY CAST(a AS VARCHAR)
+----
+-- DISTINCT: an expression grouping key with two distinct argument sets, which
+-- dedups through MarkDistinct rather than a native distinct aggregation.
+SELECT a % 2, count(DISTINCT c), count(DISTINCT b) FROM t GROUP BY a % 2

--- a/axiom/optimizer/tests/sql/unnest.sql
+++ b/axiom/optimizer/tests/sql/unnest.sql
@@ -65,3 +65,13 @@ JOIN (VALUES (10), (40)) AS u(k) ON u.k = y
 ----
 -- `alias.*` on an UNNEST relation whose alias carries no column list.
 SELECT u.* FROM (VALUES (1, ARRAY[10, 20])) AS s(a, b) CROSS JOIN UNNEST(b) AS u
+----
+-- Join whose other side unnests a constant array.
+SELECT a.x, s
+FROM arrays a
+JOIN (SELECT s FROM UNNEST(ARRAY[7, 8]) AS u(s)) ON a.x = s
+----
+-- The same, with the unnest on the null-padded side of an outer join.
+SELECT a.x, s
+FROM arrays a
+LEFT JOIN (SELECT s FROM UNNEST(ARRAY[7, 8]) AS u(s)) ON a.x = s

--- a/axiom/optimizer/v2/Builder.cpp
+++ b/axiom/optimizer/v2/Builder.cpp
@@ -200,7 +200,11 @@ void Builder::addEquivalences(const Join::Key& key) {
 
 std::pair<NodeCP, ExprVector> Builder::materializeKeys(
     NodeCP input,
-    const ExprVector& keys) {
+    const ExprVector& keys,
+    const ColumnVector& aliases) {
+  if (!aliases.empty()) {
+    VELOX_CHECK_EQ(aliases.size(), keys.size());
+  }
   if (std::all_of(keys.begin(), keys.end(), [](ExprCP key) {
         return key->is(PlanType::kColumnExpr);
       })) {
@@ -215,12 +219,15 @@ std::pair<NodeCP, ExprVector> Builder::materializeKeys(
   }
   ExprVector newKeys;
   newKeys.reserve(keys.size());
-  for (ExprCP key : keys) {
+  for (size_t i = 0; i < keys.size(); ++i) {
+    ExprCP key = keys[i];
     if (key->is(PlanType::kColumnExpr)) {
       newKeys.push_back(key);
       continue;
     }
-    ColumnCP column = Column::create("__p", key->value());
+    ColumnCP alias = aliases.empty() ? nullptr : aliases[i];
+    ColumnCP column =
+        alias != nullptr ? alias : Column::create("__p", key->value());
     exprs.push_back(key);
     columns.push_back(column);
     newKeys.push_back(column);

--- a/axiom/optimizer/v2/Builder.h
+++ b/axiom/optimizer/v2/Builder.h
@@ -160,9 +160,16 @@ class Builder {
   /// consumer above read the same column instead of computing the value a
   /// second time. Returns 'input' and 'keys' unchanged when every key is
   /// already a column.
+  ///
+  /// 'aliases' names the materialized columns positionally; a null entry, or an
+  /// empty vector, mints a fresh name. A caller whose node already publishes
+  /// the key under a column of its own — an `Aggregate` grouping key, which its
+  /// `outputColumns` names — must pass that column, since consumers reference
+  /// the key by it.
   std::pair<NodeCP, ExprVector> materializeKeys(
       NodeCP input,
-      const ExprVector& keys);
+      const ExprVector& keys,
+      const ColumnVector& aliases = {});
 
  private:
   // For a binary `Call` whose 'name' is in `reversibleFunctions_`,

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -1035,6 +1035,16 @@ velox::core::PlanNodePtr Emitter::makeAggregationNode(
     std::vector<std::string> names,
     std::vector<velox::core::AggregationNode::Aggregate> aggregates,
     velox::core::PlanNodePtr input) {
+  // A Velox AggregationNode names its output after its grouping-key fields, so
+  // a key must be published under the column the Aggregate outputs for it. A
+  // pass that materializes a key under a fresh name has to reuse that column;
+  // otherwise consumers read a column the node does not output.
+  for (size_t i = 0; i < groupingKeys.size(); ++i) {
+    VELOX_CHECK_EQ(
+        groupingKeys[i]->name(),
+        aggregate.outputColumns()[i]->outputName(),
+        "Grouping key must be published under the aggregate's output column");
+  }
   std::vector<velox::vector_size_t> globalGroupingSets(
       aggregate.globalGroupingSets().begin(),
       aggregate.globalGroupingSets().end());

--- a/axiom/optimizer/v2/HypergraphBuilder.cpp
+++ b/axiom/optimizer/v2/HypergraphBuilder.cpp
@@ -82,7 +82,12 @@ RelationSet populateJoinLeaves(
     return RelationSet::singleton(it->second);
   }
   if (node->is(NodeType::kUnnest)) {
-    return populateJoinLeaves(node->as<Unnest>()->input(), leafIds, leaves);
+    // The cluster does not contain the input of an Unnest of a constant.
+    NodeCP input = node->onlyInput();
+    if (input->outputColumns().empty()) {
+      return RelationSet{};
+    }
+    return populateJoinLeaves(input, leafIds, leaves);
   }
   const auto* join = node->as<Join>();
   const RelationSet leftLeaves =
@@ -139,13 +144,13 @@ RelationSet tesExpansion(
     return RelationSet{};
   }
   if (node->is(NodeType::kUnnest)) {
+    // The cluster does not contain the input of an Unnest of a constant.
+    NodeCP input = node->onlyInput();
+    if (input->outputColumns().empty()) {
+      return RelationSet{};
+    }
     return tesExpansion(
-        node->as<Unnest>()->input(),
-        parentType,
-        parentSes,
-        leftSide,
-        leafIds,
-        leaves);
+        input, parentType, parentSes, leftSide, leafIds, leaves);
   }
 
   const auto* childJoin = node->as<Join>();
@@ -383,10 +388,10 @@ JoinHypergraph HypergraphBuilder::build(
     }
   }
 
-  // Build the directed cross-join-unnest edge for each Unnest, and record
-  // its input relations (the relation ids its input subtree contributes,
-  // resolved via the now-complete columnToLeaf) for the outer-join barrier
-  // applied in the cluster-join loop.
+  // Build the directed cross-join-unnest edge for each Unnest that depends on
+  // a relation of the cluster, and record every Unnest's input relations (the
+  // relation ids its input subtree contributes, resolved via the now-complete
+  // columnToLeaf) for the outer-join barrier applied in the cluster-join loop.
   folly::F14FastMap<int8_t, RelationSet> unnestInputRelations;
   for (UnnestCP unnest : cluster.unnests) {
     const int8_t id = unnestIds.at(unnest);
@@ -397,10 +402,17 @@ JoinHypergraph HypergraphBuilder::build(
         inputRelations.add(it->second);
       }
     }
+    unnestInputRelations.emplace(id, inputRelations);
+
+    // Nothing of the cluster precedes an Unnest of a constant, so it has no
+    // edge; the cluster's own joins connect it.
+    if (unnest->input()->outputColumns().empty()) {
+      continue;
+    }
+
     VELOX_CHECK(
         !inputRelations.empty(),
         "Unnest input subtree must contribute at least one cluster relation");
-    unnestInputRelations.emplace(id, inputRelations);
 
     RelationSet tes{inputRelations};
     tes.add(id);

--- a/axiom/optimizer/v2/JoinHypergraph.cpp
+++ b/axiom/optimizer/v2/JoinHypergraph.cpp
@@ -93,6 +93,11 @@ void JoinHypergraph::checkConsistency() const {
   // Every Unnest relation must be reachable through its cross-join-unnest
   // edge; otherwise the directed-edge connectivity was never built.
   unnestRelationIds_.forEach([&](int32_t id) {
+    // An Unnest of a constant has no input in the cluster and so no edge; the
+    // connectivity check above covers it.
+    if (relation(id).node()->onlyInput()->outputColumns().empty()) {
+      return;
+    }
     bool found = false;
     for (const auto& edge : edges_) {
       if (edge.isUnnest() && edge.right().contains(id)) {

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -128,6 +128,13 @@ class Node : public PlanObject {
   /// lifetime.
   virtual std::span<const NodeCP> inputs() const = 0;
 
+  /// Returns the only input. Throws if there is not exactly one.
+  NodeCP onlyInput() const {
+    const auto nodeInputs = inputs();
+    VELOX_CHECK_EQ(1, nodeInputs.size());
+    return nodeInputs[0];
+  }
+
   /// Double-dispatch hook for `NodeVisitor`.
   virtual void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const = 0;

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -97,7 +97,13 @@ void collectCluster(
   if (node->is(NodeType::kUnnest)) {
     const auto* unnest = node->as<Unnest>();
     cluster.unnests.push_back(unnest);
-    collectCluster(unnest->input(), cluster, dissolveCrossJoins);
+    // An Unnest of a constant, as in UNNEST(ARRAY[1, 2]), reads a subtree that
+    // produces no columns. No predicate can reference it, so it is not a
+    // relation of the cluster; the Unnest emits it as its own input.
+    NodeCP input = unnest->input();
+    if (!input->outputColumns().empty()) {
+      collectCluster(input, cluster, dissolveCrossJoins);
+    }
     return;
   }
   cluster.leaves.push_back(node);

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -400,9 +400,12 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
   // Returns the co-located input and the keys it is co-located on: a shuffle
   // needs column keys, so an expression key is computed into one here, and the
   // consumer reads that column rather than computing the value again.
+  // 'keyAliases', when set, names any key this materializes; see
+  // Builder::materializeKeys.
   std::pair<NodeCP, ExprVector> ensureCoLocated(
       NodeCP input,
-      const ExprVector& keys) {
+      const ExprVector& keys,
+      const ColumnVector& keyAliases = {}) {
     if (numWorkers_ == 1 || isGathered(input)) {
       return {input, keys};
     }
@@ -415,7 +418,8 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
       return {input, keys};
     }
 
-    auto [keyed, columnKeys] = builder().materializeKeys(input, keys);
+    auto [keyed, columnKeys] =
+        builder().materializeKeys(input, keys, keyAliases);
     return {partition(keyed, columnKeys), columnKeys};
   }
 
@@ -457,7 +461,14 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
     const ExprVector keys = node->globalGroupingSets().empty()
         ? node->groupingKeys()
         : ExprVector{};
-    auto [coLocatedInput, coLocatedKeys] = ensureCoLocated(input, keys);
+    // A grouping key is published under `outputColumns`, positionally, and
+    // consumers read it by that column. Materializing it under a fresh name
+    // would leave them referencing a column the aggregate no longer outputs.
+    const ColumnVector keyAliases{
+        node->outputColumns().begin(),
+        node->outputColumns().begin() + keys.size()};
+    auto [coLocatedInput, coLocatedKeys] =
+        ensureCoLocated(input, keys, keyAliases);
     if (coLocatedInput == node->input()) {
       return node;
     }

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -822,6 +822,16 @@ class RelationPlanner : public AstVisitor {
     processFrom(join.left());
 
     if (auto unnest = tryGetUnnest(join.right())) {
+      // The unnest is applied to every row of the left side, which is what a
+      // CROSS or comma join means; there is no join node to carry an ON
+      // condition. Presto rejects every other join type here, whatever the
+      // condition says.
+      AXIOM_PRESTO_SEMANTIC_CHECK(
+          join.joinType() == Join::Type::kCross ||
+              join.joinType() == Join::Type::kImplicit,
+          join.location(),
+          "UNNEST",
+          "UNNEST on other than the right side of CROSS JOIN is not supported");
       addCrossJoinUnnest(*unnest->first, unnest->second);
       return;
     }

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1414,6 +1414,29 @@ TEST_F(PrestoParserTest, duplicateAliases) {
       "Cannot resolve column: u");
 }
 
+// An UNNEST is applied to every row of the other side, which only a CROSS or
+// comma join expresses. Any other join type is rejected whatever its ON clause
+// says, matching Presto.
+TEST_F(PrestoParserTest, unnestJoin) {
+  testSelect(
+      "SELECT a FROM (VALUES 1) AS t(a), UNNEST(ARRAY[1, 2]) AS u(s) "
+      "WHERE a = s",
+      matchValues().project().unnest().filter("a = s").project().output({"a"}));
+
+  for (
+      const auto* query : {
+          "SELECT a FROM (VALUES 1) AS t(a) JOIN UNNEST(ARRAY[1, 2]) AS u(s) ON a = s",
+          "SELECT a FROM (VALUES 1) AS t(a) JOIN UNNEST(ARRAY[1, 2]) AS u(s) ON TRUE",
+          "SELECT a FROM (VALUES 1) AS t(a) LEFT JOIN UNNEST(ARRAY[1, 2]) AS u(s) ON TRUE",
+          "SELECT a FROM (VALUES 1) AS t(a) FULL JOIN UNNEST(ARRAY[1, 2]) AS u(s) ON TRUE",
+      }) {
+    SCOPED_TRACE(query);
+    AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+        parseSql(query),
+        "UNNEST on other than the right side of CROSS JOIN is not supported");
+  }
+}
+
 TEST_F(PrestoParserTest, outputNames) {
   auto test = [&](const std::string& sql,
                   const std::vector<std::string>& expectedNames) {


### PR DESCRIPTION
Summary:
A query that groups by an expression and aggregates with DISTINCT failed to plan under v2:

    SELECT substr(n_name, 1, 3) AS a, count(DISTINCT n_regionkey)
    FROM nation GROUP BY substr(n_name, 1, 3)

reported `Field not found: expr. Available fields are: __p3, count`. v1 plans it. It needs the expression to appear in both the SELECT list and GROUP BY, so `GROUP BY 1` and a plain column key both worked.

A DISTINCT aggregate does not split into partial and final, so it takes the single-stage path, where the input has to be shuffled to bring each group to one worker. A shuffle needs column keys, so the expression key is computed into a column first — under a fresh `__pN` name. A Velox `AggregationNode` names its output after its grouping-key fields, so the aggregation then emitted `__p3` while the project above it still read the column the aggregate declares for that key, `expr`. Materializing a grouping key now reuses that column, as lifting one in `PrecomputeProjections` already did.

`EmitPass` now checks the invariant the two passes were each remembering separately: a grouping key must be published under the aggregate's output column. A pass that renames one fails there, naming the aggregate, rather than downstream inside Velox.

Differential Revision: D116080385
