### PR TITLE
feat(optimizer): Run small queries on fewer workers (#1728)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -1438,9 +1438,8 @@ std::string printPlanWithStats(
           std::ostream& out) {
         auto it = estimates.find(nodeId);
         if (it != estimates.end()) {
-          out << indentation << "Estimate: " << it->second.cardinality
-              << " rows, " << velox::succinctBytes(it->second.peakMemory)
-              << " peak memory" << std::endl;
+          out << indentation << "Estimate: " << it->second.toString()
+              << std::endl;
         }
       });
 }

--- a/axiom/cli/tests/ExplainTest.cpp
+++ b/axiom/cli/tests/ExplainTest.cpp
@@ -68,11 +68,11 @@ TEST_P(ExplainTest, showsCardinalityEstimate) {
       ::testing::ElementsAre(
           Eq("Fragment 0: fragment1 SINGLE:"),
           StartsWith("-- Aggregation[3][SINGLE [l_orderkey] sum := sum("),
-          StartsWith("   Estimate: 249.75 rows, "),
+          Eq("   Estimate: 249.75 rows"),
           StartsWith("  -- Project[2][expressions: (l_orderkey:BIGINT, "),
-          StartsWith("     Estimate: 999.202 rows, "),
+          Eq("     Estimate: 999.202 rows"),
           StartsWith("    -- Filter[1][expression: lt(\"l_orderkey\",1000)]"),
-          StartsWith("       Estimate: 999.202 rows, "),
+          Eq("       Estimate: 999.202 rows"),
           StartsWith("      -- TableScan[0][\"default\".\"lineitem\"]"),
           Eq(""),
           Eq("")));

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -433,6 +433,22 @@ struct FilteredTableStats {
   /// the table handle.
   uint64_t numRows{0};
 
+  /// Estimated rows the scan reads in order to produce 'numRows'. A connector
+  /// may eliminate rows two ways: without reading them, by resolving part of
+  /// the accepted filters from metadata, and by evaluating the remaining
+  /// filters on rows it has read. This is the count after the first and before
+  /// the second, so it is at least 'numRows'. The two are equal when the
+  /// connector discards nothing after reading: every row it reads is returned.
+  /// A scan's work tracks the rows it reads rather than the rows it returns,
+  /// which is what makes this the measure of how large a query is -- one
+  /// returning a handful of rows may still read a great many. std::nullopt when
+  /// the connector does not distinguish the two.
+  ///
+  /// For example, a Hive-style connector skips files whose path values fail the
+  /// filter, then applies what remains to the rows it reads; 'numRawInputRows'
+  /// is what those files hold.
+  std::optional<uint64_t> numRawInputRows;
+
   /// Per-column statistics corresponding 1:1 to the 'columns' parameter of
   /// co_estimateStats. Either empty (no column stats available) or has the
   /// same size as 'columns', in the same order.

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -244,7 +244,8 @@ FilteredTableStats estimateStatsFromPartitionStats(
     }
   }
 
-  return FilteredTableStats{totalRows, std::move(columnStats)};
+  return FilteredTableStats{
+      .numRows = totalRows, .columnStats = std::move(columnStats)};
 }
 
 // Iterates over a precomputed set of partition-key tuples.
@@ -595,6 +596,11 @@ LocalHiveTableLayout::co_estimateStats(
 
   auto stats = estimateStatsFromPartitionStats(
       partitionStats_, partitionFilters, requestedColumns);
+  if (!partitionStats_.empty()) {
+    // A table with no partition statistics estimates zero rows; reporting that
+    // as the rows read would understate the scan rather than leave it unknown.
+    stats.numRawInputRows = stats.numRows;
+  }
   foldNonPartitionFilterStats(*hiveHandle, estimator, stats);
   co_return stats;
 }

--- a/axiom/graphviz/MultiFragmentPlanDotPrinter.h
+++ b/axiom/graphviz/MultiFragmentPlanDotPrinter.h
@@ -44,7 +44,7 @@ namespace facebook::axiom::graphviz {
 /// Then render with: dot -Tsvg plan.dot -o plan.svg
 class MultiFragmentPlanDotPrinter {
  public:
-  /// @param prediction Per-node cardinality / memory estimates. When a
+  /// @param prediction Per-node cardinality estimates. When a
   /// fragment's root has an entry, the estimated row count is appended to
   /// the fragment's "out:" row.
   static void print(

--- a/axiom/optimizer/Cost.cpp
+++ b/axiom/optimizer/Cost.cpp
@@ -56,6 +56,14 @@ std::optional<float> History::findSampledLeafSelectivity(
   return std::nullopt;
 }
 
+std::string NodePrediction::toString() const {
+  std::string result = fmt::format("{:g} rows", cardinality);
+  if (numRawInputRows.has_value()) {
+    result += fmt::format(", {} raw input rows", *numRawInputRows);
+  }
+  return result;
+}
+
 float shuffleCost(const ColumnVector& columns) {
   return byteSize(columns) * Costs::kByteShuffleCost;
 }

--- a/axiom/optimizer/Cost.h
+++ b/axiom/optimizer/Cost.h
@@ -24,12 +24,19 @@ namespace facebook::axiom::optimizer {
 
 /// Record the history data for a tracked PlanNode.
 struct NodePrediction {
-  /// Result cardinality for the top node of the recorded plan.
-  float cardinality;
-  ///  Peak total memory for the top node.
-  float peakMemory{0};
-  /// CPU estimate in optimizer internal units.
-  float cpu{0};
+  /// Estimated result cardinality. An optimizer operator may lower to several
+  /// Velox nodes; the entry is keyed by the outermost one, whose output is the
+  /// operator's result.
+  float cardinality{0};
+
+  /// For a table scan, the estimated rows it reads, as reported by the
+  /// connector; see `connector::FilteredTableStats::numRawInputRows`. Unset for
+  /// every other node, and for a connector that does not report it.
+  std::optional<uint64_t> numRawInputRows;
+
+  /// Returns a human-readable summary of the estimate for annotating plan
+  /// output.
+  std::string toString() const;
 };
 
 /// Interface to historical query cost and cardinality

--- a/axiom/optimizer/MultiFragmentPlan.h
+++ b/axiom/optimizer/MultiFragmentPlan.h
@@ -187,7 +187,9 @@ class MultiFragmentPlan {
     std::string queryId;
 
     /// Maximum Number of independent Tasks for one stage of execution. If 1,
-    /// there are no exchanges.
+    /// there are no exchanges. Starts as the workers available to the query.
+    /// The optimizer may lower it, so a plan carries the count it was planned
+    /// for rather than the count available.
     int32_t numWorkers{1};
 
     /// Number of threads in a fragment in a worker. If 1, there are no local

--- a/axiom/optimizer/OptimizerOptions.cpp
+++ b/axiom/optimizer/OptimizerOptions.cpp
@@ -81,6 +81,21 @@ std::vector<ConfigProperty> buildProperties(
           "Enable reducing semi joins.",
       },
       {
+          std::string(OptimizerOptions::kSmallQueryMaxScanRows),
+          ConfigPropertyType::kInteger,
+          std::to_string(OptimizerOptions::kSmallQueryMaxScanRowsDefault),
+          "A query whose scans are estimated to read at most this many rows in "
+          "total is small and runs on 'small_query_num_workers' workers. A "
+          "query that reads more, or whose scans report no estimate, runs on "
+          "all available workers. 0 disables.",
+      },
+      {
+          std::string(OptimizerOptions::kSmallQueryNumWorkers),
+          ConfigPropertyType::kInteger,
+          std::to_string(OptimizerOptions::kSmallQueryNumWorkersDefault),
+          "Workers a small query runs on, capped by the number available.",
+      },
+      {
           std::string(OptimizerOptions::kParallelProjectWidth),
           ConfigPropertyType::kInteger,
           std::to_string(OptimizerOptions::kParallelProjectWidthDefault),
@@ -150,7 +165,15 @@ OptimizerOptions::OptimizerOptions(
 std::string OptimizerOptions::normalize(
     std::string_view name,
     std::string_view value) const {
-  if (name == kParallelProjectWidth) {
+  if (name == kSmallQueryMaxScanRows) {
+    auto rows = std::stoll(std::string(value));
+    VELOX_USER_CHECK_GE(
+        rows, 0, "small_query_max_scan_rows must be >= 0: {}", value);
+  } else if (name == kSmallQueryNumWorkers) {
+    auto workers = std::stoi(std::string(value));
+    VELOX_USER_CHECK_GE(
+        workers, 1, "small_query_num_workers must be >= 1: {}", value);
+  } else if (name == kParallelProjectWidth) {
     auto width = std::stoi(std::string(value));
     VELOX_USER_CHECK_GE(
         width, 1, "parallel_project_width must be >= 1: {}", value);
@@ -182,6 +205,13 @@ OptimizerOptions OptimizerOptions::from(
     }
   };
 
+  auto setLong = [&](std::string_view key, int64_t& field) {
+    auto it = properties.find(key);
+    if (it != properties.end()) {
+      field = std::stoll(it->second);
+    }
+  };
+
   auto setCapacity = [&](std::string_view key, int64_t& field) {
     auto it = properties.find(key);
     if (it != properties.end()) {
@@ -199,6 +229,8 @@ OptimizerOptions OptimizerOptions::from(
   setBool(kSyntacticJoinOrder, options.syntacticJoinOrder);
   setBool(kAlwaysPlanPartialAggregation, options.alwaysPlanPartialAggregation);
   setBool(kEnableReducingExistences, options.enableReducingExistences);
+  setLong(kSmallQueryMaxScanRows, options.smallQueryMaxScanRows);
+  setInt(kSmallQueryNumWorkers, options.smallQueryNumWorkers);
   setInt(kParallelProjectWidth, options.parallelProjectWidth);
   setInt(kGreedyJoinThreshold, options.greedyJoinThreshold);
   setCapacity(kBroadcastSizeLimit, options.broadcastSizeLimit);

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -53,10 +53,16 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
       "broadcast_size_limit";
   static constexpr std::string_view kDphypEnumerationBudget =
       "dphyp_enumeration_budget";
+  static constexpr std::string_view kSmallQueryMaxScanRows =
+      "small_query_max_scan_rows";
+  static constexpr std::string_view kSmallQueryNumWorkers =
+      "small_query_num_workers";
   static constexpr std::string_view kTraceFlags = "trace_flags";
 
   // Default values — single source of truth for field initializers
   // and properties().
+  static constexpr int64_t kSmallQueryMaxScanRowsDefault = 0;
+  static constexpr int32_t kSmallQueryNumWorkersDefault = 1;
   static constexpr int32_t kParallelProjectWidthDefault = 1;
   static constexpr int32_t kGreedyJoinThresholdDefault = 5;
   // 100 MB. The string form is the user-facing default and accepts capacity
@@ -98,6 +104,16 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   /// Map from table name to list of map columns to be read as structs unless
   /// the whole map is accessed as a map.
   folly::F14FastMap<std::string, std::vector<std::string>> mapAsStruct;
+
+  /// A query whose scans are estimated to read at most this many rows in total
+  /// is small. A query that reads more, or whose scans report no estimate,
+  /// keeps the worker count the caller supplied. 0, the default, disables the
+  /// decision.
+  int64_t smallQueryMaxScanRows{kSmallQueryMaxScanRowsDefault};
+
+  /// The worker count a small query runs on, capped by the count the caller
+  /// supplied.
+  int32_t smallQueryNumWorkers{kSmallQueryNumWorkersDefault};
 
   /// Enable join order sampling during optimization.
   bool sampleJoins{kSampleJoinsDefault};

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1157,6 +1157,13 @@ struct BaseTable : public TableObject {
   /// the cardinality is unknown.
   std::optional<float> filteredCardinality{0};
 
+  /// Estimated rows the scan of this table reads, as reported by the
+  /// connector: filters it resolves from metadata without reading are already
+  /// reflected, filters it evaluates on rows it has read are not. See
+  /// `connector::FilteredTableStats::numRawInputRows` for the full definition.
+  /// nullopt when the connector does not report it.
+  std::optional<uint64_t> numRawInputRows;
+
   SubfieldSet controlSubfields;
 
   SubfieldSet payloadSubfields;

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -46,11 +46,8 @@ std::string PlanAndStats::toString() const {
           std::ostream& out) {
         auto it = prediction.find(planNodeId);
         if (it != prediction.end()) {
-          out << indentation << "Estimate: " << it->second.cardinality
-              << " rows, "
-              << velox::succinctBytes(
-                     static_cast<uint64_t>(it->second.peakMemory))
-              << " peak memory" << std::endl;
+          out << indentation << "Estimate: " << it->second.toString()
+              << std::endl;
         }
       });
 }

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -378,7 +378,7 @@ class ToVelox {
   // history recording.
   NodeHistoryMap nodeHistory_;
 
-  // Predicted cardinality and memory for nodes to record in history.
+  // Predicted cardinality for nodes to record in history.
   NodePredictionMap prediction_;
 
   // On when producing a remaining filter for table scan, where columns must

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -651,9 +651,8 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
             std::ostream& out) {
           auto it = estimates.find(nodeId);
           if (it != estimates.end()) {
-            out << indentation << "Estimate: " << it->second.cardinality
-                << " rows, " << succinctBytes(it->second.peakMemory)
-                << " peak memory" << std::endl;
+            out << indentation << "Estimate: " << it->second.toString()
+                << std::endl;
           }
         });
   }

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -136,6 +136,7 @@ add_executable(
   PlanTest.cpp
   RemoteOutputTest.cpp
   QueryGraphContextTest.cpp
+  QueryWidthTest.cpp
   RankingTest.cpp
   RelationOpPrinterTest.cpp
   SetTest.cpp

--- a/axiom/optimizer/tests/OptimizerOptionsTest.cpp
+++ b/axiom/optimizer/tests/OptimizerOptionsTest.cpp
@@ -48,6 +48,8 @@ TEST(OptimizerOptionsTest, codeDefaults) {
   EXPECT_EQ(
       getDefault(props, OptimizerOptions::kUseFilteredTableStats), "true");
   EXPECT_EQ(getDefault(props, OptimizerOptions::kBroadcastSizeLimit), "100MB");
+  EXPECT_EQ(getDefault(props, OptimizerOptions::kSmallQueryMaxScanRows), "0");
+  EXPECT_EQ(getDefault(props, OptimizerOptions::kSmallQueryNumWorkers), "1");
 }
 
 TEST(OptimizerOptionsTest, configOverrides) {
@@ -67,11 +69,16 @@ TEST(OptimizerOptionsTest, from) {
       {std::string(OptimizerOptions::kParallelProjectWidth), "8"},
       {std::string(OptimizerOptions::kTraceFlags), "5"},
       {std::string(OptimizerOptions::kBroadcastSizeLimit), "5GB"},
+      // Above int32, since row counts on real tables exceed it.
+      {std::string(OptimizerOptions::kSmallQueryMaxScanRows), "5000000000"},
+      {std::string(OptimizerOptions::kSmallQueryNumWorkers), "2"},
   };
   auto options = OptimizerOptions::from(props);
 
   EXPECT_TRUE(options.sampleJoins);
   EXPECT_EQ(options.parallelProjectWidth, 8);
+  EXPECT_EQ(options.smallQueryMaxScanRows, 5'000'000'000);
+  EXPECT_EQ(options.smallQueryNumWorkers, 2);
   EXPECT_EQ(options.traceFlags, 5);
   EXPECT_EQ(options.broadcastSizeLimit, 5LL << 30);
   EXPECT_FALSE(options.syntacticJoinOrder);
@@ -96,6 +103,12 @@ TEST(OptimizerOptionsTest, normalizeRejectsInvalidValues) {
   VELOX_ASSERT_THROW(
       options.normalize(OptimizerOptions::kBroadcastSizeLimit, "100"),
       "Invalid capacity string");
+  VELOX_ASSERT_THROW(
+      options.normalize(OptimizerOptions::kSmallQueryMaxScanRows, "-1"),
+      "small_query_max_scan_rows must be >= 0");
+  VELOX_ASSERT_THROW(
+      options.normalize(OptimizerOptions::kSmallQueryNumWorkers, "0"),
+      "small_query_num_workers must be >= 1");
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/QueryWidthTest.cpp
+++ b/axiom/optimizer/tests/QueryWidthTest.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+// TPC-H nation has 25 rows, region 5.
+constexpr int64_t kNationRows = 25;
+constexpr int64_t kRegionRows = 5;
+constexpr int32_t kWorkersAvailable = 4;
+
+// Verifies that the optimizer collapses a query onto fewer workers when its
+// scans are estimated to read few enough rows.
+class QueryWidthTest : public test::HiveQueriesTestBase {
+ protected:
+  static void SetUpTestCase() {
+    test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables(
+        {velox::tpch::Table::TBL_NATION, velox::tpch::Table::TBL_REGION});
+  }
+
+  void SetUp() override {
+    useV2_ = true;
+    test::HiveQueriesTestBase::SetUp();
+  }
+
+  PlanAndStats plan(std::string_view sql, const OptimizerOptions& options) {
+    return planVelox(
+        parseSelect(sql),
+        {.numWorkers = kWorkersAvailable, .numDrivers = 2},
+        options);
+  }
+
+  // Options that narrow a query reading at most 'maxRawInputRows' to a single
+  // worker.
+  static OptimizerOptions narrowingAt(int64_t maxRawInputRows) {
+    OptimizerOptions options;
+    options.smallQueryMaxScanRows = maxRawInputRows;
+    return options;
+  }
+
+  static int32_t numWorkers(const PlanAndStats& result) {
+    return result.plan->options().numWorkers;
+  }
+
+  // Sums the raw-input estimates the optimizer recorded for the plan's scans,
+  // which is what the width decision reads. nullopt when no scan reported one.
+  static std::optional<uint64_t> scanRawInputRows(const PlanAndStats& result) {
+    std::optional<uint64_t> total;
+    for (const auto& [id, prediction] : result.prediction) {
+      if (prediction.numRawInputRows.has_value()) {
+        total = total.value_or(0) + *prediction.numRawInputRows;
+      }
+    }
+    return total;
+  }
+};
+
+// A query narrows when the rows its scan is estimated to read are at most the
+// threshold, which is inclusive. A threshold of zero disables the decision.
+// The decision follows what the query reads, so an aggregation over a scan
+// behaves like the scan alone.
+TEST_F(QueryWidthTest, scan) {
+  for (const std::string_view sql :
+       {"SELECT n_nationkey FROM nation",
+        "SELECT n_regionkey, count(*) FROM nation GROUP BY 1"}) {
+    SCOPED_TRACE(sql);
+
+    {
+      const auto result = plan(sql, narrowingAt(kNationRows));
+      EXPECT_EQ(scanRawInputRows(result), kNationRows);
+      EXPECT_EQ(numWorkers(result), 1);
+    }
+
+    {
+      const auto result = plan(sql, narrowingAt(kNationRows - 1));
+      EXPECT_EQ(scanRawInputRows(result), kNationRows);
+      EXPECT_EQ(numWorkers(result), kWorkersAvailable);
+    }
+
+    {
+      const auto result = plan(sql, narrowingAt(0));
+      EXPECT_EQ(scanRawInputRows(result), kNationRows);
+      EXPECT_EQ(numWorkers(result), kWorkersAvailable);
+    }
+  }
+}
+
+// A query reading several tables is sized by their total.
+TEST_F(QueryWidthTest, join) {
+  const std::string_view sql =
+      "SELECT n_name, r_name FROM nation, region "
+      "WHERE n_regionkey = r_regionkey";
+  const int64_t bothTables = kNationRows + kRegionRows;
+
+  {
+    const auto result = plan(sql, narrowingAt(bothTables));
+    EXPECT_EQ(scanRawInputRows(result), bothTables);
+    EXPECT_EQ(numWorkers(result), 1);
+  }
+
+  {
+    const auto result = plan(sql, narrowingAt(bothTables - 1));
+    EXPECT_EQ(scanRawInputRows(result), bothTables);
+    EXPECT_EQ(numWorkers(result), kWorkersAvailable);
+  }
+}
+
+// Narrowing on a partial total would under-size a query by however much the
+// untracked table reads, so an unknown estimate declines to narrow rather than
+// counting as zero.
+TEST_F(QueryWidthTest, noStats) {
+  auto options = narrowingAt(1'000'000);
+  options.useFilteredTableStats = false;
+
+  const auto result = plan("SELECT n_nationkey FROM nation", options);
+  EXPECT_EQ(scanRawInputRows(result), std::nullopt);
+  EXPECT_EQ(numWorkers(result), kWorkersAvailable);
+}
+
+// A narrowed query gets the configured number of workers, never more than the
+// caller had available.
+TEST_F(QueryWidthTest, narrowWidth) {
+  const std::string_view sql = "SELECT n_nationkey FROM nation";
+
+  auto options = narrowingAt(kNationRows);
+  {
+    options.smallQueryNumWorkers = 2;
+    EXPECT_EQ(numWorkers(plan(sql, options)), 2);
+  }
+
+  {
+    options.smallQueryNumWorkers = kWorkersAvailable * 2;
+    EXPECT_EQ(numWorkers(plan(sql, options)), kWorkersAvailable);
+  }
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -300,10 +300,18 @@ class Emitter {
       return;
     }
     const auto& estimate = estimateProvider_.estimate(node);
-    if (estimate.cardinality.has_value()) {
-      prediction_[plan->id()] =
-          NodePrediction{.cardinality = *estimate.cardinality};
+    if (!estimate.cardinality.has_value()) {
+      return;
     }
+
+    std::optional<uint64_t> numRawInputRows;
+    if (node->is(NodeType::kScan)) {
+      numRawInputRows = node->as<Scan>()->baseTable()->numRawInputRows;
+    }
+
+    prediction_[plan->id()] = NodePrediction{
+        .cardinality = *estimate.cardinality,
+        .numRawInputRows = numRawInputRows};
   }
 
   // Local exchange inserted below a final/single aggregation at numDrivers > 1

--- a/axiom/optimizer/v2/EmitPass.h
+++ b/axiom/optimizer/v2/EmitPass.h
@@ -35,8 +35,8 @@ class EmitPass {
     std::vector<ExecutableFragment> fragments;
     /// Set when the plan writes a table; empty otherwise.
     FinishWrite finishWrite;
-    /// Per-node estimated cardinality, keyed by emitted `PlanNodeId`, for
-    /// EXPLAIN. Empty when estimates are unavailable.
+    /// Per-node estimates, keyed by emitted `PlanNodeId`, for EXPLAIN. Empty
+    /// when estimates are unavailable.
     NodePredictionMap prediction;
   };
 

--- a/axiom/optimizer/v2/EstimateLeafStatsPass.cpp
+++ b/axiom/optimizer/v2/EstimateLeafStatsPass.cpp
@@ -69,6 +69,8 @@ void applyFilteredStats(
 
   auto* baseTable = const_cast<BaseTable*>(scan.baseTable());
 
+  baseTable->numRawInputRows = stats->numRawInputRows;
+
   if (!stats->columnStats.empty()) {
     VELOX_CHECK_EQ(stats->columnStats.size(), statColumns.size());
     for (size_t i = 0; i < stats->columnStats.size(); ++i) {

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -73,6 +73,48 @@ void collectScans(
   }
 }
 
+// Sums the rows the scans under 'node' are estimated to read. One unknown
+// makes the total unknown: summing the rest would under-size the query by
+// however much the unknown table reads. Each use of a table in a query has its
+// own BaseTable, so no scan is counted twice.
+std::optional<uint64_t> totalRawInputRows(NodeCP node) {
+  if (node->is(NodeType::kScan)) {
+    return node->as<Scan>()->baseTable()->numRawInputRows;
+  }
+
+  uint64_t total{0};
+  for (NodeCP input : node->inputs()) {
+    const auto rows = totalRawInputRows(input);
+    if (!rows.has_value()) {
+      return std::nullopt;
+    }
+    total += *rows;
+  }
+
+  return total;
+}
+
+// Returns the workers to run the query rooted at 'node' on:
+// 'smallQueryNumWorkers' when its scans are estimated to read at most
+// 'smallQueryMaxScanRows', and 'maxWorkers' otherwise. Never returns more than
+// 'maxWorkers'.
+int32_t chooseNumWorkers(
+    NodeCP node,
+    const OptimizerOptions& options,
+    int32_t maxWorkers) {
+  if (options.smallQueryMaxScanRows <= 0) {
+    return maxWorkers;
+  }
+
+  const auto numRawInputRows = totalRawInputRows(node);
+  if (!numRawInputRows.has_value() ||
+      *numRawInputRows > static_cast<uint64_t>(options.smallQueryMaxScanRows)) {
+    return maxWorkers;
+  }
+
+  return std::min(options.smallQueryNumWorkers, maxWorkers);
+}
+
 } // namespace
 
 PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
@@ -95,6 +137,13 @@ PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
   if (session_.options().useFilteredTableStats) {
     EstimateLeafStatsPass::run(folded, session_, evaluator_, scanHandles);
   }
+
+  // Decide the width before physical planning, which reads numWorkers to shape
+  // exchanges and to cost broadcasts.
+  MultiFragmentPlan::Options planOptions = options;
+  planOptions.numWorkers =
+      chooseNumWorkers(folded, session_.options(), options.numWorkers);
+
   EmitPass::Result emitted = physicalPlanAndEmit(
       folded,
       frontend.translated.outputColumns,
@@ -103,11 +152,11 @@ PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
       session_,
       evaluator_,
       scanHandles,
-      options);
+      planOptions);
 
   PlanAndStats result;
   result.plan = std::make_shared<MultiFragmentPlan>(
-      std::move(emitted.fragments), options);
+      std::move(emitted.fragments), planOptions);
   result.finishWrite = std::move(emitted.finishWrite);
   result.prediction = std::move(emitted.prediction);
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/256


A query that reads little data pays for the workers it spreads across: more tasks, more exchange connections between them, and more coordinator work, none of which the data volume justifies. The optimizer can now size a query by how many rows its scans read and run a small one narrower. Two session properties control it, both off by default:

    small_query_max_scan_rows   a query whose scans read at most this many rows in total is small; 0 disables
    small_query_num_workers     workers a small query runs on, capped by the number available

Connectors report a new estimate alongside the filtered row count: the rows a scan reads, which is what the scan pays for, as against the rows it returns after the filters it evaluates on rows already read. The optimizer sums that across the query's scans and narrows when the total is at or below the threshold. A scan that reports no estimate makes the total unknown, and an unknown query keeps every worker it was offered.

Sizing by bytes read is deliberately not included. The row estimate held up when checked against real queries; the same exercise with bytes did not, and why is not yet understood well enough to build on.

Only the v2 optimizer makes this decision. Setting either property on a v1 session does nothing.

Reviewed By: xiaoxmeng

Differential Revision: D116388251


