### PR TITLE
refactor: Drop the prefix from TrackedExecutor::reportTo

### DIFF
--- a/axiom/common/CMakeLists.txt
+++ b/axiom/common/CMakeLists.txt
@@ -28,4 +28,4 @@ add_library(
   SessionConfig.cpp
 )
 
-target_link_libraries(axiom_common velox_common_base velox_config_property Folly::folly)
+target_link_libraries(axiom_common velox_common_base velox_config_property Folly::folly fmt::fmt)

--- a/axiom/common/QueryRuntimeStats.cpp
+++ b/axiom/common/QueryRuntimeStats.cpp
@@ -16,6 +16,8 @@
 
 #include "axiom/common/QueryRuntimeStats.h"
 
+#include <fmt/format.h>
+
 namespace facebook::axiom {
 
 namespace {
@@ -54,6 +56,22 @@ ScopedCpuWallStatsTimer::~ScopedCpuWallStatsTimer() {
   }
   auto wallElapsed = std::chrono::steady_clock::now() - wallStart_;
   stats_.addTiming(wallMetricName_, wallElapsed);
+}
+
+void PrefixedRuntimeStatWriter::addRuntimeStat(
+    std::string_view name,
+    const velox::RuntimeCounter& value) {
+  writer_.addRuntimeStat(prefixed(name), value);
+}
+
+void PrefixedRuntimeStatWriter::setRuntimeStat(
+    std::string_view name,
+    const velox::RuntimeMetric& metric) {
+  writer_.setRuntimeStat(prefixed(name), metric);
+}
+
+std::string PrefixedRuntimeStatWriter::prefixed(std::string_view name) const {
+  return fmt::format("{}-{}", prefix_, name);
 }
 
 } // namespace facebook::axiom

--- a/axiom/common/QueryRuntimeStats.h
+++ b/axiom/common/QueryRuntimeStats.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <chrono>
+#include <string>
 #include <string_view>
 #include <thread>
 
@@ -89,6 +90,28 @@ class QueryRuntimeStats : public velox::ConcurrentRuntimeStatWriter {
   /// Serializes all metrics to folly::dynamic for Scribe logging. Format:
   /// {"metricName": {"sum": N, "count": N, "min": N, "max": N, "unit": "..."}}
   folly::dynamic toDynamic() const;
+};
+
+/// Forwards every stat to 'writer' under "<prefix>-<name>", so several
+/// components recording into one store keep their samples apart.
+class PrefixedRuntimeStatWriter : public velox::BaseRuntimeStatWriter {
+ public:
+  PrefixedRuntimeStatWriter(
+      velox::BaseRuntimeStatWriter& writer,
+      std::string_view prefix)
+      : writer_{writer}, prefix_{prefix} {}
+
+  void addRuntimeStat(std::string_view name, const velox::RuntimeCounter& value)
+      override;
+
+  void setRuntimeStat(std::string_view name, const velox::RuntimeMetric& metric)
+      override;
+
+ private:
+  std::string prefixed(std::string_view name) const;
+
+  velox::BaseRuntimeStatWriter& writer_;
+  const std::string prefix_;
 };
 
 /// RAII timer that records a wall-clock duration into QueryRuntimeStats on

--- a/axiom/common/tests/CMakeLists.txt
+++ b/axiom/common/tests/CMakeLists.txt
@@ -22,4 +22,4 @@ add_executable(
 
 add_test(axiom_common_tests axiom_common_tests)
 
-target_link_libraries(axiom_common_tests axiom_common GTest::gtest GTest::gtest_main)
+target_link_libraries(axiom_common_tests axiom_common GTest::gmock GTest::gtest GTest::gtest_main)

--- a/axiom/common/tests/QueryRuntimeStatsTest.cpp
+++ b/axiom/common/tests/QueryRuntimeStatsTest.cpp
@@ -18,6 +18,7 @@
 
 #include <folly/BenchmarkUtil.h>
 #include <folly/dynamic.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 namespace facebook::axiom {
@@ -91,6 +92,25 @@ TEST(QueryRuntimeStatsTest, cpuMetricNaming) {
   ASSERT_TRUE(dynamic.count(key));
   EXPECT_EQ(dynamic[key]["unit"].asString(), "NANO");
   EXPECT_EQ(dynamic[key]["sum"].asInt(), 5000);
+}
+
+// Both writer entry points compose the prefix.
+TEST(QueryRuntimeStatsTest, prefixesEveryStatName) {
+  QueryRuntimeStats stats;
+  PrefixedRuntimeStatWriter writer{stats, "myOp"};
+
+  writer.addTiming("wallNanos", std::chrono::nanoseconds(1000));
+  writer.setRuntimeStat(
+      "waitNanos",
+      velox::RuntimeMetric(2000, velox::RuntimeCounter::Unit::kNanos));
+
+  auto map = stats.runtimeStats();
+  ASSERT_THAT(
+      map,
+      testing::UnorderedElementsAre(
+          testing::Key("myOp-wallNanos"), testing::Key("myOp-waitNanos")));
+  EXPECT_EQ(map.at("myOp-wallNanos").sum, 1000);
+  EXPECT_EQ(map.at("myOp-waitNanos").sum, 2000);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
`reportTo` took a prefix and wrote each metric as `<prefix>-<name>`, so the executor decided how its metrics were spelled. It now writes the bare names and leaves the naming to the caller:

    void reportTo(BaseRuntimeStatWriter& writer) const;

A caller reporting several executors into one store wraps the writer it passes in, so keeping their samples apart stays where the naming is decided.

Published names are unchanged.

Reviewed By: mbasmanova

Differential Revision: D116372892


