### PR TITLE
fix(optimizer/v2): Apply extra crossing edges as a filter

### DIFF
--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -985,6 +985,43 @@ TEST_P(UnnestTest, joinOfConstantUnnests) {
           .build());
 }
 
+// A join whose condition reads both a column replicated by the unnest and an
+// unnested one. Only the replicated equality can be a hash join key, so the
+// two optimizers place the unnest on opposite sides of the join.
+TEST_P(UnnestTest, joinEdgeCrossingWithUnnest) {
+  const parse::ParseOptions options = {.parseIntegerAsBigint = false};
+
+  auto query =
+      "SELECT t.a, e, u.k FROM (VALUES (1, ARRAY[10, 20])) AS t(a, arr) "
+      "CROSS JOIN UNNEST(arr) AS w(e) "
+      "JOIN (VALUES (1, 10)) AS u(k, m) ON u.k = t.a AND u.m = e";
+  SCOPED_TRACE(query);
+
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+
+  auto matcher = useV2_
+      ? matchValues()
+            .aliases({"a", "arr"})
+            .hashJoinInner(
+                matchValues().aliases({"k", "m"}), {.keys = {{"a = k"}}})
+            .unnest({"a", "m"}, {"arr"})
+            .aliases({"a", "m", "e"})
+            .filter("eq(e, m)")
+            .project()
+            .build()
+      : matchValues()
+            .aliases({"a", "arr"})
+            .unnest({"a"}, {"arr"})
+            .aliases({"a", "e"})
+            .hashJoinInner(
+                matchValues().aliases({"k", "m"}),
+                {.keys = {{"a = k", "e = m"}}})
+            .project()
+            .build();
+
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+}
+
 AXIOM_INSTANTIATE_V1_V2(UnnestTest);
 
 } // namespace

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -187,3 +187,22 @@ SELECT t1.a, t2.a FROM t t1, t t2 WHERE t1.b < t2.b AND 1000 / (150 - t1.b) > t2
 -- JOIN of two ORDER BY ... LIMIT subqueries.
 SELECT l.a, l.b, r.b
 FROM (SELECT * FROM t ORDER BY b LIMIT 5) l JOIN (SELECT * FROM t ORDER BY b DESC LIMIT 5) r ON l.a = r.a
+----
+-- An inner join above a left join, on a column of the null-padded side wrapped
+-- in COALESCE. The COALESCE does not reject nulls, so a row with no match on
+-- the left join can still satisfy the inner join and reach the output with
+-- NULLs for that side.
+SELECT l.a, c.m, e.d
+FROM (VALUES (1, 'x'), (2, 'y')) AS l(k, a)
+LEFT JOIN (VALUES (1, 10)) AS c(k, m) ON c.k = l.k
+JOIN (VALUES (1, 10, 'p'), (2, 0, 'q')) AS e(k, m, d)
+  ON e.k = l.k AND e.m = coalesce(c.m, 0)
+----
+-- The same, with a WHERE predicate that reads both sides of the left join and
+-- so can only be evaluated once both are joined.
+SELECT l.a, c.m, e.d
+FROM (VALUES (1, 'x'), (2, 'y')) AS l(k, a)
+LEFT JOIN (VALUES (1, 10)) AS c(k, m) ON c.k = l.k
+JOIN (VALUES (1, 10, 5), (2, 0, 7)) AS e(k, m, d)
+  ON e.k = l.k AND e.m = coalesce(c.m, 0)
+WHERE e.d < coalesce(c.m, 99)

--- a/axiom/optimizer/tests/sql/unnest.sql
+++ b/axiom/optimizer/tests/sql/unnest.sql
@@ -75,3 +75,10 @@ JOIN (SELECT s FROM UNNEST(ARRAY[7, 8]) AS u(s)) ON a.x = s
 SELECT a.x, s
 FROM arrays a
 LEFT JOIN (SELECT s FROM UNNEST(ARRAY[7, 8]) AS u(s)) ON a.x = s
+----
+-- A join on both a replicated column and an unnested one, projecting a column
+-- from each side.
+SELECT a.x, y, u.k
+FROM arrays a
+CROSS JOIN UNNEST(a.ys) AS _(y)
+JOIN (VALUES (7, 10), (8, 30)) AS u(k, m) ON u.k = a.x AND u.m = y

--- a/axiom/optimizer/v2/CostModel.cpp
+++ b/axiom/optimizer/v2/CostModel.cpp
@@ -20,6 +20,7 @@
 
 #include "axiom/optimizer/Cost.h"
 #include "axiom/optimizer/EstimateMath.h"
+#include "axiom/optimizer/Filters.h"
 #include "axiom/optimizer/Schema.h"
 #include "axiom/optimizer/v2/JoinFanout.h"
 #include "velox/common/base/Exceptions.h"
@@ -113,6 +114,26 @@ std::optional<float> innerEdgeSelectivity(
   return 1.0f / std::max(jointNdvLeft, jointNdvRight);
 }
 
+// Applies the selectivities of the extra edges that filter `join`'s output —
+// the inner edges that crossed alongside an Unnest or an outer join, which the
+// emitter puts in a Filter above it. An edge whose selectivity is unknown is
+// left out rather than making the cover uncostable: a filter can only reduce,
+// so the unfiltered count stays a valid upper bound, whereas an unknown would
+// drop every candidate for the cover and leave the join graph unplannable.
+std::optional<float> applyExtraEdges(
+    std::optional<float> cardinality,
+    const JoinOp& join,
+    const JoinHypergraph& graph,
+    const ConstraintMap& constraints) {
+  for (size_t extraIndex : join.extraEdges) {
+    if (const auto selectivity = innerEdgeSelectivity(
+            graph.edges()[extraIndex], graph, constraints)) {
+      cardinality = mul(cardinality, *selectivity);
+    }
+  }
+  return cardinality;
+}
+
 // The conjuncts this join evaluates: for an inner join those the emitter places
 // here — within this cover but within neither child's, so no child has applied
 // them — and for any other type the edge's own filter. Assigning a conjunct to
@@ -135,19 +156,23 @@ ExprVector appliedConjuncts(const JoinOp& join, const JoinHypergraph& graph) {
 }
 
 // Product of the operand cardinalities and the selectivities of the edges
-// crossing the join (its primary edge plus any inner extra edges of a cyclic
-// cover). This is the inner-join match count, and — for an all-inner cover —
-// the cover's output cardinality.
+// crossing the join: its primary edge, plus the extra edges of a cyclic cover
+// when the primary is inner and they join it as keys. This is the inner-join
+// match count, and — for an all-inner cover — the cover's output cardinality.
+// Under a non-inner primary the extra edges filter the shaped output instead,
+// so they are applied by the caller after the join type has been accounted for.
 std::optional<float> innerMatchCardinality(
     const JoinOp& join,
     const JoinHypergraph& graph,
     const ConstraintMap& constraints,
     std::optional<float> leftCardinality,
     std::optional<float> rightCardinality) {
+  const auto& edge = graph.edges()[join.edgeIndex];
   std::optional<float> matched = mul(leftCardinality, rightCardinality);
-  matched = mul(
-      matched,
-      innerEdgeSelectivity(graph.edges()[join.edgeIndex], graph, constraints));
+  matched = mul(matched, innerEdgeSelectivity(edge, graph, constraints));
+  if (edge.joinType() != velox::core::JoinType::kInner) {
+    return matched;
+  }
   for (size_t extraIndex : join.extraEdges) {
     matched = mul(
         matched,
@@ -200,8 +225,15 @@ Cost leafCost(
 
 // Records the estimate for a cross-join-unnest cover: the input cover's
 // constraints pass through (the unnest adds columns but does not change the
-// input columns' NDVs) and its cardinality scales by the unnest fanout.
-const Estimate& unnestEstimate(const JoinOp& join, BySetMap& bySet) {
+// input columns' NDVs) and its cardinality scales by the unnest fanout, then by
+// the filters the emitter applies on the expansion: the edges that crossed
+// alongside the unnest (see `applyExtraEdges`) and the pool conjuncts this
+// cover makes ready that the input cover did not already apply. A conjunct of
+// unknown selectivity is skipped for the same reason an edge is.
+const Estimate& unnestEstimate(
+    const JoinOp& join,
+    const JoinHypergraph& graph,
+    BySetMap& bySet) {
   const RelationSet cover = join.cover();
   const auto it = bySet.find(cover);
   if (it != bySet.end()) {
@@ -210,8 +242,27 @@ const Estimate& unnestEstimate(const JoinOp& join, BySetMap& bySet) {
   const Estimate& input = coverEstimate(join.left->cover(), bySet);
   Estimate result;
   mergeConstraints(input.constraints, result.constraints);
-  result.cardinality =
-      maxOf(1.0f, mul(input.cardinality, kDefaultUnnestFanout));
+  std::optional<float> cardinality = applyExtraEdges(
+      mul(input.cardinality, kDefaultUnnestFanout),
+      join,
+      graph,
+      result.constraints);
+  ExprVector conjuncts;
+  for (const auto& conjunct : graph.filterConjuncts()) {
+    if (conjunct.relations.isSubset(cover) &&
+        !conjunct.relations.isSubset(join.left->cover())) {
+      conjuncts.push_back(conjunct.expr);
+    }
+  }
+  if (!conjuncts.empty()) {
+    if (const auto selectivity = optimizer::conjunctsSelectivity(
+            result.constraints,
+            std::span<const ExprCP>{conjuncts.data(), conjuncts.size()},
+            /*updateConstraints=*/true)) {
+      cardinality = mul(cardinality, selectivity->trueFraction);
+    }
+  }
+  result.cardinality = maxOf(1.0f, cardinality);
   return bySet.emplace(cover, std::move(result)).first->second;
 }
 
@@ -226,7 +277,7 @@ Cost unnestJoinCost(
   const std::optional<float> inputCardinality = join.left->cost.cardinality;
   const float rowBytes = coveredRowBytes(join.cover(), graph);
   Cost out;
-  out.cardinality = unnestEstimate(join, bySet).cardinality;
+  out.cardinality = unnestEstimate(join, graph, bySet).cardinality;
   // The per-row cost depends on the output cardinality; when that is unknown
   // the whole cost is unknown (propagated, not fabricated).
   const std::optional<float> perRowCost = out.cardinality.has_value()
@@ -271,15 +322,20 @@ joinEstimate(const JoinOp& join, const JoinHypergraph& graph, BySetMap& bySet) {
   // Operands are passed in the edge's orientation, which `outputCardinality`
   // requires for kAnti: a reversed antijoin swaps them but has no flipped type.
   const bool edgeLeftIsPhysicalLeft = edge.left().isSubset(join.left->cover());
-  result.cardinality = maxOf(
-      1.0f,
-      JoinFanout::outputCardinality(
-          edge.joinType(),
-          edgeLeftIsPhysicalLeft ? left.cardinality : right.cardinality,
-          edgeLeftIsPhysicalLeft ? right.cardinality : left.cardinality,
-          matched,
-          appliedConjuncts(join, graph),
-          result.constraints));
+  std::optional<float> cardinality = JoinFanout::outputCardinality(
+      edge.joinType(),
+      edgeLeftIsPhysicalLeft ? left.cardinality : right.cardinality,
+      edgeLeftIsPhysicalLeft ? right.cardinality : left.cardinality,
+      matched,
+      appliedConjuncts(join, graph),
+      result.constraints);
+  // Extra edges under a non-inner primary are a filter above the join, so they
+  // reduce what the join type shaped — including the null-padded rows, which
+  // fail an equality on the padded side.
+  if (edge.joinType() != velox::core::JoinType::kInner) {
+    cardinality = applyExtraEdges(cardinality, join, graph, result.constraints);
+  }
+  result.cardinality = maxOf(1.0f, cardinality);
   return bySet.emplace(cover, std::move(result)).first->second;
 }
 

--- a/axiom/optimizer/v2/DPhyp.cpp
+++ b/axiom/optimizer/v2/DPhyp.cpp
@@ -50,6 +50,15 @@ DPhyp::DPhyp(
 
 namespace {
 
+// True for the join types whose output keeps both sides' columns, so an inner
+// equality applied above the join can still read them. Semi and anti keep only
+// one side, so a co-crossing inner edge has nowhere to go.
+bool isOuterJoin(velox::core::JoinType joinType) {
+  return joinType == velox::core::JoinType::kLeft ||
+      joinType == velox::core::JoinType::kRight ||
+      joinType == velox::core::JoinType::kFull;
+}
+
 // Vertices reachable from `set` via one hyperedge whose "other" side
 // is fully outside `set`. Excludes any vertex in `forbidden`.
 RelationSet neighborhood(
@@ -367,15 +376,57 @@ class Enumerator {
       return;
     }
 
+    // At most one crossing edge can be other than a plain inner edge. An
+    // Unnest expands the rows and an outer join null-pads them; either way the
+    // remaining edges can only constrain what it produced, so they filter its
+    // output rather than joining its condition — which would null-pad the rows
+    // they reject instead of dropping them, and is what applying an inner join
+    // above means. Two such edges have no single well-defined step and fall
+    // through to the check below.
+    std::optional<size_t> specialPosition;
+    for (size_t i = 0; i < crossing.size(); ++i) {
+      const auto& edge = graph_.edges()[crossing[i].first];
+      if (!edge.isUnnest() &&
+          edge.joinType() == velox::core::JoinType::kInner) {
+        continue;
+      }
+      if (specialPosition.has_value()) {
+        specialPosition.reset();
+        break;
+      }
+      specialPosition = i;
+    }
+
+    if (specialPosition.has_value()) {
+      const size_t specialEdge = crossing[*specialPosition].first;
+      std::vector<size_t> residual;
+      residual.reserve(crossing.size() - 1);
+      for (size_t i = 0; i < crossing.size(); ++i) {
+        if (i != *specialPosition) {
+          residual.push_back(crossing[i].first);
+        }
+      }
+      emitSingleEdge(
+          specialEdge,
+          crossing[*specialPosition].second,
+          leftPlan,
+          rightPlan,
+          combined,
+          std::move(residual));
+      return;
+    }
+
     // Several inner edges cross: apply them as one inner join over all their
-    // keys. A non-inner edge co-crossing has no single well-defined join
-    // type here and is not supported; fail rather than drop a predicate.
+    // keys. Reaching here with an Unnest or a non-inner edge means two or more
+    // of them cross, which has no single well-defined step; fail rather than
+    // drop a predicate.
     for (const auto& [edgeIndex, forward] : crossing) {
       const auto& edge = graph_.edges()[edgeIndex];
       VELOX_CHECK(
           edge.joinType() == velox::core::JoinType::kInner && !edge.isUnnest(),
-          "Multiple edges cross one join partition with a non-inner edge: {}",
-          velox::core::JoinTypeName::toName(edge.joinType()));
+          "Two or more edges crossing one join partition are not plain inner joins: {}, unnest: {}",
+          edge.joinTypeName(),
+          edge.isUnnest());
     }
     std::sort(
         crossing.begin(), crossing.end(), [](const auto& lhs, const auto& rhs) {
@@ -447,14 +498,23 @@ class Enumerator {
 
   // Emits join candidates for a single edge crossing the partition,
   // preserving orientation rules (native-only for unnest / anti /
-  // null-aware semi-project; both orientations otherwise).
+  // null-aware semi-project; both orientations otherwise). `extraEdges` are
+  // co-crossing inner edges the emitter applies as a filter above the join.
   void emitSingleEdge(
       size_t edgeIndex,
       bool forward,
       MemoOpCP leftPlan,
       MemoOpCP rightPlan,
-      RelationSet combined) {
+      RelationSet combined,
+      std::vector<size_t> extraEdges = {}) {
     const auto& edge = graph_.edges()[edgeIndex];
+    // Extra edges reach the emitter as a filter above the join, which only an
+    // Unnest or an outer join can carry: both keep every column the equalities
+    // read. Semi and anti keep one side only.
+    VELOX_CHECK(
+        extraEdges.empty() || edge.isUnnest() || isOuterJoin(edge.joinType()),
+        "An edge crossing a join partition alongside a {} edge is not supported",
+        edge.joinTypeName());
     // `probeOnLeft` plays the edge's left operand; `probeOnRight` its right.
     MemoOpCP probeOnLeft = forward ? leftPlan : rightPlan;
     MemoOpCP probeOnRight = forward ? rightPlan : leftPlan;
@@ -465,7 +525,13 @@ class Enumerator {
          !hasRightProjectVariant(edge));
     if (nativeOnly) {
       considerCandidate(
-          probeOnLeft, probeOnRight, edgeIndex, edge.joinType(), combined);
+          probeOnLeft,
+          probeOnRight,
+          edgeIndex,
+          edge.joinType(),
+          combined,
+          /*reversedAnti=*/false,
+          std::move(extraEdges));
       // Antijoin can additionally build on the preserved (left) side by
       // probing with the right input (the reversed orientation).
       if (edge.joinType() == velox::core::JoinType::kAnti &&
@@ -481,17 +547,27 @@ class Enumerator {
       return;
     }
 
-    // Flip the joinType when the subgraph plays the edge's right operand.
+    // Flip the joinType when the subgraph plays the edge's right operand. The
+    // extra edges are equalities filtering the output, so they are carried
+    // unchanged into either orientation.
     const auto leftTypeForSubgraph =
         forward ? edge.joinType() : flipJoinType(edge.joinType());
     considerCandidate(
-        leftPlan, rightPlan, edgeIndex, leftTypeForSubgraph, combined);
+        leftPlan,
+        rightPlan,
+        edgeIndex,
+        leftTypeForSubgraph,
+        combined,
+        /*reversedAnti=*/false,
+        extraEdges);
     considerCandidate(
         rightPlan,
         leftPlan,
         edgeIndex,
         flipJoinType(leftTypeForSubgraph),
-        combined);
+        combined,
+        /*reversedAnti=*/false,
+        std::move(extraEdges));
   }
 
   // Records an enforcement exchange and returns a stable pointer to it.

--- a/axiom/optimizer/v2/JoinEdge.h
+++ b/axiom/optimizer/v2/JoinEdge.h
@@ -156,6 +156,10 @@ class JoinEdge {
     return joinType_;
   }
 
+  std::string_view joinTypeName() const {
+    return velox::core::JoinTypeName::toName(joinType_);
+  }
+
   bool nullAware() const {
     return nullAware_;
   }

--- a/axiom/optimizer/v2/JoinTreeEmitter.cpp
+++ b/axiom/optimizer/v2/JoinTreeEmitter.cpp
@@ -29,13 +29,31 @@ namespace facebook::axiom::optimizer::v2 {
 
 namespace {
 
+// Appends the columns of `side` that a node over `cover` emits: those `needed`
+// demands, plus any column produced by no relation in `cover` (e.g. a semijoin
+// mark synthesized below, or a key a shuffle materialized), which is outside
+// the demand universe and is always kept.
+void appendNarrowed(
+    ColumnVector& columns,
+    NodeCP side,
+    const PlanObjectSet& needed,
+    const PlanObjectSet& coverColumns) {
+  for (ColumnCP column : side->outputColumns()) {
+    if (!coverColumns.contains(column) || needed.contains(column)) {
+      columns.push_back(column);
+    }
+  }
+}
+
 // An intermediate join emits the columns a consumer above `cover` demands —
 // `graph.coverOutputColumns(cover)`, which collapses each within-cover
 // equi-group to one representative — exactly the set the cost model charges
-// for, so the executed plan matches its estimated width. Left-then-right order
-// is preserved. A column produced by no relation in `cover` (e.g. a semijoin
-// mark synthesized below, or a key a shuffle materialized) is outside the
-// demand universe and is always kept.
+// for, so the executed plan matches its estimated width. The one exception is
+// an outer join carrying extra edges, which keeps both columns of each so the
+// filter above it can read them. Left-then-right order is preserved. A column
+// produced by no relation in `cover` (e.g. a semijoin mark synthesized below,
+// or a key a shuffle materialized) is outside the demand universe and is always
+// kept.
 ColumnVector coverNarrowedColumns(
     const JoinHypergraph& graph,
     const RelationSet& cover,
@@ -44,13 +62,8 @@ ColumnVector coverNarrowedColumns(
   const PlanObjectSet needed = graph.coverOutputColumns(cover);
   const PlanObjectSet coverColumns = graph.coverColumns(cover);
   ColumnVector columns;
-  for (NodeCP side : {left, right}) {
-    for (ColumnCP column : side->outputColumns()) {
-      if (!coverColumns.contains(column) || needed.contains(column)) {
-        columns.push_back(column);
-      }
-    }
-  }
+  appendNarrowed(columns, left, needed, coverColumns);
+  appendNarrowed(columns, right, needed, coverColumns);
   return columns;
 }
 
@@ -197,6 +210,28 @@ NodeCP restoreTargets(
       Project::Key{node, std::move(exprs), ColumnVector{targets}});
 }
 
+// The equalities of the inner edges applied above `join` — the ones that
+// crossed the same partition as an Unnest or an outer join, which cannot take
+// them as keys. Equality is symmetric, so the edges' orientation does not
+// matter here. Inner edges carry no filter (`JoinEdge` enforces that), so the
+// keys are the whole predicate.
+ExprVector extraEdgeEqualities(
+    const JoinOp* join,
+    const ExprFactory::ExprSubstitution& substitution,
+    EmitState& state) {
+  ExprVector predicates;
+  for (size_t extraIndex : join->extraEdges) {
+    const auto& extra = state.graph.edges()[extraIndex];
+    const auto& leftKeys = extra.leftKeys();
+    const auto& rightKeys = extra.rightKeys();
+    VELOX_CHECK_EQ(leftKeys.size(), rightKeys.size());
+    for (size_t i = 0; i < leftKeys.size(); ++i) {
+      predicates.push_back(state.exprs.makeEq(leftKeys[i], rightKeys[i]));
+    }
+  }
+  return rewrite(predicates, substitution, state);
+}
+
 void checkAllConjunctsPlaced(const EmitState& state) {
   const size_t unplaced =
       std::count(state.fired.begin(), state.fired.end(), false);
@@ -215,15 +250,42 @@ NodeCP emitLeaf(const LeafOp* leaf, EmitState& state) {
 // `join->left` is the input-side plan and `join->right` is the
 // singleton Unnest leaf. `unnestExpressions`, `unnestColumns`, and
 // `ordinalityColumn` come from the original Unnest IR node stored on
-// the Unnest relation. `replicatedColumns` conservatively forwards
-// every input column.
+// the Unnest relation.
 Emitted buildUnnest(const JoinOp* join, Emitted input, EmitState& state) {
   const auto& edge = state.graph.edges()[join->edgeIndex];
   const int8_t unnestRelId = edge.right().min();
   const auto* origUnnest =
       state.graph.relation(unnestRelId).node()->as<Unnest>();
 
-  ColumnVector replicatedColumns{input.node->outputColumns()};
+  const auto substitution = merge(
+      collapsedColumns(state.graph.coverColumnReps(join->left->cover())),
+      input.materialized);
+  ExprVector unnestExpressions =
+      rewrite(origUnnest->unnestExpressions(), substitution, state);
+
+  // Inner edges that crossed alongside the Unnest constrain what it produced,
+  // so they filter its output: both sides of each equality are columns of this
+  // node. Conjuncts from the filter pool that this cover makes ready are
+  // applied here too — after the expansion, since one may read an unnested
+  // column.
+  ExprVector predicates = rewrite(
+      takeReadyConjuncts(state.graph, join->cover(), state.fired),
+      substitution,
+      state);
+  appendAll(predicates, extraEdgeEqualities(join, substitution, state));
+
+  // The expansion replicates the columns a consumer above the cover demands,
+  // plus those the predicates above read: the Filter sits on this node's
+  // output, so its inputs have to survive the expansion even when nothing
+  // above wants them.
+  PlanObjectSet needed = state.graph.coverOutputColumns(join->cover());
+  needed.unionColumns(predicates);
+  ColumnVector replicatedColumns;
+  appendNarrowed(
+      replicatedColumns,
+      input.node,
+      needed,
+      state.graph.coverColumns(join->cover()));
 
   ColumnVector outputColumns{replicatedColumns};
   for (const auto& perExpr : origUnnest->unnestColumns()) {
@@ -235,12 +297,6 @@ Emitted buildUnnest(const JoinOp* join, Emitted input, EmitState& state) {
     outputColumns.push_back(origUnnest->ordinalityColumn());
   }
 
-  const auto substitution = merge(
-      collapsedColumns(state.graph.coverColumnReps(join->left->cover())),
-      input.materialized);
-  ExprVector unnestExpressions =
-      rewrite(origUnnest->unnestExpressions(), substitution, state);
-
   NodeCP node = state.builder.make<Unnest>(Unnest::Key{
       input.node,
       std::move(unnestExpressions),
@@ -248,6 +304,11 @@ Emitted buildUnnest(const JoinOp* join, Emitted input, EmitState& state) {
       origUnnest->unnestColumns(),
       origUnnest->ordinalityColumn(),
       std::move(outputColumns)});
+
+  if (!predicates.empty()) {
+    node = state.builder.make<Filter>(Filter::Key{node, std::move(predicates)});
+  }
+
   retainVisible(input.materialized, node);
   return {node, std::move(input.materialized)};
 }
@@ -312,19 +373,24 @@ Emitted buildJoin(
     std::swap(leftKeys, rightKeys);
   }
 
-  // Conjoin the keys of any additional inner edges this join applies (a
-  // cyclic join graph can have several edges crossing one partition). Each
-  // is orientation-corrected independently. Inner edges carry no filter
-  // (their non-equi conjuncts live in the hypergraph's filter pool).
-  for (size_t extraIndex : join->extraEdges) {
-    const auto& extra = state.graph.edges()[extraIndex];
-    ExprVector extraLeftKeys{extra.leftKeys()};
-    ExprVector extraRightKeys{extra.rightKeys()};
-    if (extra.left().isSubset(join->right->cover())) {
-      std::swap(extraLeftKeys, extraRightKeys);
+  // Additional inner edges this join applies (a cyclic join graph can have
+  // several edges crossing one partition), each orientation-corrected
+  // independently. Under an inner join they conjoin into its keys. Under an
+  // outer join they cannot: a condition null-pads the rows it rejects, while
+  // these must drop them, so they filter the join's output instead — which is
+  // what applying the inner join above the outer one means. Inner edges carry
+  // no filter (their non-equi conjuncts live in the hypergraph's filter pool).
+  if (isInner) {
+    for (size_t extraIndex : join->extraEdges) {
+      const auto& extra = state.graph.edges()[extraIndex];
+      ExprVector extraLeftKeys{extra.leftKeys()};
+      ExprVector extraRightKeys{extra.rightKeys()};
+      if (extra.left().isSubset(join->right->cover())) {
+        std::swap(extraLeftKeys, extraRightKeys);
+      }
+      appendAll(leftKeys, extraLeftKeys);
+      appendAll(rightKeys, extraRightKeys);
     }
-    appendAll(leftKeys, extraLeftKeys);
-    appendAll(rightKeys, extraRightKeys);
   }
 
   ExprVector filter;
@@ -340,6 +406,42 @@ Emitted buildJoin(
   leftKeys = rewrite(leftKeys, substitution, state);
   rightKeys = rewrite(rightKeys, substitution, state);
   filter = rewrite(filter, substitution, state);
+  // A non-inner join applies its own condition — the edge's filter, above —
+  // and everything else this cover makes ready goes above it: the extra edges'
+  // equalities, and the pool conjuncts no child could apply. Neither can join
+  // the condition, which would null-pad the rows they reject instead of
+  // dropping them.
+  ExprVector aboveJoin;
+  if (!isInner) {
+    aboveJoin = extraEdgeEqualities(join, substitution, state);
+    appendAll(
+        aboveJoin,
+        rewrite(
+            takeReadyConjuncts(state.graph, join->cover(), state.fired),
+            substitution,
+            state));
+  }
+
+  // The cover collapses the equated columns of an extra edge to one
+  // representative, so the narrowed output carries only that one. The filter
+  // reads both, and both are emitted by the children — the collapse spans the
+  // two child covers, so neither child applied it — so keep them here.
+  if (!aboveJoin.empty()) {
+    PlanObjectSet extraColumns;
+    extraColumns.unionColumns(aboveJoin);
+    PlanObjectSet present;
+    for (ColumnCP column : outputColumns) {
+      present.add(column);
+    }
+    for (NodeCP side : {left.node, right.node}) {
+      for (ColumnCP column : side->outputColumns()) {
+        if (extraColumns.contains(column) && !present.contains(column)) {
+          outputColumns.push_back(column);
+          present.add(column);
+        }
+      }
+    }
+  }
 
   NodeCP node = state.builder.make<Join>(Join::Key{
       left.node,
@@ -351,6 +453,9 @@ Emitted buildJoin(
       edge.nullAware(),
       edge.nullAsValue(),
       std::move(outputColumns)});
+  if (!aboveJoin.empty()) {
+    node = state.builder.make<Filter>(Filter::Key{node, std::move(aboveJoin)});
+  }
   retainVisible(materialized, node);
   return {node, std::move(materialized)};
 }
@@ -421,7 +526,17 @@ Emitted emitJoin(
   const auto& edge = state.graph.edges()[join->edgeIndex];
   Emitted left = emitOp(join->left, state);
   if (edge.isUnnest()) {
-    return buildUnnest(join, std::move(left), state);
+    Emitted result = buildUnnest(join, std::move(left), state);
+    if (rootOutputColumns == nullptr) {
+      return result;
+    }
+    const auto rootReps = state.graph.coverColumnReps(join->cover());
+    if (hasCollapsedTarget(rootReps, *rootOutputColumns)) {
+      result.node =
+          restoreTargets(result.node, rootReps, *rootOutputColumns, state);
+      retainVisible(result.materialized, result.node);
+    }
+    return result;
   }
   Emitted right = emitOp(join->right, state);
   if (join->reversedAnti) {


### PR DESCRIPTION
Summary:
Two production queries failed to plan with:

    Multiple edges cross one join partition with a non-inner edge

A cyclic join graph can have more than one edge crossing the partition the join enumeration is considering. Several inner edges merged into a single join over all their keys; any other combination threw.

The two kinds of edge that cannot merge are an unnest, which expands rows rather than matching them, and an outer join, whose condition null-pads the rows it rejects instead of dropping them. The other edges still have to be applied, so they now filter that node's output. For an outer join, a filter above it is what applying the inner join later means. Each such edge equates two columns and the cover keeps only one of them, so the join now emits the other one too and the filter can read both. A semi or anti edge projects one side only, so it still throws, as do two non-mergeable edges in one partition.

Also on this path:

- An unnest replicated every input column; it now forwards only what a consumer above or the filter reads.
- A root column collapsed into its representative was not restored above an unnest, so the plan failed with `Field not found`.
- Ready filter conjuncts were drained only at inner joins; an unnest and a non-inner join now apply theirs above themselves.

Under a non-inner join the extra edges' selectivity applied to the match count; it now applies to the join's output, after the join type has shaped it. An unnest did not account for them at all and now does. An unknown selectivity is skipped rather than propagated: the unfiltered count is still a valid upper bound, while an unknown cost would discard every candidate for the cover and leave the graph unplannable.

Differential Revision: D116111783


