### PR TITLE
fix(optimizer): Keep RANGE frame bounds in a column

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1774,13 +1774,19 @@ WindowFunctionVector flattenWindowFunctions(
     auto args = precompute.toColumns(
         func->args(), /*aliases=*/nullptr, /*preserveLiterals=*/true);
     Frame frame = func->frame();
+    // A ROWS bound is an offset in rows, which Velox reads as a constant. A
+    // RANGE bound is the boundary value for each row, which Velox reads from a
+    // column, so it stays a column even when it folds to a literal — as it
+    // does when the ORDER BY key is constant.
+    const bool preserveLiterals =
+        frame.type == logical_plan::WindowExpr::WindowType::kRows;
     if (frame.startValue) {
       frame.startValue = precompute.toColumn(
-          frame.startValue, /*alias=*/nullptr, /*preserveLiterals=*/true);
+          frame.startValue, /*alias=*/nullptr, preserveLiterals);
     }
     if (frame.endValue) {
       frame.endValue = precompute.toColumn(
-          frame.endValue, /*alias=*/nullptr, /*preserveLiterals=*/true);
+          frame.endValue, /*alias=*/nullptr, preserveLiterals);
     }
     result.emplace_back(
         make<WindowFunction>(

--- a/axiom/optimizer/tests/sql/window.sql
+++ b/axiom/optimizer/tests/sql/window.sql
@@ -265,3 +265,12 @@ ORDER BY sum(b) * 1.0 / sum(sum(b)) OVER () DESC
 SELECT count(*) OVER (ORDER BY max(d) RANGE BETWEEN INTERVAL '1' DAY PRECEDING AND CURRENT ROW) AS c
 FROM (VALUES (DATE '2025-01-01', 1), (DATE '2025-01-02', 2), (DATE '2025-01-03', 3)) AS t(d, n)
 GROUP BY d
+----
+-- A RANGE offset frame whose ORDER BY key is a constant. Every row is a peer,
+-- so the frame covers the whole partition.
+SELECT array_agg(a) OVER (ORDER BY a RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+FROM (SELECT 1 AS a FROM (VALUES (1), (2), (3)) AS t(x)) AS u(a)
+----
+-- The same, with the constant written in the ORDER BY itself.
+SELECT array_agg(x) OVER (ORDER BY (1 + 1) RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+FROM (VALUES (1), (2)) AS t(x)

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
@@ -436,10 +436,13 @@ NodeCP Rewriter::rewriteWindow(const Window* window, NoContext& context) {
     newOrderKeys.push_back(precompute.toColumn(key));
   }
 
-  // Frame bounds must be FieldAccess or Constant in Velox.
-  auto liftBound = [&](ExprCP value) -> ExprCP {
+  // A ROWS bound is an offset in rows, which Velox reads as a constant. A
+  // RANGE bound is the boundary value for each row, which Velox reads from a
+  // column, so it stays a column even when it folds to a literal — as it does
+  // when the ORDER BY key is constant.
+  auto liftBound = [&](ExprCP value, bool allowConstant) -> ExprCP {
     return value != nullptr
-        ? precompute.toColumn(value, /*alias=*/nullptr, /*allowConstant=*/true)
+        ? precompute.toColumn(value, /*alias=*/nullptr, allowConstant)
         : nullptr;
   };
 
@@ -456,12 +459,14 @@ NodeCP Rewriter::rewriteWindow(const Window* window, NoContext& context) {
     auto* newCall = builder().makeCall(
         call->name(), call->value(), std::move(newArgs), call->functions());
     const Frame& frame = windowFunction.frame;
+    const bool allowConstant =
+        frame.type == logical_plan::WindowExpr::WindowType::kRows;
     Frame newFrame{
         frame.type,
         frame.startType,
-        liftBound(frame.startValue),
+        liftBound(frame.startValue, allowConstant),
         frame.endType,
-        liftBound(frame.endValue),
+        liftBound(frame.endValue, allowConstant),
     };
     newFunctions.push_back({newCall, newFrame, windowFunction.ignoreNulls});
   }


### PR DESCRIPTION
Summary:
A window query whose ORDER BY key is a constant failed to plan:

    SELECT array_agg(x) OVER (ORDER BY (1 + 1) RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES (1), (2)) AS t(x)

reported:

    Window frame of type RANGE does not support constant arguments

Both optimizers are affected. v1 fails whenever the ORDER BY key is a constant; v2 fails when the parser folds the whole bound, as it does above.

Velox reads the two kinds of frame bound differently. A ROWS bound is an offset in rows, so a constant is what it expects. A RANGE bound is the boundary value for each row — the planner precomputes `<order key> ± <offset>` — so Velox reads it from a column and rejects a constant, which would otherwise let a planner pass the raw offset and silently compute the wrong frames.

Both optimizers lifted frame bounds into columns while passing literals through untouched, which is right for ROWS but wrong for RANGE: once the ORDER BY key is constant the bound folds to a literal and went straight to Velox. Literals now survive only under a ROWS frame.

Differential Revision: D116279658


