### PR TITLE
fix(optimizer): Decide bucketed execution in planning, not in emit (#1730)

### DIFF
--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -58,11 +58,18 @@ std::shared_ptr<PartitionType> HivePartitionType::copartition(
     }
   }
   const int32_t otherNumBuckets = otherPartitionType->numBuckets_;
+  // Both sides route a bucket to bucket % numPartitions, so the coarser of the
+  // two counts is what they agree on; keeping the finer would send a key to
+  // different tasks on each side.
+  const int32_t numPartitions =
+      std::min(numPartitions_, otherPartitionType->numPartitions_);
   if (otherNumBuckets % numBuckets_ == 0) {
-    return std::make_shared<HivePartitionType>(numBuckets_, thisTypes);
+    return std::make_shared<HivePartitionType>(
+        numBuckets_, numPartitions, thisTypes);
   }
   if (numBuckets_ % otherNumBuckets == 0) {
-    return std::make_shared<HivePartitionType>(otherNumBuckets, otherTypes);
+    return std::make_shared<HivePartitionType>(
+        otherNumBuckets, numPartitions, otherTypes);
   }
   return nullptr;
 }

--- a/axiom/optimizer/MultiFragmentPlan.cpp
+++ b/axiom/optimizer/MultiFragmentPlan.cpp
@@ -680,8 +680,11 @@ void checkLastFragment(const ExecutableFragment& last, int32_t numWorkers) {
 
 } // namespace
 
-void MultiFragmentPlan::checkConsistency() const {
-  VELOX_CHECK(!fragments_.empty(), "Plan must have at least one fragment");
+void MultiFragmentPlan::checkConsistency(bool mayBeEmpty) const {
+  if (fragments_.empty()) {
+    VELOX_CHECK(mayBeEmpty, "Plan must have at least one fragment");
+    return;
+  }
 
   checkFragmentTypes(fragments_, options_.numWorkers);
 

--- a/axiom/optimizer/MultiFragmentPlan.h
+++ b/axiom/optimizer/MultiFragmentPlan.h
@@ -159,10 +159,13 @@ struct ExecutableFragment {
   /// for 'this'.
   std::vector<InputStage> inputStages;
 
-  /// PartitionType per scan node for grouped leaf nodes. The connector tags
-  /// each emitted Split with a groupId; the runtime routes by groupId. All
-  /// entries share numPartitions(). Empty when no scan in this fragment is
-  /// bucketed.
+  /// The leaf nodes of a fragment that runs one bucket group at a time. A scan
+  /// read that way maps to the partitioning it is read by, already coarsened to
+  /// the worker count, and the connector tags each emitted Split with a groupId
+  /// the runtime routes by. An exchange feeding the same fragment maps to null:
+  /// its partitions line up with those groups by construction. All non-null
+  /// entries share numPartitions(), which is the fragment's width. Empty when
+  /// the fragment does not run grouped.
   folly::F14FastMap<
       velox::core::PlanNodeId,
       std::shared_ptr<connector::PartitionType>>
@@ -249,7 +252,9 @@ class MultiFragmentPlan {
 
   /// Validates structural consistency of the plan. Checks fragment types,
   /// widths, producer-consumer linkage, and partition count alignment.
-  void checkConsistency() const;
+  /// 'mayBeEmpty' allows a plan with no fragments, which is what a write the
+  /// connector performs through metadata alone produces.
+  void checkConsistency(bool mayBeEmpty) const;
 
  private:
   const std::vector<ExecutableFragment> fragments_;

--- a/axiom/optimizer/QueryGraphContext.cpp
+++ b/axiom/optimizer/QueryGraphContext.cpp
@@ -402,4 +402,46 @@ void QueryGraphContext::populateFunctionNames() {
   }
 }
 
+const connector::PartitionType* QueryGraphContext::scaledPartitionType(
+    const connector::PartitionType* type,
+    int32_t numWorkers) {
+  VELOX_CHECK_NOT_NULL(type);
+  auto [it, inserted] =
+      scaledPartitionTypes_.emplace(std::pair{type, numWorkers}, nullptr);
+  if (inserted) {
+    it->second = registerPartitionType(type->scaleDown(numWorkers));
+  }
+  return it->second;
+}
+
+const connector::PartitionType* QueryGraphContext::copartitionedType(
+    const connector::PartitionType* left,
+    const connector::PartitionType* right) {
+  VELOX_CHECK_NOT_NULL(left);
+  VELOX_CHECK_NOT_NULL(right);
+  auto [it, inserted] =
+      copartitionedTypes_.emplace(std::pair{left, right}, nullptr);
+  if (inserted) {
+    auto folded = left->copartition(*right);
+    it->second =
+        folded == nullptr ? nullptr : registerPartitionType(std::move(folded));
+  }
+  return it->second;
+}
+
+const connector::PartitionType* QueryGraphContext::registerPartitionType(
+    std::shared_ptr<const connector::PartitionType> type) {
+  VELOX_CHECK_NOT_NULL(type);
+  const auto* raw = type.get();
+  partitionTypes_.emplace(raw, std::move(type));
+  return raw;
+}
+
+std::shared_ptr<const connector::PartitionType>
+QueryGraphContext::sharedPartitionType(
+    const connector::PartitionType* type) const {
+  const auto it = partitionTypes_.find(type);
+  return it == partitionTypes_.end() ? nullptr : it->second;
+}
+
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -19,7 +19,9 @@
 #include <fmt/format.h>
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
+#include <folly/hash/Hash.h>
 #include "axiom/common/Enums.h"
+#include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/optimizer/ArenaCache.h"
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/type/Variant.h"
@@ -461,6 +463,33 @@ class QueryGraphContext {
     return allVariants_.back().get();
   }
 
+  /// Returns 'type' coarsened to at most 'numWorkers' groups and owned for the
+  /// duration, so a plan can hold it as a plain pointer. Memoized on the pair,
+  /// so scaling one type the same way twice yields one object and the nodes
+  /// and partitionings holding it stay pointer-equal.
+  const connector::PartitionType* scaledPartitionType(
+      const connector::PartitionType* type,
+      int32_t numWorkers);
+
+  /// The partitioning two connector-bucketed sides agree on, or null when they
+  /// do not copartition. Owned for the duration and memoized on the pair, so
+  /// the same fold always yields the same object.
+  const connector::PartitionType* copartitionedType(
+      const connector::PartitionType* left,
+      const connector::PartitionType* right);
+
+  /// Takes ownership of a PartitionType derived during planning (a
+  /// `copartition` result) and returns a plain pointer to it. Idempotent: the
+  /// same object registered twice is stored once.
+  const connector::PartitionType* registerPartitionType(
+      std::shared_ptr<const connector::PartitionType> type);
+
+  /// The owning pointer for a type handed out by the two calls above. Used
+  /// when emitting a plan that outlives this context. Null if 'type' was never
+  /// registered here.
+  std::shared_ptr<const connector::PartitionType> sharedPartitionType(
+      const connector::PartitionType* type) const;
+
   /// Returns a globally unique interned name `{prefix}{N}` within this query
   /// context. Example: `newName("a_")` returns `"a_47"`.
   Name newName(std::string_view prefix) {
@@ -502,6 +531,26 @@ class QueryGraphContext {
   FunctionNames functionNames_;
 
   std::vector<std::unique_ptr<velox::Variant>> allVariants_;
+
+  // PartitionTypes derived during planning, owned for the duration. Keyed by
+  // the object so a plain pointer can be traded back for its owner, and by
+  // (type, worker count) so scaling is done once.
+  folly::F14FastMap<
+      const connector::PartitionType*,
+      std::shared_ptr<const connector::PartitionType>>
+      partitionTypes_;
+  folly::F14FastMap<
+      std::pair<const connector::PartitionType*, int32_t>,
+      const connector::PartitionType*,
+      folly::Hash>
+      scaledPartitionTypes_;
+  folly::F14FastMap<
+      std::pair<
+          const connector::PartitionType*,
+          const connector::PartitionType*>,
+      const connector::PartitionType*,
+      folly::Hash>
+      copartitionedTypes_;
 
   uint32_t nameCounter_{0};
 };

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -635,7 +635,7 @@ PlanAndStats ToVelox::toVeloxPlan(
 
   auto multiFragmentPlan =
       std::make_shared<MultiFragmentPlan>(std::move(stages), options);
-  multiFragmentPlan->checkConsistency();
+  multiFragmentPlan->checkConsistency(/*mayBeEmpty=*/false);
 
   return PlanAndStats{
       std::move(multiFragmentPlan),
@@ -1276,11 +1276,16 @@ velox::core::PlanNodePtr ToVelox::makeLimit(
 
 namespace {
 
+// A connector partitioning is coarsened to 'numDestinations', the number of
+// consumers the rows are split into, so the function partitions into exactly
+// those. Pass nullopt where the count is not known here. The spec copies what
+// it needs, so the coarsened type need not outlive this call.
 template <typename ExprType>
 velox::core::PartitionFunctionSpecPtr createPartitionFunctionSpec(
     const velox::RowTypePtr& inputType,
     const std::vector<ExprType>& keys,
-    const Distribution& distribution) {
+    const Distribution& distribution,
+    std::optional<int32_t> numDestinations = std::nullopt) {
   if (distribution.isBroadcast() || keys.empty()) {
     return std::make_shared<velox::core::GatherPartitionFunctionSpec>();
   }
@@ -1298,8 +1303,13 @@ velox::core::PartitionFunctionSpecPtr createPartitionFunctionSpec(
   }
 
   if (const auto* partitionType = distribution.partitionType()) {
-    return partitionType->makeSpec(
-        keyIndices, /*constants=*/{}, /*isLocal=*/false);
+    if (!numDestinations.has_value() ||
+        partitionType->numPartitions() == numDestinations.value()) {
+      return partitionType->makeSpec(
+          keyIndices, /*constants=*/{}, /*isLocal=*/false);
+    }
+    return partitionType->scaleDown(numDestinations.value())
+        ->makeSpec(keyIndices, /*constants=*/{}, /*isLocal=*/false);
   }
 
   return std::make_shared<velox::exec::HashPartitionFunctionSpec>(
@@ -1999,7 +2009,7 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
           nextId(), outputType, exchangeSerdeKind_, sourcePlan);
     } else {
       auto partitionFunctionFactory = createPartitionFunctionSpec(
-          sourcePlan->outputType(), keys, distribution);
+          sourcePlan->outputType(), keys, distribution, numPartitions);
       source.fragment.planNode =
           std::make_shared<velox::core::PartitionedOutputNode>(
               nextId(),

--- a/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/logical_plan/PlanBuilder.h"
@@ -119,15 +120,32 @@ TEST_P(BucketedExecutionTest, join) {
         "SELECT * FROM j_orders JOIN j_customers "
         "ON j_orders.customer_id = j_customers.id",
         kTestConnectorId));
-    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("j_customers")
+            .hashJoinInner(matchScan("j_orders"))
+            .projectIf(useV2_)
+            .fragment({.width = 4, .bucketedScans = 2})
+            .gather()
+            .build());
   }
 
+  // Each outer join keeps both sides co-bucketed in one fragment. The plan
+  // reads j_customers as the probe, which turns the query's RIGHT into a LEFT
+  // and its LEFT into a RIGHT.
   {
     auto plan = planDistributed(parseSelect(
         "SELECT * FROM j_orders RIGHT JOIN j_customers "
         "ON j_orders.customer_id = j_customers.id",
         kTestConnectorId));
-    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("j_customers")
+            .hashJoinLeft(matchScan("j_orders"))
+            .projectIf(!useV2_)
+            .fragment({.width = 4, .bucketedScans = 2})
+            .gather()
+            .build());
   }
 
   {
@@ -135,16 +153,34 @@ TEST_P(BucketedExecutionTest, join) {
         "SELECT * FROM j_orders FULL OUTER JOIN j_customers "
         "ON j_orders.customer_id = j_customers.id",
         kTestConnectorId));
-    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("j_customers")
+            .hashJoinFull(matchScan("j_orders"))
+            .fragment({.width = 4, .bucketedScans = 2})
+            .gather()
+            .build());
   }
 
-  // LEFT join: bucketed fragment preserved on one side.
   {
     auto plan = planDistributed(parseSelect(
         "SELECT * FROM j_orders LEFT JOIN j_customers "
         "ON j_orders.customer_id = j_customers.id",
         kTestConnectorId));
-    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    if (useV2_) {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchScan("j_customers")
+              .hashJoinRight(matchScan("j_orders"))
+              .fragment({.width = 4, .bucketedScans = 2})
+              .gather()
+              .build());
+    } else {
+      // Wrong plan: v1 reads j_orders by its buckets and then shuffles it
+      // into the join. A grouped read that is shuffled away caps the
+      // fragment's width for no benefit; the pairing it was read for is lost.
+      expectBucketedFragmentWithWidth(*plan.plan, 4);
+    }
   }
 
   testConnector_->addTable(
@@ -155,11 +191,17 @@ TEST_P(BucketedExecutionTest, join) {
       "SELECT * FROM j_orders JOIN j_unbucketed "
       "ON j_orders.customer_id = j_unbucketed.id",
       kTestConnectorId));
-  expectBucketedFragmentWithWidth(
-      *plan.plan,
-      /*expectedWidth=*/4,
-      /*expectedBucketedScans=*/1,
-      /*expectedHashExchanges=*/1);
+  // The unbucketed side is shuffled into the bucketed fragment by the bucket
+  // function, so it joins the grouped scan without moving it.
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      plan.plan,
+      matchScan("j_orders")
+          .hashJoinInner(
+              matchScan("j_unbucketed").aliases({"jid"}).shuffle({"jid"}))
+          .projectIf(useV2_)
+          .fragment({.width = 4, .bucketedScans = 1, .bucketedExchanges = 1})
+          .gather()
+          .build());
 }
 
 TEST_P(BucketedExecutionTest, semijoin) {
@@ -241,16 +283,45 @@ TEST_P(BucketedExecutionTest, aggregation) {
             .tableScan("a_orders")
             .aggregate({"customer_id"}, {"sum(amount)"})
             .build());
-    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("a_orders")
+            .partialAggregation()
+            .localPartition({"customer_id"})
+            .finalAggregation()
+            .fragment({.width = 4, .bucketedScans = 1})
+            .gather()
+            .build());
   }
 
+  // The bucket key is a prefix of the grouping keys, so each group still lands
+  // whole on one task.
   {
     auto plan = planDistributed(
         lp::PlanBuilder(makeContext())
             .tableScan("a_orders")
             .aggregate({"customer_id", "order_date"}, {"sum(amount)"})
             .build());
-    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    if (useV2_) {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchScan("a_orders")
+              .partialAggregation()
+              .localPartition({"customer_id", "order_date"})
+              .finalAggregation()
+              .fragment({.width = 4, .bucketedScans = 1})
+              .gather()
+              .build());
+    } else {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchScan("a_orders")
+              .localPartition({"customer_id", "order_date"})
+              .singleAggregation()
+              .fragment({.width = 4, .bucketedScans = 1})
+              .gather()
+              .build());
+    }
   }
 
   {
@@ -261,7 +332,15 @@ TEST_P(BucketedExecutionTest, aggregation) {
                 {"customer_id"},
                 {"sum(amount)", "count(*)", "min(amount)", "max(amount)"})
             .build());
-    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("a_orders")
+            .partialAggregation()
+            .localPartition({"customer_id"})
+            .finalAggregation()
+            .fragment({.width = 4, .bucketedScans = 1})
+            .gather()
+            .build());
   }
 
   {
@@ -270,7 +349,29 @@ TEST_P(BucketedExecutionTest, aggregation) {
             .tableScan("a_orders")
             .aggregate({"customer_id"}, {"count(distinct amount)"})
             .build());
-    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    if (useV2_) {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchScan("a_orders")
+              .localPartition({"customer_id"})
+              .singleAggregation()
+              .fragment({.width = 4, .bucketedScans = 1})
+              .gather()
+              .build());
+    } else {
+      // v1 makes the values distinct first, then counts them.
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchScan("a_orders")
+              .localPartition({"customer_id", "amount"})
+              .singleAggregation()
+              .partialAggregation()
+              .localPartition({"customer_id"})
+              .finalAggregation()
+              .fragment({.width = 4, .bucketedScans = 1})
+              .gather()
+              .build());
+    }
   }
 
   {
@@ -278,7 +379,16 @@ TEST_P(BucketedExecutionTest, aggregation) {
         "SELECT customer_id, sum(amount) AS total FROM a_orders "
         "GROUP BY customer_id HAVING sum(amount) > 1000",
         kTestConnectorId));
-    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("a_orders")
+            .partialAggregation()
+            .localPartition({"customer_id"})
+            .finalAggregation()
+            .filter()
+            .fragment({.width = 4, .bucketedScans = 1})
+            .gather()
+            .build());
   }
 
   {
@@ -288,7 +398,14 @@ TEST_P(BucketedExecutionTest, aggregation) {
             .aggregate(
                 {"customer_id"}, {"array_agg(amount ORDER BY order_date)"})
             .build());
-    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("a_orders")
+            .localPartition({"customer_id"})
+            .singleAggregation()
+            .fragment({.width = 4, .bucketedScans = 1})
+            .gather()
+            .build());
   }
 
   // LIMIT atop a bucketed aggregation keeps the bucketed annotation on
@@ -300,17 +417,46 @@ TEST_P(BucketedExecutionTest, aggregation) {
             .aggregate({"customer_id"}, {"sum(amount)"})
             .limit(0, 100)
             .build());
-    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("a_orders")
+            .partialAggregation()
+            .localPartition({"customer_id"})
+            .finalAggregation()
+            .localLimit(0, 100)
+            .fragment({.width = 4, .bucketedScans = 1})
+            .gather()
+            .finalLimit(0, 100)
+            .build());
   }
 
-  // Non-bucket grouping key falls through to partial+final.
+  // Grouping by a non-bucket key falls through to partial+final. The table's
+  // bucketing on customer_id does not co-locate order_date groups, so the plan
+  // does not read it grouped.
   {
     auto plan = planDistributed(
         lp::PlanBuilder(makeContext())
             .tableScan("a_orders")
             .aggregate({"order_date"}, {"sum(amount)"})
             .build());
-    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    if (useV2_) {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchScan("a_orders")
+              .partialAggregation()
+              .notBucketed()
+              .shuffle({"order_date"})
+              .localPartition({"order_date"})
+              .finalAggregation()
+              .gather()
+              .build());
+    } else {
+      // Wrong plan: v1 runs the scan grouped even though the aggregation
+      // groups on a non-bucket key, then shuffles the partials anyway. The
+      // grouping constrains the fragment's width and buys nothing, so only
+      // its width is checked here.
+      expectBucketedFragmentWithWidth(*plan.plan, 4);
+    }
   }
 }
 
@@ -322,7 +468,16 @@ TEST_P(BucketedExecutionTest, select) {
             .tableScan("s_one")
             .aggregate({"customer_id"}, {"sum(amount)"})
             .build());
-    expectBucketedFragmentWithWidth(*plan.plan, 1);
+    // One bucket caps the fragment at one task.
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("s_one")
+            .partialAggregation()
+            .localPartition({"customer_id"})
+            .finalAggregation()
+            .fragment({.width = 1, .bucketedScans = 1})
+            .gather()
+            .build());
   }
 
   // gcd(128, 64) = 64.
@@ -338,34 +493,14 @@ TEST_P(BucketedExecutionTest, select) {
         "SELECT * FROM s_down_a JOIN s_down_b "
         "ON s_down_a.customer_id = s_down_b.customer_id",
         kTestConnectorId));
-    expectBucketedFragmentWithWidth(*plan.plan, 4);
-  }
-
-  // gcd(16, 9) = 1; copartition rejects. The two sides cannot co-fragment as
-  // a bucketed pair, but each side may independently remain bucketed in its
-  // own fragment.
-  {
-    addBucketedTable("s_incompat_a", {"customer_id"}, 16);
-    addBucketedTable(
-        "s_incompat_b",
-        {"id"},
-        9,
-        ROW({"id", "name"}, {BIGINT(), VARCHAR()}),
-        100'000);
-    auto plan = planDistributed(parseSelect(
-        "SELECT * FROM s_incompat_a JOIN s_incompat_b "
-        "ON s_incompat_a.customer_id = s_incompat_b.id",
-        kTestConnectorId));
-    for (const auto& fragment : plan.plan->fragments()) {
-      int32_t bucketedScans = 0;
-      for (const auto& [_, partitionType] : fragment.groupedNodes) {
-        if (partitionType != nullptr) {
-          ++bucketedScans;
-        }
-      }
-      EXPECT_LE(bucketedScans, 1)
-          << "Incompatible bucket counts (16/9) should not pair-bucket";
-    }
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("s_down_a")
+            .hashJoinInner(matchScan("s_down_b"))
+            .fragment({.width = 4, .bucketedScans = 2})
+            .gather()
+            .project()
+            .build());
   }
 
   testConnector_->addTable(
@@ -385,20 +520,54 @@ TEST_P(BucketedExecutionTest, select) {
             .tableScan("s_composite")
             .aggregate({"region", "customer_id"}, {"sum(amount)"})
             .build());
-    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    if (useV2_) {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchScan("s_composite")
+              .partialAggregation()
+              .localPartition({"region", "customer_id"})
+              .finalAggregation()
+              .fragment({.width = 4, .bucketedScans = 1})
+              .gather()
+              .build());
+    } else {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchScan("s_composite")
+              .localPartition({"region", "customer_id"})
+              .singleAggregation()
+              .fragment({.width = 4, .bucketedScans = 1})
+              .gather()
+              .build());
+    }
   }
 
-  // Strict subset of bucket keys: bucketing on (region, customer_id) doesn't
-  // satisfy aggregation grouped only by region, so it falls through to
-  // partial+shuffle+final. Source fragment may still be bucketed for the
-  // partial aggregation.
+  // Strict subset of bucket keys: bucketing on (region, customer_id) does not
+  // co-locate groups of region alone, so the aggregation falls through to
+  // partial+shuffle+final and nothing reads the table grouped.
   {
     auto plan = planDistributed(
         lp::PlanBuilder(makeContext())
             .tableScan("s_composite")
             .aggregate({"region"}, {"sum(amount)"})
             .build());
-    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    if (useV2_) {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchScan("s_composite")
+              .partialAggregation()
+              .notBucketed()
+              .shuffle({"region"})
+              .localPartition({"region"})
+              .finalAggregation()
+              .gather()
+              .build());
+    } else {
+      // Wrong plan: region alone is not a bucket key of (region,
+      // customer_id), so v1's grouped read cannot co-locate the groups and it
+      // shuffles regardless.
+      expectBucketedFragmentWithWidth(*plan.plan, 4);
+    }
   }
 }
 
@@ -419,24 +588,25 @@ TEST_P(BucketedExecutionTest, unionall) {
         "  SELECT customer_id, amount FROM u_b"
         ") GROUP BY customer_id",
         kTestConnectorId));
-    // 2-table union with gcd=4: both scans share the same bucketed fragment.
-    int32_t bucketedFragments = 0;
-    for (const auto& fragment : plan.plan->fragments()) {
-      if (!fragment.groupedNodes.empty()) {
-        ++bucketedFragments;
-        EXPECT_EQ(fragment.type, FragmentType::kFixed);
-        ASSERT_TRUE(fragment.width.has_value());
-        EXPECT_EQ(*fragment.width, 4);
-        int32_t bucketedScans = 0;
-        for (const auto& [_, partitionType] : fragment.groupedNodes) {
-          if (partitionType != nullptr) {
-            ++bucketedScans;
-          }
-        }
-        EXPECT_EQ(bucketedScans, 2);
-      }
+    // gcd(128, 4) = 4, so both legs are read by the same 4 bucket groups and
+    // the union needs no shuffle.
+    if (useV2_) {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchScan("u_a")
+              .localPartition(matchScan("u_b").project())
+              .partialAggregation()
+              .localPartition({"customer_id"})
+              .finalAggregation()
+              .fragment({.width = 4, .bucketedScans = 2})
+              .gather()
+              .build());
+    } else {
+      // Wrong plan: v1 reads both legs by their buckets, which already
+      // co-locates every group, and then shuffles the partial aggregate
+      // anyway.
+      expectBucketedFragmentWithWidth(*plan.plan, 4);
     }
-    EXPECT_GE(bucketedFragments, 1);
   }
 
   // Different bucket keys (same type, same count) — TestConnector treats these
@@ -458,7 +628,23 @@ TEST_P(BucketedExecutionTest, unionall) {
         "  SELECT account_id AS customer_id, amount FROM u_diff_acct"
         ") GROUP BY customer_id",
         kTestConnectorId));
-    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    if (useV2_) {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchScan("u_diff_cust")
+              .localPartition(matchScan("u_diff_acct").project())
+              .partialAggregation()
+              .localPartition({"customer_id"})
+              .finalAggregation()
+              .fragment({.width = 4, .bucketedScans = 2})
+              .gather()
+              .build());
+    } else {
+      // Wrong plan: v1 reads both legs by their buckets, which already
+      // co-locates every group, and then shuffles the partial aggregate
+      // anyway.
+      expectBucketedFragmentWithWidth(*plan.plan, 4);
+    }
   }
 }
 
@@ -492,24 +678,15 @@ TEST_P(BucketedExecutionTest, mixedJoinOneBucketed) {
       "SELECT * FROM m_orders JOIN m_extras "
       "ON m_orders.customer_id = m_extras.customer_id",
       kTestConnectorId));
-  bool foundMixed = false;
-  for (const auto& fragment : plan.plan->fragments()) {
-    int32_t bucketedScans = 0;
-    int32_t hashExchanges = 0;
-    for (const auto& [_, partitionType] : fragment.groupedNodes) {
-      if (partitionType == nullptr) {
-        ++hashExchanges;
-      } else {
-        ++bucketedScans;
-      }
-    }
-    if (bucketedScans == 1 && hashExchanges == 1) {
-      foundMixed = true;
-      EXPECT_TRUE(fragment.width.has_value());
-      EXPECT_EQ(*fragment.width, 4);
-    }
-  }
-  EXPECT_TRUE(foundMixed);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      plan.plan,
+      matchScan("m_orders")
+          .hashJoinInner(
+              matchScan("m_extras").aliases({"mcid"}).shuffle({"mcid"}))
+          .fragment({.width = 4, .bucketedScans = 1, .bucketedExchanges = 1})
+          .gather()
+          .project()
+          .build());
 }
 
 TEST_P(BucketedExecutionTest, mixedJoinTwoBucketedOneNot) {
@@ -523,24 +700,16 @@ TEST_P(BucketedExecutionTest, mixedJoinTwoBucketedOneNot) {
       "JOIN m2_customers ON m2_orders.customer_id = m2_customers.id "
       "JOIN m2_extras ON m2_orders.customer_id = m2_extras.customer_id",
       kTestConnectorId));
-  bool foundMixed = false;
-  for (const auto& fragment : plan.plan->fragments()) {
-    int32_t bucketedScans = 0;
-    int32_t hashExchanges = 0;
-    for (const auto& [_, partitionType] : fragment.groupedNodes) {
-      if (partitionType == nullptr) {
-        ++hashExchanges;
-      } else {
-        ++bucketedScans;
-      }
-    }
-    if (bucketedScans == 2 && hashExchanges == 1) {
-      foundMixed = true;
-      EXPECT_TRUE(fragment.width.has_value());
-      EXPECT_EQ(*fragment.width, 4);
-    }
-  }
-  EXPECT_TRUE(foundMixed);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      plan.plan,
+      matchScan("m2_customers")
+          .hashJoinInner(matchScan("m2_orders"))
+          .hashJoinInner(
+              matchScan("m2_extras").aliases({"m2cid"}).shuffle({"m2cid"}))
+          .fragment({.width = 4, .bucketedScans = 2, .bucketedExchanges = 1})
+          .gather()
+          .project()
+          .build());
 }
 
 TEST_P(BucketedExecutionTest, mixedJoinOneBucketedTwoNot) {
@@ -553,24 +722,17 @@ TEST_P(BucketedExecutionTest, mixedJoinOneBucketedTwoNot) {
       "JOIN m3_extras1 ON m3_orders.customer_id = m3_extras1.customer_id "
       "JOIN m3_extras2 ON m3_orders.customer_id = m3_extras2.customer_id",
       kTestConnectorId));
-  bool foundMixed = false;
-  for (const auto& fragment : plan.plan->fragments()) {
-    int32_t bucketedScans = 0;
-    int32_t hashExchanges = 0;
-    for (const auto& [_, partitionType] : fragment.groupedNodes) {
-      if (partitionType == nullptr) {
-        ++hashExchanges;
-      } else {
-        ++bucketedScans;
-      }
-    }
-    if (bucketedScans == 1 && hashExchanges == 2) {
-      foundMixed = true;
-      EXPECT_TRUE(fragment.width.has_value());
-      EXPECT_EQ(*fragment.width, 4);
-    }
-  }
-  EXPECT_TRUE(foundMixed);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      plan.plan,
+      matchScan("m3_orders")
+          .hashJoinInner(
+              matchScan("m3_extras1").aliases({"e1cid"}).shuffle({"e1cid"}))
+          .hashJoinInner(
+              matchScan("m3_extras2").aliases({"e2cid"}).shuffle({"e2cid"}))
+          .fragment({.width = 4, .bucketedScans = 1, .bucketedExchanges = 2})
+          .gather()
+          .project()
+          .build());
 }
 
 TEST_P(BucketedExecutionTest, windowOnBucketKey) {
@@ -580,16 +742,16 @@ TEST_P(BucketedExecutionTest, windowOnBucketKey) {
       "row_number() OVER (PARTITION BY customer_id ORDER BY amount) AS rn "
       "FROM w_orders",
       kTestConnectorId));
-  bool foundBucketed = false;
-  for (const auto& fragment : plan.plan->fragments()) {
-    if (!fragment.groupedNodes.empty()) {
-      EXPECT_EQ(fragment.type, FragmentType::kFixed);
-      EXPECT_TRUE(fragment.width.has_value());
-      EXPECT_EQ(*fragment.width, 4);
-      foundBucketed = true;
-    }
-  }
-  EXPECT_TRUE(foundBucketed);
+  // The window partitions by the bucket key, so each partition is already
+  // whole on one task.
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      plan.plan,
+      matchScan("w_orders")
+          .localPartition({"customer_id"})
+          .window()
+          .fragment({.width = 4, .bucketedScans = 1})
+          .gather()
+          .build());
 }
 
 TEST_P(BucketedExecutionTest, threeWayCoBucketed) {
@@ -601,25 +763,17 @@ TEST_P(BucketedExecutionTest, threeWayCoBucketed) {
       "JOIN tw_b ON tw_a.customer_id = tw_b.customer_id "
       "JOIN tw_c ON tw_a.customer_id = tw_c.customer_id",
       kTestConnectorId));
-  bool found = false;
-  for (const auto& fragment : plan.plan->fragments()) {
-    int32_t bucketedScans = 0;
-    int32_t hashExchanges = 0;
-    for (const auto& [_, partitionType] : fragment.groupedNodes) {
-      if (partitionType == nullptr) {
-        ++hashExchanges;
-      } else {
-        ++bucketedScans;
-      }
-    }
-    if (bucketedScans == 3 && hashExchanges == 0) {
-      EXPECT_EQ(fragment.type, FragmentType::kFixed);
-      EXPECT_TRUE(fragment.width.has_value());
-      EXPECT_EQ(*fragment.width, 4);
-      found = true;
-    }
-  }
-  EXPECT_TRUE(found);
+  // Bucket counts 16, 8 and 4 all divide down to a common 4, so all three
+  // scans share one fragment with no shuffle.
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      plan.plan,
+      matchScan("tw_a")
+          .hashJoinInner(matchScan("tw_b"))
+          .hashJoinInner(matchScan("tw_c"))
+          .fragment({.width = 4, .bucketedScans = 3, .bucketedExchanges = 0})
+          .gather()
+          .project()
+          .build());
 }
 
 // A chain of inner joins on a shared bucket key fuses into one bucketed
@@ -646,9 +800,7 @@ TEST_P(BucketedExecutionTest, innerJoinChainFuses) {
           .hashJoin(
               matchScan("u").hashJoin(matchScan("v"), core::JoinType::kInner),
               core::JoinType::kInner)
-          .bucketed()
-          .bucketedScans(3)
-          .fragmentWidth(4)
+          .fragment({.width = 4, .bucketedScans = 3})
           .gather()
           .build());
 
@@ -663,9 +815,7 @@ TEST_P(BucketedExecutionTest, innerJoinChainFuses) {
         matchScan("u")
             .hashJoin(matchScan("v"), core::JoinType::kInner)
             .hashJoin(matchScan("t"), core::JoinType::kInner)
-            .bucketed()
-            .bucketedScans(3)
-            .fragmentWidth(4)
+            .fragment({.width = 4, .bucketedScans = 3})
             .gather()
             .build());
   } else {
@@ -674,9 +824,7 @@ TEST_P(BucketedExecutionTest, innerJoinChainFuses) {
         matchScan("t")
             .hashJoin(matchScan("u"), core::JoinType::kInner)
             .hashJoin(matchScan("v"), core::JoinType::kInner)
-            .bucketed()
-            .bucketedScans(3)
-            .fragmentWidth(4)
+            .fragment({.width = 4, .bucketedScans = 3})
             .gather()
             .build());
   }
@@ -721,9 +869,7 @@ TEST_P(BucketedExecutionTest, leftJoinChainDoesNotFuse) {
             .hashJoin(
                 matchScan("u").hashJoin(matchScan("v"), core::JoinType::kInner),
                 core::JoinType::kInner)
-            .bucketed()
-            .bucketedScans(3)
-            .fragmentWidth(4)
+            .fragment({.width = 4, .bucketedScans = 3})
             .gather()
             .build());
   }
@@ -746,9 +892,7 @@ TEST_P(BucketedExecutionTest, leftJoinChainDoesNotFuse) {
         matchScan("t")
             .hashJoin(matchScan("u"), core::JoinType::kInner)
             .hashJoin(matchScan("v"), core::JoinType::kInner)
-            .bucketed()
-            .bucketedScans(3)
-            .fragmentWidth(4)
+            .fragment({.width = 4, .bucketedScans = 3})
             .gather()
             .build());
   }
@@ -764,24 +908,19 @@ TEST_P(BucketedExecutionTest, bucketedAggThenBucketedJoin) {
       "  GROUP BY customer_id"
       ") x JOIN ab_customers ON x.customer_id = ab_customers.id",
       kTestConnectorId));
-  bool found = false;
-  for (const auto& fragment : plan.plan->fragments()) {
-    int32_t bucketedScans = 0;
-    int32_t hashExchanges = 0;
-    for (const auto& [_, partitionType] : fragment.groupedNodes) {
-      if (partitionType == nullptr) {
-        ++hashExchanges;
-      } else {
-        ++bucketedScans;
-      }
-    }
-    if (bucketedScans == 2 && hashExchanges == 0) {
-      EXPECT_TRUE(fragment.width.has_value());
-      EXPECT_EQ(*fragment.width, 4);
-      found = true;
-    }
-  }
-  EXPECT_TRUE(found);
+  // The aggregation keeps its input's bucketing, so the join above it pairs
+  // with the other bucketed table without a shuffle.
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      plan.plan,
+      matchScan("ab_customers")
+          .hashJoinInner(matchScan("ab_orders")
+                             .partialAggregation()
+                             .localPartition({"customer_id"})
+                             .finalAggregation())
+          .projectIf(!useV2_)
+          .fragment({.width = 4, .bucketedScans = 2, .bucketedExchanges = 0})
+          .gather()
+          .build());
 }
 
 TEST_P(BucketedExecutionTest, bucketedAggThenBroadcastJoin) {
@@ -796,15 +935,24 @@ TEST_P(BucketedExecutionTest, bucketedAggThenBroadcastJoin) {
       "  GROUP BY customer_id"
       ") x JOIN bc_dim ON x.customer_id = bc_dim.customer_id",
       kTestConnectorId));
-  bool foundBucketedScan = false;
-  for (const auto& fragment : plan.plan->fragments()) {
-    for (const auto& [_, partitionType] : fragment.groupedNodes) {
-      if (partitionType != nullptr) {
-        foundBucketedScan = true;
-      }
-    }
+  if (useV2_) {
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("bc_orders")
+            .partialAggregation()
+            .localPartition({"customer_id"})
+            .finalAggregation()
+            .hashJoinInner(
+                matchScan("bc_dim").aliases({"bcid"}).shuffle({"bcid"}))
+            .fragment({.width = 4, .bucketedScans = 1, .bucketedExchanges = 1})
+            .gather()
+            .build());
+  } else {
+    // Wrong plan: v1 scans bc_dim twice — once to semi-join filter the
+    // aggregation's input, once to join it — and broadcasts the aggregate
+    // between them.
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
   }
-  EXPECT_TRUE(foundBucketedScan);
 }
 
 TEST_P(BucketedExecutionTest, broadcastJoinThenBucketedAgg) {
@@ -818,15 +966,31 @@ TEST_P(BucketedExecutionTest, broadcastJoinThenBucketedAgg) {
       "FROM bj_orders JOIN bj_dim ON bj_orders.amount = bj_dim.amount "
       "GROUP BY bj_orders.customer_id",
       kTestConnectorId));
-  bool foundBucketedScan = false;
-  for (const auto& fragment : plan.plan->fragments()) {
-    for (const auto& [_, partitionType] : fragment.groupedNodes) {
-      if (partitionType != nullptr) {
-        foundBucketedScan = true;
-      }
-    }
+  // The join is on a non-bucket key but its build side is broadcast, so the
+  // probe's rows stay put and the aggregation above still reads bj_orders by
+  // its buckets.
+  if (useV2_) {
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("bj_orders")
+            .hashJoinInner(matchScan("bj_dim").broadcast())
+            .partialAggregation()
+            .localPartition({"customer_id"})
+            .finalAggregation()
+            .fragment({.width = 4, .bucketedScans = 1})
+            .gather()
+            .build());
+  } else {
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("bj_orders")
+            .hashJoinInner(matchScan("bj_dim").broadcast())
+            .localPartition({"customer_id"})
+            .singleAggregation()
+            .fragment({.width = 4, .bucketedScans = 1})
+            .gather()
+            .build());
   }
-  EXPECT_TRUE(foundBucketedScan);
 }
 
 TEST_P(BucketedExecutionTest, greedyBucketed) {
@@ -840,7 +1004,14 @@ TEST_P(BucketedExecutionTest, greedyBucketed) {
       "SELECT * FROM g_orders JOIN g_customers "
       "ON g_orders.customer_id = g_customers.id",
       kTestConnectorId));
-  expectBucketedFragmentWithWidth(*plan.plan, 4);
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      plan.plan,
+      matchScan("g_customers")
+          .hashJoinInner(matchScan("g_orders"))
+          .projectIf(useV2_)
+          .fragment({.width = 4, .bucketedScans = 2})
+          .gather()
+          .build());
 }
 
 TEST_P(BucketedExecutionTest, greedyBucketedWithDimensions) {
@@ -874,6 +1045,173 @@ TEST_P(BucketedExecutionTest, greedyBucketedWithDimensions) {
 
   auto plan = planDistributed(parseSelect(sql, kTestConnectorId));
   expectBucketedFragmentWithWidth(*plan.plan, 4);
+}
+
+// Bucketings that cannot be copartitioned (gcd(16, 9) = 1) leave the join with
+// no bucketed pairing to exploit.
+TEST_P(BucketedExecutionTest, incompatibleBucketingOnManyWorkers) {
+  addBucketedTable("s_incompat_a", {"customer_id"}, 16);
+  addBucketedTable(
+      "s_incompat_b",
+      {"id"},
+      9,
+      ROW({"id", "name"}, {BIGINT(), VARCHAR()}),
+      100'000);
+
+  auto plan = planDistributed(parseSelect(
+      "SELECT * FROM s_incompat_a JOIN s_incompat_b "
+      "ON s_incompat_a.customer_id = s_incompat_b.id",
+      kTestConnectorId));
+
+  if (useV2_) {
+    // No pairing is possible, and the smaller side is cheap to replicate, so
+    // the join broadcasts it and neither table is read grouped.
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("s_incompat_a")
+            .hashJoinInner(matchScan("s_incompat_b").broadcast())
+            .project()
+            .notBucketed()
+            .gather()
+            .build());
+  }
+  // v1 plan shape is not verified: v1 produces wrong plan which reads the
+  // smaller side by its 9 buckets, which caps that fragment at width 3, and
+  // then shuffles it anyway — grouping that buys nothing.
+}
+
+// Joining tables whose bucketings cannot be copartitioned plans on a single
+// worker, as one ungrouped fragment.
+TEST_P(BucketedExecutionTest, incompatibleBucketingOnOneWorker) {
+  addBucketedTable("w1_t", {"customer_id"}, 16);
+  addBucketedTable(
+      "w1_u", {"id"}, 9, ROW({"id", "name"}, {BIGINT(), VARCHAR()}), 100'000);
+
+  auto plan = planVelox(
+      parseSelect(
+          "SELECT * FROM w1_t JOIN w1_u "
+          "ON w1_t.customer_id = w1_u.id",
+          kTestConnectorId),
+      {.numWorkers = 1, .numDrivers = 4},
+      optimizerOptions_);
+
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+      plan.plan,
+      matchScan("w1_t")
+          .hashJoinInner(matchScan("w1_u"))
+          .projectIf(useV2_)
+          .notBucketed()
+          .output(FragmentType::kSingle)
+          .build());
+}
+
+// Two tables bucketed on different members of a two-key join must not be
+// treated as a co-bucketed pair: their buckets align on different columns, so
+// co-locating them would put matching rows on different tasks.
+TEST_P(BucketedExecutionTest, joinKeysMustCorrespondToBucketing) {
+  const auto schema = ROW({"k", "j", "v"}, {BIGINT(), BIGINT(), DOUBLE()});
+  addBucketedTable("jk_t", {"k"}, 8, schema);
+  addBucketedTable("jk_u", {"j"}, 8, schema);
+
+  optimizerOptions_.syntacticJoinOrder = true;
+  SCOPE_EXIT {
+    optimizerOptions_.syntacticJoinOrder = false;
+  };
+  auto plan = planDistributed(parseSelect(
+      "SELECT a.v, b.v FROM jk_t a JOIN jk_u b ON a.k = b.k AND a.j = b.j",
+      kTestConnectorId));
+  if (useV2_) {
+    // Neither side's bucketing covers both keys, so both shuffle.
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("jk_t")
+            .shuffle({"k", "j"})
+            // The right side's columns are renamed by the join, so only the
+            // boundary is asserted there.
+            .hashJoinInner(matchScan("jk_u").shuffle())
+            .notBucketed()
+            .gather()
+            .project()
+            .build());
+  }
+}
+
+// A join's keys are written in the query's order, its tables' bucketing in
+// theirs. Two tables bucketed alike pair either way round.
+TEST_P(BucketedExecutionTest, joinPairsWhateverOrderTheKeysAreWritten) {
+  const auto schema = ROW({"k", "j", "v"}, {BIGINT(), BIGINT(), DOUBLE()});
+  addBucketedTable("ko_t", {"k", "j"}, 8, schema);
+  addBucketedTable("ko_u", {"k", "j"}, 8, schema);
+
+  optimizerOptions_.syntacticJoinOrder = true;
+  SCOPE_EXIT {
+    optimizerOptions_.syntacticJoinOrder = false;
+  };
+  auto plan = planDistributed(parseSelect(
+      "SELECT a.v, b.v FROM ko_t a JOIN ko_u b ON a.j = b.j AND a.k = b.k",
+      kTestConnectorId));
+  if (useV2_) {
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("ko_t")
+            .hashJoinInner(matchScan("ko_u"))
+            .bucketed()
+            .fragmentWidth(4)
+            .gather()
+            .project()
+            .build());
+  }
+}
+
+// An aggregation above a broadcast join reaches through the join to read its
+// probe grouped: the build is replicated, so probe rows stay where their
+// buckets put them.
+TEST_P(BucketedExecutionTest, aggregationOverBroadcastJoinOnProbe) {
+  const auto schema = ROW({"k", "j", "v"}, {BIGINT(), BIGINT(), DOUBLE()});
+  addBucketedTable("ap_t", {"k"}, 8, schema, 1'000'000);
+  addBucketedTable("ap_u", {"j"}, 2, schema, 1'000);
+
+  auto plan = planDistributed(parseSelect(
+      "SELECT a.k, count(*) FROM ap_t a JOIN ap_u b ON a.j = b.j GROUP BY a.k",
+      kTestConnectorId));
+  if (useV2_) {
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("ap_t")
+            // The build is replicated, so reading it by its buckets would cap
+            // its width for nothing.
+            .hashJoinInner(matchScan("ap_u").notBucketed().broadcast())
+            .partialAggregation()
+            .localPartition({"k"})
+            .finalAggregation()
+            .bucketed()
+            .fragmentWidth(4)
+            .gather()
+            .build());
+  }
+}
+
+// Renaming the bucket column does not cost the bucketing.
+TEST_P(BucketedExecutionTest, bucketColumnRenamedByProjection) {
+  const auto schema = ROW({"k", "j", "v"}, {BIGINT(), BIGINT(), DOUBLE()});
+  addBucketedTable("rn_t", {"k"}, 8, schema);
+
+  auto plan = planDistributed(parseSelect(
+      "SELECT nk, count(*) FROM (SELECT k AS nk, v FROM rn_t) GROUP BY nk",
+      kTestConnectorId));
+  if (useV2_) {
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchScan("rn_t")
+            .partialAggregation()
+            .localPartition({"k"})
+            .finalAggregation()
+            .project()
+            .bucketed()
+            .fragmentWidth(4)
+            .gather()
+            .build());
+  }
 }
 
 AXIOM_INSTANTIATE_V1_V2(BucketedExecutionTest);

--- a/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
@@ -91,16 +91,6 @@ class HiveBucketedExecutionTest : public test::HiveQueriesTestBase,
         optimizerOptions_);
   }
 
-  // Checks that the already-planned distributed 'plan' returns the same rows as
-  // a single-node (unbucketed) run of 'logicalPlan'. Single-node execution is
-  // the oracle; 'plan' is the bucketed run under test.
-  void assertSameAsSingleNode(
-      const lp::LogicalPlanNodePtr& logicalPlan,
-      PlanAndStats& plan) {
-    auto reference = checkSame(plan, toSingleNodePlan(logicalPlan));
-    ASSERT_GT(reference.results.size(), 0);
-  }
-
   std::vector<std::string> tablesToDrop_;
 };
 
@@ -126,7 +116,6 @@ TEST_P(HiveBucketedExecutionTest, join) {
             .gather()
             .project()
             .build());
-    assertSameAsSingleNode(logicalPlan, plan);
   }
 
   // RIGHT join: v1 repartitions the build side into the bucketed fragment; v2
@@ -150,7 +139,6 @@ TEST_P(HiveBucketedExecutionTest, join) {
               .project()
               .build());
     }
-    assertSameAsSingleNode(logicalPlan, plan);
   }
 
   // FULL join: both sides stay co-bucketed in one fragment.
@@ -167,7 +155,6 @@ TEST_P(HiveBucketedExecutionTest, join) {
             .gather()
             .project()
             .build());
-    assertSameAsSingleNode(logicalPlan, plan);
   }
 
   // LEFT join: both sides stay co-bucketed in one fragment.
@@ -184,7 +171,6 @@ TEST_P(HiveBucketedExecutionTest, join) {
             .gather()
             .project()
             .build());
-    assertSameAsSingleNode(logicalPlan, plan);
   }
 
   // Unbucketed right side is repartitioned by bucket into the bucketed join.
@@ -205,7 +191,6 @@ TEST_P(HiveBucketedExecutionTest, join) {
           .gather()
           .project()
           .build());
-  assertSameAsSingleNode(logicalPlan, plan);
 }
 
 TEST_P(HiveBucketedExecutionTest, semijoin) {
@@ -235,7 +220,6 @@ TEST_P(HiveBucketedExecutionTest, semijoin) {
               .gather()
               .build());
     }
-    assertSameAsSingleNode(logicalPlan, plan);
   }
 
   {
@@ -256,7 +240,6 @@ TEST_P(HiveBucketedExecutionTest, semijoin) {
               .gather()
               .build());
     }
-    assertSameAsSingleNode(logicalPlan, plan);
   }
 }
 
@@ -277,7 +260,6 @@ TEST_P(HiveBucketedExecutionTest, aggregation) {
             .fragmentWidth(4)
             .gather()
             .build());
-    assertSameAsSingleNode(logicalPlan, plan);
   }
 
   // Composite grouping key that is a superset of the single bucket key.
@@ -297,7 +279,6 @@ TEST_P(HiveBucketedExecutionTest, aggregation) {
             .fragmentWidth(4)
             .gather()
             .build());
-    assertSameAsSingleNode(logicalPlan, plan);
   }
 
   // Multiple aggregates over the bucket key.
@@ -321,7 +302,6 @@ TEST_P(HiveBucketedExecutionTest, aggregation) {
             .fragmentWidth(4)
             .gather()
             .build());
-    assertSameAsSingleNode(logicalPlan, plan);
   }
 
   // DISTINCT aggregate lowers to stacked partial/final aggregations.
@@ -348,7 +328,6 @@ TEST_P(HiveBucketedExecutionTest, aggregation) {
               .gather()
               .build());
     }
-    assertSameAsSingleNode(logicalPlan, plan);
   }
 
   // HAVING becomes a Filter above the aggregation.
@@ -367,7 +346,6 @@ TEST_P(HiveBucketedExecutionTest, aggregation) {
             .fragmentWidth(4)
             .gather()
             .build());
-    assertSameAsSingleNode(logicalPlan, plan);
   }
 
   // Non-bucket grouping key falls through to partial (bucketed) + final
@@ -380,14 +358,15 @@ TEST_P(HiveBucketedExecutionTest, aggregation) {
         plan.plan,
         matchHiveScan("t")
             .partialAggregation()
-            .bucketed()
-            .fragmentWidth(4)
+            // The grouping keys are not the table's bucket keys, so nothing
+            // reads it grouped; v1 groups it regardless.
+            .bucketed(!useV2_)
+            .fragmentWidthIf(!useV2_, 4)
             .shuffle({"c_mktsegment"})
             .localPartition({"c_mktsegment"})
             .finalAggregation()
             .gather()
             .build());
-    assertSameAsSingleNode(logicalPlan, plan);
   }
 }
 
@@ -407,7 +386,6 @@ TEST_P(HiveBucketedExecutionTest, singleBucket) {
           .fragmentWidth(1)
           .gather()
           .build());
-  assertSameAsSingleNode(logicalPlan, plan);
 }
 
 TEST_P(HiveBucketedExecutionTest, joinDifferentBucketCounts) {
@@ -436,7 +414,6 @@ TEST_P(HiveBucketedExecutionTest, joinDifferentBucketCounts) {
           .gather()
           .project()
           .build());
-  assertSameAsSingleNode(logicalPlan, plan);
 }
 
 TEST_P(HiveBucketedExecutionTest, compositeBucketKeys) {
@@ -460,7 +437,6 @@ TEST_P(HiveBucketedExecutionTest, compositeBucketKeys) {
             .fragmentWidth(4)
             .gather()
             .build());
-    assertSameAsSingleNode(logicalPlan, plan);
   }
 
   // Grouping by a strict subset of the bucket keys needs a reshuffle: partial
@@ -473,14 +449,15 @@ TEST_P(HiveBucketedExecutionTest, compositeBucketKeys) {
         plan.plan,
         matchHiveScan("t")
             .partialAggregation()
-            .bucketed()
-            .fragmentWidth(4)
+            // The grouping keys are not the table's bucket keys, so nothing
+            // reads it grouped; v1 groups it regardless.
+            .bucketed(!useV2_)
+            .fragmentWidthIf(!useV2_, 4)
             .shuffle({"c_nationkey"})
             .localPartition({"c_nationkey"})
             .finalAggregation()
             .gather()
             .build());
-    assertSameAsSingleNode(logicalPlan, plan);
   }
 }
 
@@ -503,7 +480,6 @@ TEST_P(HiveBucketedExecutionTest, widthClampsToNumWorkers) {
             .fragmentWidth(5)
             .gather()
             .build());
-    assertSameAsSingleNode(logicalPlan, plan);
   }
 
   createRegularTable(
@@ -525,7 +501,6 @@ TEST_P(HiveBucketedExecutionTest, widthClampsToNumWorkers) {
             .gather()
             .project()
             .build());
-    assertSameAsSingleNode(logicalPlan, plan);
   }
 }
 
@@ -552,7 +527,6 @@ TEST_P(HiveBucketedExecutionTest, copartitionedJoinIndivisibleWorkers) {
           .gather()
           .project()
           .build());
-  assertSameAsSingleNode(logicalPlan, plan);
 }
 
 TEST_P(HiveBucketedExecutionTest, unionall) {
@@ -571,23 +545,114 @@ TEST_P(HiveBucketedExecutionTest, unionall) {
       ") GROUP BY 1");
   auto plan = planDistributed(logicalPlan);
   // Each leg contributes its own bucket column as the union key (t:
-  // c_nationkey, u: c_custkey), which hash identically, so v2 co-buckets the
-  // legs and aggregates without the remote reshuffle v1 adds. Results are
-  // checked below.
-  if (!useV2_) {
+  // c_nationkey, u: c_custkey), and they hash identically, so the legs
+  // co-bucket and the aggregation needs no shuffle.
+  //
+  // Wrong plan under v1: it reads both legs by their buckets, which already
+  // co-locates every group, and then shuffles on the grouping key anyway, so
+  // only v2's shape is pinned.
+  if (useV2_) {
     AXIOM_ASSERT_DISTRIBUTED_PLAN(
         plan.plan,
         matchHiveScan("t")
             .localPartition(matchHiveScan("u").project())
-            .bucketed()
-            .fragmentWidth(4)
-            .shuffle({"c_nationkey"})
+            .partialAggregation()
             .localPartition({"c_nationkey"})
-            .singleAggregation({"c_nationkey"}, {"count(*)"})
+            .finalAggregation()
+            .fragment({.width = 4, .bucketedScans = 2})
             .gather()
             .build());
   }
-  assertSameAsSingleNode(logicalPlan, plan);
+}
+
+// A join between tables whose bucket counts coarsen to different widths runs
+// on one side's buckets; everything else joining it is shuffled onto them.
+TEST_P(HiveBucketedExecutionTest, bucketCountsThatScaleDifferently) {
+  createBucketedTable(
+      "t", 16, {"c_nationkey"}, "SELECT c_custkey, c_nationkey FROM customer");
+  createBucketedTable(
+      "u",
+      2,
+      {"c_nationkey"},
+      "SELECT DISTINCT c_nationkey, cast(c_nationkey AS varchar) AS label FROM customer");
+  createRegularTable("v", "SELECT c_custkey, c_nationkey FROM customer");
+
+  // The unbucketed table is shuffled onto the wider table's buckets.
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT t.c_custkey, u.label, count(*) FROM t, u, v "
+        "WHERE t.c_nationkey = u.c_nationkey AND t.c_nationkey = v.c_nationkey "
+        "GROUP BY t.c_custkey, u.label"));
+    if (useV2_) {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchHiveScan("t")
+              .hashJoinInner(matchHiveScan("u").aliases({"uk"}).shuffle({"uk"}))
+              .hashJoinInner(matchHiveScan("v").aliases({"vk"}).shuffle({"vk"}))
+              .partialAggregation()
+              .fragment(
+                  {.width = 4, .bucketedScans = 1, .bucketedExchanges = 2})
+              .shuffle({"c_custkey", "label"})
+              .localPartition({"c_custkey", "label"})
+              .finalAggregation()
+              .gather()
+              .build());
+    }
+  }
+
+  // Aggregating the wider table first keeps its width; the result is then
+  // shuffled onto the narrower table's buckets.
+  {
+    auto plan = planDistributed(parseSelect(
+        "SELECT x.c_nationkey, x.cnt, u.label FROM "
+        "(SELECT c_nationkey, count(*) AS cnt FROM t GROUP BY c_nationkey) x, u "
+        "WHERE x.c_nationkey = u.c_nationkey"));
+    if (useV2_) {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchHiveScan("u")
+              .hashJoinInner(matchHiveScan("t")
+                                 .partialAggregation()
+                                 .localPartition({"c_nationkey"})
+                                 .finalAggregation()
+                                 .fragment({.width = 4, .bucketedScans = 1})
+                                 .shuffle({"c_nationkey"}))
+              .fragment(
+                  {.width = 2, .bucketedScans = 1, .bucketedExchanges = 1})
+              .gather()
+              .build());
+    }
+  }
+}
+
+// A union of a bucketed and an unbucketed leg cannot be read by buckets: the
+// unbucketed leg has none, so the union has none either.
+TEST_P(HiveBucketedExecutionTest, unionAllWithUnbucketedLeg) {
+  createBucketedTable(
+      "t", 16, {"c_nationkey"}, "SELECT c_nationkey, c_custkey FROM customer");
+  createRegularTable("u", "SELECT c_nationkey, c_custkey FROM customer");
+
+  auto plan = planDistributed(parseSelect(
+      "SELECT c_nationkey, count(*) FROM ("
+      "  SELECT c_nationkey FROM t"
+      "  UNION ALL"
+      "  SELECT c_nationkey FROM u"
+      ") GROUP BY 1"));
+  // Wrong plan under v1: it reads t by its buckets even though the union's
+  // other leg has none, so the grouping cannot be used and is shuffled away.
+  if (useV2_) {
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchHiveScan("t")
+            .localPartition(matchHiveScan("u").project())
+            .partialAggregation()
+            .notBucketed()
+            .shuffle({"c_nationkey"})
+            .localPartition({"c_nationkey"})
+            .finalAggregation()
+            .gather()
+            .build());
+  }
 }
 
 AXIOM_INSTANTIATE_V1_V2(HiveBucketedExecutionTest);

--- a/axiom/optimizer/tests/MultiFragmentPlanTest.cpp
+++ b/axiom/optimizer/tests/MultiFragmentPlanTest.cpp
@@ -94,7 +94,7 @@ TEST_F(MultiFragmentPlanTest, validSingleFragment) {
       FragmentType::kSource,
       std::nullopt,
       MultiFragmentPlan::Options::singleNode());
-  EXPECT_NO_THROW(plan.checkConsistency());
+  EXPECT_NO_THROW(plan.checkConsistency(/*mayBeEmpty=*/false));
 }
 
 TEST_F(MultiFragmentPlanTest, validDistributedPlan) {
@@ -115,40 +115,46 @@ TEST_F(MultiFragmentPlanTest, validDistributedPlan) {
 
   auto plan =
       MultiFragmentPlan({std::move(producer), std::move(consumer)}, options);
-  EXPECT_NO_THROW(plan.checkConsistency());
+  EXPECT_NO_THROW(plan.checkConsistency(/*mayBeEmpty=*/false));
 }
 
 TEST_F(MultiFragmentPlanTest, emptyFragments) {
   VELOX_ASSERT_THROW(
-      MultiFragmentPlan({}, defaultOptions()).checkConsistency(),
+      MultiFragmentPlan({}, defaultOptions())
+          .checkConsistency(/*mayBeEmpty=*/false),
       "Plan must have at least one fragment");
 }
 
 TEST_F(MultiFragmentPlanTest, fixedWithoutWidth) {
   VELOX_ASSERT_THROW(
-      makeSingleFragmentPlan(FragmentType::kFixed).checkConsistency(),
+      makeSingleFragmentPlan(FragmentType::kFixed)
+          .checkConsistency(/*mayBeEmpty=*/false),
       "kFixed fragment must have width set");
 }
 
 TEST_F(MultiFragmentPlanTest, singleWithWidth) {
   VELOX_ASSERT_THROW(
-      makeSingleFragmentPlan(FragmentType::kSingle, 1).checkConsistency(),
+      makeSingleFragmentPlan(FragmentType::kSingle, 1)
+          .checkConsistency(/*mayBeEmpty=*/false),
       "fragment must not have width set");
 }
 
 TEST_F(MultiFragmentPlanTest, coordinatorWithWidth) {
   VELOX_ASSERT_THROW(
-      makeSingleFragmentPlan(FragmentType::kCoordinator, 1).checkConsistency(),
+      makeSingleFragmentPlan(FragmentType::kCoordinator, 1)
+          .checkConsistency(/*mayBeEmpty=*/false),
       "fragment must not have width set");
 }
 
 TEST_F(MultiFragmentPlanTest, invalidWidth) {
   VELOX_ASSERT_THROW(
-      makeSingleFragmentPlan(FragmentType::kFixed, 0).checkConsistency(),
+      makeSingleFragmentPlan(FragmentType::kFixed, 0)
+          .checkConsistency(/*mayBeEmpty=*/false),
       "Fragment width must be positive");
 
   VELOX_ASSERT_THROW(
-      makeSingleFragmentPlan(FragmentType::kFixed, 20).checkConsistency(),
+      makeSingleFragmentPlan(FragmentType::kFixed, 20)
+          .checkConsistency(/*mayBeEmpty=*/false),
       "Fragment width exceeds numWorkers");
 }
 
@@ -156,7 +162,7 @@ TEST_F(MultiFragmentPlanTest, sourceWithWidthHint) {
   auto options = defaultOptions();
   options.remoteOutput = true;
   auto plan = makeSingleFragmentPlan(FragmentType::kSource, 5, options);
-  EXPECT_NO_THROW(plan.checkConsistency());
+  EXPECT_NO_THROW(plan.checkConsistency(/*mayBeEmpty=*/false));
 }
 
 TEST_F(MultiFragmentPlanTest, missingProducer) {
@@ -169,7 +175,7 @@ TEST_F(MultiFragmentPlanTest, missingProducer) {
 
   auto plan = MultiFragmentPlan({std::move(fragment)}, defaultOptions());
   VELOX_ASSERT_THROW(
-      plan.checkConsistency(),
+      plan.checkConsistency(/*mayBeEmpty=*/false),
       "Producer fragment not found: nonexistent, consumer: stage0");
 }
 
@@ -187,7 +193,9 @@ TEST_F(MultiFragmentPlanTest, producerNotPartitionedOutput) {
 
   auto plan = MultiFragmentPlan(
       {std::move(producer), std::move(consumer)}, defaultOptions());
-  VELOX_ASSERT_THROW(plan.checkConsistency(), "Expected PartitionedOutputNode");
+  VELOX_ASSERT_THROW(
+      plan.checkConsistency(/*mayBeEmpty=*/false),
+      "Expected PartitionedOutputNode");
 }
 
 TEST_F(MultiFragmentPlanTest, lastFragmentIsProducer) {
@@ -210,12 +218,13 @@ TEST_F(MultiFragmentPlanTest, lastFragmentIsProducer) {
   {
     auto plan = MultiFragmentPlan({consumer, producer}, options);
     VELOX_ASSERT_THROW(
-        plan.checkConsistency(), "Last fragment cannot be a producer");
+        plan.checkConsistency(/*mayBeEmpty=*/false),
+        "Last fragment cannot be a producer");
   }
 
   {
     auto plan = MultiFragmentPlan({producer, consumer}, options);
-    ASSERT_NO_THROW(plan.checkConsistency());
+    ASSERT_NO_THROW(plan.checkConsistency(/*mayBeEmpty=*/false));
   }
 }
 
@@ -237,7 +246,8 @@ TEST_F(MultiFragmentPlanTest, partitionCountMismatch) {
 
   auto plan =
       MultiFragmentPlan({std::move(producer), std::move(consumer)}, options);
-  VELOX_ASSERT_THROW(plan.checkConsistency(), "Partition count mismatch");
+  VELOX_ASSERT_THROW(
+      plan.checkConsistency(/*mayBeEmpty=*/false), "Partition count mismatch");
 }
 
 TEST_F(MultiFragmentPlanTest, broadcastSkipsWidthCheck) {
@@ -254,7 +264,7 @@ TEST_F(MultiFragmentPlanTest, broadcastSkipsWidthCheck) {
 
   auto plan = MultiFragmentPlan(
       {std::move(producer), std::move(consumer)}, defaultOptions());
-  EXPECT_NO_THROW(plan.checkConsistency());
+  EXPECT_NO_THROW(plan.checkConsistency(/*mayBeEmpty=*/false));
 }
 
 TEST_F(MultiFragmentPlanTest, lastFragmentType) {
@@ -263,12 +273,12 @@ TEST_F(MultiFragmentPlanTest, lastFragmentType) {
 
   VELOX_ASSERT_THROW(
       makeSingleFragmentPlan(FragmentType::kFixed, 4, options)
-          .checkConsistency(),
+          .checkConsistency(/*mayBeEmpty=*/false),
       "Last fragment must be kSingle or kCoordinator");
 
   VELOX_ASSERT_THROW(
       makeSingleFragmentPlan(FragmentType::kSource, std::nullopt, options)
-          .checkConsistency(),
+          .checkConsistency(/*mayBeEmpty=*/false),
       "Last fragment must be kSingle or kCoordinator");
 
   // kSource is allowed as last fragment with numWorkers == 1.
@@ -276,12 +286,12 @@ TEST_F(MultiFragmentPlanTest, lastFragmentType) {
                       FragmentType::kSource,
                       std::nullopt,
                       MultiFragmentPlan::Options::singleNode())
-                      .checkConsistency());
+                      .checkConsistency(/*mayBeEmpty=*/false));
 
   // kFixed is allowed as last fragment with remoteOutput.
   options.remoteOutput = true;
   EXPECT_NO_THROW(makeSingleFragmentPlan(FragmentType::kFixed, 4, options)
-                      .checkConsistency());
+                      .checkConsistency(/*mayBeEmpty=*/false));
 }
 
 TEST_F(MultiFragmentPlanTest, orphanFragment) {
@@ -302,7 +312,7 @@ TEST_F(MultiFragmentPlanTest, orphanFragment) {
   auto plan =
       MultiFragmentPlan({std::move(orphan), std::move(output)}, options);
   VELOX_ASSERT_THROW(
-      plan.checkConsistency(),
+      plan.checkConsistency(/*mayBeEmpty=*/false),
       "Non-last fragment must be referenced by exactly one consumer: stage0");
 }
 
@@ -335,7 +345,7 @@ TEST_F(MultiFragmentPlanTest, producerReferencedByMultipleConsumers) {
       {std::move(producer), std::move(consumerA), std::move(consumerB)},
       options);
   VELOX_ASSERT_THROW(
-      plan.checkConsistency(),
+      plan.checkConsistency(/*mayBeEmpty=*/false),
       "Producer fragment referenced by multiple consumers: stage0");
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -2540,7 +2540,7 @@ PlanMatcherBuilder& PlanMatcherBuilder::bucketed() {
   matcher_ = std::make_shared<BucketedAssertionMatcher>(
       matcher_, [](const axiom::optimizer::ExecutableFragment& fragment) {
         EXPECT_FALSE(fragment.groupedNodes.empty())
-            << "Expected bucketed fragment but groupedNodes is empty";
+            << "fragment does not run grouped";
       });
   return *this;
 }
@@ -2550,55 +2550,59 @@ PlanMatcherBuilder& PlanMatcherBuilder::notBucketed() {
   matcher_ = std::make_shared<BucketedAssertionMatcher>(
       matcher_, [](const axiom::optimizer::ExecutableFragment& fragment) {
         EXPECT_TRUE(fragment.groupedNodes.empty())
-            << "Expected non-bucketed fragment but groupedNodes has "
-            << fragment.groupedNodes.size() << " entries";
+            << "fragment runs grouped over " << fragment.groupedNodes.size()
+            << " nodes";
       });
   return *this;
 }
 
-PlanMatcherBuilder& PlanMatcherBuilder::bucketedScans(int32_t count) {
+PlanMatcherBuilder& PlanMatcherBuilder::fragment(FragmentDetails details) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
+  // Zero holds for every non-bucketed plan, so it asserts nothing.
+  if (details.bucketedScans.has_value()) {
+    VELOX_USER_CHECK_GT(details.bucketedScans.value(), 0);
+  }
   matcher_ = std::make_shared<BucketedAssertionMatcher>(
-      matcher_, [count](const axiom::optimizer::ExecutableFragment& fragment) {
-        int32_t observed = 0;
-        for (const auto& [_, partitionType] : fragment.groupedNodes) {
+      matcher_,
+      [details](const axiom::optimizer::ExecutableFragment& fragment) {
+        if (details.width.has_value()) {
+          ASSERT_TRUE(fragment.width.has_value())
+              << "fragment width is not set";
+          EXPECT_EQ(*fragment.width, details.width.value()) << "fragment width";
+        }
+        if (!details.bucketedScans.has_value() &&
+            !details.bucketedExchanges.has_value()) {
+          return;
+        }
+        int32_t scans = 0;
+        int32_t exchanges = 0;
+        for (const auto& [nodeId, partitionType] : fragment.groupedNodes) {
+          const auto* node = velox::core::PlanNode::findNodeById(
+              fragment.fragment.planNode.get(), nodeId);
+          ASSERT_TRUE(node != nullptr)
+              << "grouped leaf " << nodeId << " is not in this fragment";
           if (partitionType != nullptr) {
-            ++observed;
+            ++scans;
+            EXPECT_TRUE(
+                dynamic_cast<const velox::core::TableScanNode*>(node) !=
+                nullptr)
+                << "grouped leaf " << nodeId << " is a " << node->name()
+                << ", not a scan";
+          } else {
+            ++exchanges;
+            EXPECT_TRUE(
+                dynamic_cast<const velox::core::ExchangeNode*>(node) != nullptr)
+                << "grouped leaf " << nodeId << " is a " << node->name()
+                << ", not an exchange";
           }
         }
-        EXPECT_EQ(observed, count)
-            << "Expected " << count << " bucketed scans but found " << observed;
-      });
-  return *this;
-}
-
-PlanMatcherBuilder& PlanMatcherBuilder::hashExchanges(int32_t count) {
-  VELOX_USER_CHECK_NOT_NULL(matcher_);
-  matcher_ = std::make_shared<BucketedAssertionMatcher>(
-      matcher_, [count](const axiom::optimizer::ExecutableFragment& fragment) {
-        int32_t observed = 0;
-        for (const auto& [_, partitionType] : fragment.groupedNodes) {
-          if (partitionType == nullptr) {
-            ++observed;
-          }
+        if (details.bucketedScans.has_value()) {
+          EXPECT_EQ(scans, details.bucketedScans.value()) << "bucketed scans";
         }
-        EXPECT_EQ(observed, count)
-            << "Expected " << count << " consumer-side hash exchanges but "
-            << "found " << observed;
-      });
-  return *this;
-}
-
-PlanMatcherBuilder& PlanMatcherBuilder::fragmentWidth(int32_t width) {
-  VELOX_USER_CHECK_NOT_NULL(matcher_);
-  matcher_ = std::make_shared<BucketedAssertionMatcher>(
-      matcher_, [width](const axiom::optimizer::ExecutableFragment& fragment) {
-        ASSERT_TRUE(fragment.width.has_value())
-            << "Expected fragment.width == " << width
-            << " but width is not set";
-        EXPECT_EQ(*fragment.width, width)
-            << "Expected fragment.width == " << width << " but got "
-            << *fragment.width;
+        if (details.bucketedExchanges.has_value()) {
+          EXPECT_EQ(exchanges, details.bucketedExchanges.value())
+              << "bucketed exchanges";
+        }
       });
   return *this;
 }
@@ -2608,10 +2612,7 @@ PlanMatcherBuilder& PlanMatcherBuilder::output(
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<BucketedAssertionMatcher>(
       matcher_, [type](const axiom::optimizer::ExecutableFragment& fragment) {
-        EXPECT_EQ(fragment.type, type)
-            << "Output fragment type mismatch: expected "
-            << fmt::format("{}", type) << ", got "
-            << fmt::format("{}", fragment.type);
+        EXPECT_EQ(fragment.type, type) << "output fragment type";
       });
   return *this;
 }

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -794,16 +794,39 @@ class PlanMatcherBuilder {
   /// scheduling).
   PlanMatcherBuilder& notBucketed();
 
-  /// Asserts the current fragment has exactly 'count' entries in groupedNodes
-  /// with a non-null PartitionType (bucketed scans).
-  PlanMatcherBuilder& bucketedScans(int32_t count);
+  /// Asserts the current fragment is bucketed when 'expected', and is not when
+  /// it is false. For a suite where the two optimizers differ.
+  PlanMatcherBuilder& bucketed(bool expected) {
+    return expected ? bucketed() : notBucketed();
+  }
 
-  /// Asserts the current fragment has exactly 'count' entries in groupedNodes
-  /// with a null PartitionType (consumer-side hash exchanges).
-  PlanMatcherBuilder& hashExchanges(int32_t count);
+  /// What the fragment holding the current node must look like. An unset field
+  /// is not checked.
+  struct FragmentDetails {
+    /// Number of tasks the fragment runs as.
+    std::optional<int32_t> width;
 
-  /// Asserts the current fragment has fragment.width == 'width'.
-  PlanMatcherBuilder& fragmentWidth(int32_t width);
+    /// Scans read one bucket group at a time. Each must be a TableScan.
+    std::optional<int32_t> bucketedScans;
+
+    /// Exchanges delivering bucket-aligned partitions to those same groups.
+    /// Each must be an Exchange.
+    std::optional<int32_t> bucketedExchanges;
+  };
+
+  /// Asserts 'details' about the fragment holding the current node.
+  PlanMatcherBuilder& fragment(FragmentDetails details);
+
+  /// Asserts the fragment holding the current node runs as 'width' tasks.
+  PlanMatcherBuilder& fragmentWidth(int32_t width) {
+    return fragment({.width = width});
+  }
+
+  /// Adds a width assertion (see `fragmentWidth()`) only when 'condition' is
+  /// true; otherwise a no-op.
+  PlanMatcherBuilder& fragmentWidthIf(bool condition, int32_t width) {
+    return condition ? fragmentWidth(width) : *this;
+  }
 
   /// Asserts the type of the root (output) fragment. Use as the final call in
   /// the chain: it binds to the plan's output fragment, which has no closing

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -36,6 +36,8 @@
 #include "velox/dwio/dwrf/RegisterDwrfReader.h"
 #include "velox/dwio/dwrf/RegisterDwrfWriter.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
+#include "velox/serializers/PrestoSerializer.h"
 
 namespace facebook::axiom::optimizer::test {
 namespace {
@@ -50,6 +52,11 @@ class SqlTestEnvironment : public testing::Environment {
  public:
   void SetUp() override {
     SqlTestBase::SetUpTestCase();
+    // Any plan that spans fragments needs these, including a single-node one.
+    // Registered here because setup statements run before any test's SetUp.
+    velox::serializer::presto::PrestoVectorSerde::tryRegisterNamedVectorSerde();
+    velox::exec::ExchangeSource::registerFactory(
+        velox::exec::test::createLocalExchangeSource);
   }
 
   void TearDown() override {
@@ -200,6 +207,8 @@ class SqlTest : public SqlTestBase {
     suiteOptimizerPool_ = suiteRootPool_->addLeafChild("optimizer");
     suiteDuckDbRunner_ = std::make_unique<exec::test::DuckDbQueryRunner>();
 
+    // Setup statements install tables; a file's queries are what it tests.
+    // Running them single-node keeps a CTAS off the remote-exchange path.
     auto runnerFactory = [](const logical_plan::LogicalPlanNodePtr& plan) {
       const auto buildRunner = UseV2 ? makeLocalRunnerV2 : makeLocalRunner;
       return buildRunner(
@@ -208,8 +217,8 @@ class SqlTest : public SqlTestBase {
           /*asyncDataCache=*/nullptr,
           suiteRootPool_,
           suiteOptimizerPool_,
-          /*numWorkers=*/4,
-          /*numDrivers=*/4,
+          /*numWorkers=*/1,
+          /*numDrivers=*/1,
           /*syntacticJoinOrder=*/false);
     };
 
@@ -472,6 +481,7 @@ int main(int argc, char** argv) {
 
   registerQueryFile<"aggregation">();
   registerQueryFile<"basic">();
+  registerQueryFile<"bucketedExecution">();
   registerQueryFile<"coercion">();
   registerQueryFile<"cte">();
   registerQueryFile<"datetime">();

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -101,7 +101,11 @@ std::shared_ptr<runner::LocalRunner> makeLocalRunnerImpl(
       core::QueryConfig{{}},
       {},
       asyncDataCache,
-      rootPool->addAggregateChild(queryId));
+      rootPool->addAggregateChild(queryId),
+      /*spillExecutor=*/nullptr,
+      // Task ids are built from this, and exchanges find their source by task
+      // id.
+      queryId);
 
   auto allocator = std::make_unique<HashStringAllocator>(optimizerPool.get());
   auto graphContext =

--- a/axiom/optimizer/tests/sql/bucketedExecution.sql
+++ b/axiom/optimizer/tests/sql/bucketedExecution.sql
@@ -1,0 +1,115 @@
+-- connector: hive
+-- setup
+CREATE TABLE t WITH (bucket_count = 8, bucketed_by = ARRAY['k']) AS
+  SELECT * FROM (VALUES
+    (1, 100, 10),
+    (2, 200, 20),
+    (3, 300, 30),
+    (1, 100, 40),
+    (2, 200, 50),
+    (3, 300, 60),
+    (4, 400, 70),
+    (5, 500, 80),
+    (1, 100, 90))
+  AS _(k, j, v)
+----
+CREATE TABLE u WITH (bucket_count = 16, bucketed_by = ARRAY['k']) AS
+  SELECT * FROM (VALUES
+    (1, 100, 10),
+    (2, 200, 20),
+    (3, 300, 30),
+    (4, 400, 70),
+    (5, 500, 80))
+  AS _(k, j, v)
+----
+CREATE TABLE v WITH (bucket_count = 8, bucketed_by = ARRAY['j']) AS
+  SELECT * FROM (VALUES
+    (1, 100, 11),
+    (2, 200, 22),
+    (3, 300, 33),
+    (4, 400, 44))
+  AS _(k, j, v)
+----
+CREATE TABLE b16 WITH (bucket_count = 16, bucketed_by = ARRAY['k']) AS
+  SELECT * FROM (VALUES
+    (1, 1),
+    (2, 2),
+    (3, 3),
+    (4, 4),
+    (5, 5),
+    (6, 6),
+    (7, 7),
+    (8, 8),
+    (9, 9),
+    (10, 10),
+    (11, 11),
+    (12, 12),
+    (13, 13),
+    (14, 14),
+    (15, 15),
+    (16, 16),
+    (17, 17),
+    (18, 18),
+    (19, 19),
+    (20, 20))
+  AS _(k, v)
+----
+CREATE TABLE b2 WITH (bucket_count = 2, bucketed_by = ARRAY['k']) AS
+  SELECT k, v * 100 AS m FROM b16
+----
+CREATE TABLE plain AS
+  SELECT k, v AS p FROM b16
+-- end_setup
+
+-- Grouping on a non-bucket key: the bucketing cannot help.
+SELECT j, count(*), sum(v) FROM t GROUP BY j
+----
+-- Two tables bucketed the same way on the join key, counts 8 and 16 (one
+-- divides the other), so the join can pair them without a shuffle.
+SELECT a.k, a.v, b.v FROM t a JOIN u b ON a.k = b.k
+----
+-- Only one side is bucketed on the join key: the other's bucketing is on a
+-- different column and cannot be used to pair them.
+SELECT a.k, a.v, c.v FROM t a JOIN v c ON a.k = c.k
+----
+-- Two join keys where each side is bucketed on only one of them.
+SELECT a.v, c.v FROM t a JOIN v c ON a.k = c.k AND a.j = c.j
+----
+-- Aggregation above a join, grouping on the probe's bucket key.
+SELECT a.k, count(*) FROM t a JOIN u b ON a.k = b.k GROUP BY a.k
+----
+-- Every leg of a union bucketed the same way.
+SELECT k, count(*) FROM (SELECT k FROM t UNION ALL SELECT k FROM u) GROUP BY k
+----
+-- One leg bucketed on a different column: the union cannot be read grouped.
+SELECT k, count(*) FROM (SELECT k FROM t UNION ALL SELECT j AS k FROM v) GROUP BY k
+
+----
+-- Bucket counts that coarsen to different widths, joined with an unbucketed
+-- table on the same key.
+SELECT b16.k, b2.m, count(*) FROM b16, b2, plain
+  WHERE b16.k = b2.k AND b16.k = plain.k
+  GROUP BY b16.k, b2.m
+
+----
+-- Existence join on the bucket key.
+SELECT k, v FROM t WHERE k IN (SELECT k FROM u)
+----
+-- Anti join on the bucket key.
+SELECT k, v FROM t WHERE k NOT IN (SELECT k FROM u WHERE k < 3)
+----
+-- count(DISTINCT) grouped by the bucket key.
+SELECT k, count(DISTINCT v) FROM t GROUP BY k
+----
+-- HAVING over an aggregation on the bucket key.
+SELECT k, count(*) FROM t GROUP BY k HAVING count(*) > 1
+----
+-- Window partitioned by the bucket key.
+SELECT k, v, row_number() OVER (PARTITION BY k ORDER BY v) AS rn FROM t
+
+----
+-- Aggregation over the wider table, joined with a table bucketed on the same
+-- key but into fewer buckets.
+SELECT x.k, x.cnt, b2.m FROM
+  (SELECT k, count(*) AS cnt FROM b16 GROUP BY k) x, b2
+  WHERE x.k = b2.k

--- a/axiom/optimizer/v2/DPhyp.cpp
+++ b/axiom/optimizer/v2/DPhyp.cpp
@@ -630,7 +630,42 @@ class Enumerator {
     if (it == memo_.end()) {
       return nullptr;
     }
-    return it->second.bestBucketed(keysInCoverSchema(keys, cover));
+    const ExprVector coverKeys = keysInCoverSchema(keys, cover);
+    if (MemoOpCP bucketed = it->second.bestBucketed(coverKeys)) {
+      return bucketed;
+    }
+
+    // Nothing in the memo is bucketed on these keys, but a single relation
+    // whose storage is bucketed on them can be read that way. Reading it so
+    // costs no more and saves the shuffle, so it is preferred rather than
+    // offered for costing. A grouped read only pays off against a shuffle, and
+    // considerCandidate takes the single-fragment path before it asks for a
+    // bucketed side, so this is never reached with one worker.
+    VELOX_DCHECK_GT(numWorkers_, 1);
+    if (cover.size() != 1) {
+      return nullptr;
+    }
+    const int32_t relationId = cover.min();
+    const NodeCP node = graph_.relation(relationId).node();
+    if (!node->is(NodeType::kScan)) {
+      return nullptr;
+    }
+    Partitioning storageBucketing = node->as<Scan>()->storageBucketing();
+    if (!storageBucketing.isBucketedOn(coverKeys)) {
+      return nullptr;
+    }
+    // Coarsened to the worker count, like every other grouped read: the memo
+    // costs and compares the read the plan will actually run.
+    storageBucketing.partitionType = queryCtx()->scaledPartitionType(
+        storageBucketing.partitionType, numWorkers_);
+
+    auto grouped = std::make_unique<LeafOp>(
+        Cost{}, static_cast<int8_t>(relationId), std::move(storageBucketing));
+    grouped->cost = costModel_.cost(grouped.get(), graph_);
+    it->second.addPlan(std::move(grouped), graph_, costModel_);
+    // Read back rather than keeping the pointer: addPlan drops a plan an
+    // existing one dominates, and enumeration asks for this cover repeatedly.
+    return it->second.bestBucketed(coverKeys);
   }
 
   // Cheapest plan for `cover` broadcast to all tasks. Null when `cover` has no
@@ -767,39 +802,33 @@ class Enumerator {
     };
 
     if (leftBucketed != nullptr && rightBucketed != nullptr) {
-      const connector::PartitionType* leftType =
-          leftBucketed->outputPartitioning().partitionType;
-      const connector::PartitionType* rightType =
-          rightBucketed->outputPartitioning().partitionType;
-      // copartition is only a feasibility check; the output reuses the
-      // min-partition-count input's layout-owned type, whose count equals
-      // copartition's (a fresh shared_ptr we can't retain as a raw pointer).
-      if (const auto compatible = leftType->copartition(*rightType)) {
-        const connector::PartitionType* outputType =
-            leftType->numPartitions() <= rightType->numPartitions() ? leftType
-                                                                    : rightType;
-        VELOX_DCHECK_EQ(
-            outputType->numPartitions(),
-            compatible->numPartitions(),
-            "Co-bucketed output must reuse a layout type matching copartition's count");
-        add(leftBucketed, rightBucketed, outputType);
+      const auto* leftType = leftBucketed->outputPartitioning().partitionType;
+      const auto* rightType = rightBucketed->outputPartitioning().partitionType;
+      const auto* folded = queryCtx()->copartitionedType(leftType, rightType);
+      if (folded == nullptr) {
+        return;
       }
-      return;
+      // Both sides are kept only when the partitioning they agree on runs at
+      // the width they already run at. Otherwise one side is repartitioned
+      // onto the other's grid below, which rebuilds it at that width.
+      if (folded->numPartitions() == leftType->numPartitions() &&
+          folded->numPartitions() == rightType->numPartitions()) {
+        add(leftBucketed, rightBucketed, folded);
+        return;
+      }
     }
 
     if (leftBucketed != nullptr) {
-      const connector::PartitionType* leftType =
-          leftBucketed->outputPartitioning().partitionType;
+      const auto* leftType = leftBucketed->outputPartitioning().partitionType;
       MemoOpCP rightAligned =
           repartitionedTo(right->cover(), rightKeys, leftType);
       if (rightAligned != nullptr) {
         add(leftBucketed, rightAligned, leftType);
       }
-    } else {
-      // Only the right side is bucketed here (the both-null case returned
-      // early).
-      const connector::PartitionType* rightType =
-          rightBucketed->outputPartitioning().partitionType;
+    }
+
+    if (rightBucketed != nullptr) {
+      const auto* rightType = rightBucketed->outputPartitioning().partitionType;
       MemoOpCP leftAligned =
           repartitionedTo(left->cover(), leftKeys, rightType);
       if (leftAligned != nullptr) {

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -524,7 +524,7 @@ class Emitter {
 
   // A grouped leaf of the fragment currently being built: a source that runs
   // per bucket-group under grouped execution. `partitionType` is the
-  // connector's (unscaled) partitioning for a bucketed scan, or null for a
+  // partitioning planning chose for a bucketed scan, or null for a
   // hash-partitioned consumer exchange that must route by group. Saved and
   // restored around each child-fragment build so leaves don't leak across
   // fragments.
@@ -704,11 +704,8 @@ velox::core::PlanNodePtr Emitter::emitScan(const Scan& scan) {
       tableHandle,
       std::move(assignments));
 
-  // A scan of a bucketed table is a grouped leaf: it runs per bucket-group
-  // under grouped execution, tagging the fragment as bucketed. The layout's
-  // partition type is null when the table is not bucketed.
-  if (const auto* partitionType =
-          scan.baseTable()->layout()->partitionType().get()) {
+  // A grouped scan makes its fragment bucketed.
+  if (const auto* partitionType = scan.groupedPartitionType()) {
     groupedLeaves_.push_back({scanNode->id(), partitionType});
   }
 
@@ -1825,39 +1822,42 @@ void decideFragmentType(
 }
 
 void Emitter::finalizeGroupedLeaves(ExecutableFragment& fragment) {
-  // Fold the bucketed scans' partitionings into one compatible type. `folded`
-  // owns the running copartition result so `base`, which points into it (or the
-  // first scan's layout-owned type before any fold), never dangles.
-  const connector::PartitionType* base = nullptr;
-  std::shared_ptr<connector::PartitionType> folded;
+  // Fold the grouped scans' partitionings into the one every task reads by.
+  // Planning already coarsened each to the worker count and only groups scans
+  // it checked copartition, so the fold must succeed and its count is the
+  // fragment's width.
+  const connector::PartitionType* folded = nullptr;
   for (const auto& leaf : groupedLeaves_) {
     if (leaf.partitionType == nullptr) {
       continue;
     }
-    if (base == nullptr) {
-      base = leaf.partitionType;
+    if (folded == nullptr) {
+      folded = leaf.partitionType;
       continue;
     }
-    // Scans share a fragment without an intervening exchange only because the
-    // memo found them co-partitionable, so `copartition` must succeed.
-    folded = base->copartition(*leaf.partitionType);
+    auto next = folded->copartition(*leaf.partitionType);
     VELOX_CHECK_NOT_NULL(
-        folded, "Co-fragmented bucketed scans must be copartitionable");
-    base = folded.get();
+        next, "Co-fragmented bucketed scans must be copartitionable");
+    folded = queryCtx()->registerPartitionType(std::move(next));
   }
 
-  if (base == nullptr) {
+  if (folded == nullptr) {
     return;
   }
 
-  std::shared_ptr<connector::PartitionType> scaled =
-      base->scaleDown(options_.numWorkers);
+  // The plan outlives this optimization, so it takes the owning pointer.
+  auto owned = queryCtx()->sharedPartitionType(folded);
+  VELOX_CHECK_NOT_NULL(
+      owned, "A grouped leaf's PartitionType must be owned by the context");
   for (const auto& leaf : groupedLeaves_) {
     fragment.groupedNodes.emplace(
-        leaf.nodeId, leaf.partitionType != nullptr ? scaled : nullptr);
+        leaf.nodeId,
+        leaf.partitionType != nullptr
+            ? std::const_pointer_cast<connector::PartitionType>(owned)
+            : nullptr);
   }
   fragment.type = FragmentType::kFixed;
-  fragment.width = scaled->numPartitions();
+  fragment.width = folded->numPartitions();
 }
 
 velox::core::PlanNodePtr Emitter::emitChildFragment(
@@ -1925,18 +1925,19 @@ velox::core::PlanNodePtr Emitter::makeExchangeProducer(
           toFieldAccessList(partitioning.keys, "Exchange partition key");
 
       // A partitionType aligns this shuffle to a bucketed side: use the
-      // connector's partition function (scaled to the worker count) so rows
-      // land in the same groups as the bucketed scan, matching the grouped
-      // fragment's width. Otherwise standard Velox hash over numWorkers
-      // partitions.
+      // connector's partition function so rows land in the same groups as that
+      // side. Planning coarsened it to the worker count, so its partition count
+      // is the consumer fragment's width. Otherwise standard Velox hash over
+      // numWorkers partitions.
       int32_t numPartitions = options_.numWorkers;
       velox::core::PartitionFunctionSpecPtr spec;
       if (partitioning.partitionType != nullptr) {
-        auto scaled =
-            partitioning.partitionType->scaleDown(options_.numWorkers);
-        numPartitions = scaled->numPartitions();
+        numPartitions = partitioning.partitionType->numPartitions();
         spec = connectorPartitionSpec(
-            *scaled, outputType, fields, /*isLocal=*/false);
+            *partitioning.partitionType,
+            outputType,
+            fields,
+            /*isLocal=*/false);
       } else {
         spec = makeHashPartitionSpec(outputType, fields);
       }
@@ -1998,10 +1999,9 @@ velox::core::PlanNodePtr Emitter::emitExchange(const Exchange& exchange) {
 
   // A partitioned exchange feeding the outer fragment is a group-routed leaf
   // there: if that fragment turns out bucketed, the exchange delivers per
-  // group. Recorded as a null-typed leaf (the fragment's bucketed scan, if any,
-  // anchors the width); `finalizeGroupedLeaves` drops it when the fragment has
-  // none. A bucketed write, whose fragment has no scan, anchors this leaf
-  // explicitly — see emitTableWrite.
+  // group. Recorded as a null-typed leaf, since the fragment's bucketed scans
+  // are what fix its width; `finalizeGroupedLeaves` drops it when there are
+  // none.
   if (partitioning.kind == PartitionKind::kPartitioned) {
     groupedLeaves_.push_back({consumer->id(), nullptr});
   }
@@ -2085,18 +2085,18 @@ velox::core::PlanNodePtr Emitter::emitTableWrite(const TableWrite& tableWrite) {
 
   velox::core::PlanNodePtr input = emit(tableWrite.input());
 
-  // A bucketed write's input is the remote bucket exchange (physical planning
-  // inserts it unless the source is already co-bucketed). The writer fragment
-  // has no bucketed scan to anchor grouped execution, so anchor it on that
-  // exchange: each of its bucket partitions becomes one writer group producing
-  // one bucket file, matching the exchange's partition count.
+  // A bucketed write reads a bucket exchange (physical planning inserts one
+  // unless the source is already co-bucketed), and its writer task count must
+  // equal that exchange's partition count: one task per bucket group, each
+  // producing one bucket file. The fragment runs no grouped scan, so this is a
+  // task count, not grouped execution.
   if (distributed && !layout->partitionColumns().empty() &&
       tableWrite.input()->is(NodeType::kExchange)) {
-    for (auto& leaf : groupedLeaves_) {
-      if (leaf.nodeId == input->id()) {
-        leaf.partitionType = layout->partitionType().get();
-        break;
-      }
+    const auto& exchangeType =
+        tableWrite.input()->physicalProperties().globalPartition.partitionType;
+    if (exchangeType != nullptr) {
+      writerFragment.type = FragmentType::kFixed;
+      writerFragment.width = exchangeType->numPartitions();
     }
   }
 

--- a/axiom/optimizer/v2/JoinTreeEmitter.cpp
+++ b/axiom/optimizer/v2/JoinTreeEmitter.cpp
@@ -242,7 +242,22 @@ void checkAllConjunctsPlaced(const EmitState& state) {
 }
 
 NodeCP emitLeaf(const LeafOp* leaf, EmitState& state) {
-  return state.graph.relation(leaf->relationId).node();
+  NodeCP node = state.graph.relation(leaf->relationId).node();
+  // The relation's node reads the table ungrouped. When the plan that won reads
+  // it one bucket-group at a time, that is a different read, so it is a
+  // different scan.
+  const auto* partitionType = leaf->outputPartitioning().partitionType;
+  if (partitionType != nullptr && node->is(NodeType::kScan)) {
+    const auto* scan = node->as<Scan>();
+    if (scan->groupedPartitionType() != partitionType) {
+      return state.builder.make<Scan>(Scan::Key{
+          .baseTable = scan->baseTable(),
+          .outputColumns = scan->outputColumns(),
+          .filters = scan->filters(),
+          .groupedPartitionType = partitionType});
+    }
+  }
+  return node;
 }
 
 // Builds a new `Unnest` IR node from a JoinOp wrapping a directed

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -375,15 +375,31 @@ ExprCP survivingEquiKey(ExprCP key, const PlanObjectSet& outputColumns) {
 Partitioning joinGlobalPartition(
     velox::core::JoinType joinType,
     NodeCP left,
+    NodeCP right,
     const ColumnVector& outputColumns) {
   if (joinType != velox::core::JoinType::kInner &&
       joinType != velox::core::JoinType::kLeft) {
     return {};
   }
 
-  const Partitioning& probe = left->physicalProperties().globalPartition;
+  Partitioning probe = left->physicalProperties().globalPartition;
   if (probe.kind != PartitionKind::kPartitioned) {
     return probe.dropOrder();
+  }
+
+  // Both sides connector-bucketed: the join runs on the partitioning the two
+  // agree on, which can be coarser than the probe's. Reporting the probe's
+  // would let a consumer align a shuffle to more partitions than the join's
+  // fragment has tasks.
+  const auto* buildType =
+      right->physicalProperties().globalPartition.partitionType;
+  if (probe.partitionType != nullptr && buildType != nullptr) {
+    const auto* folded =
+        queryCtx()->copartitionedType(probe.partitionType, buildType);
+    if (folded == nullptr) {
+      return {};
+    }
+    probe.partitionType = folded;
   }
 
   const auto outputSet = PlanObjectSet::fromObjects(outputColumns);
@@ -464,21 +480,14 @@ Partitioning aggregateGlobalPartition(
   return aggregateInputPartition(input, groupingKeys, groupingColumns);
 }
 
-// Output partitioning of a scan of a bucketed (connector-partitioned) table:
-// the connector's partition function on the output columns matching the
-// layout's partition columns. Unspecified when the table is not partitioned or
-// a partition column is not in the scan's output (so the partitioning can't be
-// expressed over the output).
-Partitioning scanGlobalPartition(const Scan::Key& key) {
-  const connector::TableLayout* layout = key.baseTable->layout();
-  // A coordinator-only layout's data lives solely on the coordinator, so its
-  // scan produces a single partition there. Model that as a gather (single
-  // partition, like Values); the coordinator placement itself is a separate
-  // leaf fact read at fragment-typing time.
-  if (layout->runsOnCoordinator()) {
-    return Partitioning::globalGather();
-  }
-  const auto partitionType = layout->partitionType();
+// Partitioning of 'partitionType' expressed over 'outputColumns': the
+// connector's partition function on the columns matching 'layout's partition
+// columns. Unspecified when a partition column is not among 'outputColumns',
+// so the partitioning cannot be stated over them.
+Partitioning bucketPartition(
+    const connector::TableLayout* layout,
+    const ColumnVector& outputColumns,
+    const connector::PartitionType* partitionType) {
   const auto& partitionColumns = layout->partitionColumns();
   if (partitionType == nullptr || partitionColumns.empty()) {
     return {};
@@ -488,7 +497,7 @@ Partitioning scanGlobalPartition(const Scan::Key& key) {
   keys.reserve(partitionColumns.size());
   for (const auto* partitionColumn : partitionColumns) {
     ColumnCP match = nullptr;
-    for (ColumnCP column : key.outputColumns) {
+    for (ColumnCP column : outputColumns) {
       if (column->name() == partitionColumn->name()) {
         match = column;
         break;
@@ -501,9 +510,24 @@ Partitioning scanGlobalPartition(const Scan::Key& key) {
   }
   return Partitioning{
       .kind = PartitionKind::kPartitioned,
-      .partitionType = partitionType.get(),
+      .partitionType = partitionType,
       .keys = std::move(keys),
       .scope = PropertyScope::kGlobal};
+}
+
+// Output partitioning of a scan: what the plan chose to read it by, not what
+// its table affords. Unspecified for an ordinary read, so nothing downstream
+// inherits a partitioning the plan does not rely on.
+Partitioning scanGlobalPartition(const Scan::Key& key) {
+  const connector::TableLayout* layout = key.baseTable->layout();
+  // A coordinator-only layout's data lives solely on the coordinator, so its
+  // scan produces a single partition there. Model that as a gather (single
+  // partition, like Values); the coordinator placement itself is a separate
+  // leaf fact read at fragment-typing time.
+  if (layout->runsOnCoordinator()) {
+    return Partitioning::globalGather();
+  }
+  return bucketPartition(layout, key.outputColumns, key.groupedPartitionType);
 }
 
 } // namespace
@@ -514,7 +538,8 @@ Scan::Scan(Key key)
           ColumnVector{key.outputColumns},
           PhysicalProperties{.globalPartition = scanGlobalPartition(key)}),
       baseTable_(key.baseTable),
-      filters_(std::move(key.filters)) {
+      filters_(std::move(key.filters)),
+      groupedPartitionType_(key.groupedPartitionType) {
   VELOX_CHECK_NOT_NULL(baseTable_);
   folly::F14FastSet<std::string_view> schemaNames;
   folly::F14FastSet<std::string> outputNames;
@@ -533,23 +558,36 @@ Scan::Scan(Key key)
 }
 
 size_t Scan::KeyHash::operator()(const Scan* node) const {
-  return hashOf(node->baseTable(), node->outputColumns(), node->filters());
+  return hashOf(
+      node->baseTable(),
+      node->outputColumns(),
+      node->filters(),
+      node->groupedPartitionType());
+}
+
+Partitioning Scan::storageBucketing() const {
+  const connector::TableLayout* layout = baseTable_->layout();
+  return bucketPartition(
+      layout, outputColumns(), layout->partitionType().get());
 }
 
 size_t Scan::KeyHash::operator()(const Key& key) const {
-  return hashOf(key.baseTable, key.outputColumns, key.filters);
+  return hashOf(
+      key.baseTable, key.outputColumns, key.filters, key.groupedPartitionType);
 }
 
 bool Scan::KeyEq::operator()(const Scan* left, const Scan* right) const {
   return left->baseTable() == right->baseTable() &&
       left->outputColumns() == right->outputColumns() &&
-      left->filters() == right->filters();
+      left->filters() == right->filters() &&
+      left->groupedPartitionType() == right->groupedPartitionType();
 }
 
 bool Scan::KeyEq::operator()(const Key& key, const Scan* node) const {
   return key.baseTable == node->baseTable() &&
       key.outputColumns == node->outputColumns() &&
-      key.filters == node->filters();
+      key.filters == node->filters() &&
+      key.groupedPartitionType == node->groupedPartitionType();
 }
 
 bool Scan::KeyEq::operator()(const Scan* node, const Key& key) const {
@@ -1291,21 +1329,11 @@ Partitioning unionGlobalPartition(const UnionAll::Key& key) {
         return {};
       }
     } else {
-      // copartition is only a feasibility check; the output reuses the
-      // min-partition-count leg's layout-owned type, whose count equals
-      // copartition's (a fresh shared_ptr we can't retain as a raw pointer).
-      const auto compatible = representative->copartition(*part.partitionType);
+      auto compatible = representative->copartition(*part.partitionType);
       if (compatible == nullptr) {
         return {};
       }
-      if (part.partitionType->numPartitions() <
-          representative->numPartitions()) {
-        representative = part.partitionType;
-      }
-      VELOX_DCHECK_EQ(
-          representative->numPartitions(),
-          compatible->numPartitions(),
-          "Co-bucketed union output must reuse a layout type matching copartition's count");
+      representative = queryCtx()->registerPartitionType(std::move(compatible));
     }
   }
   return Partitioning{
@@ -1404,6 +1432,7 @@ Join::Join(Key key)
               .globalPartition = joinGlobalPartition(
                   key.joinType,
                   key.left,
+                  key.right,
                   key.outputColumns),
               .local = joinLocal(key.joinType, key.left, key.outputColumns)}),
       inputs_{key.left, key.right},

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -165,6 +165,7 @@ class Scan : public Node {
  public:
   struct Key {
     BaseTableCP baseTable;
+
     /// Strict consumer-required output columns; may be empty (e.g.
     /// `SELECT count(1) FROM t` needs no column values from the table).
     /// Distinct by pointer; both `outputName()` and the underlying `name()`
@@ -172,10 +173,19 @@ class Scan : public Node {
     /// NOT in this set; the connector-side read schema is computed as
     /// `outputColumns ∪ refs(filters)` when building the final Velox plan.
     ColumnVector outputColumns;
+
     /// Filters on the scanned rows, as conjuncts joined with AND; may be empty.
     /// At Emit the connector evaluates those it can; the rest are re-applied as
     /// a `Filter` node above the `TableScan` in the final Velox plan.
     ExprVector filters;
+
+    /// The partitioning this scan is read with, when physical planning chose to
+    /// read the table one bucket-group at a time, already coarsened to the
+    /// worker count. Null for an ordinary read, which produces no partitioning
+    /// the plan can rely on. Part of the scan's identity: a grouped and an
+    /// ungrouped read of the same table are different plans with different
+    /// execution properties.
+    const connector::PartitionType* groupedPartitionType{nullptr};
   };
 
   /// Transparent hasher for interning `Scan`s by identity.
@@ -203,6 +213,18 @@ class Scan : public Node {
     return filters_;
   }
 
+  /// The partitioning this scan is read with; null for an ordinary read.
+  const connector::PartitionType* groupedPartitionType() const {
+    return groupedPartitionType_;
+  }
+
+  /// The bucketing this scan's table storage affords, expressed over the
+  /// columns this scan outputs. Empty when the table is not bucketed, or when
+  /// a bucketing column is not in the output and the partitioning therefore
+  /// cannot be stated over it. This is what is possible; `groupedPartitionType`
+  /// is what the plan chose.
+  Partitioning storageBucketing() const;
+
   std::span<const NodeCP> inputs() const override {
     return {};
   }
@@ -213,6 +235,7 @@ class Scan : public Node {
  private:
   const BaseTableCP baseTable_;
   const ExprVector filters_;
+  const connector::PartitionType* const groupedPartitionType_;
 };
 
 using ScanCP = const Scan*;

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -157,6 +157,8 @@ PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
   PlanAndStats result;
   result.plan = std::make_shared<MultiFragmentPlan>(
       std::move(emitted.fragments), planOptions);
+  result.plan->checkConsistency(
+      /*mayBeEmpty=*/plan_.is(logical_plan::NodeKind::kTableWrite));
   result.finishWrite = std::move(emitted.finishWrite);
   result.prediction = std::move(emitted.prediction);
 

--- a/axiom/optimizer/v2/PhysicalProperties.h
+++ b/axiom/optimizer/v2/PhysicalProperties.h
@@ -92,6 +92,9 @@ struct Partitioning {
   PartitionKind kind{PartitionKind::kUnspecified};
 
   /// Connector-specific partition function, or null for standard Velox hash.
+  /// Lifetime is managed externally: a layout-owned type lives for the
+  /// connector's lifetime, one derived during planning (scaleDown, copartition)
+  /// is owned by `QueryGraphContext`.
   const connector::PartitionType* partitionType{nullptr};
 
   /// Partition keys; empty unless `kind == kPartitioned`.

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/optimizer/v2/PlanPhysicalPass.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <numeric>
 #include <vector>
@@ -125,6 +126,133 @@ bool hasEndpointStrandedRelation(const JoinHypergraph& graph) {
   tesUnion.except(endpoints);
   return !tesUnion.empty();
 }
+
+// What a consumer needs of an input's partitioning.
+enum class Alignment {
+  // Rows that agree on the keys share a partition. The partitioning may be on
+  // any subset of them, in any order. Enough for an aggregation: every group
+  // lands whole on one task.
+  kCoLocated,
+
+  // Partitioned on exactly these keys, in this order. A join and a write need
+  // this: each compares its keys against another side's, so key i of one must
+  // be hashed the same as key i of the other, which a subset does not give.
+  kExactKeys,
+};
+
+// True when 'partitioning' meets 'alignment' on 'keys'.
+bool satisfies(
+    const Partitioning& partitioning,
+    const ExprVector& keys,
+    Alignment alignment) {
+  switch (alignment) {
+    case Alignment::kCoLocated:
+      return partitioning.coLocates(keys);
+    case Alignment::kExactKeys:
+      return partitioning.isBucketedOn(keys);
+  }
+  VELOX_UNREACHABLE();
+}
+
+// True when regrouping the scans under 'node' can make it bucketed. Mirrors
+// GroupedScanRewriter's two stopping rules -- only a scan of a bucketed table
+// contributes, and nothing past an exchange does -- but reads the tree instead
+// of rebuilding it, so asking costs no allocation.
+bool hasRegroupableScan(NodeCP node, folly::F14FastMap<NodeCP, bool>& answers) {
+  if (node->is(NodeType::kExchange)) {
+    return false;
+  }
+  const auto it = answers.find(node);
+  if (it != answers.end()) {
+    return it->second;
+  }
+  bool answer;
+  if (node->is(NodeType::kScan)) {
+    answer = node->as<Scan>()->storageBucketing().partitionType != nullptr;
+  } else if (node->is(NodeType::kUnionAll)) {
+    // A union is bucketed only when every leg is.
+    answer = std::ranges::all_of(node->inputs(), [&](NodeCP leg) {
+      return hasRegroupableScan(leg, answers);
+    });
+  } else {
+    answer = std::ranges::any_of(node->inputs(), [&](NodeCP input) {
+      return hasRegroupableScan(input, answers);
+    });
+  }
+  answers.emplace(node, answer);
+  return answer;
+}
+
+// Nodes are interned, so one subtree can hang off several parents -- and the
+// same node can be two legs of one union. Answers are remembered per node so a
+// diamond is walked once and a repeated leg reports what it is.
+bool hasRegroupableScan(NodeCP node) {
+  folly::F14FastMap<NodeCP, bool> answers;
+  return hasRegroupableScan(node, answers);
+}
+
+// Rewrites a subtree so every scan of a bucketed table is read one bucket-group
+// at a time. Nodes above are rebuilt by the base rewriter, which re-derives
+// their partitioning from the new inputs.
+class GroupedScanRewriter : public NodeRewriter<> {
+ public:
+  GroupedScanRewriter(Builder& builder, int32_t numWorkers)
+      : NodeRewriter<>(builder), numWorkers_{numWorkers} {}
+
+  // True when at least one scan was read grouped.
+  bool regrouped() const {
+    return regrouped_;
+  }
+
+ protected:
+  // Past an exchange the rows are redistributed, so how the source was read
+  // cannot help this consumer; leave that subtree alone.
+  NodeCP rewriteExchange(const Exchange* node, NoContext& /*context*/)
+      override {
+    return node;
+  }
+
+  // A union is bucketed only when every leg is, so one ungroupable leg forfeits
+  // it for all of them. Checking that first keeps the groupable legs from being
+  // rebuilt only to be thrown away.
+  NodeCP rewriteUnionAll(const UnionAll* node, NoContext& context) override {
+    for (NodeCP leg : node->inputs()) {
+      if (!hasRegroupableScan(leg)) {
+        return node;
+      }
+    }
+    return NodeRewriter<>::rewriteUnionAll(node, context);
+  }
+
+  NodeCP rewriteScan(const Scan* node, NoContext& /*context*/) override {
+    // Whether this bucketing is any use to the consumer is not decided here —
+    // the keys it asked for may belong to another leg or another side of a
+    // join. A table with no bucketing at all is left alone, so a subtree that
+    // could never be grouped rebuilds to itself and allocates nothing.
+    const Partitioning available = node->storageBucketing();
+    if (available.partitionType == nullptr) {
+      return node;
+    }
+    // Coarsened to the worker count here so the plan carries the group count
+    // it will run with, and two scans that scale alike stay one node.
+    NodeCP grouped = builder().make<Scan>(Scan::Key{
+        .baseTable = node->baseTable(),
+        .outputColumns = node->outputColumns(),
+        .filters = node->filters(),
+        .groupedPartitionType = queryCtx()->scaledPartitionType(
+            available.partitionType, numWorkers_)});
+    // A scan already read this way interns back to itself, and then this
+    // rewrite changed nothing.
+    if (grouped != node) {
+      regrouped_ = true;
+    }
+    return grouped;
+  }
+
+ private:
+  const int32_t numWorkers_;
+  bool regrouped_{false};
+};
 
 class PhysicalPlanRewriter : public NodeRewriter<> {
  public:
@@ -337,36 +465,144 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
     return builder().make<Exchange>({input, std::move(partitioning)});
   }
 
-  // Co-locates a keyed join without shuffling the bucketed side(s): keeps both
-  // when both are already bucketed on the keys and copartitionable, else aligns
-  // the unbucketed side to the bucketed one's connector partitioning. Returns
-  // true and updates 'left'/'right' when co-location applies; false when
-  // neither side is bucketed, or both are bucketed but not copartitionable — in
-  // either case the caller falls back to the standard shuffle.
-  // Updates 'leftKeys' / 'rightKeys' when a side is repartitioned to the
-  // other's bucketing: the shuffle needs column keys, so an expression key is
-  // computed first and the join reads that column.
+  // Follows single-input nodes down to a scan and returns the bucketing its
+  // table affords, or null if the chain forks or ends elsewhere. A rough
+  // answer on purpose: it does not check that those nodes preserve
+  // partitioning, so it can name a bucketing `groupedRead` would decline to
+  // build. Used only to skip building a subtree that could not pair anyway —
+  // a wrong yes costs a build that is discarded, a wrong no costs a grouped
+  // read, and neither changes results.
+  static const connector::PartitionType* leafStorageBucketing(NodeCP node) {
+    while (!node->is(NodeType::kScan)) {
+      if (node->inputs().size() != 1) {
+        return nullptr;
+      }
+      node = node->inputs()[0];
+    }
+    return node->as<Scan>()->storageBucketing().partitionType;
+  }
+
+  // Where 'node's bucket columns sit in 'keys', or nullopt when it is not
+  // bucketed or a bucket column is not among them. A join pairs leftKeys[i]
+  // with rightKeys[i], so equal positions on both sides mean their bucketings
+  // line up column for column, whatever order the query wrote the keys in.
+  //
+  // A key repeated in 'keys' reports its first position. Since a pair is taken
+  // only when both sides report the same positions, and the join equates the
+  // keys at those positions, the two bucketings still agree value for value;
+  // picking the first of several equal keys can only cost a pairing, never
+  // make a wrong one.
+  static std::optional<std::vector<size_t>> bucketKeyPositions(
+      NodeCP node,
+      const ExprVector& keys) {
+    if (node == nullptr) {
+      return std::nullopt;
+    }
+    const auto& partition = node->physicalProperties().globalPartition;
+    if (partition.partitionType == nullptr || partition.keys.empty()) {
+      return std::nullopt;
+    }
+    std::vector<size_t> positions;
+    positions.reserve(partition.keys.size());
+    for (ExprCP partitionKey : partition.keys) {
+      const auto it = std::find_if(keys.begin(), keys.end(), [&](ExprCP key) {
+        return key->sameOrEqual(*partitionKey);
+      });
+      if (it == keys.end()) {
+        return std::nullopt;
+      }
+      positions.push_back(it - keys.begin());
+    }
+    return positions;
+  }
+
+  // The connector bucketing 'node' produces, or null when it has none. A null
+  // 'node' is the ordinary case of a side with no grouped read to offer.
+  static const connector::PartitionType* bucketingAt(NodeCP node) {
+    return node == nullptr
+        ? nullptr
+        : node->physicalProperties().globalPartition.partitionType;
+  }
+
+  // Co-locates a keyed join on the sides' bucketing instead of shuffling both.
+  // A side qualifies when it is already bucketed on its keys or its table can
+  // be read grouped by them. Both qualify and copartition: keep both. One
+  // qualifies: align the other to its connector partitioning. Neither, or two
+  // that do not copartition: returns false and the caller shuffles.
+  // Updates 'left'/'right' and, where a side is repartitioned to the other's
+  // bucketing, 'leftKeys'/'rightKeys': that shuffle needs column keys, so an
+  // expression key is computed first and the join reads that column.
   bool coBucketJoinSides(
       NodeCP& left,
       NodeCP& right,
       ExprVector& leftKeys,
       ExprVector& rightKeys) {
-    const auto& leftPart = left->physicalProperties().globalPartition;
-    const auto& rightPart = right->physicalProperties().globalPartition;
-    const bool leftBucketed = leftPart.isBucketedOn(leftKeys);
-    const bool rightBucketed = rightPart.isBucketedOn(rightKeys);
-    if (leftBucketed && rightBucketed) {
-      return leftPart.partitionType->copartition(*rightPart.partitionType) !=
-          nullptr;
-    }
-    if (leftBucketed) {
-      std::tie(right, rightKeys) = builder().materializeKeys(right, rightKeys);
-      right = partitionTo(right, rightKeys, leftPart.partitionType);
+    // What a side can offer: itself when already bucketed on keys the join
+    // uses, else a grouped read of its table by them, else nothing. Which of
+    // the join's keys, and in what order, is settled below — a side's bucketing
+    // follows its table, not the order the query wrote the join in.
+    const auto offer = [&](NodeCP side, const ExprVector& keys) -> NodeCP {
+      return side->physicalProperties().globalPartition.coLocates(keys)
+          ? side
+          : groupedRead(side, keys, Alignment::kCoLocated);
+    };
+
+    const NodeCP leftOffer = offer(left, leftKeys);
+    const auto leftAt = bucketKeyPositions(leftOffer, leftKeys);
+
+    // Building the right side's offer is wasted when its table's bucketing
+    // could not meet the left's anyway.
+    const auto* leftType = bucketingAt(leftOffer);
+    const auto* rightStorage = leafStorageBucketing(right);
+    // Skip only when the right side's table is known not to meet the left's.
+    // A null answer means unknown — its subtree is not a single table — and
+    // then it must be built and judged on its own partitioning.
+    const bool worthBuilding = leftType == nullptr || rightStorage == nullptr ||
+        leftType->copartition(*rightStorage) != nullptr;
+    const NodeCP rightOffer = worthBuilding ? offer(right, rightKeys) : nullptr;
+    const auto rightAt = bucketKeyPositions(rightOffer, rightKeys);
+    const auto* rightType = bucketingAt(rightOffer);
+
+    // Repartitions the side that has nothing to offer onto the other's
+    // bucketing, on the keys that correspond to the other's bucket columns.
+    // That shuffle needs column keys, so an expression key is computed first
+    // and the join then reads that column.
+    const auto alignTo = [&](NodeCP& side,
+                             ExprVector& keys,
+                             const std::vector<size_t>& at,
+                             const connector::PartitionType* target) {
+      ExprVector shuffleKeys;
+      shuffleKeys.reserve(at.size());
+      for (const size_t position : at) {
+        shuffleKeys.push_back(keys[position]);
+      }
+      auto [keyed, columnKeys] = builder().materializeKeys(side, shuffleKeys);
+      side = partitionTo(keyed, columnKeys, target);
+    };
+
+    if (leftAt.has_value() && rightAt.has_value()) {
+      // Equal positions mean bucket column i of one side joins bucket column i
+      // of the other; unequal ones would send matching rows to different tasks.
+      // Both sides are kept only when the partitioning they agree on runs at
+      // the width they already run at; otherwise the caller shuffles.
+      const auto* folded = queryCtx()->copartitionedType(leftType, rightType);
+      if (*leftAt != *rightAt || folded == nullptr ||
+          folded->numPartitions() != leftType->numPartitions() ||
+          folded->numPartitions() != rightType->numPartitions()) {
+        return false;
+      }
+      left = leftOffer;
+      right = rightOffer;
       return true;
     }
-    if (rightBucketed) {
-      std::tie(left, leftKeys) = builder().materializeKeys(left, leftKeys);
-      left = partitionTo(left, leftKeys, rightPart.partitionType);
+    if (leftAt.has_value()) {
+      left = leftOffer;
+      alignTo(right, rightKeys, *leftAt, leftType);
+      return true;
+    }
+    if (rightAt.has_value()) {
+      right = rightOffer;
+      alignTo(left, leftKeys, *rightAt, rightType);
       return true;
     }
     return false;
@@ -418,6 +654,12 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
       return {input, keys};
     }
 
+    // Reading the input by its storage bucketing co-locates the keys without
+    // moving a row, so it beats a shuffle whenever it is available.
+    if (NodeCP grouped = groupedRead(input, keys, Alignment::kCoLocated)) {
+      return {grouped, keys};
+    }
+
     auto [keyed, columnKeys] =
         builder().materializeKeys(input, keys, keyAliases);
     return {partition(keyed, columnKeys), columnKeys};
@@ -443,7 +685,13 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
       // Remote two-stage: the input must shuffle across workers to co-locate
       // its groups, so the partial reduces rows before that remote exchange.
       if (numWorkers_ > 1 && needsShuffle(input, node->groupingKeys())) {
-        return rewriteAggregateSplit(node, input, /*remoteExchange=*/true);
+        // Reading the input grouped co-locates the groups without a shuffle.
+        if (NodeCP grouped = groupedRead(
+                input, node->groupingKeys(), Alignment::kCoLocated)) {
+          input = grouped;
+        } else {
+          return rewriteAggregateSplit(node, input, /*remoteExchange=*/true);
+        }
       }
       // Local two-stage: the input is already co-located (e.g. a bucketed
       // scan's grouped fragment), but at numDrivers > 1 a local exchange still
@@ -508,11 +756,40 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
     return true;
   }
 
-  // True when co-locating 'input's groups on 'keys' requires a shuffle — i.e.
-  // when the single-stage path's `ensureCoLocated` would add one. Mirrors its
-  // conditions: a gathered input already co-locates any keys; a global
-  // aggregate (no keys) needs a gather unless already gathered; otherwise a
-  // shuffle is needed unless the input is already partitioned on the keys.
+  // Returns 'input' with every scan under it read one bucket-group at a time,
+  // when that makes the result meet 'alignment' on 'keys'; null otherwise.
+  //
+  // Which operators carry a scan's bucketing upward is not decided here: the
+  // subtree is rebuilt and each node derives its own partitioning, so a join
+  // keeps its probe's, a union keeps what its legs agree on, and anything that
+  // redistributes keeps nothing. The answer is then read off the rebuilt root.
+  //
+  // Nodes are interned, so rebuilding one over unchanged inputs returns the
+  // node itself; only a scan that is actually regrouped, and its ancestors,
+  // are new.
+  NodeCP
+  groupedRead(NodeCP input, const ExprVector& keys, Alignment alignment) {
+    if (numWorkers_ == 1 || keys.empty()) {
+      return nullptr;
+    }
+
+    GroupedScanRewriter rewriter{builder(), numWorkers_};
+    NoContext context;
+    NodeCP grouped = rewriter.rewrite(input, context);
+    if (!rewriter.regrouped()) {
+      return nullptr;
+    }
+    return satisfies(
+               grouped->physicalProperties().globalPartition, keys, alignment)
+        ? grouped
+        : nullptr;
+  }
+
+  // True when 'input' is not already arranged so that rows agreeing on 'keys'
+  // share a task: a gathered input co-locates any keys; a global aggregate (no
+  // keys) needs a gather unless already gathered; otherwise the input must be
+  // partitioned on the keys. Callers that can avoid the shuffle by reading the
+  // source grouped ask `groupedRead` after this returns true.
   bool needsShuffle(NodeCP input, const ExprVector& keys) const {
     if (isGathered(input)) {
       return false;
@@ -864,7 +1141,10 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
       const auto* layout = node->table()->layouts().front();
       const auto& partitionColumns = layout->partitionColumns();
       if (!partitionColumns.empty()) {
-        const auto* targetType = layout->partitionType().get();
+        // Coarsened here, not at emit: the exchange's partition count and the
+        // writer fragment's task count are the same decision.
+        const auto* targetType = queryCtx()->scaledPartitionType(
+            layout->partitionType().get(), numWorkers_);
         const auto& schema = node->table()->type();
         ExprVector keys;
         keys.reserve(partitionColumns.size());
@@ -872,8 +1152,21 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
           keys.push_back(node->columnExprs().at(
               schema->getChildIdx(partitionColumn->name())));
         }
-        const auto& partition = newInput->physicalProperties().globalPartition;
-        if (!partition.isBucketedCompatibleWith(keys, *targetType)) {
+        // Reading the source by its own bucketing can deliver rows already
+        // grouped the way the target is written, which saves the shuffle.
+        if (!newInput->physicalProperties()
+                 .globalPartition.isBucketedCompatibleWith(keys, *targetType)) {
+          if (NodeCP grouped =
+                  groupedRead(newInput, keys, Alignment::kExactKeys)) {
+            if (grouped->physicalProperties()
+                    .globalPartition.isBucketedCompatibleWith(
+                        keys, *targetType)) {
+              newInput = grouped;
+            }
+          }
+        }
+        if (!newInput->physicalProperties()
+                 .globalPartition.isBucketedCompatibleWith(keys, *targetType)) {
           auto [keyed, columnKeys] = builder().materializeKeys(newInput, keys);
           newInput = partitionTo(keyed, columnKeys, targetType);
           for (size_t i = 0; i < keys.size(); ++i) {


### PR DESCRIPTION
Summary:

Planning a query on a single worker could fail with:

    Co-fragmented bucketed scans must be copartitionable

when the query joined two bucketed tables whose bucketings do not match. A query joining two bucketed tables whose bucket counts coarsen to different widths, together with an unbucketed table on the same key, failed differently: it hung under v2 and indexed past the end of a destination vector under v1.

Both come from the same place. A scan advertised its table's bucketing as though it were the plan's execution partitioning, and since every operator inherits its input's partitioning, the whole tree repeated a claim nothing had decided. A scan now states the partitioning the plan chose to read it by, which is part of the scan's identity: a grouped and an ordinary read of one table are different plans. What the table's storage affords is a separate question, answered by `Scan::storageBucketing()` and asked only by physical planning.

An operator that needs rows with equal keys on one task can get there two ways: shuffle them over the network, or read a table already stored bucketed on those keys and hand whole buckets to tasks, moving nothing. Every consumer that needs such an arrangement now asks one function for it rather than deciding alone. That function rebuilds the subtree with each bucketed scan read one bucket-group at a time and lets every node above re-derive its own partitioning, so what survives the rebuild is what the plan can rely on; it stops at an exchange, since past one the rows have been redistributed. The consumer says how strong an arrangement it needs, since an aggregation only needs equal keys to share a partition while a join or a write needs its keys aligned position by position.

How wide a bucketed fragment runs is a planning decision too. Planning coarsens a connector partitioning to the worker count and the plan carries the result, so a fragment's task count and the partition count of every exchange feeding it come from one number rather than being recomputed at emit. Two bucketed sides are co-located only when the partitioning they agree on runs at the width both already run at; otherwise one is repartitioned onto the other's grid. Emit lowers what planning chose and decides nothing. Types derived while planning are owned by `QueryGraphContext`, like literals, and memoized so that nodes scaled alike stay interned.

A bucketed table that a plan does not exploit no longer produces a grouped fragment; it becomes an ordinary source fragment. At one worker nothing is read grouped at all, since grouping exists to avoid a shuffle and there are none. Both are v2 only; v1 keeps reading bucketed tables grouped regardless. v1 does now build a shuffle's partition function at the number of destinations the shuffle has, and `MultiFragmentPlan::checkConsistency()`, which compares those two counts, runs for v2 as it already did for v1.

Reviewed By: xiaoxmeng

Differential Revision: D116501864


