### PR TITLE
fix(optimizer/v2): Dedup grouping keys by expression

### DIFF
--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -1022,6 +1022,81 @@ TEST_P(UnnestTest, joinEdgeCrossingWithUnnest) {
   AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
 }
 
+// An IN subquery whose source unnests a column of another relation. The IN
+// test is applied above the unnest, and the outer column reaches the output.
+TEST_P(UnnestTest, inSubqueryOverUnnest) {
+  auto query =
+      "SELECT a FROM (VALUES ('x')) AS s(a) "
+      "WHERE a IN ("
+      "  SELECT e FROM (VALUES (ARRAY['x'])) AS m(data) "
+      "  CROSS JOIN UNNEST(data) AS t(e))";
+  SCOPED_TRACE(query);
+
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+
+  auto matcher = matchValues()
+                     .aliases({"data"})
+                     .unnest({}, {"data"})
+                     .aliases({"e"})
+                     .hashJoinRightSemiFilter(
+                         matchValues().aliases({"a"}), {.keys = {{"e = a"}}})
+                     .project({"a"})
+                     .build();
+
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+
+  // Two single-row inputs stay on one task, so distributing changes nothing.
+  auto distributed = planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributed.plan, matcher);
+}
+
+// An expansion goes above a join that does not read what it produces, so the
+// join runs on the rows before they multiply.
+TEST_P(UnnestTest, unnestPlacedAboveJoin) {
+  auto query =
+      "SELECT s.a, e "
+      "FROM (VALUES (1, ARRAY[10, 20])) AS m(k, data) "
+      "CROSS JOIN UNNEST(m.data) AS t(e) "
+      "JOIN (VALUES (1)) AS s(a) ON s.a = m.k";
+  SCOPED_TRACE(query);
+
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+
+  // v1 expands before the join, so the join reads the multiplied rows. That
+  // plan is the worse one and is not checked.
+  if (!useV2_) {
+    ASSERT_NO_THROW(toSingleNodePlan(logicalPlan));
+    return;
+  }
+
+  auto matcher =
+      matchValues()
+          .aliases({"k", "data"})
+          .hashJoinInner(matchValues().aliases({"a"}), {.keys = {{"k = a"}}})
+          .unnest({"a"}, {"data"})
+          .project()
+          .build();
+
+  {
+    SCOPED_TRACE("cost-based enumeration");
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+
+    auto distributed =
+        planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributed.plan, matcher);
+  }
+
+  {
+    SCOPED_TRACE("greedy fallback");
+    optimizerOptions_.dphypEnumerationBudget = 1;
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+
+    auto distributed =
+        planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributed.plan, matcher);
+  }
+}
+
 AXIOM_INSTANTIATE_V1_V2(UnnestTest);
 
 } // namespace

--- a/axiom/optimizer/tests/sql/aggregation.sql
+++ b/axiom/optimizer/tests/sql/aggregation.sql
@@ -24,6 +24,10 @@
 -- Dedup: duplicate grouping key expressions and aggregate calls.
 SELECT a + b AS x, a + b AS y, count(1) AS c1, count(1) AS c2 FROM t GROUP BY 1, 2
 ----
+-- Dedup: grouping keys that differ only in operand order group as one key, so
+-- p equals q on every row and there is one row per distinct a.
+SELECT a + 1 AS p, 1 + a AS q FROM t GROUP BY 1, 2
+----
 -- Dedup: column used in both GROUP BY and aggregate.
 SELECT a + b AS x, a + b AS y, count(a + b) AS z FROM t GROUP BY 1, 2
 ----

--- a/axiom/optimizer/tests/sql/unnest.sql
+++ b/axiom/optimizer/tests/sql/unnest.sql
@@ -57,6 +57,13 @@ FROM arrays a
 JOIN (VALUES (7), (8)) AS u(k) ON u.k = a.x
 CROSS JOIN UNNEST(a.ys) AS _(y)
 ----
+-- The same rows with the unnest written below the join, where the join reads
+-- no unnested column.
+SELECT a.x, u.k, y
+FROM arrays a
+CROSS JOIN UNNEST(a.ys) AS _(y)
+JOIN (VALUES (7), (8)) AS u(k) ON u.k = a.x
+----
 -- Join on an unnested column.
 SELECT a.x, y
 FROM arrays a
@@ -82,3 +89,18 @@ SELECT a.x, y, u.k
 FROM arrays a
 CROSS JOIN UNNEST(a.ys) AS _(y)
 JOIN (VALUES (7, 10), (8, 30)) AS u(k, m) ON u.k = a.x AND u.m = y
+----
+-- An IN subquery whose source unnests a column of another relation.
+SELECT a
+FROM (VALUES ('x')) AS s(a)
+WHERE a IN (
+  SELECT e FROM (VALUES (ARRAY['x'])) AS m(data) CROSS JOIN UNNEST(data) AS t(e))
+----
+-- An EXISTS subquery whose source unnests a column, correlated only by a
+-- comparison on the unnested column.
+SELECT x
+FROM arrays a
+WHERE EXISTS (
+  SELECT 1
+  FROM (VALUES (ARRAY[8, 5])) AS m(data) CROSS JOIN UNNEST(data) AS t(e)
+  WHERE e > a.x)

--- a/axiom/optimizer/v2/Cost.h
+++ b/axiom/optimizer/v2/Cost.h
@@ -22,8 +22,8 @@ namespace facebook::axiom::optimizer::v2 {
 
 /// Default per-input-row fanout assumed for an UNNEST when per-array
 /// size statistics are unavailable. The cardinality of an Unnest
-/// relation and the cost of its cross-join-unnest edge must use the
-/// same value so the two estimates agree.
+/// relation and the cost of expanding a plan by it must use the same
+/// value so the two estimates agree.
 constexpr float kDefaultUnnestFanout = 10;
 
 /// Cost of a candidate physical plan or subplan, used to score memo

--- a/axiom/optimizer/v2/CostModel.cpp
+++ b/axiom/optimizer/v2/CostModel.cpp
@@ -114,18 +114,18 @@ std::optional<float> innerEdgeSelectivity(
   return 1.0f / std::max(jointNdvLeft, jointNdvRight);
 }
 
-// Applies the selectivities of the extra edges that filter `join`'s output —
-// the inner edges that crossed alongside an Unnest or an outer join, which the
-// emitter puts in a Filter above it. An edge whose selectivity is unknown is
-// left out rather than making the cover uncostable: a filter can only reduce,
-// so the unfiltered count stays a valid upper bound, whereas an unknown would
-// drop every candidate for the cover and leave the join graph unplannable.
+// Applies the selectivities of `extraEdges` — the inner edges that crossed
+// alongside an Unnest or an outer join, which the emitter puts in a Filter
+// above it. An edge whose selectivity is unknown is left out rather than making
+// the cover uncostable: a filter can only reduce, so the unfiltered count stays
+// a valid upper bound, whereas an unknown would drop every candidate for the
+// cover and leave the join graph unplannable.
 std::optional<float> applyExtraEdges(
     std::optional<float> cardinality,
-    const JoinOp& join,
+    const std::vector<size_t>& extraEdges,
     const JoinHypergraph& graph,
     const ConstraintMap& constraints) {
-  for (size_t extraIndex : join.extraEdges) {
+  for (size_t extraIndex : extraEdges) {
     if (const auto selectivity = innerEdgeSelectivity(
             graph.edges()[extraIndex], graph, constraints)) {
       cardinality = mul(cardinality, *selectivity);
@@ -223,34 +223,34 @@ Cost leafCost(
   return out;
 }
 
-// Records the estimate for a cross-join-unnest cover: the input cover's
-// constraints pass through (the unnest adds columns but does not change the
+// Records the estimate for an unnest cover: the input cover's constraints
+// pass through (the unnest adds columns but does not change the
 // input columns' NDVs) and its cardinality scales by the unnest fanout, then by
 // the filters the emitter applies on the expansion: the edges that crossed
 // alongside the unnest (see `applyExtraEdges`) and the pool conjuncts this
 // cover makes ready that the input cover did not already apply. A conjunct of
 // unknown selectivity is skipped for the same reason an edge is.
 const Estimate& unnestEstimate(
-    const JoinOp& join,
+    const UnnestOp& unnest,
     const JoinHypergraph& graph,
     BySetMap& bySet) {
-  const RelationSet cover = join.cover();
+  const RelationSet cover = unnest.cover();
   const auto it = bySet.find(cover);
   if (it != bySet.end()) {
     return it->second;
   }
-  const Estimate& input = coverEstimate(join.left->cover(), bySet);
+  const Estimate& input = coverEstimate(unnest.input->cover(), bySet);
   Estimate result;
   mergeConstraints(input.constraints, result.constraints);
   std::optional<float> cardinality = applyExtraEdges(
       mul(input.cardinality, kDefaultUnnestFanout),
-      join,
+      unnest.extraEdges,
       graph,
       result.constraints);
   ExprVector conjuncts;
   for (const auto& conjunct : graph.filterConjuncts()) {
     if (conjunct.relations.isSubset(cover) &&
-        !conjunct.relations.isSubset(join.left->cover())) {
+        !conjunct.relations.isSubset(unnest.input->cover())) {
       conjuncts.push_back(conjunct.expr);
     }
   }
@@ -266,25 +266,24 @@ const Estimate& unnestEstimate(
   return bySet.emplace(cover, std::move(result)).first->second;
 }
 
-// Cost for a JoinOp wrapping a directed cross-join-unnest edge.
-// `join->left` is the input-side plan (the orientation enforcement in
-// DPhyp guarantees this); cardinality scales by the unnest fanout.
-Cost unnestJoinCost(
-    const JoinOp& join,
+// Cost for expanding a plan by an Unnest relation; cardinality scales by the
+// unnest fanout.
+Cost unnestCost(
+    const UnnestOp& unnest,
     const JoinHypergraph& graph,
     BySetMap& bySet) {
   using optimizer::Costs;
-  const std::optional<float> inputCardinality = join.left->cost.cardinality;
-  const float rowBytes = coveredRowBytes(join.cover(), graph);
+  const std::optional<float> inputCardinality = unnest.input->cost.cardinality;
+  const float rowBytes = coveredRowBytes(unnest.cover(), graph);
   Cost out;
-  out.cardinality = unnestEstimate(join, graph, bySet).cardinality;
+  out.cardinality = unnestEstimate(unnest, graph, bySet).cardinality;
   // The per-row cost depends on the output cardinality; when that is unknown
   // the whole cost is unknown (propagated, not fabricated).
   const std::optional<float> perRowCost = out.cardinality.has_value()
       ? std::optional<float>{Costs::hashRowCost(*out.cardinality, rowBytes)}
       : std::nullopt;
   out.cost =
-      add(add(join.left->cost.cost, mul(inputCardinality, perRowCost)),
+      add(add(unnest.input->cost.cost, mul(inputCardinality, perRowCost)),
           mul(out.cardinality, perRowCost));
   return out;
 }
@@ -333,7 +332,8 @@ joinEstimate(const JoinOp& join, const JoinHypergraph& graph, BySetMap& bySet) {
   // reduce what the join type shaped — including the null-padded rows, which
   // fail an equality on the padded side.
   if (edge.joinType() != velox::core::JoinType::kInner) {
-    cardinality = applyExtraEdges(cardinality, join, graph, result.constraints);
+    cardinality = applyExtraEdges(
+        cardinality, join.extraEdges, graph, result.constraints);
   }
   result.cardinality = maxOf(1.0f, cardinality);
   return bySet.emplace(cover, std::move(result)).first->second;
@@ -446,14 +446,10 @@ Cost DefaultCostModel::cost(MemoOpCP op, const JoinHypergraph& graph) const {
   switch (op->kind()) {
     case MemoOpKind::kLeaf:
       return leafCost(*op->as<LeafOp>(), graph, estimateProvider_, bySet_);
-    case MemoOpKind::kJoin: {
-      const auto* join = op->as<JoinOp>();
-      const auto& edge = graph.edges()[join->edgeIndex];
-      if (edge.isUnnest()) {
-        return unnestJoinCost(*join, graph, bySet_);
-      }
-      return hashJoinCost(*join, graph, bySet_);
-    }
+    case MemoOpKind::kJoin:
+      return hashJoinCost(*op->as<JoinOp>(), graph, bySet_);
+    case MemoOpKind::kUnnest:
+      return unnestCost(*op->as<UnnestOp>(), graph, bySet_);
     case MemoOpKind::kExchange:
       VELOX_UNREACHABLE("ExchangeOp cost is set at construction");
   }

--- a/axiom/optimizer/v2/DPhyp.cpp
+++ b/axiom/optimizer/v2/DPhyp.cpp
@@ -202,6 +202,12 @@ class Enumerator {
     component.forEach([&](int32_t id) { ids.push_back(id); });
     // Descending id: each (subgraph, complement) pair is emitted once.
     for (auto it = ids.rbegin(); it != ids.rend(); ++it) {
+      // A relation an Unnest expands is never the smallest of a set that has a
+      // plan, so seeding from it would enumerate only unbuildable sets — and
+      // spend enumeration budget doing it.
+      if (graph_.expandedRelationIds().contains(*it)) {
+        continue;
+      }
       const RelationSet subgraph = RelationSet::singleton(*it);
       emitCsg(subgraph);
       enumerateCsgRec(subgraph, RelationSet::prefixThrough(*it));
@@ -234,6 +240,9 @@ class Enumerator {
     // before doing merge work; the caller falls back to syntactic order.
     bool allCardinalitiesKnown = true;
     component.forEach([&](int32_t id) {
+      if (graph_.expandedRelationIds().contains(id)) {
+        return;
+      }
       const auto it = memo_.find(RelationSet::singleton(id));
       if (it == memo_.end() || !it->second.cardinality().has_value()) {
         allCardinalitiesKnown = false;
@@ -242,9 +251,14 @@ class Enumerator {
     if (!allCardinalitiesKnown) {
       return nullptr;
     }
+    // An expanded relation is never a fragment of its own: it is applied to
+    // the fragment whose rows it expands.
     std::vector<RelationSet> fragments;
-    component.forEach(
-        [&](int32_t id) { fragments.push_back(RelationSet::singleton(id)); });
+    component.forEach([&](int32_t id) {
+      if (!graph_.expandedRelationIds().contains(id)) {
+        fragments.push_back(RelationSet::singleton(id));
+      }
+    });
     while (fragments.size() > 1) {
       std::optional<float> bestCardinality;
       size_t bestLeft = 0;
@@ -273,6 +287,11 @@ class Enumerator {
         }
       }
       if (!bestCardinality.has_value()) {
+        // An edge may read columns an Unnest has yet to produce, and until it
+        // does nothing connects across it. Expand one fragment and retry.
+        if (expandOneFragment(fragments)) {
+          continue;
+        }
         // No remaining fragment pair can be costed into a single join. In a
         // connected component connectivity is never the blocker — contracting
         // merged fragments keeps the graph connected, so an edge-joined pair
@@ -285,14 +304,110 @@ class Enumerator {
       fragments[bestLeft] = bestCombined;
       fragments.erase(fragments.begin() + bestRight);
     }
+    // Apply any Unnest no join step consumed on top of the finished tree. An
+    // Unnest chain roots at a relation nothing expands, so a fragment remains.
+    VELOX_DCHECK_EQ(fragments.size(), 1);
+    expandThroughUnnests(fragments.front());
     const auto it = memo_.find(component);
     return it == memo_.end() ? nullptr : it->second.cheapest();
   }
 
  private:
-  // Adds a LeafOp for every relation in `relations` not already in the memo.
+  // Relations `set` would gain by applying every Unnest whose input it covers,
+  // transitively. Answers what an expansion would produce without recording
+  // one.
+  RelationSet expandableRelations(RelationSet set) const {
+    RelationSet gained;
+    bool grown{true};
+    while (grown) {
+      grown = false;
+      for (const auto& edge : graph_.edges()) {
+        RelationSet reached{set};
+        reached.unionSet(gained);
+        if (!edge.isUnnest() || !edge.left().isSubset(reached) ||
+            edge.right().isSubset(reached)) {
+          continue;
+        }
+        gained.unionSet(edge.right());
+        grown = true;
+      }
+    }
+    return gained;
+  }
+
+  // Expands the fragment an edge is waiting on: one whose expansion produces
+  // relations some edge reads to reach beyond that fragment. Nothing else is
+  // expanded, so the rows an expansion multiplies pass through as few joins as
+  // possible. Returns true only when a fragment grew, so the caller's retry
+  // always follows progress; false says no expansion would connect anything, or
+  // none could be costed. Fragments are visited in index order, so the choice
+  // is deterministic.
+  bool expandOneFragment(std::vector<RelationSet>& fragments) {
+    for (auto& fragment : fragments) {
+      const RelationSet gained = expandableRelations(fragment);
+      if (gained.empty()) {
+        continue;
+      }
+      RelationSet reached{fragment};
+      reached.unionSet(gained);
+      for (const auto& edge : graph_.edges()) {
+        if (edge.isUnnest()) {
+          continue;
+        }
+        RelationSet endpoints{edge.left()};
+        endpoints.unionSet(edge.right());
+        // An edge wholly inside the expanded fragment joins nothing new; only
+        // one reaching outside can merge this fragment with another.
+        if (!endpoints.hasIntersection(gained) || endpoints.isSubset(reached)) {
+          continue;
+        }
+        const RelationSet before = fragment;
+        expandThroughUnnests(fragment);
+        if (fragment != before) {
+          return true;
+        }
+        // The expansion has no costable plan. Leave this fragment alone and
+        // look for another; expanding it again would not get any further.
+        break;
+      }
+    }
+    return false;
+  }
+
+  // Applies every Unnest whose input `set` covers, repeatedly, since one
+  // expansion can make another's input ready. Grows `set` by the relations
+  // expanded and records a plan for each step.
+  void expandThroughUnnests(RelationSet& set) {
+    bool grown{true};
+    while (grown) {
+      grown = false;
+      for (size_t edgeIndex{0}; edgeIndex < graph_.edges().size();
+           ++edgeIndex) {
+        const auto& edge = graph_.edges()[edgeIndex];
+        if (!edge.isUnnest() || !edge.left().isSubset(set) ||
+            edge.right().isSubset(set)) {
+          continue;
+        }
+        RelationSet expanded{set};
+        expanded.unionSet(edge.right());
+        emitUnnest(set, edgeIndex, expanded, {});
+        if (cheapestPlan(expanded) == nullptr) {
+          continue;
+        }
+        set = expanded;
+        grown = true;
+      }
+    }
+  }
+
+  // Adds a LeafOp for every relation in `relations` not already in the memo. A
+  // relation an Unnest edge expands gets none: it enters a plan only as the
+  // expansion of the rows it multiplies.
   void initLeaves(RelationSet relations) {
     relations.forEach([&](int32_t id) {
+      if (graph_.expandedRelationIds().contains(id)) {
+        return;
+      }
       const RelationSet singleton = RelationSet::singleton(id);
       if (memo_.contains(singleton)) {
         return;
@@ -334,16 +449,18 @@ class Enumerator {
     }
   }
 
+  // Cheapest plan for `set`, or null when it has none: a set holding an Unnest
+  // relation without the relations it expands is never built, and enumeration
+  // walks such sets.
+  MemoOpCP cheapestPlan(RelationSet set) const {
+    const auto it = memo_.find(set);
+    return it == memo_.end() ? nullptr : it->second.cheapest();
+  }
+
   void emitCsgCmp(RelationSet subgraph, RelationSet complement) {
     if (budget_.consume()) {
       return;
     }
-    const auto itLeft = memo_.find(subgraph);
-    const auto itRight = memo_.find(complement);
-    VELOX_DCHECK(itLeft != memo_.end(), "subgraph not memoized");
-    VELOX_DCHECK(itRight != memo_.end(), "complement not memoized");
-    MemoOpCP leftPlan = itLeft->second.cheapest();
-    MemoOpCP rightPlan = itRight->second.cheapest();
     RelationSet combined{subgraph};
     combined.unionSet(complement);
 
@@ -371,8 +488,13 @@ class Enumerator {
       return;
     }
     if (crossing.size() == 1) {
-      emitSingleEdge(
-          crossing[0].first, crossing[0].second, leftPlan, rightPlan, combined);
+      applyCrossingEdge(
+          crossing[0].first,
+          crossing[0].second,
+          subgraph,
+          complement,
+          combined,
+          {});
       return;
     }
 
@@ -406,11 +528,11 @@ class Enumerator {
           residual.push_back(crossing[i].first);
         }
       }
-      emitSingleEdge(
+      applyCrossingEdge(
           specialEdge,
           crossing[*specialPosition].second,
-          leftPlan,
-          rightPlan,
+          subgraph,
+          complement,
           combined,
           std::move(residual));
       return;
@@ -465,6 +587,12 @@ class Enumerator {
       }
     };
 
+    MemoOpCP leftPlan = cheapestPlan(subgraph);
+    MemoOpCP rightPlan = cheapestPlan(complement);
+    if (leftPlan == nullptr || rightPlan == nullptr) {
+      return;
+    }
+
     const size_t primary{crossing.front().first};
     markClasses(graph_.edges()[primary]);
     std::vector<size_t> extras;
@@ -496,9 +624,76 @@ class Enumerator {
         extras);
   }
 
+  // Applies the edge crossing this partition: an Unnest expands the side
+  // holding its input, anything else joins the two sides' plans. `forward` is
+  // true when the edge's left operand is `subgraph`.
+  void applyCrossingEdge(
+      size_t edgeIndex,
+      bool forward,
+      RelationSet subgraph,
+      RelationSet complement,
+      RelationSet combined,
+      std::vector<size_t> extraEdges) {
+    const auto& edge = graph_.edges()[edgeIndex];
+    if (edge.isUnnest()) {
+      // Enumeration never seeds a subgraph from the Unnest relation and grows
+      // subgraphs from their seed, so the relation reaches a partition only as
+      // the complement, alone. A complement holding anything else is a set the
+      // enumeration cannot build; expanding it would record a plan under a
+      // cover it never assembled.
+      if (complement != edge.right()) {
+        return;
+      }
+      emitUnnest(subgraph, edgeIndex, combined, std::move(extraEdges));
+      return;
+    }
+
+    MemoOpCP leftPlan = cheapestPlan(subgraph);
+    MemoOpCP rightPlan = cheapestPlan(complement);
+    if (leftPlan == nullptr || rightPlan == nullptr) {
+      return;
+    }
+    emitSingleEdge(
+        edgeIndex,
+        forward,
+        leftPlan,
+        rightPlan,
+        combined,
+        std::move(extraEdges));
+  }
+
+  // Adds the candidate that expands `inputSet`'s plan by the Unnest relation
+  // of `edgeIndex`. Offered for every input the expansion may sit on, so cost
+  // decides where it goes.
+  void emitUnnest(
+      RelationSet inputSet,
+      size_t edgeIndex,
+      RelationSet combined,
+      std::vector<size_t> extraEdges) {
+    MemoOpCP input = cheapestPlan(inputSet);
+    if (input == nullptr) {
+      return;
+    }
+    budget_.consume();
+    auto candidate = std::make_unique<UnnestOp>(
+        Cost{},
+        input,
+        edgeIndex,
+        graph_.edges()[edgeIndex].right(),
+        std::move(extraEdges));
+    // The memo is keyed by cover, so a candidate filed under a set it does not
+    // cover would claim relations no operator below it reads.
+    VELOX_DCHECK_EQ(candidate->cover().bits(), combined.bits());
+    candidate->cost = costModel_.cost(candidate.get(), graph_);
+    if (!candidate->cost.cost.has_value()) {
+      return;
+    }
+    memo_[combined].addPlan(std::move(candidate), graph_, costModel_);
+  }
+
   // Emits join candidates for a single edge crossing the partition,
-  // preserving orientation rules (native-only for unnest / anti /
-  // null-aware semi-project; both orientations otherwise). `extraEdges` are
+  // preserving orientation rules (native-only for anti / null-aware
+  // semi-project; both orientations otherwise). `extraEdges` are
   // co-crossing inner edges the emitter applies as a filter above the join.
   void emitSingleEdge(
       size_t edgeIndex,
@@ -506,21 +701,20 @@ class Enumerator {
       MemoOpCP leftPlan,
       MemoOpCP rightPlan,
       RelationSet combined,
-      std::vector<size_t> extraEdges = {}) {
+      std::vector<size_t> extraEdges) {
     const auto& edge = graph_.edges()[edgeIndex];
     // Extra edges reach the emitter as a filter above the join, which only an
-    // Unnest or an outer join can carry: both keep every column the equalities
-    // read. Semi and anti keep one side only.
+    // outer join can carry: it keeps every column the equalities read. Semi and
+    // anti keep one side only.
     VELOX_CHECK(
-        extraEdges.empty() || edge.isUnnest() || isOuterJoin(edge.joinType()),
+        extraEdges.empty() || isOuterJoin(edge.joinType()),
         "An edge crossing a join partition alongside a {} edge is not supported",
         edge.joinTypeName());
     // `probeOnLeft` plays the edge's left operand; `probeOnRight` its right.
     MemoOpCP probeOnLeft = forward ? leftPlan : rightPlan;
     MemoOpCP probeOnRight = forward ? rightPlan : leftPlan;
 
-    const bool nativeOnly = edge.isUnnest() ||
-        edge.joinType() == velox::core::JoinType::kAnti ||
+    const bool nativeOnly = edge.joinType() == velox::core::JoinType::kAnti ||
         (edge.joinType() == velox::core::JoinType::kLeftSemiProject &&
          !hasRightProjectVariant(edge));
     if (nativeOnly) {
@@ -860,9 +1054,11 @@ class Enumerator {
       return;
     }
 
-    // Unnest expands rows worker-locally, so it needs no exchange and keeps the
-    // probe (left) partitioning.
-    if (graph_.edges()[edgeIndex].isUnnest()) {
+    // Both inputs already sit on one task, so joining them moves no rows and
+    // the result stays there. Offered next to the partitioned strategies below,
+    // which would shuffle two single-task inputs apart; cost decides.
+    if (left->outputPartitioning().is(PartitionKind::kGather) &&
+        right->outputPartitioning().is(PartitionKind::kGather)) {
       addJoinCandidate(
           left,
           right,
@@ -870,9 +1066,8 @@ class Enumerator {
           joinType,
           combined,
           reversedAnti,
-          std::move(extraEdges),
-          left->outputPartitioning());
-      return;
+          extraEdges,
+          Partitioning::globalGather());
     }
 
     const auto [leftKeys, rightKeys] =

--- a/axiom/optimizer/v2/HypergraphBuilder.cpp
+++ b/axiom/optimizer/v2/HypergraphBuilder.cpp
@@ -388,10 +388,10 @@ JoinHypergraph HypergraphBuilder::build(
     }
   }
 
-  // Build the directed cross-join-unnest edge for each Unnest that depends on
-  // a relation of the cluster, and record every Unnest's input relations (the
-  // relation ids its input subtree contributes, resolved via the now-complete
-  // columnToLeaf) for the outer-join barrier applied in the cluster-join loop.
+  // Build the unnest edge for each Unnest that depends on a relation
+  // of the cluster, and record every Unnest's input relations (the relation ids
+  // its input subtree contributes, resolved via the now-complete columnToLeaf)
+  // for the outer-join barrier applied in the cluster-join loop.
   folly::F14FastMap<int8_t, RelationSet> unnestInputRelations;
   for (UnnestCP unnest : cluster.unnests) {
     const int8_t id = unnestIds.at(unnest);
@@ -417,11 +417,7 @@ JoinHypergraph HypergraphBuilder::build(
     RelationSet tes{inputRelations};
     tes.add(id);
     graph.addEdge(
-        JoinEdge{
-            inputRelations,
-            RelationSet::singleton(id),
-            unnest->unnestExpressions()},
-        tes);
+        JoinEdge::unnest(inputRelations, RelationSet::singleton(id)), tes);
   }
 
   folly::F14FastMap<JoinCP, JoinLeaves> joinLeaves;
@@ -474,16 +470,6 @@ JoinHypergraph HypergraphBuilder::build(
             /*leftSide=*/false,
             leafIds,
             joinLeaves));
-
-        // Consumer edges that reference an Unnest produced column must
-        // wait until the Unnest's input relations are in cover, so the
-        // cross-join-unnest fires before any consumer joins Unnest with
-        // its other side.
-        for (const auto& [unnestId, inputRelations] : unnestInputRelations) {
-          if (ses.contains(unnestId)) {
-            tes.unionSet(inputRelations);
-          }
-        }
 
         graph.addEdge(
             JoinEdge{
@@ -541,19 +527,17 @@ JoinHypergraph HypergraphBuilder::build(
           leafIds,
           joinLeaves));
 
-      // Unnest barrier: if an Unnest's input subtree contributes a
-      // relation on this outer join's null-padded side, the
-      // cross-join-unnest must fire before the outer join. Otherwise
-      // null-padding flows into UNNEST and rows drop. Expand TES to
-      // include the Unnest relation id so DPhyp pins the order.
+      // Outer-join barrier: if an Unnest's input subtree contributes a relation
+      // on this outer join's null-padded side, the unnest edge must fire before
+      // the outer join. Otherwise null-padding flows into UNNEST and rows drop.
+      // Expand TES to include the Unnest relation id so DPhyp pins the order.
       RelationSet joinRelations{leaves.left};
       joinRelations.unionSet(leaves.right);
       for (const auto& [unnestId, inputRelations] : unnestInputRelations) {
-        // An outer join inside the Unnest's input subtree is already
-        // ordered before the Unnest by the directed cross-join-unnest
-        // edge. The barrier would demand the reverse order, which no
-        // plan can satisfy when this join is the only edge co-locating
-        // the input relations.
+        // An outer join inside the Unnest's input subtree is already ordered
+        // before the Unnest by the unnest edge. The barrier would demand the
+        // reverse order, which no plan can satisfy when this join is the only
+        // edge co-locating the input relations.
         if (joinRelations.isSubset(inputRelations)) {
           continue;
         }

--- a/axiom/optimizer/v2/JoinCluster.h
+++ b/axiom/optimizer/v2/JoinCluster.h
@@ -33,9 +33,9 @@ namespace facebook::axiom::optimizer::v2 {
 /// `unnests` records Unnest IR nodes the cluster collection
 /// descended through. Each becomes its own relation in the
 /// hypergraph, connected to the leaves contributed by its input
-/// subtree via a directed cross-join-unnest edge. Order is descent
-/// order (innermost first) so dependent chains (`UNNEST(u1.x) u2`)
-/// have `u1`'s cardinality computed before `u2`'s.
+/// subtree via an unnest edge. Order is descent order (innermost
+/// first) so dependent chains (`UNNEST(u1.x) u2`) have `u1`'s
+/// cardinality computed before `u2`'s.
 struct JoinCluster {
   JoinCP root;
   std::vector<NodeCP> leaves;

--- a/axiom/optimizer/v2/JoinEdge.h
+++ b/axiom/optimizer/v2/JoinEdge.h
@@ -52,18 +52,23 @@ inline bool canBroadcastBuild(velox::core::JoinType joinType) {
 ///     above would let null-padded rows pass through, changing
 ///     semantics. `nullAware` and `nullAsValue` carry Velox null
 ///     semantics.
-///   - Directed cross-join-unnest. Built by the unnest constructor
-///     overload. `left` covers the relations whose subtree feeds the
-///     Unnest; `right` is the single Unnest relation. `unnestExprs`
-///     carries the ARRAY/MAP expressions to unnest. No equi-keys, no
-///     filter. `isUnnest()` discriminates.
+///   - Unnest. Built by `JoinEdge::unnest`. `left` covers the
+///     relations whose subtree feeds the Unnest; `right` is the
+///     single Unnest relation. No equi-keys, no filter;
+///     `isUnnest()` discriminates. Unlike the other flavors this
+///     edge never becomes a join: an Unnest expands the rows of the
+///     relations on `left` rather than pairing two inputs, so DPhyp
+///     lowers it to a unary `UnnestOp` over whichever plan covers
+///     `left`. The edge states connectivity and ordering — the
+///     Unnest relation is reachable only through it, so no plan
+///     holds that relation without the relations it expands.
 ///
 /// Invariants:
 ///   - `left` and `right` are non-empty and disjoint.
 ///   - Equi-join flavors: `leftKeys.size() == rightKeys.size()` and
 ///     is non-empty.
-///   - Unnest flavor: `unnestExprs` non-empty; `leftKeys` /
-///     `rightKeys` / `filter` empty; `joinType == kInner`.
+///   - Unnest flavor: `leftKeys` / `rightKeys` / `filter` empty;
+///     `joinType == kInner`.
 class JoinEdge {
  public:
   JoinEdge(
@@ -102,21 +107,12 @@ class JoinEdge {
         velox::core::JoinTypeName::toName(joinType_));
   }
 
-  /// Constructs a directed cross-join-unnest edge: input relations on
-  /// `left`, the Unnest relation on `right`, the ARRAY/MAP expressions
-  /// to unnest in `unnestExprs`. Equi-key invariants don't apply; see
-  /// the class doc.
-  JoinEdge(RelationSet left, RelationSet right, ExprVector unnestExprs)
-      : left_{std::move(left)},
-        right_{std::move(right)},
-        joinType_{velox::core::JoinType::kInner},
-        unnestExprs_{std::move(unnestExprs)} {
-    VELOX_CHECK(!left_.empty());
-    VELOX_CHECK(!right_.empty());
-    VELOX_CHECK(!left_.hasIntersection(right_));
-    VELOX_CHECK(
-        !unnestExprs_.empty(),
-        "Cross-join-unnest edge must carry at least one unnest expression");
+  /// Constructs an unnest edge: the relations whose subtree feeds the
+  /// Unnest on `left`, the Unnest relation on `right`. The expressions to
+  /// unnest live on that relation's IR node; the edge only states where the
+  /// expansion happens. Equi-key invariants don't apply; see the class doc.
+  static JoinEdge unnest(RelationSet left, RelationSet right) {
+    return JoinEdge{std::move(left), std::move(right)};
   }
 
   const RelationSet& left() const {
@@ -141,15 +137,9 @@ class JoinEdge {
     return filter_;
   }
 
-  /// ARRAY/MAP expressions to unnest. Non-empty iff this is a
-  /// cross-join-unnest edge.
-  const ExprVector& unnestExprs() const {
-    return unnestExprs_;
-  }
-
-  /// True iff this is a directed cross-join-unnest edge.
+  /// True iff this is an unnest edge.
   bool isUnnest() const {
-    return !unnestExprs_.empty();
+    return isUnnest_;
   }
 
   velox::core::JoinType joinType() const {
@@ -176,6 +166,17 @@ class JoinEdge {
   }
 
  private:
+  // Builds an unnest edge; see the `unnest` factory.
+  JoinEdge(RelationSet left, RelationSet right)
+      : left_{std::move(left)},
+        right_{std::move(right)},
+        joinType_{velox::core::JoinType::kInner},
+        isUnnest_{true} {
+    VELOX_CHECK(!left_.empty());
+    VELOX_CHECK(!right_.empty());
+    VELOX_CHECK(!left_.hasIntersection(right_));
+  }
+
   RelationSet left_;
   RelationSet right_;
   ExprVector leftKeys_;
@@ -187,7 +188,7 @@ class JoinEdge {
   // The mark/exists column produced by a kLeftSemiProject join;
   // nullptr otherwise. Populated in Phase 2.
   ColumnCP markColumn_{nullptr};
-  ExprVector unnestExprs_;
+  bool isUnnest_{false};
 };
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinHypergraph.cpp
+++ b/axiom/optimizer/v2/JoinHypergraph.cpp
@@ -90,8 +90,8 @@ void JoinHypergraph::checkConsistency() const {
   VELOX_CHECK_EQ(
       reached.size(), relations_.size(), "Hypergraph is not connected");
 
-  // Every Unnest relation must be reachable through its cross-join-unnest
-  // edge; otherwise the directed-edge connectivity was never built.
+  // Every Unnest relation must be reachable through its unnest edge;
+  // otherwise the directed-edge connectivity was never built.
   unnestRelationIds_.forEach([&](int32_t id) {
     // An Unnest of a constant has no input in the cluster and so no edge; the
     // connectivity check above covers it.
@@ -105,7 +105,7 @@ void JoinHypergraph::checkConsistency() const {
         break;
       }
     }
-    VELOX_CHECK(found, "Unnest relation has no cross-join-unnest edge: {}", id);
+    VELOX_CHECK(found, "Unnest relation has no unnest edge: {}", id);
   });
 }
 
@@ -217,7 +217,13 @@ PlanObjectSet JoinHypergraph::coverOutputColumns(
       neededAbove.unionColumns(edge.leftKeys());
       neededAbove.unionColumns(edge.rightKeys());
       neededAbove.unionColumns(edge.filter());
-      neededAbove.unionColumns(edge.unnestExprs());
+      if (edge.isUnnest()) {
+        // An Unnest not yet applied reads what it expands from below.
+        neededAbove.unionColumns(relation(edge.right().min())
+                                     .node()
+                                     ->as<Unnest>()
+                                     ->unnestExpressions());
+      }
     }
   }
   for (const auto& conjunct : filterConjuncts_) {
@@ -247,6 +253,14 @@ void JoinHypergraph::addEdge(JoinEdge edge, RelationSet tes) {
   VELOX_CHECK(
       tes.isSubset(relationIds_),
       "TES must reference only relations already added");
+  if (edge.isUnnest()) {
+    // Relations are registered before the Unnests over them. Enumeration
+    // relies on this: a set holding an expanded relation always holds a
+    // smaller id, so such a set is never enumerated from the expanded
+    // relation as its seed.
+    VELOX_CHECK_LT(edge.left().min(), edge.right().min());
+    expandedRelationIds_.unionSet(edge.right());
+  }
   edges_.push_back(std::move(edge));
   tes_.push_back(tes);
   invalidateCoverCaches();

--- a/axiom/optimizer/v2/JoinHypergraph.h
+++ b/axiom/optimizer/v2/JoinHypergraph.h
@@ -78,9 +78,13 @@ class JoinHypergraph {
       std::optional<float> cardinality,
       PlanObjectSet columns);
 
-  /// Relation ids registered via `addUnnestRelation`.
-  const RelationSet& unnestRelationIds() const {
-    return unnestRelationIds_;
+  /// Relations an unnest edge expands. These produce rows only for the
+  /// relations they expand, so they have no plan of their own and enumeration
+  /// reaches them only by applying the edge. An Unnest of a constant expands
+  /// nothing, carries no edge, and is an ordinary source rather than one of
+  /// these.
+  const RelationSet& expandedRelationIds() const {
+    return expandedRelationIds_;
   }
 
   /// Appends an edge with its TES. `tes` must be a superset of
@@ -177,6 +181,8 @@ class JoinHypergraph {
   RelationSet relationIds_;
   // Bitset of relations registered via `addUnnestRelation`.
   RelationSet unnestRelationIds_;
+  // Unnest relations an unnest edge expands; see `expandedRelationIds()`.
+  RelationSet expandedRelationIds_;
   // Columns the cluster's plan must output. See setTargetColumns().
   PlanObjectSet targetColumns_;
 

--- a/axiom/optimizer/v2/JoinTreeEmitter.cpp
+++ b/axiom/optimizer/v2/JoinTreeEmitter.cpp
@@ -210,17 +210,17 @@ NodeCP restoreTargets(
       Project::Key{node, std::move(exprs), ColumnVector{targets}});
 }
 
-// The equalities of the inner edges applied above `join` — the ones that
-// crossed the same partition as an Unnest or an outer join, which cannot take
-// them as keys. Equality is symmetric, so the edges' orientation does not
-// matter here. Inner edges carry no filter (`JoinEdge` enforces that), so the
-// keys are the whole predicate.
+// The equalities of `extraEdges` — the inner edges that crossed the same
+// partition as an Unnest or an outer join, which cannot take them as keys.
+// Equality is symmetric, so the edges' orientation does not matter here. Inner
+// edges carry no filter (`JoinEdge` enforces that), so the keys are the whole
+// predicate.
 ExprVector extraEdgeEqualities(
-    const JoinOp* join,
+    const std::vector<size_t>& extraEdges,
     const ExprFactory::ExprSubstitution& substitution,
     EmitState& state) {
   ExprVector predicates;
-  for (size_t extraIndex : join->extraEdges) {
+  for (size_t extraIndex : extraEdges) {
     const auto& extra = state.graph.edges()[extraIndex];
     const auto& leftKeys = extra.leftKeys();
     const auto& rightKeys = extra.rightKeys();
@@ -260,20 +260,17 @@ NodeCP emitLeaf(const LeafOp* leaf, EmitState& state) {
   return node;
 }
 
-// Builds a new `Unnest` IR node from a JoinOp wrapping a directed
-// cross-join-unnest edge. DPhyp's orientation enforcement guarantees
-// `join->left` is the input-side plan and `join->right` is the
-// singleton Unnest leaf. `unnestExpressions`, `unnestColumns`, and
-// `ordinalityColumn` come from the original Unnest IR node stored on
-// the Unnest relation.
-Emitted buildUnnest(const JoinOp* join, Emitted input, EmitState& state) {
-  const auto& edge = state.graph.edges()[join->edgeIndex];
+// Builds a new `Unnest` IR node over the plan `unnest` expands.
+// `unnestExpressions`, `unnestColumns`, and `ordinalityColumn` come from the
+// original Unnest IR node stored on the Unnest relation.
+Emitted buildUnnest(const UnnestOp* unnest, Emitted input, EmitState& state) {
+  const auto& edge = state.graph.edges()[unnest->edgeIndex];
   const int8_t unnestRelId = edge.right().min();
   const auto* origUnnest =
       state.graph.relation(unnestRelId).node()->as<Unnest>();
 
   const auto substitution = merge(
-      collapsedColumns(state.graph.coverColumnReps(join->left->cover())),
+      collapsedColumns(state.graph.coverColumnReps(unnest->input->cover())),
       input.materialized);
   ExprVector unnestExpressions =
       rewrite(origUnnest->unnestExpressions(), substitution, state);
@@ -284,23 +281,24 @@ Emitted buildUnnest(const JoinOp* join, Emitted input, EmitState& state) {
   // applied here too — after the expansion, since one may read an unnested
   // column.
   ExprVector predicates = rewrite(
-      takeReadyConjuncts(state.graph, join->cover(), state.fired),
+      takeReadyConjuncts(state.graph, unnest->cover(), state.fired),
       substitution,
       state);
-  appendAll(predicates, extraEdgeEqualities(join, substitution, state));
+  appendAll(
+      predicates, extraEdgeEqualities(unnest->extraEdges, substitution, state));
 
   // The expansion replicates the columns a consumer above the cover demands,
   // plus those the predicates above read: the Filter sits on this node's
   // output, so its inputs have to survive the expansion even when nothing
   // above wants them.
-  PlanObjectSet needed = state.graph.coverOutputColumns(join->cover());
+  PlanObjectSet needed = state.graph.coverOutputColumns(unnest->cover());
   needed.unionColumns(predicates);
   ColumnVector replicatedColumns;
   appendNarrowed(
       replicatedColumns,
       input.node,
       needed,
-      state.graph.coverColumns(join->cover()));
+      state.graph.coverColumns(unnest->cover()));
 
   ColumnVector outputColumns{replicatedColumns};
   for (const auto& perExpr : origUnnest->unnestColumns()) {
@@ -428,7 +426,7 @@ Emitted buildJoin(
   // dropping them.
   ExprVector aboveJoin;
   if (!isInner) {
-    aboveJoin = extraEdgeEqualities(join, substitution, state);
+    aboveJoin = extraEdgeEqualities(join->extraEdges, substitution, state);
     appendAll(
         aboveJoin,
         rewrite(
@@ -530,6 +528,19 @@ Emitted buildReversedAnti(
   return {node, std::move(materialized)};
 }
 
+// Re-materializes the demanded names on a cluster root whose equivalence
+// collapse replaced some of them by a representative. Callers test
+// `hasCollapsedTarget` first.
+Emitted restoreRootTargets(
+    Emitted result,
+    const folly::F14FastMap<ColumnCP, ColumnCP>& rootReps,
+    const ColumnVector& rootOutputColumns,
+    EmitState& state) {
+  result.node = restoreTargets(result.node, rootReps, rootOutputColumns, state);
+  retainVisible(result.materialized, result.node);
+  return result;
+}
+
 // Emits a join op and everything below it. `rootOutputColumns` is non-null only
 // for the cluster root, whose output must be exactly those columns; an
 // equivalence collapse that dropped a target in favor of its representative is
@@ -538,21 +549,7 @@ Emitted emitJoin(
     const JoinOp* join,
     EmitState& state,
     const ColumnVector* rootOutputColumns) {
-  const auto& edge = state.graph.edges()[join->edgeIndex];
   Emitted left = emitOp(join->left, state);
-  if (edge.isUnnest()) {
-    Emitted result = buildUnnest(join, std::move(left), state);
-    if (rootOutputColumns == nullptr) {
-      return result;
-    }
-    const auto rootReps = state.graph.coverColumnReps(join->cover());
-    if (hasCollapsedTarget(rootReps, *rootOutputColumns)) {
-      result.node =
-          restoreTargets(result.node, rootReps, *rootOutputColumns, state);
-      retainVisible(result.materialized, result.node);
-    }
-    return result;
-  }
   Emitted right = emitOp(join->right, state);
   if (join->reversedAnti) {
     return buildReversedAnti(join, left, right, state);
@@ -573,16 +570,35 @@ Emitted emitJoin(
         join, left, right, ColumnVector{*rootOutputColumns}, state);
   }
 
-  Emitted result = buildJoin(
-      join,
-      left,
-      right,
-      coverNarrowedColumns(state.graph, join->cover(), left.node, right.node),
+  return restoreRootTargets(
+      buildJoin(
+          join,
+          left,
+          right,
+          coverNarrowedColumns(
+              state.graph, join->cover(), left.node, right.node),
+          state),
+      rootReps,
+      *rootOutputColumns,
       state);
-  result.node =
-      restoreTargets(result.node, rootReps, *rootOutputColumns, state);
-  retainVisible(result.materialized, result.node);
-  return result;
+}
+
+// Emits an Unnest op and everything below it. `rootOutputColumns` as in
+// `emitJoin`.
+Emitted emitUnnest(
+    const UnnestOp* unnest,
+    EmitState& state,
+    const ColumnVector* rootOutputColumns) {
+  Emitted result = buildUnnest(unnest, emitOp(unnest->input, state), state);
+  if (rootOutputColumns == nullptr) {
+    return result;
+  }
+  const auto rootReps = state.graph.coverColumnReps(unnest->cover());
+  if (!hasCollapsedTarget(rootReps, *rootOutputColumns)) {
+    return result;
+  }
+  return restoreRootTargets(
+      std::move(result), rootReps, *rootOutputColumns, state);
 }
 
 // A shuffle partitions on columns of the row it shuffles, so an expression key
@@ -616,6 +632,9 @@ Emitted emitOp(MemoOpCP op, EmitState& state) {
       return {emitLeaf(op->as<LeafOp>(), state), {}};
     case MemoOpKind::kJoin:
       return emitJoin(op->as<JoinOp>(), state, /*rootOutputColumns=*/nullptr);
+    case MemoOpKind::kUnnest:
+      return emitUnnest(
+          op->as<UnnestOp>(), state, /*rootOutputColumns=*/nullptr);
     case MemoOpKind::kExchange:
       return emitExchange(op->as<ExchangeOp>(), state);
   }
@@ -638,6 +657,9 @@ NodeCP JoinTreeEmitter::emit(
       break;
     case MemoOpKind::kJoin:
       result = emitJoin(root->as<JoinOp>(), state, &rootOutputColumns).node;
+      break;
+    case MemoOpKind::kUnnest:
+      result = emitUnnest(root->as<UnnestOp>(), state, &rootOutputColumns).node;
       break;
     case MemoOpKind::kExchange:
       // The chosen join-tree root is never an exchange: a final gather is added

--- a/axiom/optimizer/v2/MemoOp.cpp
+++ b/axiom/optimizer/v2/MemoOp.cpp
@@ -26,6 +26,7 @@ const folly::F14FastMap<MemoOpKind, std::string_view>& memoOpKindNames() {
   static const folly::F14FastMap<MemoOpKind, std::string_view> kNames = {
       {MemoOpKind::kLeaf, "Leaf"},
       {MemoOpKind::kJoin, "Join"},
+      {MemoOpKind::kUnnest, "Unnest"},
       {MemoOpKind::kExchange, "Exchange"},
   };
   return kNames;
@@ -34,6 +35,12 @@ const folly::F14FastMap<MemoOpKind, std::string_view>& memoOpKindNames() {
 RelationSet combinedCover(MemoOpCP left, MemoOpCP right) {
   RelationSet result{left->cover()};
   result.unionSet(right->cover());
+  return result;
+}
+
+RelationSet expandedCover(MemoOpCP input, RelationSet unnestRelation) {
+  RelationSet result{input->cover()};
+  result.unionSet(unnestRelation);
   return result;
 }
 
@@ -58,5 +65,18 @@ JoinOp::JoinOp(
       reversedAnti{reversedAnti},
       extraEdges{std::move(extraEdges)},
       cover_{combinedCover(leftChild, rightChild)} {}
+
+UnnestOp::UnnestOp(
+    Cost cost,
+    MemoOpCP inputChild,
+    size_t edge,
+    RelationSet unnestRelation,
+    std::vector<size_t> extraEdges)
+    // Unnest expands rows within a task, so the input's partitioning survives.
+    : MemoOp{cost, MemoOpKind::kUnnest, inputChild->outputPartitioning()},
+      input{inputChild},
+      edgeIndex{edge},
+      extraEdges{std::move(extraEdges)},
+      cover_{expandedCover(inputChild, unnestRelation)} {}
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/MemoOp.h
+++ b/axiom/optimizer/v2/MemoOp.h
@@ -30,6 +30,7 @@ namespace facebook::axiom::optimizer::v2 {
 enum class MemoOpKind : uint8_t {
   kLeaf,
   kJoin,
+  kUnnest,
   kExchange,
 };
 
@@ -135,6 +136,37 @@ class JoinOp : public MemoOp {
       bool reversedAnti = false,
       std::vector<size_t> extraEdges = {},
       Partitioning outputPartitioning = {});
+
+  RelationSet cover() const override {
+    return cover_;
+  }
+
+ private:
+  const RelationSet cover_;
+};
+
+/// Unnest entry: expands `input` by the Unnest relation at
+/// `graph.edges()[edgeIndex].right()`, adding that relation to the cover. Unary
+/// because an Unnest has no plan of its own — it produces rows only for the
+/// input it expands — so a relation set containing the Unnest relation is
+/// reachable only through this op, applied once the input relations are
+/// covered. Which input it is applied to is the placement DPhyp costs.
+class UnnestOp : public MemoOp {
+ public:
+  MemoOpCP const input;
+  const size_t edgeIndex;
+
+  /// Inner equi-join edges that also cross the partition this Unnest was
+  /// applied at, and are applied as a filter above it. See
+  /// `JoinOp::extraEdges`.
+  const std::vector<size_t> extraEdges;
+
+  UnnestOp(
+      Cost cost,
+      MemoOpCP inputChild,
+      size_t edge,
+      RelationSet unnestRelation,
+      std::vector<size_t> extraEdges);
 
   RelationSet cover() const override {
     return cover_;

--- a/axiom/optimizer/v2/PlanSet.cpp
+++ b/axiom/optimizer/v2/PlanSet.cpp
@@ -27,7 +27,8 @@ namespace {
 
 // Total order over plans so dominance and selection are independent of memo
 // insertion order. Plans in one set cover the same relation set; the tuple
-// distinguishes a join, an exchange wrapping a plan, or a lone leaf.
+// distinguishes a join, an unnest of a plan, an exchange wrapping a plan, or a
+// lone leaf.
 using TieKey = std::tuple<uint64_t, uint64_t, size_t, int, int>;
 TieKey tieKey(MemoOpCP op) {
   if (op->is(MemoOpKind::kJoin)) {
@@ -38,6 +39,10 @@ TieKey tieKey(MemoOpCP op) {
         join->edgeIndex,
         static_cast<int>(join->joinType),
         static_cast<int>(join->reversedAnti)};
+  }
+  if (op->is(MemoOpKind::kUnnest)) {
+    const auto* unnest = op->as<UnnestOp>();
+    return {unnest->input->cover().bits(), 0, unnest->edgeIndex, 0, 2};
   }
   if (op->is(MemoOpKind::kExchange)) {
     const auto* exchange = op->as<ExchangeOp>();

--- a/axiom/optimizer/v2/Relation.h
+++ b/axiom/optimizer/v2/Relation.h
@@ -33,9 +33,9 @@ namespace facebook::axiom::optimizer::v2 {
 /// Kinds of nodes:
 ///   - Scan, Values: leaf nodes with no inputs.
 ///   - Unnest: a deferred operator registered as its own relation;
-///     the cross-join-unnest edge built by `HypergraphBuilder`
-///     supplies connectivity to the relations whose subtree feeds
-///     the Unnest's input.
+///     the unnest edge built by `HypergraphBuilder` supplies
+///     connectivity to the relations whose subtree feeds the
+///     Unnest's input.
 ///   - Root of an already-planned subtree past a barrier (Sort,
 ///     Limit, Window, ...).
 ///

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -457,6 +457,20 @@ class Translator {
   Translated translateAggregate(
       const lp::AggregateNode& aggregate,
       const LpNameSet& required);
+
+  // Translates 'aggregate''s grouping keys into 'keys' and the columns they are
+  // published under into 'columns', binding every grouping-key name in 'scope'.
+  // Keys that translate to one expression are kept once and the other names
+  // read the surviving column; grouping sets keep every key, since the set
+  // indices are positional.
+  void translateGroupingKeys(
+      const lp::AggregateNode& aggregate,
+      const Scope& inputScope,
+      NodeCP& currentInput,
+      ExprVector& keys,
+      ColumnVector& columns,
+      Scope& scope);
+
   // Lowers GROUPING SETS / ROLLUP / CUBE to a GroupId plus a plain aggregate
   // keyed on an explicit group-id column. Returns the aggregation node.
   NodeCP lowerGroupingSets(
@@ -466,9 +480,11 @@ class Translator {
       const ColumnVector& outputColumns,
       NodeCP currentInput,
       Scope& newScope);
+
   // The result of an aggregate over the empty set (constant false/null FILTER):
   // the aggregate's empty-input value from the function registry.
   ExprCP emptySetResult(const optimizer::Aggregate* call);
+
   // Wraps 'node' in a Project appending 'columns' (each defined by the matching
   // expr) to its outputs. Returns 'node' unchanged when 'columns' is empty.
   NodeCP appendConstantColumns(
@@ -1417,6 +1433,55 @@ NodeCP Translator::appendConstantColumns(
       {node, std::move(projectExprs), std::move(projectColumns)});
 }
 
+void Translator::translateGroupingKeys(
+    const lp::AggregateNode& aggregate,
+    const Scope& inputScope,
+    NodeCP& currentInput,
+    ExprVector& keys,
+    ColumnVector& columns,
+    Scope& scope) {
+  const auto& names = aggregate.outputNames();
+  const auto& keyExpressions = aggregate.groupingKeys();
+  const bool hasGroupingSets = !aggregate.groupingSets().empty();
+
+  folly::F14FastMap<ExprCP, ColumnCP> keyToOutput;
+  if (!hasGroupingSets) {
+    keyToOutput.reserve(keyExpressions.size());
+  }
+
+  for (size_t i = 0; i < keyExpressions.size(); ++i) {
+    ExprCP keyExpr =
+        translateExpr(*keyExpressions[i], inputScope, &currentInput);
+    if (!hasGroupingSets) {
+      const auto it = keyToOutput.find(keyExpr);
+      if (it != keyToOutput.end()) {
+        scope[names[i]] = it->second;
+        continue;
+      }
+    }
+    // Reuse the input column when the grouping key is a column reference:
+    // Velox `AggregationNode` emits grouping-key output under the input
+    // field-access name. For grouping sets, `GroupIdNode` requires output
+    // names distinct from the input columns for the NULL-padded copies, so
+    // mint a fresh column rather than reusing the (possibly colliding) LP
+    // symbol.
+    ColumnCP column;
+    if (hasGroupingSets) {
+      column = Column::create(toName(names[i]), keyExpr->value());
+    } else if (keyExpr->is(PlanType::kColumnExpr)) {
+      column = keyExpr->as<Column>();
+    } else {
+      column = Column::createForSymbol(toName(names[i]), keyExpr->value());
+    }
+    if (!hasGroupingSets) {
+      keyToOutput.emplace(keyExpr, column);
+    }
+    scope[names[i]] = column;
+    keys.push_back(keyExpr);
+    columns.push_back(column);
+  }
+}
+
 Translated Translator::translateAggregate(
     const lp::AggregateNode& aggregate,
     const LpNameSet& required) {
@@ -1455,39 +1520,15 @@ Translated Translator::translateAggregate(
   outputColumns.reserve(
       numGroupingKeys + keptAggregateIndices.size() + groupIdSlots);
   Scope newScope;
-  // Grouping-sets case keeps positional alignment between groupingKeys and
-  // the set indices; only the simple GROUP BY case can dedup safely here.
-  const bool canDedupGroupingKeys = groupingSets.empty();
-  folly::F14FastSet<ColumnCP> seenGroupingOutputs;
-  if (canDedupGroupingKeys) {
-    seenGroupingOutputs.reserve(numGroupingKeys);
-  }
 
   NodeCP currentInput = input.node;
-  for (size_t i = 0; i < numGroupingKeys; ++i) {
-    ExprCP keyExpr =
-        translateExpr(*groupingKeyExpressions[i], input.scope, &currentInput);
-    // Reuse the input column when the grouping key is a column reference:
-    // Velox `AggregationNode` emits grouping-key output under the input
-    // field-access name. For grouping sets, `GroupIdNode` requires output
-    // names distinct from the input columns for the NULL-padded copies, so
-    // mint a fresh column rather than reusing the (possibly colliding) LP
-    // symbol.
-    ColumnCP column;
-    if (groupingSets.empty() && keyExpr->is(PlanType::kColumnExpr)) {
-      column = keyExpr->as<Column>();
-    } else if (groupingSets.empty()) {
-      column = Column::createForSymbol(toName(names[i]), keyExpr->value());
-    } else {
-      column = Column::create(toName(names[i]), keyExpr->value());
-    }
-    newScope[names[i]] = column;
-    if (canDedupGroupingKeys && !seenGroupingOutputs.insert(column).second) {
-      continue;
-    }
-    groupingKeys.push_back(keyExpr);
-    outputColumns.push_back(column);
-  }
+  translateGroupingKeys(
+      aggregate,
+      input.scope,
+      currentInput,
+      groupingKeys,
+      outputColumns,
+      newScope);
 
   // Aggregates whose FILTER folded to constant false/null see the empty set;
   // their output is the aggregate's empty-input value, materialized by a


### PR DESCRIPTION
Summary:
A query that groups by the same expression written two ways failed to plan:

    SELECT a + 1 AS p, 1 + a AS q FROM t GROUP BY 1, 2

reported:

    Grouping key must be published under the aggregate's output column

The two keys become one expression, since `a + 1` and `1 + a` canonicalize to the same call. Translation deduplicated grouping keys by the column it minted for each key rather than by the key itself, and a key that is not a plain column reference mints a fresh column per position. So the aggregation kept one key but published two columns for it, and lowering to Velox — which names an aggregation's output after its grouping-key fields — had no column to name. Grouping keys are now deduplicated on the expression, and the names of the keys that drop out read the surviving column, which is what v1 does.

Moves the grouping-key step of `translateAggregate` into a function of its own. It is the whole of what changed here and the enclosing function was long.

Differential Revision: D116624933
