### PR TITLE
refactor(optimizer/v2): Negotiate scan filters during pushdown (#1733)

### DIFF
--- a/axiom/cli/tests/DeleteTest.cpp
+++ b/axiom/cli/tests/DeleteTest.cpp
@@ -19,6 +19,7 @@
 
 #include "axiom/cli/Connectors.h"
 #include "axiom/cli/tests/SqlQueryRunnerTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 
@@ -165,6 +166,16 @@ TEST_F(DeleteTest, partitionPredicate) {
 
   EXPECT_EQ(4, fetchSingleValue<int64_t>("DELETE FROM test"));
   EXPECT_EQ(0, runCount("FROM test"));
+}
+
+// A delete drops whole partitions, so a predicate on a data column is refused.
+TEST_F(DeleteTest, unsupportedPredicate) {
+  run("CREATE TABLE t WITH (partitioned_by = ARRAY['pk']) AS "
+      "SELECT x, x % 3 AS pk FROM unnest(array[1, 2, 3, 4, 5, 6]) AS t(x)");
+
+  VELOX_ASSERT_THROW(
+      run("DELETE FROM t WHERE x = 1"),
+      "DELETE supports only filters on partition columns: x");
 }
 
 } // namespace

--- a/axiom/cli/tests/ExplainIoTest.cpp
+++ b/axiom/cli/tests/ExplainIoTest.cpp
@@ -207,6 +207,25 @@ TEST_P(ExplainIoTest, columnConstraints) {
             ]
           })")));
 
+  // The filtered column need not be selected.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT x FROM t "
+          "   WHERE ds = '2026-03-17'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-17", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
+
   // Equality on a boolean explain_io column yields a single-value domain.
   ASSERT_EQ(
       getJson(

--- a/axiom/cli/tests/ExplainTest.cpp
+++ b/axiom/cli/tests/ExplainTest.cpp
@@ -42,9 +42,10 @@ class ExplainTest : public SqlQueryRunnerTestBase,
 // estimate, drawn from the registered TPC-H statistics and the WHERE
 // selectivity: the filter and project carry the post-filter row count, the
 // aggregation the distinct l_orderkey count within that range. A single-worker,
-// single-driver plan collapses to one Aggregation with no repartition, so v1
-// and v2 emit the same shape; StartsWith covers the Aggregation and Project
-// lines, whose optimizer-internal column names differ between v1 and v2.
+// single-driver plan collapses to one Aggregation with no repartition; the two
+// optimizers differ only in whether the scan carries an estimate of its own.
+// StartsWith covers the Aggregation and Project lines, whose
+// optimizer-internal column names differ between v1 and v2.
 TEST_P(ExplainTest, showsCardinalityEstimate) {
   testConnector_->addTpchTables(1);
 
@@ -63,19 +64,25 @@ TEST_P(ExplainTest, showsCardinalityEstimate) {
   using ::testing::Eq;
   using ::testing::StartsWith;
 
-  EXPECT_THAT(
-      lines,
-      ::testing::ElementsAre(
-          Eq("Fragment 0: fragment1 SINGLE:"),
-          StartsWith("-- Aggregation[3][SINGLE [l_orderkey] sum := sum("),
-          Eq("   Estimate: 249.75 rows"),
-          StartsWith("  -- Project[2][expressions: (l_orderkey:BIGINT, "),
-          Eq("     Estimate: 999.202 rows"),
-          StartsWith("    -- Filter[1][expression: lt(\"l_orderkey\",1000)]"),
-          Eq("       Estimate: 999.202 rows"),
-          StartsWith("      -- TableScan[0][\"default\".\"lineitem\"]"),
-          Eq(""),
-          Eq("")));
+  std::vector<::testing::Matcher<std::string>> expected{
+      Eq("Fragment 0: fragment1 SINGLE:"),
+      StartsWith("-- Aggregation[3][SINGLE [l_orderkey] sum := sum("),
+      Eq("   Estimate: 249.75 rows"),
+      StartsWith("  -- Project[2][expressions: (l_orderkey:BIGINT, "),
+      Eq("     Estimate: 999.202 rows"),
+      StartsWith("    -- Filter[1][expression: lt(\"l_orderkey\",1000)]"),
+      Eq("       Estimate: 999.202 rows"),
+      StartsWith("      -- TableScan[0][\"default\".\"lineitem\"]"),
+  };
+  if (useV2_) {
+    // v2 reports the rows the scan reads before the filter; v1 prints no
+    // estimate for the scan. Both report the rows that pass the filter.
+    expected.push_back(Eq("         Estimate: 6.00122e+06 rows"));
+  }
+  expected.push_back(Eq(""));
+  expected.push_back(Eq(""));
+
+  EXPECT_THAT(lines, ::testing::ElementsAreArray(expected));
 }
 
 TEST_P(ExplainTest, explainCreateTable) {

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -366,6 +366,52 @@ velox::connector::ConnectorTableHandlePtr HiveTableLayout::createTableHandle(
       tableName.schema);
 }
 
+std::vector<const Column*> HiveTableLayout::nonPartitionFilterColumns(
+    const velox::connector::hive::HiveTableHandle& handle) const {
+  std::unordered_set<std::string> filterColumnNames;
+  for (const auto& [subfield, filter] : handle.subfieldFilters()) {
+    filterColumnNames.emplace(subfield.baseName());
+  }
+  if (handle.remainingFilter() != nullptr) {
+    extractInputFields(handle.remainingFilter(), filterColumnNames);
+  }
+
+  folly::F14FastSet<std::string> partitionColumnNames;
+  for (const auto* column : hivePartitionColumns_) {
+    partitionColumnNames.insert(column->name());
+  }
+
+  std::vector<const Column*> filterColumns;
+  for (const auto* column : columns()) {
+    if (filterColumnNames.contains(column->name()) &&
+        !partitionColumnNames.contains(column->name())) {
+      filterColumns.push_back(column);
+    }
+  }
+  return filterColumns;
+}
+
+std::vector<std::string> HiveTableLayout::withFilterColumns(
+    const velox::connector::hive::HiveTableHandle& handle,
+    const std::vector<std::string>& requested,
+    const std::function<bool(const std::string&)>& hasStats) const {
+  std::vector<std::string> columnNames = requested;
+  std::unordered_set<std::string> seen{requested.begin(), requested.end()};
+  for (const auto* column : nonPartitionFilterColumns(handle)) {
+    if (seen.insert(column->name()).second && hasStats(column->name())) {
+      columnNames.emplace_back(column->name());
+    }
+  }
+  return columnNames;
+}
+
+void trimColumnStats(FilteredTableStats& stats, size_t numColumns) {
+  if (stats.columnStats.size() > numColumns) {
+    stats.columnStats.erase(
+        stats.columnStats.begin() + numColumns, stats.columnStats.end());
+  }
+}
+
 void HiveTableLayout::foldNonPartitionFilterStats(
     const velox::connector::hive::HiveTableHandle& handle,
     const FilterSelectivityEstimator& estimator,

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -207,11 +207,32 @@ class HiveTableLayout : public TableLayout {
       const FilterSelectivityEstimator& estimator,
       FilteredTableStats& stats) const;
 
+  // Returns the non-partition columns the filters in 'handle' read. Their
+  // statistics are what estimating those filters needs, even when the
+  // optimizer did not request the columns. A column read only inside a lambda
+  // body is not reported; the estimate then falls back to a default for that
+  // filter.
+  std::vector<const Column*> nonPartitionFilterColumns(
+      const velox::connector::hive::HiveTableHandle& handle) const;
+
+  // Returns the names in 'requested' followed by the columns from
+  // `nonPartitionFilterColumns` that are not already there and that 'hasStats'
+  // reports statistics for. Statistics for a column without any would be
+  // synthesized, which reads as a filter that passes nothing.
+  std::vector<std::string> withFilterColumns(
+      const velox::connector::hive::HiveTableHandle& handle,
+      const std::vector<std::string>& requested,
+      const std::function<bool(const std::string&)>& hasStats) const;
+
   const velox::dwio::common::FileFormat fileFormat_;
   const std::vector<const Column*> hivePartitionColumns_;
   const std::optional<int32_t> numBuckets_;
   const std::shared_ptr<const HivePartitionType> partitionType_;
 };
+
+/// Drops the per-column statistics past the first 'numColumns', which a
+/// connector added only to estimate the filters in its own table handle.
+void trimColumnStats(FilteredTableStats& stats, size_t numColumns);
 
 class HiveConnectorWriteHandle : public ConnectorWriteHandle {
  public:

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -182,6 +182,20 @@ struct PartitionFilter {
   const Column* column;
 };
 
+// True if any partition carries statistics for 'columnName'.
+bool hasPartitionStats(
+    const std::vector<PartitionStats>& partitionStats,
+    const std::string& columnName) {
+  for (const auto& partition : partitionStats) {
+    for (const auto& columnStats : partition.columnStats) {
+      if (columnStats.name == columnName) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 // Estimates table stats from persisted partition-level stats. Matches
 // partitions against the partition-key filters, merges matching partitions'
 // column stats, and returns them aligned 1:1 with 'requestedColumns'.
@@ -574,12 +588,20 @@ LocalHiveTableLayout::co_estimateStats(
     partitionColumnsByName[column->name()] = column;
   }
 
-  std::vector<const Column*> requestedColumns;
-  requestedColumns.reserve(columns.size());
-  for (const auto& columnName : columns) {
+  // Estimating the accepted filters needs statistics for the columns they
+  // read, which the optimizer has no reason to request: a column only a filter
+  // reads is not one the scan produces.
+  const auto statsColumnNames =
+      withFilterColumns(*hiveHandle, columns, [&](const std::string& name) {
+        return hasPartitionStats(partitionStats_, name);
+      });
+
+  std::vector<const Column*> statsColumns;
+  statsColumns.reserve(statsColumnNames.size());
+  for (const auto& columnName : statsColumnNames) {
     const auto* column = table().findColumn(columnName);
     VELOX_CHECK_NOT_NULL(column, "Column not found: {}", columnName);
-    requestedColumns.push_back(column);
+    statsColumns.push_back(column);
   }
 
   // Partition-key subfield filters drive the base estimate from partition
@@ -595,13 +617,14 @@ LocalHiveTableLayout::co_estimateStats(
   }
 
   auto stats = estimateStatsFromPartitionStats(
-      partitionStats_, partitionFilters, requestedColumns);
+      partitionStats_, partitionFilters, statsColumns);
   if (!partitionStats_.empty()) {
     // A table with no partition statistics estimates zero rows; reporting that
     // as the rows read would understate the scan rather than leave it unknown.
     stats.numRawInputRows = stats.numRows;
   }
   foldNonPartitionFilterStats(*hiveHandle, estimator, stats);
+  trimColumnStats(stats, columns.size());
   co_return stats;
 }
 

--- a/axiom/optimizer/docs/FilteredTableStats.md
+++ b/axiom/optimizer/docs/FilteredTableStats.md
@@ -134,17 +134,26 @@ estimator. Gated by the `useFilteredTableStats` optimizer option
    `filteredCardinality = numRows * selectivity`, plus the rejected filters'
    column constraints.
 
-The v2 path (`EstimateLeafStatsPass` + `ScanHandle`) mirrors this.
+The v2 path differs in step 3. `PushdownAndPrunePass` negotiates with the
+connector as the conjuncts reach the scan and turns the rejected ones into a
+`Filter` above it, so there is nothing to post-apply: `filteredCardinality =
+numRows` always, and the rejected conjuncts are estimated at that `Filter` like
+any other. The conjuncts the connector accepted are inside its table handle and
+are not visible to the optimizer.
 
-### `ToVelox::LeafTableData` / `ScanHandle`
+### `ToVelox::LeafTableData` (v1) / `ScanHandle` (v2)
 
-Per-leaf-table data stores:
+v1's per-leaf-table data stores:
 - `handle` -- table handle with filters pushed into the connector.
 - `extraFilters` -- filters rejected by `createTableHandle`, evaluated
   post-scan (execution).
 - `rejectedExprs` -- the same `createTableHandle`-rejected filters as `ExprCP`,
   for the optimizer to post-apply selectivity. Built by mapping each rejected
   index back to the aligned `ExprCP` conjunct.
+
+v2's `ScanHandle` stores only `tableHandle` and a per-column `columnHandles`
+map. It has no rejected-filter fields: `ScanHandle::build` hands the rejected
+conjuncts back to the pushdown pass, which puts them in the plan.
 
 ## Hive-family Implementation
 

--- a/axiom/optimizer/tests/FilteredTableStatsTest.cpp
+++ b/axiom/optimizer/tests/FilteredTableStatsTest.cpp
@@ -16,9 +16,6 @@
 
 #include <folly/ScopeGuard.h>
 #include <gtest/gtest.h>
-#include "axiom/optimizer/Optimization.h"
-#include "axiom/optimizer/Plan.h"
-#include "axiom/optimizer/RelationOp.h"
 #include "axiom/optimizer/tests/HiveQueriesTestBase.h"
 
 using namespace facebook::velox;
@@ -28,7 +25,8 @@ namespace {
 
 constexpr double kCardinalityTolerance = 1;
 
-class FilteredTableStatsTest : public test::HiveQueriesTestBase {
+class FilteredTableStatsTest : public test::HiveQueriesTestBase,
+                               public ::testing::WithParamInterface<bool> {
  protected:
   static void SetUpTestCase() {
     test::HiveQueriesTestBase::SetUpTestCase();
@@ -36,6 +34,7 @@ class FilteredTableStatsTest : public test::HiveQueriesTestBase {
   }
 
   void SetUp() override {
+    useV2_ = GetParam();
     test::HiveQueriesTestBase::SetUp();
 
     runCtas(
@@ -49,104 +48,103 @@ class FilteredTableStatsTest : public test::HiveQueriesTestBase {
     test::HiveQueriesTestBase::TearDown();
   }
 
-  // Parses SQL, optimizes, and invokes the callback with the best plan.
-  // Uses sampleFilters=false to ensure the optimizer relies on
-  // co_estimateStats rather than sampling.
-  void verifyPlan(
-      const std::string& sql,
-      const std::function<void(const Plan&)>& callback) {
+  // Returns the cardinality the optimizer estimates for 'sql'. Sampling is off
+  // so the estimate comes from co_estimateStats.
+  float estimatedCardinality(const std::string& sql) {
     auto logicalPlan = parseSelect(sql, velox::exec::test::kHiveConnectorId);
 
-    verifyOptimization(
-        *logicalPlan,
-        [&](Optimization& optimization) {
-          auto* plan = optimization.bestPlan();
-          ASSERT_NE(plan, nullptr) << "Best plan should not be null";
+    OptimizerOptions optimizerOptions;
+    optimizerOptions.sampleJoins = false;
+    optimizerOptions.sampleFilters = false;
 
-          callback(*plan);
-        },
-        [] {
-          OptimizerOptions options;
-          options.sampleJoins = false;
-          options.sampleFilters = false;
-          return options;
-        }());
+    auto planAndStats = planVelox(
+        logicalPlan,
+        {.numWorkers = 1, .numDrivers = 1},
+        std::move(optimizerOptions));
+
+    const auto& root = planAndStats.plan->fragments().back().fragment.planNode;
+    auto it = planAndStats.prediction.find(root->id());
+    VELOX_CHECK(
+        it != planAndStats.prediction.end(),
+        "No estimate for the plan's root node");
+    return it->second.cardinality;
   }
 };
 
 // Verifies that co_estimateStats provides accurate row counts for an
 // unpartitioned TPC-H table scan. The nation table has 25 rows.
-TEST_F(FilteredTableStatsTest, noFilter) {
-  verifyPlan("SELECT n_nationkey, n_name FROM nation", [](const Plan& plan) {
-    const auto& op = *plan.op;
-    EXPECT_NEAR(op.resultCardinality().value(), 25, kCardinalityTolerance);
-  });
+TEST_P(FilteredTableStatsTest, noFilter) {
+  EXPECT_NEAR(
+      estimatedCardinality("SELECT n_nationkey, n_name FROM nation"),
+      25,
+      kCardinalityTolerance);
 }
 
 // Verifies that a filter on a data column reduces cardinality, using
 // min/max from per-file stats for range-based selectivity estimation.
-TEST_F(FilteredTableStatsTest, dataFilter) {
-  verifyPlan(
-      "SELECT n_nationkey FROM nation WHERE n_nationkey > 10",
-      [](const Plan& plan) {
-        const auto& op = *plan.op;
-        // n_nationkey in [0, 24]. n_nationkey > 10 should give ~14/24 of rows.
-        EXPECT_NEAR(
-            op.resultCardinality().value(),
-            25.0 * 14 / 24,
-            kCardinalityTolerance);
-      });
+TEST_P(FilteredTableStatsTest, dataFilter) {
+  // n_nationkey in [0, 24]. n_nationkey > 10 should give ~14/24 of rows,
+  // whether or not the query selects the column the filter reads.
+  EXPECT_NEAR(
+      estimatedCardinality(
+          "SELECT n_nationkey FROM nation WHERE n_nationkey > 10"),
+      25.0 * 14 / 24,
+      kCardinalityTolerance);
+
+  EXPECT_NEAR(
+      estimatedCardinality("SELECT n_name FROM nation WHERE n_nationkey > 10"),
+      25.0 * 14 / 24,
+      kCardinalityTolerance);
 }
 
 // Verifies that a partition key filter prunes partitions, resulting in
 // reduced estimated row count from co_estimateStats.
-TEST_F(FilteredTableStatsTest, partitionFilter) {
-  verifyPlan("SELECT a FROM t WHERE k = 0", [](const Plan& plan) {
-    const auto& op = *plan.op;
-    // Partition k=0 has 9 rows (nationkeys 0,3,6,9,12,15,18,21,24).
-    EXPECT_NEAR(op.resultCardinality().value(), 9, kCardinalityTolerance);
-  });
+TEST_P(FilteredTableStatsTest, partitionFilter) {
+  // Partition k=0 has 9 rows (nationkeys 0,3,6,9,12,15,18,21,24).
+  EXPECT_NEAR(
+      estimatedCardinality("SELECT a FROM t WHERE k = 0"),
+      9,
+      kCardinalityTolerance);
 
-  verifyPlan("SELECT a FROM t WHERE k IN (1, 2)", [](const Plan& plan) {
-    const auto& op = *plan.op;
-    // Partitions k=1 and k=2 have 8 rows each (16 total).
-    EXPECT_NEAR(op.resultCardinality().value(), 16, kCardinalityTolerance);
-  });
+  // Partitions k=1 and k=2 have 8 rows each (16 total).
+  EXPECT_NEAR(
+      estimatedCardinality("SELECT a FROM t WHERE k IN (1, 2)"),
+      16,
+      kCardinalityTolerance);
 }
 
 // Verifies that a partition key filter combined with a data column filter
 // first prunes by partition, then applies data filter selectivity.
-TEST_F(FilteredTableStatsTest, partitionAndDataFilter) {
-  verifyPlan("SELECT a FROM t WHERE k = 0 AND a > 10", [](const Plan& plan) {
-    const auto& op = *plan.op;
-    // Partition k=0 has 9 rows with a in [0, 24].
-    // a > 10 gives selectivity of 14/24, so ~9 * 14/24 = 5.25 rows.
-    EXPECT_NEAR(
-        op.resultCardinality().value(), 9.0 * 14 / 24, kCardinalityTolerance);
-  });
+TEST_P(FilteredTableStatsTest, partitionAndDataFilter) {
+  // Partition k=0 has 9 rows with a in [0, 24]. a > 10 gives selectivity of
+  // 14/24, so ~9 * 14/24 = 5.25 rows.
+  EXPECT_NEAR(
+      estimatedCardinality("SELECT a FROM t WHERE k = 0 AND a > 10"),
+      9.0 * 14 / 24,
+      kCardinalityTolerance);
 }
 
 // Verifies that a join key column with all NULLs (numDistinct = 0 from
 // connector stats) does not produce non-finite cardinality via division by
 // zero in estimateFanout.
-TEST_F(FilteredTableStatsTest, joinKeyWithZeroDistinctValues) {
+TEST_P(FilteredTableStatsTest, joinKeyWithZeroDistinctValues) {
   runCtas(
       "CREATE TABLE u AS SELECT n_nationkey AS a, CAST(NULL AS INTEGER) AS b FROM nation");
   SCOPE_EXIT {
     hiveMetadata().dropTableIfExists("u");
   };
 
-  verifyPlan(
-      "SELECT u1.a + u2.b FROM u AS u1 LEFT JOIN u AS u2 ON u1.b = u2.b",
-      [](const Plan& plan) {
-        // TODO: Improve estimate for all-NULL join keys. The correct result
-        // is 25 (left join preserves all left-side rows, no matches on NULLs),
-        // but NDV is clamped from 0 to 1, producing fanout = 25 and
-        // resultCardinality = 625.
-        EXPECT_NEAR(
-            plan.op->resultCardinality().value(), 625, kCardinalityTolerance);
-      });
+  // TODO: Improve estimate for all-NULL join keys. The correct result is 25
+  // (left join preserves all left-side rows, no matches on NULLs), but NDV is
+  // clamped from 0 to 1, producing fanout = 25 and cardinality = 625.
+  EXPECT_NEAR(
+      estimatedCardinality(
+          "SELECT u1.a + u2.b FROM u AS u1 LEFT JOIN u AS u2 ON u1.b = u2.b"),
+      625,
+      kCardinalityTolerance);
 }
+
+AXIOM_INSTANTIATE_V1_V2(FilteredTableStatsTest);
 
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/SubqueryFoldTest.cpp
+++ b/axiom/optimizer/tests/SubqueryFoldTest.cpp
@@ -145,6 +145,7 @@ TEST_P(SubqueryFoldTest, foldable) {
                        .hashJoinInner(matchScan("t")
                                           .aliases({"ds", "a"})
                                           .filter("a > 5")
+                                          .projectIf(useV2_, {"ds"})
                                           .aggregation())
                        .build();
     AXIOM_ASSERT_PLAN(plan, matcher);

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -156,6 +156,9 @@ FROM (VALUES (1, 10), (2, 20)) t(a, b)
 FULL JOIN (VALUES (1, 1), (3, 3)) u(x, y) ON a = x
 WHERE coalesce(y, 1) > 0
 ----
+-- The projected b is the left side's, not the right side's filtered b.
+SELECT t_left.b FROM t t_left JOIN t t_right ON t_left.a = t_right.a WHERE t_right.b = 10
+----
 -- 8-way self-join hitting the greedy join-enumeration cutoff.
 SELECT count(*)
 FROM t t1

--- a/axiom/optimizer/v2/Builder.h
+++ b/axiom/optimizer/v2/Builder.h
@@ -18,10 +18,12 @@
 
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
+#include <deque>
 #include <numeric>
 #include "axiom/optimizer/QueryGraph.h"
 #include "axiom/optimizer/QueryGraphContext.h"
 #include "axiom/optimizer/v2/Node.h"
+#include "axiom/optimizer/v2/ScanHandle.h"
 
 namespace facebook::axiom::optimizer::v2 {
 
@@ -171,6 +173,13 @@ class Builder {
       const ExprVector& keys,
       const ColumnVector& aliases = {});
 
+  /// Takes ownership of 'handle' and returns a stable pointer to it, for a
+  /// `Scan` to point at. Handles are not interned: each one is a separate
+  /// negotiation with the connector.
+  const ScanHandle* takeScanHandle(ScanHandle handle) {
+    return &scanHandles_.emplace_back(std::move(handle));
+  }
+
  private:
   // For a binary `Call` whose 'name' is in `reversibleFunctions_`,
   // swaps 'args' (and renames to the reverse) when `args[0]` should
@@ -280,6 +289,10 @@ class Builder {
   DedupSet<Literal> literals_;
   DedupSet<Call> calls_;
   DedupSet<optimizer::Aggregate> aggregateCalls_;
+
+  // Owns the connector handles the IR's `Scan`s point at. A deque so the
+  // pointers stay valid as more are added.
+  std::deque<ScanHandle> scanHandles_;
 };
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/optimizer/v2/EmitPass.h"
+#include "axiom/optimizer/v2/ScanHandle.h"
 
 #include <folly/ScopeGuard.h>
 #include <folly/container/F14Set.h>
@@ -225,12 +226,10 @@ class Emitter {
   Emitter(
       const OptimizerSession& session,
       velox::core::ExpressionEvaluator& evaluator,
-      ScanHandleCache& scanHandles,
       const MultiFragmentPlan::Options& options)
       : session_{session},
         evaluator_{evaluator},
         exprEmitter_{evaluator.pool()},
-        scanHandles_{scanHandles},
         options_{options} {}
 
   velox::core::PlanNodePtr emit(NodeCP node) {
@@ -364,12 +363,6 @@ class Emitter {
       const ColumnVector& outputColumns,
       const std::vector<std::string>& outputNames);
 
-  // Returns 'scan's cached handle, building it into 'storage' if there is none.
-  // The reference is valid for as long as 'storage'. Emitting must not write to
-  // the cache: it is keyed by base table, so caching this scan's handle would
-  // hand it to a later scan of the same table with different filters.
-  const ScanHandle& scanHandle(const Scan& scan, ScanHandle& storage);
-
   velox::core::PlanNodePtr emitScan(const Scan& scan);
   velox::core::PlanNodePtr emitFilter(const Filter& filter);
   velox::core::PlanNodePtr emitProject(const Project& project);
@@ -411,12 +404,6 @@ class Emitter {
       velox::core::PlanNodePtr left,
       velox::core::PlanNodePtr right,
       velox::core::TypedExprPtr filter);
-
-  // Drops columns the emitted plan carries beyond what 'node' outputs. See
-  // the definition for why they can appear.
-  velox::core::PlanNodePtr trimToNodeColumns(
-      NodeCP node,
-      velox::core::PlanNodePtr input);
 
   // Wraps 'input' in a `ProjectNode` that keeps only 'keepColumns'.
   velox::core::PlanNodePtr projectToColumns(
@@ -505,7 +492,6 @@ class Emitter {
   const OptimizerSession& session_;
   velox::core::ExpressionEvaluator& evaluator_;
   ExprEmitter exprEmitter_;
-  ScanHandleCache& scanHandles_;
   const MultiFragmentPlan::Options& options_;
   int32_t nextNodeId_{0};
 
@@ -570,19 +556,6 @@ class Emitter {
   }
 };
 
-// A scan whose filter the connector rejected emits the filter's columns, so
-// the emitted plan can be wider than 'node' says. A Velox window operator
-// passes its input through, so those columns would ride through it and be
-// dropped only at the root. Trims them off first.
-velox::core::PlanNodePtr Emitter::trimToNodeColumns(
-    NodeCP node,
-    velox::core::PlanNodePtr input) {
-  if (input->outputType()->size() <= node->outputColumns().size()) {
-    return input;
-  }
-  return projectToColumns(node->outputColumns(), std::move(input));
-}
-
 velox::core::PlanNodePtr Emitter::projectToColumns(
     const ColumnVector& keepColumns,
     velox::core::PlanNodePtr input) {
@@ -604,98 +577,32 @@ velox::RowTypePtr Emitter::makeRowType(const ColumnVector& columns) const {
   return velox::ROW(std::move(names), std::move(types));
 }
 
-// Collects names of every input-column `FieldAccessTypedExpr` reachable
-// from `expr`, excluding references bound by an enclosing lambda. Used
-// to compute the columns a rejected filter reads, so the scan's
-// projected schema can include them.
-//
-// `LambdaTypedExpr` stores its body outside `inputs()`; descend into it
-// explicitly so outer-column captures inside higher-order filters
-// (`array_filter`, `any_match`, ...) are picked up. The lambda's
-// signature parameters are removed before recursing so a field access
-// to a bound name (e.g. `x` in `array_filter(arr, x -> x > 0)`) isn't
-// mistaken for a scan-column reference.
-void collectInputColumnNamesImpl(
-    const velox::core::TypedExprPtr& expr,
-    folly::F14FastSet<std::string>& names,
-    const folly::F14FastSet<std::string>& boundNames) {
-  if (expr->isFieldAccessKind()) {
-    const auto* field = expr->asUnchecked<velox::core::FieldAccessTypedExpr>();
-    if (field->isInputColumn() && !boundNames.contains(field->name())) {
-      names.insert(field->name());
-    }
-  } else if (expr->isLambdaKind()) {
-    const auto* lambda = expr->asUnchecked<velox::core::LambdaTypedExpr>();
-    folly::F14FastSet<std::string> childBound = boundNames;
-    for (const auto& paramName : lambda->signature()->names()) {
-      childBound.insert(paramName);
-    }
-    collectInputColumnNamesImpl(lambda->body(), names, childBound);
-  }
-  for (const auto& input : expr->inputs()) {
-    collectInputColumnNamesImpl(input, names, boundNames);
-  }
-}
-
-void collectInputColumnNames(
-    const velox::core::TypedExprPtr& expr,
-    folly::F14FastSet<std::string>& names) {
-  collectInputColumnNamesImpl(expr, names, /*boundNames=*/{});
-}
-
-const ScanHandle& Emitter::scanHandle(const Scan& scan, ScanHandle& storage) {
-  if (const ScanHandle* cached = scanHandles_.find(scan)) {
-    return *cached;
-  }
-  storage = ScanHandle::build(scan, session_, evaluator_);
-  return storage;
-}
-
 velox::core::PlanNodePtr Emitter::emitScan(const Scan& scan) {
-  // The read schema is the consumer output columns followed by the filter-only
-  // columns, with columnHandles aligned to that order. Consumer columns keep
-  // their `outputName` (alias) in the scan's row type; the rename happens
-  // inside the scan via `assignments[outputName] = handle`. Filter-only
-  // columns keep their schema name.
-  ScanHandle built;
-  const ScanHandle& handle = scanHandle(scan, built);
+  VELOX_CHECK_NOT_NULL(
+      scan.scanHandle(), "Scan reaches emit without a connector handle");
+  const ScanHandle& handle = *scan.scanHandle();
   const ColumnVector& consumerColumns = scan.outputColumns();
-  const ColumnVector& filterOnlyColumns = handle.filterOnlyColumns;
   const auto& columnHandles = handle.columnHandles;
   const auto& tableHandle = handle.tableHandle;
-  std::vector<velox::core::TypedExprPtr> rejectedFilters =
-      handle.rejectedFilters;
 
-  // Scan row type keeps consumer columns (named by outputName) plus
-  // any filter-only column actually referenced by a rejected filter.
-  // Columns referenced only by accepted filters were read by the
-  // connector but stay off the projected row.
-  folly::F14FastSet<std::string> rejectedFilterRefs;
-  for (const auto& rejected : rejectedFilters) {
-    collectInputColumnNames(rejected, rejectedFilterRefs);
-  }
-
+  // Scan row type is the consumer columns, named by outputName. A column read
+  // only by an accepted filter reaches the connector through the table handle,
+  // so it is neither projected nor assigned here.
   std::vector<std::string> scanOutputNames;
   std::vector<velox::TypePtr> scanOutputTypes;
   velox::connector::ColumnHandleMap assignments;
-  scanOutputNames.reserve(consumerColumns.size() + filterOnlyColumns.size());
-  scanOutputTypes.reserve(consumerColumns.size() + filterOnlyColumns.size());
-  for (size_t i = 0; i < consumerColumns.size(); ++i) {
-    ColumnCP column = consumerColumns[i];
+  scanOutputNames.reserve(consumerColumns.size());
+  scanOutputTypes.reserve(consumerColumns.size());
+  for (ColumnCP column : consumerColumns) {
     std::string outputName{column->outputName()};
     scanOutputTypes.push_back(toTypePtr(column->value().type));
-    assignments[outputName] = columnHandles[i];
+    const auto handleIt = columnHandles.find(column);
+    VELOX_CHECK(
+        handleIt != columnHandles.end(),
+        "Scan reads a column the connector handle was not built for: {}",
+        column->name());
+    assignments[outputName] = handleIt->second;
     scanOutputNames.push_back(std::move(outputName));
-  }
-  for (size_t i = 0; i < filterOnlyColumns.size(); ++i) {
-    ColumnCP column = filterOnlyColumns[i];
-    std::string schemaName{column->name()};
-    if (!rejectedFilterRefs.contains(schemaName)) {
-      continue;
-    }
-    scanOutputTypes.push_back(toTypePtr(column->value().type));
-    assignments[schemaName] = columnHandles[consumerColumns.size() + i];
-    scanOutputNames.push_back(std::move(schemaName));
   }
 
   auto scanNode = std::make_shared<velox::core::TableScanNode>(
@@ -717,29 +624,6 @@ velox::core::PlanNodePtr Emitter::emitScan(const Scan& scan) {
   }
 
   velox::core::PlanNodePtr result = std::move(scanNode);
-
-  if (!rejectedFilters.empty()) {
-    velox::core::TypedExprPtr predicate = rejectedFilters.size() == 1
-        ? rejectedFilters.front()
-        : std::make_shared<velox::core::CallTypedExpr>(
-              velox::BOOLEAN(),
-              std::move(rejectedFilters),
-              velox::expression::kAnd);
-
-    std::unordered_map<std::string, velox::core::TypedExprPtr> rejectedRename;
-    for (ColumnCP column : consumerColumns) {
-      if (column->name() != column->outputName()) {
-        rejectedRename.emplace(
-            std::string{column->name()}, toFieldAccess(column));
-      }
-    }
-
-    if (!rejectedRename.empty()) {
-      predicate = predicate->rewriteInputNames(rejectedRename);
-    }
-    result = std::make_shared<velox::core::FilterNode>(
-        nextId(), std::move(predicate), std::move(result));
-  }
 
   return result;
 }
@@ -1515,8 +1399,7 @@ velox::core::PlanNodePtr Emitter::emitValues(const Values& values) {
 }
 
 velox::core::PlanNodePtr Emitter::emitWindow(const Window& window) {
-  velox::core::PlanNodePtr input =
-      trimToNodeColumns(window.input(), emit(window.input()));
+  velox::core::PlanNodePtr input = emit(window.input());
 
   auto partitionKeys =
       toFieldAccessList(window.partitionKeys(), "Window partition key");
@@ -1581,8 +1464,7 @@ velox::core::PlanNodePtr Emitter::emitWindow(const Window& window) {
 }
 
 velox::core::PlanNodePtr Emitter::emitRowNumber(const RowNumber& node) {
-  velox::core::PlanNodePtr input =
-      trimToNodeColumns(node.input(), emit(node.input()));
+  velox::core::PlanNodePtr input = emit(node.input());
   auto partitionKeys =
       toFieldAccessList(node.partitionKeys(), "RowNumber partition key");
   // At numDrivers > 1 each partition must be complete in one driver:
@@ -1603,8 +1485,7 @@ velox::core::PlanNodePtr Emitter::emitRowNumber(const RowNumber& node) {
 }
 
 velox::core::PlanNodePtr Emitter::emitTopNRowNumber(const TopNRowNumber& node) {
-  velox::core::PlanNodePtr input =
-      trimToNodeColumns(node.input(), emit(node.input()));
+  velox::core::PlanNodePtr input = emit(node.input());
   auto partitionKeys =
       toFieldAccessList(node.partitionKeys(), "TopNRowNumber partition key");
   // At numDrivers > 1 each partition must be complete in one driver:
@@ -2012,10 +1893,15 @@ velox::core::PlanNodePtr Emitter::emitExchange(const Exchange& exchange) {
 
 velox::connector::ConnectorTableHandlePtr Emitter::deletedRowsHandle(
     const TableWrite& tableWrite) {
-  // The scan handle is the only description of the rows to remove, so the
-  // write must sit directly on a scan whose filters the connector took in
-  // full.
+  // The scan handle is the only description of the rows to remove, so the rows
+  // reaching the write must be the rows the scan reads.
   NodeCP input = tableWrite.input();
+  if (input->is(NodeType::kFilter) &&
+      input->as<Filter>()->input()->is(NodeType::kScan)) {
+    VELOX_USER_FAIL(
+        "Connector cannot apply this WHERE clause for DELETE: {}",
+        input->as<Filter>()->predicates().front()->toString());
+  }
   VELOX_USER_CHECK(
       input->is(NodeType::kScan),
       "DELETE requires a scan with an optional filter");
@@ -2029,15 +1915,9 @@ velox::connector::ConnectorTableHandlePtr Emitter::deletedRowsHandle(
       tableWrite.table()->name().toString(),
       scan.baseTable()->schemaTable->connectorTable->name().toString());
 
-  ScanHandle built;
-  const ScanHandle& handle = scanHandle(scan, built);
-  const auto& rejectedFilters = handle.rejectedFilters;
-  VELOX_USER_CHECK(
-      rejectedFilters.empty(),
-      "Connector cannot apply this WHERE clause for DELETE: {}",
-      rejectedFilters.front()->toString());
-
-  return handle.tableHandle;
+  VELOX_CHECK_NOT_NULL(
+      scan.scanHandle(), "Scan reaches emit without a connector handle");
+  return scan.scanHandle()->tableHandle;
 }
 
 velox::core::PlanNodePtr Emitter::emitTableWrite(const TableWrite& tableWrite) {
@@ -2320,10 +2200,9 @@ EmitPass::Result EmitPass::run(
     const std::vector<std::string>& outputNames,
     const OptimizerSession& session,
     velox::core::ExpressionEvaluator& evaluator,
-    ScanHandleCache& scanHandles,
     const MultiFragmentPlan::Options& options) {
   VELOX_CHECK_EQ(outputColumns.size(), outputNames.size());
-  Emitter emitter(session, evaluator, scanHandles, options);
+  Emitter emitter(session, evaluator, options);
   auto fragments = emitter.emitFragments(root, outputColumns, outputNames);
   return Result{
       std::move(fragments),

--- a/axiom/optimizer/v2/EmitPass.h
+++ b/axiom/optimizer/v2/EmitPass.h
@@ -20,7 +20,6 @@
 #include "axiom/optimizer/OptimizerSession.h"
 #include "axiom/optimizer/ToVelox.h"
 #include "axiom/optimizer/v2/Node.h"
-#include "axiom/optimizer/v2/ScanHandle.h"
 #include "velox/core/Expressions.h"
 #include "velox/core/PlanNode.h"
 
@@ -46,17 +45,16 @@ class EmitPass {
   /// fragment ending in `PartitionedOutput`, a consumer `Exchange`). For
   /// `options.numWorkers > 1` a final gather collects the distributed output
   /// into a single root fragment; for `numWorkers == 1` the result is one
-  /// fragment. 'session' supplies the connector session for Scan handles;
-  /// 'evaluator' folds filter constants; 'scanHandles' carries handles built by
-  /// `EstimateLeafStatsPass`. Throws VELOX_NYI for unsupported node or
-  /// expression types.
+  /// fragment. 'session' supplies the connector
+  /// session for table writes; 'evaluator' folds filter constants. A `Scan`
+  /// carries the connector handle it is read with. Throws VELOX_NYI for
+  /// unsupported node or expression types.
   static Result run(
       NodeCP root,
       const ColumnVector& outputColumns,
       const std::vector<std::string>& outputNames,
       const OptimizerSession& session,
       velox::core::ExpressionEvaluator& evaluator,
-      ScanHandleCache& scanHandles,
       const MultiFragmentPlan::Options& options);
 };
 

--- a/axiom/optimizer/v2/EstimateLeafStatsPass.cpp
+++ b/axiom/optimizer/v2/EstimateLeafStatsPass.cpp
@@ -15,12 +15,12 @@
  */
 
 #include "axiom/optimizer/v2/EstimateLeafStatsPass.h"
+#include "axiom/optimizer/v2/ScanHandle.h"
 
 #include "folly/coro/BlockingWait.h"
 #include "folly/coro/Collect.h"
 
 #include "axiom/connectors/ConnectorMetadata.h"
-#include "axiom/optimizer/Filters.h"
 #include "axiom/optimizer/QueryGraph.h"
 #include "axiom/optimizer/QueryGraphContext.h"
 #include "axiom/optimizer/Schema.h"
@@ -52,17 +52,13 @@ void applyColumnStats(
 }
 
 // Applies one base table's connector stats result. Sets filteredCardinality to
-// the connector's post-filter row count, scaled by the optimizer's own
-// selectivity for any filters the connector rejected. A nullopt result (the
-// connector does not support stats) leaves filteredCardinality at 0 so
-// downstream estimation falls back to constraint-based selectivity. Rejected
-// filters scale only the row count; per-column constraints are re-derived
-// downstream.
+// the connector's post-filter row count. A nullopt result (the connector does
+// not support stats) leaves filteredCardinality at 0 so downstream estimation
+// falls back to constraint-based selectivity.
 void applyFilteredStats(
     const Scan& scan,
     const std::vector<ColumnCP>& statColumns,
-    const std::optional<connector::FilteredTableStats>& stats,
-    const ExprVector& rejectedFilters) {
+    const std::optional<connector::FilteredTableStats>& stats) {
   if (!stats.has_value()) {
     return;
   }
@@ -78,36 +74,14 @@ void applyFilteredStats(
     }
   }
 
-  // The connector accounted for its accepted filters in numRows. Post-apply
-  // selectivity for the filters createTableHandle rejected (kept as ExprCP).
-  if (rejectedFilters.empty()) {
-    baseTable->filteredCardinality = std::max<float>(1, stats->numRows);
-    return;
-  }
-
-  ConstraintMap constraints;
-  const auto selectivity = conjunctsSelectivity(
-      constraints,
-      {rejectedFilters.data(), rejectedFilters.size()},
-      /*updateConstraints=*/false);
-  // When the rejected filters' selectivity is unknown, the post-filter row
-  // count is unknown too: leave `filteredCardinality` unset so downstream
-  // estimation propagates the unknown rather than fabricating a fraction.
-  if (!selectivity.has_value()) {
-    baseTable->filteredCardinality = std::nullopt;
-    return;
-  }
-  baseTable->filteredCardinality =
-      std::max<float>(1, stats->numRows * selectivity->trueFraction);
+  // numRows is post-filter for the filters the connector took; the refused
+  // ones are estimated at the Filter above the scan.
+  baseTable->filteredCardinality = std::max<float>(1, stats->numRows);
 }
 
 } // namespace
 
-void EstimateLeafStatsPass::run(
-    NodeCP root,
-    const OptimizerSession& session,
-    velox::core::ExpressionEvaluator& evaluator,
-    ScanHandleCache& scanHandles) {
+void EstimateLeafStatsPass::run(NodeCP root, const OptimizerSession& session) {
   std::vector<ScanCP> scans;
   collectScans(root, scans);
 
@@ -115,9 +89,6 @@ void EstimateLeafStatsPass::run(
   struct TableTask {
     ScanCP scan;
     std::vector<ColumnCP> statColumns;
-    // Copied from the cached ScanHandle: a reference would dangle when a later
-    // getOrBuild rehashes the ScanHandleCache and moves the ScanHandle.
-    ExprVector rejectedExprs;
   };
   std::vector<TableTask> tasks;
   std::vector<folly::coro::Task<std::optional<connector::FilteredTableStats>>>
@@ -133,35 +104,28 @@ void EstimateLeafStatsPass::run(
     if (!seen.insert(baseTable->id()).second) {
       continue;
     }
-    const ScanHandle& handle =
-        scanHandles.getOrBuild(*scan, session, evaluator);
+    const ScanHandle* handle = scan->scanHandle();
+    VELOX_CHECK_NOT_NULL(
+        handle, "Filtered-table stats need the connector's read handle");
 
     const auto* layout = baseTable->schemaTable->columnGroups[0]->layout;
     auto connectorSession =
         session.toConnectorSession(layout->connector()->connectorId());
 
-    // Request stats for the top-level columns of the read schema. Subfield
-    // columns have no connector-level statistics.
+    // Subfield columns have no connector-level statistics.
     std::vector<ColumnCP> statColumns;
     std::vector<std::string> columnNames;
-    const auto addColumn = [&](ColumnCP column) {
+    for (ColumnCP column : scan->outputColumns()) {
       if (column->topColumn() == nullptr) {
         statColumns.push_back(column);
         columnNames.emplace_back(column->name());
       }
-    };
-    for (ColumnCP column : scan->outputColumns()) {
-      addColumn(column);
-    }
-    for (ColumnCP column : handle.filterOnlyColumns) {
-      addColumn(column);
     }
 
-    tasks.push_back(
-        TableTask{scan, std::move(statColumns), handle.rejectedExprs});
+    tasks.push_back(TableTask{scan, std::move(statColumns)});
     requests.push_back(layout->co_estimateStats(
         std::move(connectorSession),
-        handle.tableHandle,
+        handle->tableHandle,
         std::move(columnNames),
         estimator));
   }
@@ -177,11 +141,7 @@ void EstimateLeafStatsPass::run(
       folly::coro::collectAllRange(std::move(requests)));
 
   for (size_t i = 0; i < tasks.size(); ++i) {
-    applyFilteredStats(
-        *tasks[i].scan,
-        tasks[i].statColumns,
-        results[i],
-        tasks[i].rejectedExprs);
+    applyFilteredStats(*tasks[i].scan, tasks[i].statColumns, results[i]);
   }
 }
 

--- a/axiom/optimizer/v2/EstimateLeafStatsPass.h
+++ b/axiom/optimizer/v2/EstimateLeafStatsPass.h
@@ -16,29 +16,25 @@
 
 #pragma once
 
-#include "axiom/optimizer/v2/ScanHandle.h"
+#include "axiom/optimizer/OptimizerSession.h"
+#include "axiom/optimizer/v2/Node.h"
 
 namespace facebook::axiom::optimizer::v2 {
 
 /// Annotates base tables with connector filtered-table statistics.
 class EstimateLeafStatsPass {
  public:
-  /// For each base table reachable from 'root', builds (and caches in
-  /// 'scanHandles') the connector handle, calls
-  /// `TableLayout::co_estimateStats`, and writes the post-filter row count into
-  /// `BaseTable::filteredCardinality` and the per-column min/max/ndv into each
-  /// `Column::value()`, in place; join-order planning then reads these via
-  /// `EstimateProvider`. Runs after filter pushdown and before join-order
-  /// planning. The caller gates this on the `useFilteredTableStats` option;
-  /// when it does not run, or a connector returns no stats for a table, that
-  /// table's `filteredCardinality` stays 0 and `EstimateProvider` falls back to
-  /// constraint-based selectivity. 'session' supplies connector sessions;
-  /// 'evaluator' constant-folds filters during handle construction.
-  static void run(
-      NodeCP root,
-      const OptimizerSession& session,
-      velox::core::ExpressionEvaluator& evaluator,
-      ScanHandleCache& scanHandles);
+  /// For each base table reachable from 'root', calls
+  /// `TableLayout::co_estimateStats` with the handle its `Scan` points at, and
+  /// writes the post-filter row count into `BaseTable::filteredCardinality` and
+  /// the per-column min/max/ndv into each `Column::value()`, in place;
+  /// join-order planning then reads these via `EstimateProvider`. Runs after
+  /// filter pushdown and before join-order planning. The caller gates this on
+  /// the `useFilteredTableStats` option; when it does not run, or a connector
+  /// returns no stats for a table, that table's `filteredCardinality` stays 0
+  /// and `EstimateProvider` falls back to constraint-based selectivity.
+  /// 'session' supplies connector sessions.
+  static void run(NodeCP root, const OptimizerSession& session);
 };
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/EstimateProvider.cpp
+++ b/axiom/optimizer/v2/EstimateProvider.cpp
@@ -101,33 +101,19 @@ Estimate EstimateProvider::compute(NodeCP node) {
       const auto* scan = node->as<Scan>();
       const auto* baseTable = scan->baseTable();
       Estimate result;
-      // Narrow per-column constraints from the scan filters; join propagation
-      // reads these regardless of the cardinality source. The filter
-      // selectivity is unknown when `conjunctsSelectivity` cannot estimate it;
-      // an unknown selectivity makes the constraint-derived cardinality
-      // unknown (no fabricated 1.0 fallback).
-      std::optional<float> selectivity{1.0f};
-      if (!scan->filters().empty()) {
-        const auto sel = conjunctsSelectivity(
-            result.constraints,
-            toSpan(scan->filters()),
-            /*updateConstraints=*/true);
-        selectivity = sel.has_value() ? std::optional<float>{sel->trueFraction}
-                                      : std::nullopt;
-      }
+      // A connector that takes a filter reports the statistics of the rows it
+      // will return, so the scan's own estimate needs no selectivity of its
+      // own.
       if (!baseTable->filteredCardinality.has_value()) {
-        // Filtered-stats pass ran but could not estimate the post-filter row
-        // count (a rejected filter's selectivity was unknown); propagate the
-        // unknown rather than falling back to a fabricated estimate.
+        // The post-filter row count is not known; propagate the unknown rather
+        // than falling back to a fabricated estimate.
         result.cardinality = std::nullopt;
       } else if (*baseTable->filteredCardinality > 0) {
         // Connector filtered-stats pass populated the post-filter row count.
         result.cardinality = std::max(1.0f, *baseTable->filteredCardinality);
       } else if (baseTable->schemaTable != nullptr) {
-        // filteredCardinality == 0: no connector stats; fall back to base-table
-        // cardinality scaled by the optimizer's own selectivity.
-        result.cardinality =
-            maxOf(1.0f, mul(baseTable->schemaTable->cardinality, selectivity));
+        // filteredCardinality == 0: no connector stats.
+        result.cardinality = maxOf(1.0f, baseTable->schemaTable->cardinality);
       } else {
         // No base-table statistics: cardinality is unknown.
         result.cardinality = std::nullopt;

--- a/axiom/optimizer/v2/FoldMetadataAggregatePass.cpp
+++ b/axiom/optimizer/v2/FoldMetadataAggregatePass.cpp
@@ -34,15 +34,8 @@ using logical_plan::SpecialAggregateKind;
 
 class Folder : public NodeRewriter<NoContext> {
  public:
-  Folder(
-      Builder& builder,
-      const OptimizerSession& session,
-      velox::core::ExpressionEvaluator& evaluator,
-      ScanHandleCache& scanHandles)
-      : NodeRewriter(builder),
-        session_(session),
-        evaluator_(evaluator),
-        scanHandles_(scanHandles) {}
+  Folder(Builder& builder, const OptimizerSession& session)
+      : NodeRewriter(builder), session_(session) {}
 
  protected:
   NodeCP rewriteAggregate(AggregateCP node, NoContext& context) override {
@@ -134,15 +127,9 @@ class Folder : public NodeRewriter<NoContext> {
       nullCountIndex.push_back(it->second);
     }
 
-    const ScanHandle& handle =
-        scanHandles_.getOrBuild(*scan, session_, evaluator_);
-
-    // co_metadataCounts accounts only for the filters the connector accepted
-    // into the handle. If any filter was rejected, its effect is not reflected
-    // in the counts, so folding would overcount; bail to a live scan.
-    if (!handle.rejectedExprs.empty()) {
-      return nullptr;
-    }
+    VELOX_CHECK_NOT_NULL(
+        scan->scanHandle(), "Metadata counts need the connector's read handle");
+    const ScanHandle& handle = *scan->scanHandle();
 
     auto connectorSession =
         session_.toConnectorSession(layout->connector()->connectorId());
@@ -246,8 +233,6 @@ class Folder : public NodeRewriter<NoContext> {
   }
 
   const OptimizerSession& session_;
-  velox::core::ExpressionEvaluator& evaluator_;
-  ScanHandleCache& scanHandles_;
 };
 
 } // namespace
@@ -255,10 +240,8 @@ class Folder : public NodeRewriter<NoContext> {
 NodeCP FoldMetadataAggregatePass::run(
     NodeCP root,
     Builder& builder,
-    const OptimizerSession& session,
-    velox::core::ExpressionEvaluator& evaluator,
-    ScanHandleCache& scanHandles) {
-  Folder folder(builder, session, evaluator, scanHandles);
+    const OptimizerSession& session) {
+  Folder folder(builder, session);
   return folder.rewrite(root);
 }
 

--- a/axiom/optimizer/v2/FoldMetadataAggregatePass.h
+++ b/axiom/optimizer/v2/FoldMetadataAggregatePass.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
+#include "axiom/optimizer/OptimizerSession.h"
 #include "axiom/optimizer/v2/Builder.h"
-#include "axiom/optimizer/v2/ScanHandle.h"
 
 namespace facebook::axiom::optimizer::v2 {
 
@@ -37,12 +37,8 @@ namespace facebook::axiom::optimizer::v2 {
 /// none reaches emit, where the kind name is not a Velox aggregate.
 class FoldMetadataAggregatePass {
  public:
-  static NodeCP run(
-      NodeCP root,
-      Builder& builder,
-      const OptimizerSession& session,
-      velox::core::ExpressionEvaluator& evaluator,
-      ScanHandleCache& scanHandles);
+  static NodeCP
+  run(NodeCP root, Builder& builder, const OptimizerSession& session);
 };
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinTreeEmitter.cpp
+++ b/axiom/optimizer/v2/JoinTreeEmitter.cpp
@@ -253,7 +253,7 @@ NodeCP emitLeaf(const LeafOp* leaf, EmitState& state) {
       return state.builder.make<Scan>(Scan::Key{
           .baseTable = scan->baseTable(),
           .outputColumns = scan->outputColumns(),
-          .filters = scan->filters(),
+          .scanHandle = scan->scanHandle(),
           .groupedPartitionType = partitionType});
     }
   }

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -538,7 +538,7 @@ Scan::Scan(Key key)
           ColumnVector{key.outputColumns},
           PhysicalProperties{.globalPartition = scanGlobalPartition(key)}),
       baseTable_(key.baseTable),
-      filters_(std::move(key.filters)),
+      scanHandle_(key.scanHandle),
       groupedPartitionType_(key.groupedPartitionType) {
   VELOX_CHECK_NOT_NULL(baseTable_);
   folly::F14FastSet<std::string_view> schemaNames;
@@ -561,7 +561,7 @@ size_t Scan::KeyHash::operator()(const Scan* node) const {
   return hashOf(
       node->baseTable(),
       node->outputColumns(),
-      node->filters(),
+      node->scanHandle(),
       node->groupedPartitionType());
 }
 
@@ -573,20 +573,23 @@ Partitioning Scan::storageBucketing() const {
 
 size_t Scan::KeyHash::operator()(const Key& key) const {
   return hashOf(
-      key.baseTable, key.outputColumns, key.filters, key.groupedPartitionType);
+      key.baseTable,
+      key.outputColumns,
+      key.scanHandle,
+      key.groupedPartitionType);
 }
 
 bool Scan::KeyEq::operator()(const Scan* left, const Scan* right) const {
   return left->baseTable() == right->baseTable() &&
       left->outputColumns() == right->outputColumns() &&
-      left->filters() == right->filters() &&
+      left->scanHandle() == right->scanHandle() &&
       left->groupedPartitionType() == right->groupedPartitionType();
 }
 
 bool Scan::KeyEq::operator()(const Key& key, const Scan* node) const {
   return key.baseTable == node->baseTable() &&
       key.outputColumns == node->outputColumns() &&
-      key.filters == node->filters() &&
+      key.scanHandle == node->scanHandle() &&
       key.groupedPartitionType == node->groupedPartitionType();
 }
 

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -30,6 +30,8 @@
 /// shared `QueryGraphContext`.
 namespace facebook::axiom::optimizer::v2 {
 
+struct ScanHandle;
+
 /// Discriminator for Node subtypes.
 enum class NodeType : uint8_t {
   kScan,
@@ -169,15 +171,18 @@ class Scan : public Node {
     /// Strict consumer-required output columns; may be empty (e.g.
     /// `SELECT count(1) FROM t` needs no column values from the table).
     /// Distinct by pointer; both `outputName()` and the underlying `name()`
-    /// are unique within the vector. `filters` may reference columns that are
-    /// NOT in this set; the connector-side read schema is computed as
-    /// `outputColumns ∪ refs(filters)` when building the final Velox plan.
+    /// are unique within the vector. A column read only by a predicate the
+    /// connector evaluates is not here: the connector reads it without
+    /// projecting it.
     ColumnVector outputColumns;
 
-    /// Filters on the scanned rows, as conjuncts joined with AND; may be empty.
-    /// At Emit the connector evaluates those it can; the rest are re-applied as
-    /// a `Filter` node above the `TableScan` in the final Velox plan.
-    ExprVector filters;
+    /// How the connector reads this table: the table and column handles, and
+    /// with them the predicates the connector took responsibility for. One
+    /// handle per base table, made by the pushdown pass. Null before that pass,
+    /// and after it only when the pass ran with `ConnectorPushdown::kSkip`,
+    /// whose result describes IO and cannot be emitted. Part of the scan's
+    /// identity.
+    const ScanHandle* scanHandle{nullptr};
 
     /// The partitioning this scan is read with, when physical planning chose to
     /// read the table one bucket-group at a time, already coarsened to the
@@ -209,8 +214,10 @@ class Scan : public Node {
     return baseTable_;
   }
 
-  const ExprVector& filters() const {
-    return filters_;
+  /// The connector's read specification for this scan, including the filters
+  /// it evaluates. Null as described on `Key::scanHandle`.
+  const ScanHandle* scanHandle() const {
+    return scanHandle_;
   }
 
   /// The partitioning this scan is read with; null for an ordinary read.
@@ -234,7 +241,7 @@ class Scan : public Node {
 
  private:
   const BaseTableCP baseTable_;
-  const ExprVector filters_;
+  const ScanHandle* const scanHandle_;
   const connector::PartitionType* const groupedPartitionType_;
 };
 

--- a/axiom/optimizer/v2/NodePrinter.cpp
+++ b/axiom/optimizer/v2/NodePrinter.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/optimizer/v2/NodePrinter.h"
+#include "axiom/optimizer/v2/ScanHandle.h"
 
 #include <fmt/format.h>
 #include <fmt/ranges.h>
@@ -82,8 +83,8 @@ class Printer : public NodeVisitor {
     header(
         ctx, node, fmt::format("[{}]", node.baseTable()->schemaTable->name()));
     const auto pad = spaces(ctx.indent + 2);
-    for (ExprCP filter : node.filters()) {
-      ctx.out << pad << "filter: " << formatExpr(filter) << '\n';
+    if (const ScanHandle* handle = node.scanHandle(); handle != nullptr) {
+      ctx.out << pad << "handle: " << handle->tableHandle->toString() << '\n';
     }
     visitInputs(node, ctx);
   }

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -27,7 +27,6 @@
 #include "axiom/optimizer/v2/LimitAndOrderPass.h"
 #include "axiom/optimizer/v2/PhysicalPlanAndEmit.h"
 #include "axiom/optimizer/v2/PushdownAndPrunePass.h"
-#include "axiom/optimizer/v2/ScanHandle.h"
 #include "axiom/optimizer/v2/TranslatePass.h"
 
 namespace facebook::axiom::optimizer::v2 {
@@ -49,25 +48,43 @@ FrontendResult translateAndPushdown(
     velox::core::ExpressionEvaluator& evaluator,
     Builder& builder,
     const OptimizerSession& session,
-    const std::shared_ptr<velox::core::QueryCtx>& queryCtx) {
+    const std::shared_ptr<velox::core::QueryCtx>& queryCtx,
+    PushdownAndPrunePass::ConnectorPushdown connectorPushdown) {
   ConstantPlanRunner constantPlanRunner{queryCtx};
   auto translated = TranslatePass::run(
       plan, schema, evaluator, builder, session, constantPlanRunner);
   NodeCP decorrelated = DecorrelatePass::run(translated.root, builder);
   NodeCP limited = LimitAndOrderPass::run(decorrelated, builder);
   NodeCP pushed = PushdownAndPrunePass::run(
-      limited, translated.outputColumns, builder, evaluator);
+      limited,
+      translated.outputColumns,
+      builder,
+      evaluator,
+      session,
+      connectorPushdown);
   return {std::move(translated), pushed};
 }
 
-// Collects each Scan's base table and its pushed-down filter conjuncts.
+// Collects each Scan's base table and the conjuncts that reach it. Reads them
+// off the `Filter` above the `Scan`, so the caller must have run the pushdown
+// pass with `ConnectorPushdown::kSkip`, which leaves every conjunct there.
 void collectScans(
     NodeCP node,
     std::vector<std::pair<BaseTableCP, ExprVector>>& tableFilters) {
   if (node->is(NodeType::kScan)) {
-    const auto* scan = node->as<Scan>();
-    tableFilters.emplace_back(scan->baseTable(), scan->filters());
+    tableFilters.emplace_back(node->as<Scan>()->baseTable(), ExprVector{});
+    return;
   }
+
+  if (node->is(NodeType::kFilter)) {
+    const auto* filter = node->as<Filter>();
+    if (filter->input()->is(NodeType::kScan)) {
+      tableFilters.emplace_back(
+          filter->input()->as<Scan>()->baseTable(), filter->predicates());
+      return;
+    }
+  }
+
   for (auto* input : node->inputs()) {
     collectScans(input, tableFilters);
   }
@@ -126,16 +143,19 @@ PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
   // stay alive through translate, precompute, and emit.
   Schema schema(schemaResolver_);
 
-  // Connector table handles are built once here and reused at emit.
-  ScanHandleCache scanHandles;
-
   Builder builder;
   auto frontend = translateAndPushdown(
-      plan_, schema, evaluator_, builder, session_, queryCtx_);
-  NodeCP folded = FoldMetadataAggregatePass::run(
-      frontend.pushed, builder, session_, evaluator_, scanHandles);
+      plan_,
+      schema,
+      evaluator_,
+      builder,
+      session_,
+      queryCtx_,
+      PushdownAndPrunePass::ConnectorPushdown::kOffer);
+  NodeCP folded =
+      FoldMetadataAggregatePass::run(frontend.pushed, builder, session_);
   if (session_.options().useFilteredTableStats) {
-    EstimateLeafStatsPass::run(folded, session_, evaluator_, scanHandles);
+    EstimateLeafStatsPass::run(folded, session_);
   }
 
   // Decide the width before physical planning, which reads numWorkers to shape
@@ -151,7 +171,6 @@ PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
       builder,
       session_,
       evaluator_,
-      scanHandles,
       planOptions);
 
   PlanAndStats result;
@@ -184,11 +203,19 @@ std::string Optimizer::explainIo(
   // the IR's `BaseTable` nodes hold into them — stay alive for the duration.
   Schema schema(schemaResolver_);
 
-  // Run only the passes that push predicates into scans; join ordering and Emit
-  // are not needed to report IO.
+  // Run only the passes that move predicates down to the scans; join ordering
+  // and Emit are not needed to report IO. The pushdown pass does not offer
+  // them to the connector: the report is what the query applies to each table,
+  // not how some connector would read it.
   Builder builder;
   auto frontend = translateAndPushdown(
-      plan_, schema, evaluator_, builder, session_, queryCtx_);
+      plan_,
+      schema,
+      evaluator_,
+      builder,
+      session_,
+      queryCtx_,
+      PushdownAndPrunePass::ConnectorPushdown::kSkip);
 
   std::vector<std::pair<BaseTableCP, ExprVector>> tableFilters;
   collectScans(frontend.pushed, tableFilters);
@@ -199,14 +226,18 @@ QueryStats Optimizer::estimateQueryStats() {
   // Schema is owned here so its tables — and the raw pointers the IR's
   // BaseTable nodes hold into them — stay alive while the estimate is read.
   Schema schema(schemaResolver_);
-  ScanHandleCache scanHandles;
   Builder builder;
 
   auto frontend = translateAndPushdown(
-      plan_, schema, evaluator_, builder, session_, queryCtx_);
+      plan_,
+      schema,
+      evaluator_,
+      builder,
+      session_,
+      queryCtx_,
+      PushdownAndPrunePass::ConnectorPushdown::kOffer);
   if (session_.options().useFilteredTableStats) {
-    EstimateLeafStatsPass::run(
-        frontend.pushed, session_, evaluator_, scanHandles);
+    EstimateLeafStatsPass::run(frontend.pushed, session_);
   }
 
   EstimateProvider estimateProvider;

--- a/axiom/optimizer/v2/PhysicalPlanAndEmit.cpp
+++ b/axiom/optimizer/v2/PhysicalPlanAndEmit.cpp
@@ -29,7 +29,6 @@ EmitPass::Result physicalPlanAndEmit(
     Builder& builder,
     const OptimizerSession& session,
     velox::core::ExpressionEvaluator& evaluator,
-    ScanHandleCache& scanHandles,
     const MultiFragmentPlan::Options& options) {
   NodeCP physicalPlanned = PlanPhysicalPass::run(
       root, builder, session.options(), options.numWorkers, options.numDrivers);
@@ -38,13 +37,7 @@ EmitPass::Result physicalPlanAndEmit(
   // (grouping sets were already lowered to GroupId in translate).
   NodeCP expanded = ExpandAggregatePass::run(precomputed, builder);
   return EmitPass::run(
-      expanded,
-      outputColumns,
-      outputNames,
-      session,
-      evaluator,
-      scanHandles,
-      options);
+      expanded, outputColumns, outputNames, session, evaluator, options);
 }
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PhysicalPlanAndEmit.h
+++ b/axiom/optimizer/v2/PhysicalPlanAndEmit.h
@@ -32,7 +32,6 @@ EmitPass::Result physicalPlanAndEmit(
     Builder& builder,
     const OptimizerSession& session,
     velox::core::ExpressionEvaluator& evaluator,
-    ScanHandleCache& scanHandles,
     const MultiFragmentPlan::Options& options);
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -238,7 +238,7 @@ class GroupedScanRewriter : public NodeRewriter<> {
     NodeCP grouped = builder().make<Scan>(Scan::Key{
         .baseTable = node->baseTable(),
         .outputColumns = node->outputColumns(),
-        .filters = node->filters(),
+        .scanHandle = node->scanHandle(),
         .groupedPartitionType = queryCtx()->scaledPartitionType(
             available.partitionType, numWorkers_)});
     // A scan already read this way interns back to itself, and then this

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -16,6 +16,8 @@
 
 #include "axiom/optimizer/v2/PushdownAndPrunePass.h"
 
+#include "axiom/optimizer/v2/ScanHandle.h"
+
 #include <limits>
 #include <optional>
 
@@ -57,6 +59,11 @@ struct PushdownContext {
   // partition can contribute more than that many. Set only for that immediate
   // parent-child pair.
   std::optional<int32_t> rankLimit;
+
+  // Set when the consumer lists its own output columns, so a `Scan` below may
+  // leave the columns only a refused conjunct reads in its output rather than
+  // adding a `Project` to drop them.
+  bool consumerDropsExtraColumns{false};
 
   // `Column*`s whose values are guaranteed non-NULL in the current
   // subtree (derived from default-null-behavior equi-keys of an
@@ -611,9 +618,16 @@ bool holdsAtRankOne(
 // conjuncts.
 class Pushdown : public NodeRewriter<PushdownContext> {
  public:
-  Pushdown(Builder& builder, velox::core::ExpressionEvaluator& evaluator)
+  Pushdown(
+      Builder& builder,
+      velox::core::ExpressionEvaluator& evaluator,
+      const OptimizerSession& session,
+      PushdownAndPrunePass::ConnectorPushdown connectorPushdown)
       : NodeRewriter(builder),
         exprs_(builder),
+        evaluator_(evaluator),
+        session_(session),
+        connectorPushdown_(connectorPushdown),
         simplifier_(builder, evaluator) {}
 
  protected:
@@ -623,6 +637,8 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     for (ExprCP predicate : node->predicates()) {
       ExprFactory::flattenAnd(predicate, context.pending);
     }
+    // Forwards 'context' unchanged: this Filter dissolves into 'pending', so
+    // whatever consumes the result is the consumer this node had.
     return rewrite(node->input(), context);
   }
 
@@ -671,6 +687,7 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     childContext.requiredAbove = childContext.required;
     childContext.required.unionColumns(childContext.pending);
     childContext.nonNullColumns = context.nonNullColumns;
+    childContext.consumerDropsExtraColumns = true;
     NodeCP newInput = rewrite(node->input(), childContext);
 
     // Inline a child Project: a Project directly over another Project collapses
@@ -1033,13 +1050,11 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     return maybeWrapFilter(newJoin, std::move(above));
   }
 
-  // Scan: append pending conjuncts to `Scan.filters`; Emit decides
-  // what the connector absorbs. `outputColumns` is the strict consumer-
-  // required set; Emit folds in any columns referenced by retained
-  // filters and projects them away above the scan.
+  // Scan: pending conjuncts reach the table, and the connector decides which
+  // of them it will evaluate. The ones it rejects become a Filter over the
+  // Scan, and the columns they read join the Scan's output.
   NodeCP rewriteScan(const Scan* node, PushdownContext& context) override {
-    ExprVector mergedFilters = node->filters();
-    appendAll(mergedFilters, context.pending);
+    ExprVector filters = std::move(context.pending);
     context.pending.clear();
 
     ColumnVector survivingOutputs;
@@ -1050,15 +1065,97 @@ class Pushdown : public NodeRewriter<PushdownContext> {
       }
     }
 
-    const bool unchanged = mergedFilters.size() == node->filters().size() &&
-        survivingOutputs.size() == node->outputColumns().size();
-    if (unchanged) {
-      return node;
+    ExprVector rejected;
+    const ScanHandle* handle =
+        negotiate(*node->baseTable(), survivingOutputs, filters, rejected);
+    if (rejected.empty()) {
+      return builder().make<Scan>(
+          {node->baseTable(), std::move(survivingOutputs), handle});
     }
-    return builder().make<Scan>(
-        {node->baseTable(),
-         std::move(survivingOutputs),
-         std::move(mergedFilters)});
+
+    // The rejected conjuncts are evaluated above the scan, so the scan must
+    // read what they reference.
+    PlanObjectSet rejectedColumns;
+    rejectedColumns.unionColumns(rejected);
+    ColumnVector scanOutputs = survivingOutputs;
+    for (ColumnCP column : node->baseTable()->columns) {
+      if (rejectedColumns.contains(column) &&
+          std::find(scanOutputs.begin(), scanOutputs.end(), column) ==
+              scanOutputs.end()) {
+        scanOutputs.push_back(column);
+      }
+    }
+    // The Filter this rewrite puts above the scan reads only columns the scan
+    // produces.
+    const PlanObjectSet scanOutputSet = PlanObjectSet::fromObjects(scanOutputs);
+    rejectedColumns.forEach<Column>([&](ColumnCP column) {
+      VELOX_CHECK(
+          scanOutputSet.contains(column),
+          "A rejected filter reads a column the scan does not produce: {}",
+          column->name());
+    });
+
+    const bool readsExtraColumns = scanOutputs.size() > survivingOutputs.size();
+    NodeCP scan = builder().make<Scan>(
+        {node->baseTable(), std::move(scanOutputs), handle});
+    NodeCP filter = builder().make<Filter>({scan, std::move(rejected)});
+    if (!readsExtraColumns || context.consumerDropsExtraColumns) {
+      return filter;
+    }
+    // The columns only the rejected conjuncts read stop here: nothing above
+    // asked for them, and carrying them would widen every operator between
+    // this scan and the query's output.
+    ExprVector passThrough(survivingOutputs.begin(), survivingOutputs.end());
+    return builder().make<Project>(
+        {filter, std::move(passThrough), std::move(survivingOutputs)});
+  }
+
+  // Offers 'filters' to the connector for 'baseTable' read as 'outputColumns'
+  // and returns the resulting handle, appending the conjuncts the connector
+  // rejected to 'rejected'. Returns null, rejecting everything, when the
+  // caller asked for no connector pushdown.
+  const ScanHandle* negotiate(
+      const BaseTable& baseTable,
+      const ColumnVector& outputColumns,
+      const ExprVector& filters,
+      ExprVector& rejected) {
+    if (connectorPushdown_ == PushdownAndPrunePass::ConnectorPushdown::kSkip) {
+      appendAll(rejected, filters);
+      return nullptr;
+    }
+    const auto it = negotiatedByBaseTableId_.find(baseTable.id());
+    if (it != negotiatedByBaseTableId_.end()) {
+      // A rewrite that duplicated a subtree can present one Scan twice. The
+      // connector is asked once, so the second visit must be offering the same
+      // predicates and reading no more columns; otherwise its predicates would
+      // be silently dropped, or it would read a column with no handle.
+      VELOX_CHECK(
+          it->second.filters == filters,
+          "Two reads of one table offer the connector different filters: {}",
+          baseTable.schemaTable->name());
+      for (ColumnCP column : outputColumns) {
+        VELOX_CHECK(
+            it->second.handle->columnHandles.contains(column),
+            "Two reads of one table read different columns: {}.{}",
+            baseTable.schemaTable->name(),
+            column->name());
+      }
+      appendAll(rejected, it->second.rejected);
+      return it->second.handle;
+    }
+    ExprVector rejectedHere;
+    const ScanHandle* handle = builder().takeScanHandle(
+        ScanHandle::build(
+            baseTable,
+            outputColumns,
+            filters,
+            session_,
+            evaluator_,
+            rejectedHere));
+    appendAll(rejected, rejectedHere);
+    negotiatedByBaseTableId_.emplace(
+        baseTable.id(), Negotiated{handle, filters, std::move(rejectedHere)});
+    return handle;
   }
 
   NodeCP rewriteValues(const Values* node, PushdownContext& context) override {
@@ -1124,6 +1221,9 @@ class Pushdown : public NodeRewriter<PushdownContext> {
   NodeCP rewriteSort(const Sort* node, PushdownContext& context) override {
     context.required.unionColumns(node->orderKeys());
     context.requiredAbove.unionColumns(node->orderKeys());
+    // A Sort outputs its input's columns, so it is not the consumer the flag
+    // describes.
+    context.consumerDropsExtraColumns = false;
     NodeCP newInput = rewrite(node->input(), context);
     if (newInput == node->input()) {
       return node;
@@ -1642,6 +1742,11 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     child.required.unionColumns(node->columnExprs());
     child.requiredAbove = child.required;
     child.nonNullColumns = context.nonNullColumns;
+    // A delete reads no column values: the connector's handle says which rows
+    // go. An insert writes its input columns, so only a delete can take a
+    // wider input.
+    child.consumerDropsExtraColumns =
+        node->kind() == connector::WriteKind::kDelete;
     return NodeRewriter::rewriteTableWrite(node, child);
   }
 
@@ -1770,7 +1875,22 @@ class Pushdown : public NodeRewriter<PushdownContext> {
   }
 
   ExprFactory exprs_;
+  velox::core::ExpressionEvaluator& evaluator_;
+  const OptimizerSession& session_;
+  const PushdownAndPrunePass::ConnectorPushdown connectorPushdown_;
   ExprSimplifier simplifier_;
+
+  // Outcome of one negotiation with the connector.
+  struct Negotiated {
+    const ScanHandle* handle;
+    // The conjuncts offered, and of those the ones the connector rejected,
+    // which the plan applies itself.
+    ExprVector filters;
+    ExprVector rejected;
+  };
+
+  // One negotiation per base table, by base-table id.
+  folly::F14FastMap<int32_t, Negotiated> negotiatedByBaseTableId_;
 };
 
 } // namespace
@@ -1779,8 +1899,10 @@ NodeCP PushdownAndPrunePass::run(
     NodeCP root,
     const ColumnVector& outputColumns,
     Builder& builder,
-    velox::core::ExpressionEvaluator& evaluator) {
-  Pushdown pass{builder, evaluator};
+    velox::core::ExpressionEvaluator& evaluator,
+    const OptimizerSession& session,
+    ConnectorPushdown connectorPushdown) {
+  Pushdown pass{builder, evaluator, session, connectorPushdown};
   PushdownContext context;
   context.required = PlanObjectSet::fromObjects(outputColumns);
   context.requiredAbove = context.required;

--- a/axiom/optimizer/v2/PushdownAndPrunePass.h
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "axiom/optimizer/OptimizerSession.h"
 #include "axiom/optimizer/v2/Builder.h"
 #include "axiom/optimizer/v2/Node.h"
 #include "velox/core/ExpressionEvaluator.h"
@@ -56,14 +57,26 @@ namespace facebook::axiom::optimizer::v2 {
 ///  - `Apply` must already be gone: decorrelate removes every `Apply` before
 ///    this pass, so encountering one is a logic error.
 ///
-/// Post-condition: no `Filter` node sits directly above a `Scan`. Every
-/// conjunct that reaches a `Scan` is absorbed into `Scan.filters`; which of
-/// those the connector can actually evaluate is decided later (at Emit), and
-/// connector-rejected filters reappear as a `Filter` above the `TableScan` only
-/// in the final Velox plan. A rewrite running after this pass can therefore
-/// treat a `Scan` as carrying all of its predicates.
+/// Post-condition: every conjunct that reaches a `Scan` is offered to the
+/// connector. The ones it takes go into the `ScanHandle` the `Scan` points at.
+/// The ones it rejects stay in a single `Filter` directly above the `Scan`,
+/// which then also outputs the columns they read, narrowed by a `Project` when
+/// nothing above wants them and the consumer is not itself a `Project`. A
+/// rewrite running after this pass sees the nodes the query will run.
 class PushdownAndPrunePass {
  public:
+  /// Whether the conjuncts that reach a `Scan` are offered to the connector.
+  enum class ConnectorPushdown {
+    /// Offer them; the `Scan` comes out pointing at the resulting handle.
+    kOffer,
+    /// Do not call the connector. Every conjunct stays in a `Filter` over the
+    /// `Scan` and the `Scan` has no handle, so the result says which
+    /// predicates the query applies to each table without committing to a way
+    /// of reading it. This is what EXPLAIN (TYPE IO) reports, and a plan
+    /// produced this way cannot be emitted.
+    kSkip,
+  };
+
   /// Returns `root` rewritten as described in the class doc. `evaluator` backs
   /// the expression simplifier used to fold conjuncts after substitution (and
   /// to detect ones that reduce to constant `false`).
@@ -74,7 +87,9 @@ class PushdownAndPrunePass {
       NodeCP root,
       const ColumnVector& outputColumns,
       Builder& builder,
-      velox::core::ExpressionEvaluator& evaluator);
+      velox::core::ExpressionEvaluator& evaluator,
+      const OptimizerSession& session,
+      ConnectorPushdown connectorPushdown);
 };
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ScanHandle.cpp
+++ b/axiom/optimizer/v2/ScanHandle.cpp
@@ -23,69 +23,76 @@
 namespace facebook::axiom::optimizer::v2 {
 
 ScanHandle ScanHandle::build(
-    const Scan& scan,
+    const BaseTable& baseTable,
+    const ColumnVector& outputColumns,
+    const ExprVector& filters,
     const OptimizerSession& session,
-    velox::core::ExpressionEvaluator& evaluator) {
-  const auto* baseTable = scan.baseTable();
-  const auto* layout = baseTable->schemaTable->columnGroups[0]->layout;
+    velox::core::ExpressionEvaluator& evaluator,
+    ExprVector& rejected) {
+  const auto* layout = baseTable.schemaTable->columnGroups[0]->layout;
   auto connectorSession =
       session.toConnectorSession(layout->connector()->connectorId());
 
   // Read schema is the consumer output columns plus the columns referenced
-  // only by filters; the latter keep their schema names.
+  // only by filters.
   folly::F14FastSet<Name> seenSchemaNames;
-  const ColumnVector& consumerColumns = scan.outputColumns();
-  for (ColumnCP column : consumerColumns) {
+  for (ColumnCP column : outputColumns) {
     seenSchemaNames.insert(column->name());
   }
   ColumnVector filterOnlyColumns;
   PlanObjectSet filterColumns;
-  filterColumns.unionColumns(scan.filters());
+  filterColumns.unionColumns(filters);
   filterColumns.forEach<Column>([&](ColumnCP column) {
     if (seenSchemaNames.insert(column->name()).second) {
       filterOnlyColumns.push_back(column);
     }
   });
 
-  std::vector<velox::connector::ColumnHandlePtr> columnHandles;
-  columnHandles.reserve(consumerColumns.size() + filterOnlyColumns.size());
-  for (ColumnCP column : consumerColumns) {
-    columnHandles.push_back(layout->createColumnHandle(
-        connectorSession, column->name(), /*subfields=*/{}));
+  const size_t numColumns = outputColumns.size() + filterOnlyColumns.size();
+  std::vector<velox::connector::ColumnHandlePtr> readSchema;
+  readSchema.reserve(numColumns);
+  const auto addHandle = [&](ColumnCP column) {
+    auto handle = layout->createColumnHandle(
+        connectorSession, column->name(), /*subfields=*/{});
+    readSchema.push_back(handle);
+    return handle;
+  };
+
+  folly::F14FastMap<ColumnCP, velox::connector::ColumnHandlePtr> columnHandles;
+  columnHandles.reserve(outputColumns.size());
+  for (ColumnCP column : outputColumns) {
+    columnHandles.emplace(column, addHandle(column));
   }
+  // Kept aside: a filter-only column belongs in the returned map only if the
+  // connector rejects the conjunct that reads it, which puts the column in the
+  // scan's output. That is not known until the handle is built.
+  std::vector<std::pair<ColumnCP, velox::connector::ColumnHandlePtr>>
+      filterOnlyHandles;
+  filterOnlyHandles.reserve(filterOnlyColumns.size());
   for (ColumnCP column : filterOnlyColumns) {
-    columnHandles.push_back(layout->createColumnHandle(
-        connectorSession, column->name(), /*subfields=*/{}));
+    filterOnlyHandles.emplace_back(column, addHandle(column));
   }
 
-  // Build the filters as TypedExpr, keeping an aligned ExprCP list.
-  // createTableHandle reports the rejected filters by index into this list, so
-  // each can be mapped back to its ExprCP for the optimizer to post-apply its
-  // selectivity.
+  // createTableHandle reports the rejected filters by index into the vector it
+  // is given, so the TypedExprs stay aligned with 'filters'.
   ExprEmitter exprEmitter{evaluator.pool()};
-  ExprVector conjunctExprs;
-  std::vector<velox::core::TypedExprPtr> filters;
-  filters.reserve(scan.filters().size());
-  for (ExprCP filter : scan.filters()) {
-    conjunctExprs.push_back(filter);
-    filters.push_back(
+  std::vector<velox::core::TypedExprPtr> typedFilters;
+  typedFilters.reserve(filters.size());
+  for (ExprCP filter : filters) {
+    typedFilters.push_back(
         exprEmitter.toTypedExpr(filter, ColumnNaming::kSchemaName));
   }
-  std::vector<velox::core::TypedExprPtr> allConjuncts = filters;
-
   std::vector<int32_t> rejectedFilterIndices;
   velox::connector::ConnectorTableHandlePtr tableHandle =
       layout->createTableHandle(
           connectorSession,
-          columnHandles,
+          std::move(readSchema),
           evaluator,
-          std::move(filters),
+          std::move(typedFilters),
           rejectedFilterIndices);
 
-  // Each rejected index selects a conjunct to apply as a Filter above the scan
-  // (as TypedExpr) and to post-apply selectivity for (as ExprCP).
-  std::vector<velox::core::TypedExprPtr> rejectedFilters;
-  ExprVector rejectedExprs;
+  // Each rejected index selects a conjunct the caller must apply above the
+  // scan; the rest are the connector's responsibility, inside 'tableHandle'.
   for (int32_t index : rejectedFilterIndices) {
     VELOX_CHECK_GE(
         index,
@@ -93,37 +100,23 @@ ScanHandle ScanHandle::build(
         "createTableHandle returned a negative rejected filter index");
     VELOX_CHECK_LT(
         index,
-        static_cast<int32_t>(conjunctExprs.size()),
+        static_cast<int32_t>(filters.size()),
         "createTableHandle returned an out-of-range rejected filter index");
-    rejectedFilters.push_back(allConjuncts[index]);
-    rejectedExprs.push_back(conjunctExprs[index]);
+    rejected.push_back(filters[index]);
+  }
+
+  PlanObjectSet rejectedColumns;
+  rejectedColumns.unionColumns(rejected);
+  for (auto& [column, handle] : filterOnlyHandles) {
+    if (rejectedColumns.contains(column)) {
+      columnHandles.emplace(column, std::move(handle));
+    }
   }
 
   return ScanHandle{
       .tableHandle = std::move(tableHandle),
       .columnHandles = std::move(columnHandles),
-      .filterOnlyColumns = std::move(filterOnlyColumns),
-      .rejectedFilters = std::move(rejectedFilters),
-      .rejectedExprs = std::move(rejectedExprs),
   };
-}
-
-const ScanHandle& ScanHandleCache::getOrBuild(
-    const Scan& scan,
-    const OptimizerSession& session,
-    velox::core::ExpressionEvaluator& evaluator) {
-  const int32_t id = scan.baseTable()->id();
-  auto it = byBaseTableId_.find(id);
-  if (it != byBaseTableId_.end()) {
-    return it->second;
-  }
-  return byBaseTableId_.emplace(id, ScanHandle::build(scan, session, evaluator))
-      .first->second;
-}
-
-const ScanHandle* ScanHandleCache::find(const Scan& scan) const {
-  auto it = byBaseTableId_.find(scan.baseTable()->id());
-  return it != byBaseTableId_.end() ? &it->second : nullptr;
 }
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ScanHandle.h
+++ b/axiom/optimizer/v2/ScanHandle.h
@@ -16,69 +16,38 @@
 
 #pragma once
 
+#include <folly/container/F14Map.h>
+
 #include "axiom/optimizer/OptimizerSession.h"
-#include "axiom/optimizer/v2/Node.h"
+#include "axiom/optimizer/QueryGraph.h"
 #include "velox/connectors/Connector.h"
 #include "velox/core/Expressions.h"
 
 namespace facebook::axiom::optimizer::v2 {
 
-/// Connector access for a scanned leaf table, built once from a `Scan` and
-/// reused by both the filtered-stats pass (`estimateLeafStats`) and `emit`.
-/// Building the handle calls into the connector to push filters down, so it
-/// must not be repeated per consumer.
+/// Connector access for a scanned leaf table: the result of negotiating filter
+/// pushdown with the connector. Made once, by the pushdown pass, and pointed
+/// at by the `Scan` from there on.
 struct ScanHandle {
-  /// Builds the connector handle for `scan`'s base table. Calls into the
-  /// connector to push filters down.
+  /// Offers 'filters' to the connector for reading 'outputColumns' of
+  /// 'baseTable' and returns the handle it builds. Calls into the connector.
+  /// Appends to 'rejected' the conjuncts the connector rejected, which the
+  /// caller must apply itself.
   static ScanHandle build(
-      const Scan& scan,
+      const BaseTable& baseTable,
+      const ColumnVector& outputColumns,
+      const ExprVector& filters,
       const OptimizerSession& session,
-      velox::core::ExpressionEvaluator& evaluator);
+      velox::core::ExpressionEvaluator& evaluator,
+      ExprVector& rejected);
 
   /// Table handle with the accepted filters pushed into the connector.
   velox::connector::ConnectorTableHandlePtr tableHandle;
 
-  /// Column handles for the connector read schema: the scan's consumer output
-  /// columns first (in `scan->outputColumns()` order), then `filterOnlyColumns`
-  /// (aligned with the tail).
-  std::vector<velox::connector::ColumnHandlePtr> columnHandles;
-
-  /// Columns referenced only by filters and not in the scan output. Read by the
-  /// connector but, unless referenced by a rejected filter, projected away.
-  ColumnVector filterOnlyColumns;
-
-  /// Filters the connector could not push down; applied as a `Filter` above the
-  /// `TableScan` at emit time.
-  std::vector<velox::core::TypedExprPtr> rejectedFilters;
-
-  /// The createTableHandle-rejected filters as ExprCP. The connector accounts
-  /// for the accepted filters in co_estimateStats; the optimizer post-applies
-  /// selectivity for these.
-  ExprVector rejectedExprs;
-};
-
-/// Caches one `ScanHandle` per base table, keyed by base-table id. `getOrBuild`
-/// is the writing path; `find` is read-only.
-///
-///   ScanHandleCache cache;
-///   const ScanHandle& handle = cache.getOrBuild(scan, session, evaluator);
-///   ...
-///   const ScanHandle* cached = cache.find(scan);
-class ScanHandleCache {
- public:
-  /// Returns the cached `ScanHandle` for `scan`'s base table, building and
-  /// caching it on first access.
-  const ScanHandle& getOrBuild(
-      const Scan& scan,
-      const OptimizerSession& session,
-      velox::core::ExpressionEvaluator& evaluator);
-
-  /// Returns the cached handle for `scan`'s base table, or nullptr if none was
-  /// built.
-  const ScanHandle* find(const Scan& scan) const;
-
- private:
-  folly::F14FastMap<int32_t, ScanHandle> byBaseTableId_;
+  /// Column handle per column of the connector read schema: every column the
+  /// `Scan` outputs, plus the ones only the connector's own filters read,
+  /// which it reads without projecting.
+  folly::F14FastMap<ColumnCP, velox::connector::ColumnHandlePtr> columnHandles;
 };
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -794,8 +794,7 @@ Translated Translator::translateScan(
     outputColumns.push_back(column);
     scope[outName] = column;
   }
-  ScanCP scanNode = builder_.make<Scan>(
-      {baseTable, std::move(outputColumns), /*filters=*/{}});
+  ScanCP scanNode = builder_.make<Scan>({baseTable, std::move(outputColumns)});
   return {scanNode, std::move(scope)};
 }
 
@@ -2813,14 +2812,19 @@ ExprCP Translator::tryFoldConstantScalar(NodeCP body) {
     return nullptr;
   }
 
-  // Build a table handle carrying the subquery's filters so the connector
-  // narrows the listing. Translate has not pushed the filters into the Scan
-  // yet, so synthesize a Scan that carries them.
+  // Offer the subquery's filters to the connector so it narrows the listing.
+  // Which of them it takes does not matter: the Filter below re-applies all of
+  // them, so 'rejected' is not read.
   const ExprVector& filters =
       filter != nullptr ? filter->predicates() : ExprVector{};
-  const Scan* scanWithFilters = builder_.make<Scan>(
-      Scan::Key{scan->baseTable(), scan->outputColumns(), filters});
-  ScanHandle handle = ScanHandle::build(*scanWithFilters, session_, evaluator_);
+  ExprVector rejected;
+  ScanHandle handle = ScanHandle::build(
+      *scan->baseTable(),
+      scan->outputColumns(),
+      filters,
+      session_,
+      evaluator_,
+      rejected);
 
   auto connectorSession =
       session_.toConnectorSession(discreteLayout.layout->connectorId());
@@ -2832,8 +2836,8 @@ ExprCP Translator::tryFoldConstantScalar(NodeCP body) {
 
   // Build a small plan that aggregates the listed partition values:
   // Values(tuples) -> [Filter] -> Aggregate, reusing the subquery's own Filter
-  // and Aggregate specs. The Filter re-applies conjuncts the connector could
-  // not push.
+  // and Aggregate specs. The Filter re-applies every conjunct; one the listing
+  // already reflects removes nothing the second time.
   auto values = toValues(*discretePredicates);
   const Values* valuesNode = builder_.makeValues(
       /*source=*/nullptr,
@@ -2861,9 +2865,8 @@ ExprCP Translator::tryFoldConstantScalar(NodeCP body) {
   std::vector<std::string> outputNames{std::string(outputColumns[0]->name())};
 
   // Lower the mini-plan through the shared physical-planning and emit passes,
-  // then run it. It has a Values source and no Scan, so an empty handle cache
-  // and single-node options suffice.
-  ScanHandleCache scanHandles;
+  // then run it. It has a Values source and no Scan, so single-node options
+  // suffice.
   EmitPass::Result emitted = physicalPlanAndEmit(
       foldAggregate,
       outputColumns,
@@ -2871,7 +2874,6 @@ ExprCP Translator::tryFoldConstantScalar(NodeCP body) {
       builder_,
       session_,
       evaluator_,
-      scanHandles,
       MultiFragmentPlan::Options::singleNode());
   VELOX_CHECK_EQ(
       emitted.fragments.size(), 1, "Constant fold must produce one fragment");

--- a/axiom/optimizer/v2/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/v2/tests/TpchPlanTest.cpp
@@ -125,30 +125,35 @@ TEST_F(TpchPlanTest, q02) {
   //
   // region appears on both the outer and subquery sides, so bind its r_name to
   // a stable alias rather than the per-side disambiguated name.
-  auto supplierInEurope = [](const std::string& regionName) {
+  auto supplierInEurope = [](const std::string& regionName,
+                             const std::string& regionKeyName) {
     return matchScan("supplier")
         .hashJoinInner(matchScan("nation").hashJoinInner(
             matchScan("region")
-                .aliases({std::nullopt, regionName})
-                .filter(regionName + " = 'EUROPE'")));
+                .aliases({regionKeyName, regionName})
+                .filter(regionName + " = 'EUROPE'")
+                .project({regionKeyName})));
   };
 
   // The outer query's table tree: partsupp joined to the filtered part and to
   // supplier in Europe.
-  auto outerTables = matchScan("partsupp")
-                         .hashJoinInner(matchScan("part").filter(
-                             "p_size = 15 and p_type like '%BRASS'"))
-                         .hashJoinInner(supplierInEurope("r_name_outer"));
+  auto outerTables =
+      matchScan("partsupp")
+          .hashJoinInner(matchScan("part")
+                             .filter("p_size = 15 and p_type like '%BRASS'")
+                             .project({"p_partkey", "p_mfgr"}))
+          .hashJoinInner(supplierInEurope("r_name_outer", "r_regionkey_outer"));
 
   // The aggregated subquery min(ps_supplycost) per ps_partkey, joined back to
   // the outer table tree.
-  auto matcher = matchScan("partsupp")
-                     .hashJoinInner(supplierInEurope("r_name_sub"))
-                     .aggregation()
-                     .hashJoinInner(outerTables)
-                     .project()
-                     .topN()
-                     .build();
+  auto matcher =
+      matchScan("partsupp")
+          .hashJoinInner(supplierInEurope("r_name_sub", "r_regionkey_sub"))
+          .aggregation()
+          .hashJoinInner(outerTables)
+          .project()
+          .topN()
+          .build();
   AXIOM_ASSERT_PLAN(planTpch(2), matcher);
 
   ASSERT_NO_THROW(planTpchMultiNode({.query = 2, .numDrivers = 1}));
@@ -159,11 +164,13 @@ TEST_F(TpchPlanTest, q03) {
   auto matcher =
       matchScan("lineitem")
           .filter("l_shipdate > date '1995-03-15'")
+          .project({"l_orderkey", "l_extendedprice", "l_discount"})
           .hashJoinInner(
               matchScan("orders")
                   .filter("o_orderdate < date '1995-03-15'")
                   .hashJoinInner(matchScan("customer")
-                                     .filter("c_mktsegment = 'BUILDING'")))
+                                     .filter("c_mktsegment = 'BUILDING'")
+                                     .project({"c_custkey"})))
           .project()
           .aggregation()
           .project()
@@ -179,8 +186,12 @@ TEST_F(TpchPlanTest, q04) {
   auto matcher =
       matchScan("lineitem")
           .filter("l_commitdate < l_receiptdate")
-          .hashJoinRightSemiFilter(matchScan("orders").filter(
-              "o_orderdate >= date '1993-07-01' and o_orderdate < date '1993-10-01'"))
+          .project({"l_orderkey"})
+          .hashJoinRightSemiFilter(
+              matchScan("orders")
+                  .filter(
+                      "o_orderdate >= date '1993-07-01' and o_orderdate < date '1993-10-01'")
+                  .project({"o_orderkey", "o_orderpriority"}))
           .aggregation()
           .orderBy()
           .build();
@@ -203,10 +214,13 @@ TEST_F(TpchPlanTest, q05) {
                   .filter(
                       "o_orderdate >= date '1994-01-01' "
                       "and o_orderdate < date '1995-01-01'")
+                  .project({"o_orderkey", "o_custkey"})
                   .hashJoinInner(
                       matchScan("customer")
                           .hashJoinInner(matchScan("nation").hashJoinInner(
-                              matchScan("region").filter("r_name = 'ASIA'")))))
+                              matchScan("region")
+                                  .filter("r_name = 'ASIA'")
+                                  .project({"r_regionkey"})))))
           .hashJoinInner(matchScan("supplier"))
           .project()
           .aggregation()
@@ -299,14 +313,18 @@ TEST_F(TpchPlanTest, q08) {
               matchScan("orders")
                   .filter(
                       "o_orderdate between date '1995-01-01' and date '1996-12-31'")
-                  .hashJoinInner(matchScan("lineitem")
-                                     .hashJoinInner(matchScan("part").filter(
-                                         "p_type = 'ECONOMY ANODIZED STEEL'")))
+                  .hashJoinInner(
+                      matchScan("lineitem")
+                          .hashJoinInner(
+                              matchScan("part")
+                                  .filter("p_type = 'ECONOMY ANODIZED STEEL'")
+                                  .project({"p_partkey"})))
                   .hashJoinInner(
                       matchScan("customer")
                           .hashJoinInner(matchScan("nation").hashJoinInner(
-                              matchScan("region").filter(
-                                  "r_name = 'AMERICA'")))))
+                              matchScan("region")
+                                  .filter("r_name = 'AMERICA'")
+                                  .project({"r_regionkey"})))))
           .hashJoinInner(matchScan("nation"))
           .project()
           .aggregation()
@@ -340,9 +358,11 @@ TEST_F(TpchPlanTest, q09Alt) {
       matchScan("orders")
           .hashJoinInner(
               matchScan("lineitem")
-                  .hashJoinInner(matchScan("partsupp")
-                                     .hashJoinInner(matchScan("part").filter(
-                                         "p_size <= 3"))))
+                  .hashJoinInner(
+                      matchScan("partsupp")
+                          .hashJoinInner(matchScan("part")
+                                             .filter("p_size <= 3")
+                                             .project({"p_partkey"}))))
           .hashJoinInner(
               matchScan("supplier").hashJoinInner(matchScan("nation")))
           .project()
@@ -364,11 +384,15 @@ TEST_F(TpchPlanTest, q10) {
   // joins last.
   auto matcher =
       matchScan("customer")
-          .hashJoinInner(matchScan("lineitem")
-                             .filter("l_returnflag = 'R'")
-                             .hashJoinInner(matchScan("orders").filter(
-                                 "o_orderdate >= date '1993-10-01' "
-                                 "and o_orderdate < date '1994-01-01'")))
+          .hashJoinInner(
+              matchScan("lineitem")
+                  .filter("l_returnflag = 'R'")
+                  .project({"l_orderkey", "l_extendedprice", "l_discount"})
+                  .hashJoinInner(matchScan("orders")
+                                     .filter(
+                                         "o_orderdate >= date '1993-10-01' "
+                                         "and o_orderdate < date '1994-01-01'")
+                                     .project({"o_orderkey", "o_custkey"})))
           .hashJoinInner(matchScan("nation"))
           .project(
               {"c_custkey",
@@ -414,8 +438,9 @@ TEST_F(TpchPlanTest, q11) {
         return partsupp.hashJoinInner(
             matchScan("supplier")
                 .hashJoinInner(matchScan("nation")
-                                   .aliases({std::nullopt, nationName})
-                                   .filter(nationName + " = 'GERMANY'")));
+                                   .aliases({"n_nationkey", nationName})
+                                   .filter(nationName + " = 'GERMANY'")
+                                   .project({"n_nationkey"})));
       };
 
   auto matcher =
@@ -444,7 +469,9 @@ TEST_F(TpchPlanTest, q12) {
       "         l_receiptdate < date '1995-01-01')";
 
   auto matcher = matchScan("orders")
-                     .hashJoinInner(matchScan("lineitem").filter(filter))
+                     .hashJoinInner(matchScan("lineitem")
+                                        .filter(filter)
+                                        .project({"l_orderkey", "l_shipmode"}))
                      .project()
                      .aggregation()
                      .orderBy()
@@ -454,7 +481,10 @@ TEST_F(TpchPlanTest, q12) {
   auto distributed = [&](bool isMultiThreaded) {
     return matchScan("orders")
         .multiThreaded(isMultiThreaded)
-        .hashJoinInner(matchScan("lineitem").filter(filter).broadcast())
+        .hashJoinInner(matchScan("lineitem")
+                           .filter(filter)
+                           .project({"l_orderkey", "l_shipmode"})
+                           .broadcast())
         .project({
             "l_shipmode",
             "if(o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH', 1, 0) as high_line_count",
@@ -487,6 +517,7 @@ TEST_F(TpchPlanTest, q13) {
   auto matcher =
       matchScan("orders")
           .filter("o_comment not like '%special%requests%'")
+          .project({"o_orderkey", "o_custkey"})
           .hashJoinRight(matchScan("customer"))
           .singleAggregation({"c_custkey"}, {"count(o_orderkey) as cnt"})
           .project()
@@ -503,18 +534,26 @@ TEST_F(TpchPlanTest, q13) {
 TEST_F(TpchPlanTest, q14) {
   const auto filter =
       "l_shipdate >= date '1995-09-01' and l_shipdate < date '1995-10-01'";
-  auto matcher = matchScan("part")
-                     .hashJoinInner(matchScan("lineitem").filter(filter))
-                     .project()
-                     .aggregation()
-                     .project()
-                     .build();
+  auto matcher =
+      matchScan("part")
+          .hashJoinInner(
+              matchScan("lineitem")
+                  .filter(filter)
+                  .project({"l_partkey", "l_extendedprice", "l_discount"}))
+          .project()
+          .aggregation()
+          .project()
+          .build();
   AXIOM_ASSERT_PLAN(planTpch(14), matcher);
 
   auto distributed = [&](bool isMultiThreaded) {
     return matchScan("part")
         .multiThreaded(isMultiThreaded)
-        .hashJoinInner(matchScan("lineitem").filter(filter).broadcast())
+        .hashJoinInner(
+            matchScan("lineitem")
+                .filter(filter)
+                .project({"l_partkey", "l_extendedprice", "l_discount"})
+                .broadcast())
         .project({
             "if(p_type like 'PROMO%', l_extendedprice * (1.0 - l_discount), 0.0) as promo",
             "l_extendedprice * (1.0 - l_discount) as disc_price",
@@ -556,7 +595,7 @@ TEST_F(TpchPlanTest, q15) {
                   revenueAgg({"l_suppkey",
                               "l_extendedprice",
                               "l_discount",
-                              std::nullopt})
+                              "l_shipdate"})
                       .project()
                       .singleAggregation({}, {"max(total_revenue) as maxRev"})))
           .orderBy({"s_suppkey"})
@@ -576,7 +615,8 @@ TEST_F(TpchPlanTest, q16) {
                      .hashJoinInner(matchScan("part").filter(partFilter))
                      .hashJoinAnti(
                          matchScan("supplier")
-                             .filter("s_comment like '%Customer%Complaints%'"),
+                             .filter("s_comment like '%Customer%Complaints%'")
+                             .project({"s_suppkey"}),
                          {.nullAware = true})
                      .singleAggregation(
                          {"p_brand", "p_type", "p_size"},
@@ -593,6 +633,7 @@ TEST_F(TpchPlanTest, q16) {
             .hashJoinAnti(
                 matchScan("supplier")
                     .filter("s_comment like '%Customer%Complaints%'")
+                    .project({"s_suppkey"})
                     .broadcast(),
                 {.nullAware = true})
             .shuffle({"p_brand", "p_type", "p_size"});
@@ -624,8 +665,11 @@ TEST_F(TpchPlanTest, q17) {
           .hashJoinInner(
               matchScan("lineitem")
                   .aggregation()
-                  .hashJoinRight(matchScan("part").filter(
-                      "p_brand = 'Brand#23' and p_container = 'MED BOX'")))
+                  .hashJoinRight(
+                      matchScan("part")
+                          .filter(
+                              "p_brand = 'Brand#23' and p_container = 'MED BOX'")
+                          .project({"p_partkey"})))
           .filter()
           .project()
           .aggregation()
@@ -678,6 +722,7 @@ TEST_F(TpchPlanTest, q19) {
               "(l_quantity >= 1.0 and l_quantity <= 11.0) or "
               "(l_quantity >= 10.0 and l_quantity <= 20.0) or "
               "(l_quantity >= 20.0 and l_quantity <= 30.0))")
+          .project({"l_partkey", "l_quantity", "l_extendedprice", "l_discount"})
           .hashJoinInner(matchScan("part").filter(
               "(p_brand = 'Brand#12' and p_container in ('SM CASE', "
               "'SM BOX', 'SM PACK', 'SM PKG') and p_size between 1 and 5) or "
@@ -705,18 +750,22 @@ TEST_F(TpchPlanTest, q20) {
       matchScan("lineitem")
           .filter(
               "l_shipdate >= date '1994-01-01' and l_shipdate < date '1995-01-01'")
+          .project({"l_partkey", "l_suppkey", "l_quantity"})
           .aggregation()
           .hashJoinRight(matchScan("partsupp")
-                             .hashJoinLeftSemiProject(matchScan("part").filter(
-                                 "like(p_name, 'forest%')"))
+                             .hashJoinLeftSemiProject(
+                                 matchScan("part")
+                                     .filter("like(p_name, 'forest%')")
+                                     .project({"p_partkey"}))
                              .filter("mark1"))
           // TODO Optimize if(true, sum * 0.5, null) to sum * 0.5.
           .filter("cast(ps_availqty as double) > if(true, sum * 0.5, null)")
           .project()
           .hashJoinRightSemiFilter(
               matchScan("supplier")
-                  .hashJoinInner(
-                      matchScan("nation").filter("n_name = 'CANADA'")))
+                  .hashJoinInner(matchScan("nation")
+                                     .filter("n_name = 'CANADA'")
+                                     .project({"n_nationkey"})))
           .orderBy()
           .project()
           .build();
@@ -736,22 +785,27 @@ TEST_F(TpchPlanTest, q21) {
           .hashJoinRightSemiFilter(
               matchScan("lineitem")
                   .aliases(
-                      {std::nullopt,
-                       std::nullopt,
+                      {"l_orderkey",
+                       "l_suppkey",
                        "l_commitdate",
                        "l_receiptdate"})
                   .filter("l_commitdate < l_receiptdate")
+                  .project({"l_orderkey", "l_suppkey"})
                   .hashJoinRightSemiProject(
                       matchScan("orders")
                           .filter("o_orderstatus = 'F'")
+                          .project({"o_orderkey"})
                           .hashJoinInner(
                               matchScan("lineitem")
                                   .filter("l_commitdate < l_receiptdate")
+                                  .project({"l_orderkey", "l_suppkey"})
                                   .hashJoinInner(
                                       matchScan("supplier")
                                           .hashJoinInner(
-                                              matchScan("nation").filter(
-                                                  "n_name = 'SAUDI ARABIA'")))))
+                                              matchScan("nation")
+                                                  .filter(
+                                                      "n_name = 'SAUDI ARABIA'")
+                                                  .project({"n_nationkey"})))))
                   // Bind the semijoin's trailing mark column by position rather
                   // than its internal name.
                   .aliases({std::nullopt, std::nullopt, std::nullopt, "mark"})
@@ -780,8 +834,9 @@ TEST_F(TpchPlanTest, q22) {
                   .filter(countryFilter)
                   .nestedLoopJoin(
                       matchScan("customer")
-                          .aliases({"c_acctbal", std::nullopt})
+                          .aliases({"c_acctbal", "c_phone"})
                           .filter("c_acctbal > 0.0 and " + countryFilter)
+                          .project({"c_acctbal"})
                           .aggregation()))
           .aliases({std::nullopt, std::nullopt, std::nullopt, "mark"})
           .filter("not(mark)")


### PR DESCRIPTION
Summary:

A predicate the connector refuses used to be invisible in the IR. It was discovered at Emit, which rebuilt it into a Velox `FilterNode` over the `TableScan`. Every pass in between saw a `Scan` that appeared to apply all of its predicates, and costed it that way. The pushdown pass now asks the connector as the conjuncts reach the table, and the refused ones become a `Filter` above the `Scan`, so join ordering and physical planning see the nodes the query will run.

`Scan` carries a `const ScanHandle*` — the connector's table and column handles — in place of its `ExprVector` of filters. A `Scan` whose filter was refused also outputs the columns that filter reads, and a `Project` narrows them away when nothing above wants them.

Emit no longer reconstructs any of this. Removes the walker that recovered a refused filter's columns from Velox expressions, along with its lambda-scope bookkeeping, and the handle cache that existed because Emit built handles per consumer.

EXPLAIN (TYPE IO) runs the pass with connector negotiation off. It reports the predicates the query applies to each table without asking a connector how it would read it, and no longer omits the ones a connector would have refused.

Reviewed By: xiaoxmeng

Differential Revision: D116653996
