### PR TITLE
fix: Dedup window partition keys in v2

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -873,6 +873,19 @@ SqlQueryRunner::co_runExplainStatement(
     std::shared_ptr<QueryRuntimeStats> runtimeStats) {
   const auto& statement = explain.statement();
 
+  if (explain.type() == presto::ExplainStatement::Type::kValidate) {
+    // An invalid query has already failed: parsing resolved it and the caller
+    // checked permissions. Presto reports the outcome the same way for every
+    // statement kind, and does not resolve a DDL target.
+    auto result = std::dynamic_pointer_cast<velox::RowVector>(
+        velox::BaseVector::createFromVariants(
+            velox::ROW("result", velox::BOOLEAN()),
+            {velox::Variant::row({velox::Variant(true)})},
+            optimizerPool_.get()));
+    co_yield SqlResultChunk{std::move(result)};
+    co_return;
+  }
+
   logical_plan::LogicalPlanNodePtr logicalPlan;
   std::shared_ptr<connector::SchemaResolver> schemaResolver;
 
@@ -1400,7 +1413,9 @@ std::string SqlQueryRunner::runExplain(
     }
 
     case presto::ExplainStatement::Type::kIo:
-      // Handled in run() before calling runExplain().
+      [[fallthrough]];
+    case presto::ExplainStatement::Type::kValidate:
+      // Answered in co_runExplainStatement(), which never calls this.
       VELOX_UNREACHABLE();
   }
   VELOX_UNREACHABLE();

--- a/axiom/cli/tests/ExplainTest.cpp
+++ b/axiom/cli/tests/ExplainTest.cpp
@@ -85,6 +85,48 @@ TEST_P(ExplainTest, showsCardinalityEstimate) {
   EXPECT_THAT(lines, ::testing::ElementsAreArray(expected));
 }
 
+// Presto answers EXPLAIN (TYPE VALIDATE) with one row, column 'result', value
+// true, and reports an invalid query as an error rather than false. The format
+// option does not change that.
+TEST_P(ExplainTest, explainValidate) {
+  testConnector_->addTpchTables(1);
+
+  auto expectValid = [&](const std::string& sql) {
+    SCOPED_TRACE(sql);
+    auto row = fetchSingleRow(sql);
+    EXPECT_EQ(*row->type(), *ROW("result", BOOLEAN()));
+    EXPECT_TRUE(row->childAt(0)->variantAt(0).value<bool>());
+  };
+
+  for (const auto& statement :
+       {"SELECT l_orderkey FROM lineitem",
+        "CREATE TABLE t AS SELECT l_orderkey FROM lineitem",
+        "CREATE TABLE t(x BIGINT)",
+        "DROP TABLE IF EXISTS t",
+        // A DDL target is not resolved, so a missing table still validates.
+        "DROP TABLE nosuchtable",
+        // A statement kind EXPLAIN cannot render a plan for is still valid.
+        "SHOW TABLES",
+        "CREATE SCHEMA s"}) {
+    expectValid(fmt::format("EXPLAIN (TYPE VALIDATE) {}", statement));
+  }
+
+  for (const auto& format : {"TEXT", "JSON", "GRAPHVIZ"}) {
+    expectValid(
+        fmt::format(
+            "EXPLAIN (TYPE VALIDATE, FORMAT {}) SELECT l_orderkey FROM lineitem",
+            format));
+  }
+
+  VELOX_ASSERT_THROW(
+      run("EXPLAIN (TYPE VALIDATE) SELECT nosuchcolumn FROM lineitem"),
+      "Cannot resolve column: nosuchcolumn");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      run("EXPLAIN (TYPE VALIDATE) SELECT * FROM nosuchtable"),
+      "Table not found: nosuchtable");
+}
+
 TEST_P(ExplainTest, explainCreateTable) {
   auto result = run("EXPLAIN CREATE TABLE t(x int)");
   EXPECT_EQ(result.message, R"(CREATE TABLE test."default"."t")");

--- a/axiom/optimizer/tests/sql/window.sql
+++ b/axiom/optimizer/tests/sql/window.sql
@@ -274,3 +274,8 @@ FROM (SELECT 1 AS a FROM (VALUES (1), (2), (3)) AS t(x)) AS u(a)
 -- The same, with the constant written in the ORDER BY itself.
 SELECT array_agg(x) OVER (ORDER BY (1 + 1) RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
 FROM (VALUES (1), (2)) AS t(x)
+----
+-- Repeated partition keys: a literally duplicated column and two distinct
+-- columns holding the same constant.
+SELECT sum(x) OVER (PARTITION BY x, x, a, b ORDER BY x)
+FROM (SELECT y AS x, 'All' AS a, 'All' AS b FROM (VALUES (1), (2), (2)) AS t(y)) AS u

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -1144,11 +1144,11 @@ NodeCP Translator::maybeWrapInWindow(
   }
 
   // Pre-translate each lp WindowExpr into its effective spec (partition
-  // keys, order keys). Drop sort keys that duplicate a partition key (every
-  // row in a partition shares that value) or repeat an earlier sort key —
-  // both are redundant. Grouping below compares the effective specs, so two
-  // windows that differ only in a dropped order key — or only in frame, which
-  // is per-function — still share a single `Window` node.
+  // keys, order keys). Drop repeated partition keys, and sort keys that
+  // duplicate a partition key (every row in a partition shares that value) or
+  // repeat an earlier sort key — all are redundant. Grouping below compares
+  // the effective specs, so two windows that differ only in a dropped key — or
+  // only in frame, which is per-function — still share a single `Window` node.
   struct Spec {
     ExprVector partitionKeys;
     ExprVector orderKeys;
@@ -1161,14 +1161,19 @@ NodeCP Translator::maybeWrapInWindow(
     const auto* windowExpr =
         projectExprs[windowIndices[i]]->as<lp::WindowExpr>();
     Spec& spec = specs[i];
+    folly::F14FastSet<ExprCP> seenKeys;
+    spec.partitionKeys.reserve(windowExpr->partitionKeys().size());
     // Subqueries in window partition / order keys / frame bounds would
     // need lifting above the Window's input — left as nullptr until
     // that wiring lands. lp's surface allows them; rare in practice.
-    spec.partitionKeys = translateAll(
-        windowExpr->partitionKeys(), inputScope, /*applyTarget=*/nullptr);
+    for (const auto& partitionKey : windowExpr->partitionKeys()) {
+      ExprCP key =
+          translateExpr(*partitionKey, inputScope, /*applyTarget=*/nullptr);
+      if (seenKeys.insert(key).second) {
+        spec.partitionKeys.push_back(key);
+      }
+    }
 
-    folly::F14FastSet<ExprCP> seenKeys(
-        spec.partitionKeys.begin(), spec.partitionKeys.end());
     spec.orderKeys.reserve(windowExpr->ordering().size());
     spec.orderTypes.reserve(windowExpr->ordering().size());
     for (const auto& field : windowExpr->ordering()) {

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2165,65 +2165,87 @@ lp::ExprPtr resolveSqlExpression(
   return project->expressionAt(0);
 }
 
+// Resolves the EXPLAIN options and builds the statement, mirroring Presto: a
+// VALIDATE type wins from any position and over ANALYZE; otherwise the first
+// TYPE and the first FORMAT win; ANALYZE reports the plan it ran and ignores
+// both.
 SqlStatementPtr parseExplain(
     const Explain& explain,
     const SqlStatementPtr& sqlStatement) {
-  ExplainStatement::Type type = ExplainStatement::Type::kExecutable;
-  ExplainStatement::Format format = ExplainStatement::Format::kText;
+  std::optional<ExplainType::Type> explainType;
+  std::optional<ExplainFormat::Type> explainFormat;
+
+  for (const auto& option : explain.options()) {
+    if (option->is(NodeType::kExplainType)) {
+      const auto optionType = option->as<ExplainType>()->explainType();
+      if (optionType == ExplainType::Type::kValidate) {
+        return std::make_shared<ExplainStatement>(
+            sqlStatement,
+            /*analyze=*/false,
+            ExplainStatement::Type::kValidate,
+            ExplainStatement::Format::kText);
+      }
+      if (!explainType.has_value()) {
+        explainType = optionType;
+      }
+    } else if (option->is(NodeType::kExplainFormat)) {
+      if (!explainFormat.has_value()) {
+        explainFormat = option->as<ExplainFormat>()->formatType();
+      }
+    }
+  }
 
   if (explain.isAnalyze()) {
     return std::make_shared<ExplainStatement>(
         sqlStatement,
         /*analyze=*/true,
-        type,
-        format);
+        ExplainStatement::Type::kExecutable,
+        ExplainStatement::Format::kText);
   }
 
-  for (const auto& option : explain.options()) {
-    if (option->is(NodeType::kExplainType)) {
-      const auto explainType = option->as<ExplainType>()->explainType();
-      switch (explainType) {
-        case ExplainType::Type::kLogical:
-          type = ExplainStatement::Type::kLogical;
-          break;
-        case ExplainType::Type::kGraph:
-          type = ExplainStatement::Type::kGraph;
-          break;
-        case ExplainType::Type::kOptimized:
-          type = ExplainStatement::Type::kOptimized;
-          break;
-        case ExplainType::Type::kExecutable:
-          [[fallthrough]];
-        case ExplainType::Type::kDistributed:
-          type = ExplainStatement::Type::kExecutable;
-          break;
-        case ExplainType::Type::kIo:
-          type = ExplainStatement::Type::kIo;
-          break;
-        default:
-          VELOX_USER_FAIL("Unsupported EXPLAIN type");
-      }
-    } else if (option->is(NodeType::kExplainFormat)) {
-      const auto explainFormat = option->as<ExplainFormat>()->formatType();
-      switch (explainFormat) {
-        case ExplainFormat::Type::kText:
-          format = ExplainStatement::Format::kText;
-          break;
-        case ExplainFormat::Type::kGraphviz:
-          format = ExplainStatement::Format::kGraphviz;
-          break;
-        case ExplainFormat::Type::kJson:
-          format = ExplainStatement::Format::kJson;
-          break;
-      }
+  ExplainStatement::Type type{ExplainStatement::Type::kExecutable};
+  if (explainType.has_value()) {
+    switch (explainType.value()) {
+      case ExplainType::Type::kLogical:
+        type = ExplainStatement::Type::kLogical;
+        break;
+      case ExplainType::Type::kGraph:
+        type = ExplainStatement::Type::kGraph;
+        break;
+      case ExplainType::Type::kOptimized:
+        type = ExplainStatement::Type::kOptimized;
+        break;
+      case ExplainType::Type::kExecutable:
+        [[fallthrough]];
+      case ExplainType::Type::kDistributed:
+        type = ExplainStatement::Type::kExecutable;
+        break;
+      case ExplainType::Type::kIo:
+        type = ExplainStatement::Type::kIo;
+        break;
+      case ExplainType::Type::kValidate:
+        // Returned from the loop above.
+        VELOX_UNREACHABLE();
+    }
+  }
+
+  ExplainStatement::Format format{ExplainStatement::Format::kText};
+  if (explainFormat.has_value()) {
+    switch (explainFormat.value()) {
+      case ExplainFormat::Type::kText:
+        format = ExplainStatement::Format::kText;
+        break;
+      case ExplainFormat::Type::kGraphviz:
+        format = ExplainStatement::Format::kGraphviz;
+        break;
+      case ExplainFormat::Type::kJson:
+        format = ExplainStatement::Format::kJson;
+        break;
     }
   }
 
   return std::make_shared<ExplainStatement>(
-      sqlStatement,
-      /*analyze=*/false,
-      type,
-      format);
+      sqlStatement, /*analyze=*/false, type, format);
 }
 
 static facebook::axiom::connector::TablePtr findTable(

--- a/axiom/sql/presto/SqlStatement.cpp
+++ b/axiom/sql/presto/SqlStatement.cpp
@@ -90,6 +90,7 @@ const auto& explainTypeNames() {
           {ExplainStatement::Type::kOptimized, "OPTIMIZED"},
           {ExplainStatement::Type::kExecutable, "EXECUTABLE"},
           {ExplainStatement::Type::kIo, "IO"},
+          {ExplainStatement::Type::kValidate, "VALIDATE"},
       };
   return kNames;
 }

--- a/axiom/sql/presto/SqlStatement.h
+++ b/axiom/sql/presto/SqlStatement.h
@@ -588,6 +588,10 @@ class ExplainStatement : public SqlStatement {
 
     /// IO plan: input/output tables and partition column constraints.
     kIo,
+
+    /// Parse and analyze only, reporting whether the query is valid. Produces
+    /// no plan.
+    kValidate,
   };
 
   AXIOM_DECLARE_EMBEDDED_ENUM_NAME(Type);

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -421,7 +421,7 @@ TEST_F(PrestoParserTest, subqueryDepthCapped) {
     options.maxSubqueryDepth = maxSubqueryDepth;
     PrestoParser parser(
         kConnectorId, "default", makeParserSession(std::move(options)));
-    return parser.parse(sql, true);
+    return parser.parse(sql);
   };
   AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseWithDepth(kChainedCtes, 2),
@@ -446,7 +446,7 @@ TEST_F(PrestoParserTest, parseDepthCapped) {
     options.maxExpressionDepth = maxExpressionDepth;
     PrestoParser parser(
         kConnectorId, "default", makeParserSession(std::move(options)));
-    return parser.parse(sql, true);
+    return parser.parse(sql);
   };
   AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseWithDepth(10), "Expression exceeds maximum nesting depth");
@@ -1120,9 +1120,8 @@ TEST_F(PrestoParserTest, explainSelect) {
     testExplain("EXPLAIN SELECT * FROM nation", matcher);
   }
 
-  auto parser = makeParser();
   {
-    auto statement = parser.parse("EXPLAIN ANALYZE SELECT * FROM nation");
+    auto statement = parseSql("EXPLAIN ANALYZE SELECT * FROM nation");
     ASSERT_TRUE(statement->isExplain());
 
     auto explainStatement = statement->as<ExplainStatement>();
@@ -1130,8 +1129,7 @@ TEST_F(PrestoParserTest, explainSelect) {
   }
 
   {
-    auto statement =
-        parser.parse("EXPLAIN (TYPE LOGICAL) SELECT * FROM nation", true);
+    auto statement = parseSql("EXPLAIN (TYPE LOGICAL) SELECT * FROM nation");
     ASSERT_TRUE(statement->isExplain());
 
     auto explainStatement = statement->as<ExplainStatement>();
@@ -1140,8 +1138,7 @@ TEST_F(PrestoParserTest, explainSelect) {
   }
 
   {
-    auto statement =
-        parser.parse("EXPLAIN (TYPE GRAPH) SELECT * FROM nation", true);
+    auto statement = parseSql("EXPLAIN (TYPE GRAPH) SELECT * FROM nation");
     ASSERT_TRUE(statement->isExplain());
 
     auto explainStatement = statement->as<ExplainStatement>();
@@ -1150,8 +1147,7 @@ TEST_F(PrestoParserTest, explainSelect) {
   }
 
   {
-    auto statement =
-        parser.parse("EXPLAIN (TYPE OPTIMIZED) SELECT * FROM nation");
+    auto statement = parseSql("EXPLAIN (TYPE OPTIMIZED) SELECT * FROM nation");
     ASSERT_TRUE(statement->isExplain());
 
     auto explainStatement = statement->as<ExplainStatement>();
@@ -1160,8 +1156,7 @@ TEST_F(PrestoParserTest, explainSelect) {
   }
 
   {
-    auto statement =
-        parser.parse("EXPLAIN (TYPE EXECUTABLE) SELECT * FROM nation");
+    auto statement = parseSql("EXPLAIN (TYPE EXECUTABLE) SELECT * FROM nation");
     ASSERT_TRUE(statement->isExplain());
 
     auto explainStatement = statement->as<ExplainStatement>();
@@ -1172,7 +1167,7 @@ TEST_F(PrestoParserTest, explainSelect) {
 
   {
     auto statement =
-        parser.parse("EXPLAIN (TYPE DISTRIBUTED) SELECT * FROM nation");
+        parseSql("EXPLAIN (TYPE DISTRIBUTED) SELECT * FROM nation");
     ASSERT_TRUE(statement->isExplain());
 
     auto explainStatement = statement->as<ExplainStatement>();
@@ -1182,18 +1177,25 @@ TEST_F(PrestoParserTest, explainSelect) {
   }
 
   {
-    auto statement = parser.parse("EXPLAIN (TYPE IO) SELECT * FROM nation");
+    auto statement = parseSql("EXPLAIN (TYPE IO) SELECT * FROM nation");
     ASSERT_TRUE(statement->isExplain());
 
     auto explainStatement = statement->as<ExplainStatement>();
     ASSERT_FALSE(explainStatement->isAnalyze());
     ASSERT_EQ(explainStatement->type(), ExplainStatement::Type::kIo);
   }
+
+  {
+    auto statement = parseSql("EXPLAIN (TYPE VALIDATE) SELECT * FROM nation");
+    ASSERT_TRUE(statement->isExplain());
+
+    auto explainStatement = statement->as<ExplainStatement>();
+    ASSERT_FALSE(explainStatement->isAnalyze());
+    ASSERT_EQ(explainStatement->type(), ExplainStatement::Type::kValidate);
+  }
 }
 
 TEST_F(PrestoParserTest, explainFormat) {
-  auto parser = makeParser();
-
   std::vector<std::pair<std::string, ExplainStatement::Format>> formats = {
       {"TEXT", ExplainStatement::Format::kText},
       {"GRAPHVIZ", ExplainStatement::Format::kGraphviz},
@@ -1202,11 +1204,10 @@ TEST_F(PrestoParserTest, explainFormat) {
 
   for (const auto& [formatName, expectedFormat] : formats) {
     SCOPED_TRACE(formatName);
-    auto statement = parser.parse(
+    auto statement = parseSql(
         fmt::format(
             "EXPLAIN (TYPE LOGICAL, FORMAT {}) SELECT * FROM nation",
-            formatName),
-        true);
+            formatName));
     ASSERT_TRUE(statement->isExplain());
 
     auto explainStatement = statement->as<ExplainStatement>();
@@ -1216,10 +1217,59 @@ TEST_F(PrestoParserTest, explainFormat) {
 
   // Default format is TEXT.
   {
-    auto statement =
-        parser.parse("EXPLAIN (TYPE LOGICAL) SELECT * FROM nation", true);
+    auto statement = parseSql("EXPLAIN (TYPE LOGICAL) SELECT * FROM nation");
     auto explainStatement = statement->as<ExplainStatement>();
     ASSERT_EQ(explainStatement->format(), ExplainStatement::Format::kText);
+  }
+}
+
+TEST_F(PrestoParserTest, explainOptionPrecedence) {
+  // The first type and the first format win.
+  {
+    auto statement =
+        parseSql("EXPLAIN (TYPE LOGICAL, TYPE IO) SELECT * FROM nation");
+    ASSERT_TRUE(statement->isExplain());
+    EXPECT_EQ(
+        statement->as<ExplainStatement>()->type(),
+        ExplainStatement::Type::kLogical);
+  }
+
+  {
+    auto statement = parseSql(
+        "EXPLAIN (TYPE LOGICAL, FORMAT JSON, FORMAT TEXT) SELECT * FROM nation");
+    ASSERT_TRUE(statement->isExplain());
+    EXPECT_EQ(
+        statement->as<ExplainStatement>()->format(),
+        ExplainStatement::Format::kJson);
+  }
+
+  // VALIDATE wins from any position, over ANALYZE, and over a format.
+  for (const auto& sql :
+       {"EXPLAIN (TYPE VALIDATE, TYPE IO) SELECT * FROM nation",
+        "EXPLAIN (TYPE IO, TYPE VALIDATE) SELECT * FROM nation",
+        "EXPLAIN (TYPE VALIDATE, FORMAT JSON) SELECT * FROM nation",
+        "EXPLAIN ANALYZE (TYPE VALIDATE) SELECT * FROM nation"}) {
+    SCOPED_TRACE(sql);
+    auto statement = parseSql(sql);
+    ASSERT_TRUE(statement->isExplain());
+
+    auto* explain = statement->as<ExplainStatement>();
+    EXPECT_EQ(explain->type(), ExplainStatement::Type::kValidate);
+    EXPECT_EQ(explain->format(), ExplainStatement::Format::kText);
+    EXPECT_FALSE(explain->isAnalyze());
+  }
+
+  // ANALYZE reports the plan it ran, so it ignores the type and format asked
+  // for.
+  {
+    auto statement = parseSql(
+        "EXPLAIN ANALYZE (TYPE LOGICAL, FORMAT JSON) SELECT * FROM nation");
+    ASSERT_TRUE(statement->isExplain());
+
+    auto* explain = statement->as<ExplainStatement>();
+    EXPECT_TRUE(explain->isAnalyze());
+    EXPECT_EQ(explain->type(), ExplainStatement::Type::kExecutable);
+    EXPECT_EQ(explain->format(), ExplainStatement::Format::kText);
   }
 }
 
@@ -2081,12 +2131,11 @@ TEST_F(PrestoParserTest, friendlySqlTrailingCommaValues) {
 
 TEST_F(PrestoParserTest, friendlySqlFromFirst) {
   // FROM-first syntax works with Friendly SQL (default).
-  auto parser = makeParser();
-  auto statement = parser.parse("FROM nation");
+  auto statement = parseSql("FROM nation");
   ASSERT_TRUE(statement->isSelect());
 
   // With WHERE clause.
-  statement = parser.parse("FROM nation WHERE n_regionkey = 1");
+  statement = parseSql("FROM nation WHERE n_regionkey = 1");
   ASSERT_TRUE(statement->isSelect());
 
   // Rejected when Friendly SQL is disabled.


### PR DESCRIPTION
Summary:
`Window` partition keys are translated one-to-one from the logical plan, so a
spec that names the same key twice reaches Velox as a `WindowNode` with
duplicate partitioning keys and fails:

  Partitioning keys must be unique. Found duplicate key: income_5

Duplicates are not only written literally. Distinct columns that hold the same
value translate to one expression, which is how a production query hit this: a
chain of CTEs projected a dozen `'All'` dimension columns and partitioned by
all of them.

Drop repeated partition keys, where the sort keys are already deduped. v1 does
the same in `ToGraph::translateWindowExpr`.

Differential Revision: D116718353


