### PR TITLE
fix(tests): Advance Velox and rename outputType to targetColumns in LocalHiveConnectorMetadataTest (#1729)

### DIFF
--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -146,13 +146,20 @@ class LocalHiveConnectorMetadataTest
         velox::exec::test::kHiveConnectorId, handle->veloxHandle());
     auto plan = builder.startTableWriter()
                     .outputDirectoryPath(outputPath)
-                    .outputType(table->type())
+                    .targetColumns(table->type())
                     .insertHandle(insertHandle)
                     .fileFormat(format)
                     .endTableWriter()
                     .planNode();
     auto result = exec::test::AssertQueryBuilder(plan).copyResults(pool());
-    metadata_->finishWrite(session, handle, {result}, nullptr, {}).get();
+    metadata_
+        ->finishWrite(
+            session,
+            handle,
+            std::vector<velox::RowVectorPtr>{result},
+            nullptr,
+            {})
+        .get();
   }
 
   /// Read the specified files from the table. All the files must belong to


### PR DESCRIPTION
Summary:

This test was broken by https://github.com/facebookincubator/velox/pull/18490 which refactored
PlanBuilder::TableWriterBuilder::outputType() to targetColumns().

The old setter name conflicted with TableWriteNode::outputType() which
returns the write-metadata schema (rows, fragments, commitContext), while
the builder setter configures the target table columns (TableWriteNode
columns / columnNames). The refactor renamed the builder API to
targetColumns() to disambiguate.

Changes:
- Updated writeToTable() in LocalHiveConnectorMetadataTest.cpp to call
  targetColumns(table->type()) instead of the removed outputType().
- Advanced Velox submodule from 8da9b9af1d04e9c9a6913b686480ca6fcde27b10 to
  b8314718092cd4f2d463991cd083331b7995a089, the merge commit of
  facebookincubator/velox#18490 on Velox main, fixing OSS build failure
  "has no member named 'targetColumns'".
- Made finishWrite call use explicit std::vector<RowVectorPtr> to avoid
  GCC 12 initializer_list conversion failure seen in OSS CI:
  "cannot convert brace-enclosed initializer list to vector<shared_ptr<RowVector>>&".

Reviewed By: mbasmanova

Differential Revision: D116388201
