### PR TITLE
fix: Prefix logical plan serde keys with "Logical"

### DIFF
--- a/axiom/logical_plan/LogicalPlanNode.cpp
+++ b/axiom/logical_plan/LogicalPlanNode.cpp
@@ -166,27 +166,34 @@ folly::dynamic LogicalPlanNode::serializeBase(std::string_view name) const {
 
 // static
 void LogicalPlanNode::registerSerDe() {
+  // Keys are prefixed with "Logical" because this registry is shared with
+  // velox::core::PlanNode, whose physical nodes claim TableScanNode,
+  // FilterNode, ProjectNode, LimitNode, TableWriteNode and UnnestNode. Without
+  // the prefix whichever registered last would win, leaving a process able to
+  // deserialize logical plans or physical ones but never both. The prefix must
+  // stay in step with the names serializeBase() writes.
   auto& registry = velox::DeserializationWithContextRegistryForSharedPtr();
-  registry.Register("ValuesNode", ValuesNode::create);
-  registry.Register("TableScanNode", TableScanNode::create);
-  registry.Register("FilterNode", FilterNode::create);
-  registry.Register("ProjectNode", ProjectNode::create);
-  registry.Register("AggregateNode", AggregateNode::create);
-  registry.Register("JoinNode", JoinNode::create);
-  registry.Register("LateralJoinNode", LateralJoinNode::create);
-  registry.Register("SortNode", SortNode::create);
-  registry.Register("LimitNode", LimitNode::create);
-  registry.Register("SetNode", SetNode::create);
-  registry.Register("UnnestNode", UnnestNode::create);
-  registry.Register("TableWriteNode", TableWriteNode::create);
-  registry.Register("SampleNode", SampleNode::create);
-  registry.Register("OutputNode", OutputNode::create);
-  registry.Register("FixedPointNode", FixedPointNode::create);
-  registry.Register("RecursiveReferenceNode", RecursiveReferenceNode::create);
+  registry.Register("LogicalValuesNode", ValuesNode::create);
+  registry.Register("LogicalTableScanNode", TableScanNode::create);
+  registry.Register("LogicalFilterNode", FilterNode::create);
+  registry.Register("LogicalProjectNode", ProjectNode::create);
+  registry.Register("LogicalAggregateNode", AggregateNode::create);
+  registry.Register("LogicalJoinNode", JoinNode::create);
+  registry.Register("LogicalLateralJoinNode", LateralJoinNode::create);
+  registry.Register("LogicalSortNode", SortNode::create);
+  registry.Register("LogicalLimitNode", LimitNode::create);
+  registry.Register("LogicalSetNode", SetNode::create);
+  registry.Register("LogicalUnnestNode", UnnestNode::create);
+  registry.Register("LogicalTableWriteNode", TableWriteNode::create);
+  registry.Register("LogicalSampleNode", SampleNode::create);
+  registry.Register("LogicalOutputNode", OutputNode::create);
+  registry.Register("LogicalFixedPointNode", FixedPointNode::create);
+  registry.Register(
+      "LogicalRecursiveReferenceNode", RecursiveReferenceNode::create);
 }
 
 folly::dynamic ValuesNode::serialize() const {
-  auto obj = serializeBase("ValuesNode");
+  auto obj = serializeBase("LogicalValuesNode");
   obj["cardinality"] = cardinality_;
 
   // Serialize the data variant
@@ -271,7 +278,7 @@ LogicalPlanNodePtr ValuesNode::create(
 }
 
 folly::dynamic TableScanNode::serialize() const {
-  auto obj = serializeBase("TableScanNode");
+  auto obj = serializeBase("LogicalTableScanNode");
   obj["connectorId"] = connectorId_;
   obj["tableName"] = tableName_.table;
   obj["schema"] = tableName_.schema;
@@ -295,7 +302,7 @@ LogicalPlanNodePtr TableScanNode::create(
 }
 
 folly::dynamic FilterNode::serialize() const {
-  auto obj = serializeBase("FilterNode");
+  auto obj = serializeBase("LogicalFilterNode");
   obj["predicate"] = predicate_->serialize();
   return obj;
 }
@@ -313,7 +320,7 @@ LogicalPlanNodePtr FilterNode::create(
 }
 
 folly::dynamic ProjectNode::serialize() const {
-  auto obj = serializeBase("ProjectNode");
+  auto obj = serializeBase("LogicalProjectNode");
   obj["names"] =
       serializeVector(names_, [](const std::string& s) { return s; });
   obj["expressions"] = serializeVector(
@@ -335,7 +342,7 @@ LogicalPlanNodePtr ProjectNode::create(
 }
 
 folly::dynamic AggregateNode::serialize() const {
-  auto obj = serializeBase("AggregateNode");
+  auto obj = serializeBase("LogicalAggregateNode");
   obj["groupingKeys"] = serializeVector(
       groupingKeys_, [](const ExprPtr& e) { return e->serialize(); });
   obj["groupingSets"] =
@@ -393,7 +400,7 @@ LogicalPlanNodePtr AggregateNode::create(
 }
 
 folly::dynamic JoinNode::serialize() const {
-  auto obj = serializeBase("JoinNode");
+  auto obj = serializeBase("LogicalJoinNode");
   obj["joinType"] = JoinTypeName::toName(joinType_);
   if (condition_) {
     obj["condition"] = condition_->serialize();
@@ -418,7 +425,7 @@ LogicalPlanNodePtr JoinNode::create(const folly::dynamic& obj, void* context) {
 }
 
 folly::dynamic SortNode::serialize() const {
-  auto obj = serializeBase("SortNode");
+  auto obj = serializeBase("LogicalSortNode");
   obj["ordering"] = serializeVector(
       ordering_, [](const SortingField& f) { return f.serialize(); });
   return obj;
@@ -439,7 +446,7 @@ LogicalPlanNodePtr SortNode::create(const folly::dynamic& obj, void* context) {
 }
 
 folly::dynamic LimitNode::serialize() const {
-  auto obj = serializeBase("LimitNode");
+  auto obj = serializeBase("LogicalLimitNode");
   obj["offset"] = offset_;
   obj["count"] = count_;
   return obj;
@@ -457,7 +464,7 @@ LogicalPlanNodePtr LimitNode::create(const folly::dynamic& obj, void* context) {
 }
 
 folly::dynamic SetNode::serialize() const {
-  auto obj = serializeBase("SetNode");
+  auto obj = serializeBase("LogicalSetNode");
   obj["operation"] = SetOperationName::toName(operation_);
   return obj;
 }
@@ -472,7 +479,7 @@ LogicalPlanNodePtr SetNode::create(const folly::dynamic& obj, void* context) {
 }
 
 folly::dynamic UnnestNode::serialize() const {
-  auto obj = serializeBase("UnnestNode");
+  auto obj = serializeBase("LogicalUnnestNode");
   obj["unnestExpressions"] = serializeVector(
       unnestExpressions_, [](const ExprPtr& e) { return e->serialize(); });
   obj["unnestedNames"] = serializeVector(
@@ -523,7 +530,7 @@ LogicalPlanNodePtr UnnestNode::create(
 }
 
 folly::dynamic TableWriteNode::serialize() const {
-  auto obj = serializeBase("TableWriteNode");
+  auto obj = serializeBase("LogicalTableWriteNode");
   obj["connectorId"] = connectorId_;
   obj["tableName"] = tableName_.table;
   obj["schema"] = tableName_.schema;
@@ -571,7 +578,7 @@ LogicalPlanNodePtr TableWriteNode::create(
 }
 
 folly::dynamic SampleNode::serialize() const {
-  auto obj = serializeBase("SampleNode");
+  auto obj = serializeBase("LogicalSampleNode");
   obj["percentage"] = percentage_->serialize();
   obj["sampleMethod"] = SampleNode::toName(sampleMethod_);
   return obj;
@@ -864,7 +871,7 @@ bool JoinNode::equalTo(const LogicalPlanNode& other) const {
 }
 
 folly::dynamic LateralJoinNode::serialize() const {
-  auto obj = serializeBase("LateralJoinNode");
+  auto obj = serializeBase("LogicalLateralJoinNode");
   obj["joinType"] = JoinTypeName::toName(joinType_);
   if (condition_) {
     obj["condition"] = condition_->serialize();
@@ -1213,7 +1220,7 @@ bool OutputNode::equalTo(const LogicalPlanNode& other) const {
 }
 
 folly::dynamic OutputNode::serialize() const {
-  auto obj = serializeBase("OutputNode");
+  auto obj = serializeBase("LogicalOutputNode");
   obj["entries"] = serializeVector(entries_, [](const Entry& entry) {
     folly::dynamic obj = folly::dynamic::object;
     obj["index"] = entry.index;
@@ -1349,7 +1356,7 @@ bool FixedPointNode::equalTo(const LogicalPlanNode& other) const {
 }
 
 folly::dynamic FixedPointNode::serialize() const {
-  auto obj = serializeBase("FixedPointNode");
+  auto obj = serializeBase("LogicalFixedPointNode");
   obj["recursiveName"] = name_;
   return obj;
 }
@@ -1391,7 +1398,7 @@ bool RecursiveReferenceNode::equalTo(const LogicalPlanNode& other) const {
 }
 
 folly::dynamic RecursiveReferenceNode::serialize() const {
-  auto obj = serializeBase("RecursiveReferenceNode");
+  auto obj = serializeBase("LogicalRecursiveReferenceNode");
   obj["recursiveName"] = name_;
   return obj;
 }

--- a/axiom/logical_plan/tests/LogicalPlanNodeSerdeTest.cpp
+++ b/axiom/logical_plan/tests/LogicalPlanNodeSerdeTest.cpp
@@ -23,6 +23,7 @@
 #include "axiom/logical_plan/LogicalPlanNode.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "velox/common/serialization/Serializable.h"
+#include "velox/core/PlanNode.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/type/Type.h"
@@ -41,6 +42,13 @@ class LogicalPlanNodeSerdeTest : public testing::Test {
     Type::registerSerDe();
     Expr::registerSerDe();
     LogicalPlanNode::registerSerDe();
+    // Registered alongside the logical plan serde on purpose. Both populate
+    // the same global deserialization registry, and physical node names such
+    // as ValuesNode, FilterNode and ProjectNode would collide with the logical
+    // ones were the latter not prefixed with "Logical". Registering both here
+    // means every round trip in this file also proves the two coexist.
+    core::PlanNode::registerSerDe();
+    core::ITypedExpr::registerSerDe();
     functions::prestosql::registerAllScalarFunctions();
     aggregate::prestosql::registerAllAggregateFunctions();
   }
@@ -324,6 +332,43 @@ TEST_F(LogicalPlanNodeSerdeTest, recursiveReferenceNode) {
       std::vector<Variant>{Variant::row({1LL, "a"})});
   auto ref = PlanBuilder().recursiveRef("cte", anchor).planNode();
   testRoundTrip(ref);
+}
+
+// The logical and physical plan serializers share one global registry. This
+// checks the physical direction: a velox::core plan still round-trips with the
+// logical serde registered. The logical direction is covered by every other
+// test here, since SetUpTestSuite registers both.
+TEST_F(LogicalPlanNodeSerdeTest, coexistsWithPhysicalPlanSerde) {
+  auto rowType = ROW({"a", "b"}, {BIGINT(), VARCHAR()});
+  auto vector =
+      std::dynamic_pointer_cast<RowVector>(BaseVector::createFromVariants(
+          rowType,
+          std::vector<Variant>{Variant::row({1LL, "x"})},
+          pool_.get()));
+  // ValuesNode is one of the names the two registries would otherwise fight
+  // over.
+  core::PlanNodePtr physicalPlan = std::make_shared<core::ValuesNode>(
+      "0", std::vector<RowVectorPtr>{vector});
+
+  auto deserialized = ISerializable::deserialize<core::PlanNode>(
+      physicalPlan->serialize(), pool_.get());
+
+  ASSERT_NE(deserialized, nullptr);
+  EXPECT_NE(
+      std::dynamic_pointer_cast<const core::ValuesNode>(deserialized), nullptr);
+  EXPECT_EQ(
+      physicalPlan->toString(true, true), deserialized->toString(true, true));
+
+  // And a logical plan still resolves to a logical node rather than the
+  // physical one of the same shape.
+  auto logicalPlan =
+      PlanBuilder()
+          .values(rowType, std::vector<Variant>{Variant::row({1LL, "x"})})
+          .build();
+  auto logicalCopy = ISerializable::deserialize<LogicalPlanNode>(
+      logicalPlan->serialize(), pool_.get());
+  ASSERT_NE(logicalCopy, nullptr);
+  EXPECT_EQ(*logicalPlan, *logicalCopy);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
A process that registers both the logical and the physical plan serde can deserialize one or the other, never both. A coordinator must deserialize physical plans to run anything, so it could not also accept a serialized logical plan. The failure surfaced far from the cause:

    couldn't find key tableName in dynamic object

`LogicalPlanNode::registerSerDe()` and `velox::core::PlanNode::registerSerDe()` share one registry, and eight node names collided. `Registry::Register` is last-writer-wins, so the second registration pointed those names at the wrong `create`. Registers the logical nodes under `Logical`-prefixed keys, such as `LogicalTableScanNode`, and writes the same names from `serializeBase()`. Expressions were already disjoint and are untouched.

Changes the on-the-wire form of a serialized logical plan. Nothing in the repository persists that form across builds, so no compatibility shim is included. A deployment that stores serialized logical plans across versions would need one.

Differential Revision: D116716760


