### PR TITLE
fix(sql): Flatten AND/OR chains through parentheses

### DIFF
--- a/axiom/sql/presto/ParserOptions.h
+++ b/axiom/sql/presto/ParserOptions.h
@@ -68,8 +68,10 @@ struct ParserOptions : public facebook::velox::config::ConfigProvider {
 
   /// Maximum number of operands in a single flattened AND/OR chain; wider
   /// chains are rejected. Width is how many operands one flattened node holds,
-  /// e.g. a OR b OR c OR d is one node of width four. Distinct from
-  /// maxExpressionDepth, which instead bounds how deeply operators nest.
+  /// e.g. a OR b OR c OR d is one node of width four. Parentheses do not start
+  /// a new node, so (a OR b) OR (c OR d) is also one node of width four.
+  /// Distinct from maxExpressionDepth, which instead bounds how deeply
+  /// operators nest.
   ///
   /// The default is large because flattening collapses a chain into a single
   /// node whose operand count downstream passes process in linear time, and the

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -256,15 +256,18 @@ std::string stripDigitSeparators(std::string_view text, bool friendlySql) {
   return result;
 }
 
-PrestoSqlParser::IntegerLiteralContext* asIntegerLiteral(
-    PrestoSqlParser::ValueExpressionContext* valueExpr) {
+// Returns the primary expression when no operator is applied to it, or nullptr.
+PrestoSqlParser::PrimaryExpressionContext* FOLLY_NULLABLE
+asPrimaryExpression(PrestoSqlParser::ValueExpressionContext* valueExpr) {
   auto* defaultCtx =
       dynamic_cast<PrestoSqlParser::ValueExpressionDefaultContext*>(valueExpr);
-  if (defaultCtx == nullptr) {
-    return nullptr;
-  }
+  return defaultCtx == nullptr ? nullptr : defaultCtx->primaryExpression();
+}
+
+PrestoSqlParser::IntegerLiteralContext* FOLLY_NULLABLE
+asIntegerLiteral(PrestoSqlParser::ValueExpressionContext* valueExpr) {
   auto* numericCtx = dynamic_cast<PrestoSqlParser::NumericLiteralContext*>(
-      defaultCtx->primaryExpression());
+      asPrimaryExpression(valueExpr));
   if (numericCtx == nullptr) {
     return nullptr;
   }
@@ -1822,6 +1825,28 @@ std::any AstBuilder::visitPredicated(PrestoSqlParser::PredicatedContext* ctx) {
   return visitExpression(ctx->valueExpression());
 }
 
+namespace {
+
+// Returns the expression inside plain parentheses, or nullptr otherwise.
+PrestoSqlParser::BooleanExpressionContext* FOLLY_NULLABLE
+tryUnwrapParentheses(PrestoSqlParser::BooleanExpressionContext* ctx) {
+  auto* predicated = dynamic_cast<PrestoSqlParser::PredicatedContext*>(ctx);
+  if (predicated == nullptr || predicated->predicate() != nullptr) {
+    return nullptr;
+  }
+
+  auto* parenthesized =
+      dynamic_cast<PrestoSqlParser::ParenthesizedExpressionContext*>(
+          asPrimaryExpression(predicated->valueExpression()));
+  if (parenthesized == nullptr) {
+    return nullptr;
+  }
+
+  return parenthesized->expression()->booleanExpression();
+}
+
+} // namespace
+
 std::any AstBuilder::visitLogicalBinary(
     PrestoSqlParser::LogicalBinaryContext* ctx) {
   trace("visitLogicalBinary");
@@ -1832,33 +1857,34 @@ std::any AstBuilder::visitLogicalBinary(
   // Flatten a same-operator chain into one n-ary call.
   std::vector<ExpressionPtr> arguments;
 
-  // Fail fast: reject an oversize chain without building every operand.
-  auto checkWidth = [&] {
+  std::vector<PrestoSqlParser::BooleanExpressionContext*> pending{ctx};
+
+  while (!pending.empty()) {
+    // Each pending node yields at least one operand, so this is a lower bound.
     AXIOM_PRESTO_SEMANTIC_CHECK_LE(
-        arguments.size(),
+        arguments.size() + pending.size(),
         options_.maxExpressionWidth,
         location,
         /*token=*/std::nullopt,
         "Expression exceeds maximum width");
-  };
 
-  auto* current = ctx;
-  while (true) {
-    arguments.push_back(visitExpression(current->right));
-    checkWidth();
-    auto* leftBinary =
-        dynamic_cast<PrestoSqlParser::LogicalBinaryContext*>(current->left);
-    const bool leftIsSameOp =
-        leftBinary != nullptr && (leftBinary->AND() != nullptr) == isAnd;
-    if (!leftIsSameOp) {
-      break;
+    auto* node = pending.back();
+    pending.pop_back();
+
+    while (auto* inner = tryUnwrapParentheses(node)) {
+      node = inner;
     }
-    current = leftBinary;
+
+    auto* binary = dynamic_cast<PrestoSqlParser::LogicalBinaryContext*>(node);
+    if (binary != nullptr && (binary->AND() != nullptr) == isAnd) {
+      // Push right first so operands pop in source order.
+      pending.push_back(binary->right);
+      pending.push_back(binary->left);
+      continue;
+    }
+
+    arguments.push_back(visitExpression(node));
   }
-  arguments.push_back(visitExpression(current->left));
-  checkWidth();
-  // Operands were collected right to left; restore their original order.
-  std::reverse(arguments.begin(), arguments.end());
 
   return std::static_pointer_cast<Expression>(std::make_shared<FunctionCall>(
       location,

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -1327,11 +1327,51 @@ TEST_F(ExpressionParserTest, mixedOperatorsNotFlattened) {
       parseExpr("1 = 0 AND 2 = 0 OR 3 = 0"), "(1 = 0 AND 2 = 0) OR 3 = 0"));
 }
 
-// A parenthesized chain stays grouped; only a plain chain is flattened.
-TEST_F(ExpressionParserTest, parenthesizedChainNotFlattened) {
+// Parentheses only group, so a same-operator chain flattens through them.
+TEST_F(ExpressionParserTest, parenthesizedChainFlattens) {
   ASSERT_TRUE(match(
-      parseExpr("1 = 0 OR (2 = 0 OR 3 = 0)"),
-      R"("or"(1 = 0, "or"(2 = 0, 3 = 0)))"));
+      parseExpr("1 = 0 OR (2 = 0 OR 3 = 0)"), R"("or"(1 = 0, 2 = 0, 3 = 0))"));
+  ASSERT_TRUE(match(
+      parseExpr("(1 = 0 OR 2 = 0) OR 3 = 0"), R"("or"(1 = 0, 2 = 0, 3 = 0))"));
+  ASSERT_TRUE(match(
+      parseExpr("(1 = 0 AND 2 = 0) AND 3 = 0"),
+      R"("and"(1 = 0, 2 = 0, 3 = 0))"));
+  // An unbalanced shape: operands still come out in source order.
+  ASSERT_TRUE(match(
+      parseExpr("1 = 0 OR ((2 = 0 OR 3 = 0) OR 4 = 0)"),
+      R"("or"(1 = 0, 2 = 0, 3 = 0, 4 = 0))"));
+}
+
+// Two paren levels, so a single unwrap would leave the chain nested.
+TEST_F(ExpressionParserTest, repeatedParenthesesFlatten) {
+  ASSERT_TRUE(match(
+      parseExpr("1 = 0 OR ((2 = 0 OR 3 = 0))"),
+      R"("or"(1 = 0, 2 = 0, 3 = 0))"));
+}
+
+// A parenthesized chain of the other operator keeps its own node.
+TEST_F(ExpressionParserTest, parenthesizedMixedOperatorsNotFlattened) {
+  ASSERT_TRUE(match(
+      parseExpr("1 = 0 OR (2 = 0 AND 3 = 0)"),
+      R"("or"(1 = 0, "and"(2 = 0, 3 = 0)))"));
+  // Dropping these parentheses would change the result, since AND binds first.
+  ASSERT_TRUE(match(
+      parseExpr("1 = 0 AND (2 = 0 OR 3 = 0)"),
+      R"("and"(1 = 0, "or"(2 = 0, 3 = 0)))"));
+  // Each group flattens on its own; the differing parent keeps them apart.
+  ASSERT_TRUE(match(
+      parseExpr("(1 = 0 OR 2 = 0) AND (3 = 0 OR 4 = 0)"),
+      R"("and"("or"(1 = 0, 2 = 0), "or"(3 = 0, 4 = 0)))"));
+}
+
+// An operator applied to a parenthesized chain keeps it a separate operand.
+TEST_F(ExpressionParserTest, operatorOnChainBlocksFlattening) {
+  ASSERT_TRUE(match(
+      parseExpr("1 = 0 OR ((2 = 0 OR 3 = 0) IS NULL)"),
+      R"("or"(1 = 0, is_null("or"(2 = 0, 3 = 0))))"));
+  ASSERT_TRUE(match(
+      parseExpr("1 = 0 OR (NOT (2 = 0 OR 3 = 0))"),
+      R"("or"(1 = 0, not("or"(2 = 0, 3 = 0))))"));
 }
 
 // A flattened chain wider than max_expression_width is rejected.
@@ -1354,6 +1394,20 @@ TEST_F(ExpressionParserTest, nestedChainWidthEnforcedPerNode) {
       parseExpr(
           "(1 = 0 AND 1 = 1 AND 1 = 2 AND 1 = 3) OR 1 = 4",
           /*maxExpressionWidth=*/3),
+      "Expression exceeds maximum width");
+}
+
+// Same-operator groups merge into one node, so they share a width budget.
+TEST_F(ExpressionParserTest, widthSharedAcrossParenthesizedGroups) {
+  // Groups summing to exactly the cap are accepted.
+  ASSERT_TRUE(match(
+      parseExpr(
+          "(1 = 0 OR 1 = 1) OR (1 = 2 OR 1 = 3)", /*maxExpressionWidth=*/4),
+      R"("or"(1 = 0, 1 = 1, 1 = 2, 1 = 3))"));
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr(
+          "(1 = 0 OR 1 = 1) OR (1 = 2 OR 1 = 3)", /*maxExpressionWidth=*/3),
       "Expression exceeds maximum width");
 }
 


### PR DESCRIPTION
Summary:
Parentheses only group operands and produce no AST node, but a parenthesized chain still built a nested call:

    a OR b OR c    ->  or(a, b, c)
    a OR (b OR c)  ->  or(a, or(b, c))

Both now produce a single n-ary call. Velox already flattened these downstream, so query results are unchanged. The parser still does it because the width check has to reject before the operands are built, and because every downstream flattener is recursive, so a 100000-operand chain would otherwise arrive as a 100000-deep tree.

The chain walk unwraps parentheses and follows both operands through an explicit worklist, instead of descending only the left spine.

Same-operator groups now share one `max_expression_width` budget, so `(a OR b) OR (c OR d)` counts as four operands rather than two nodes of two. This closes a budget-evasion gap at the default limit of 100000: two groups of 60000 each stayed under the per-node limit while the query as a whole carried 120000 operands, which is the quantity the cap exists to bound. Queries whose groups sum past the limit are now rejected where each group previously passed on its own; `max_expression_width` is a session property, so an affected query can raise it.

The budget applies per flattened node, not to total expression size, so a chain whose groups use different operators, `(60000 ANDs) OR (60000 ANDs)`, stays under the limit as three separate nodes and keeps running as before.

Differential Revision: D114982620


