### PR TITLE
fix: Handle repeated join keys when deriving transitive filters

### DIFF
--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -235,3 +235,11 @@ LEFT JOIN (VALUES (1, 10)) AS c(k, m) ON c.k = l.k
 JOIN (VALUES (1, 10, 5), (2, 0, 7)) AS e(k, m, d)
   ON e.k = l.k AND e.m = coalesce(c.m, 0)
 WHERE e.d < coalesce(c.m, 99)
+----
+-- One column equated to a column of each of two other tables. A filter on the
+-- shared column must reach every leg and select the same rows either way.
+SELECT t.a, t.b
+FROM t
+JOIN t u ON u.a = t.a
+JOIN t v ON v.b = u.b AND v.b = t.b
+WHERE t.b > 100

--- a/axiom/optimizer/tests/sql/window.sql
+++ b/axiom/optimizer/tests/sql/window.sql
@@ -274,3 +274,8 @@ FROM (SELECT 1 AS a FROM (VALUES (1), (2), (3)) AS t(x)) AS u(a)
 -- The same, with the constant written in the ORDER BY itself.
 SELECT array_agg(x) OVER (ORDER BY (1 + 1) RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
 FROM (VALUES (1), (2)) AS t(x)
+----
+-- Repeated partition keys: a literally duplicated column and two distinct
+-- columns holding the same constant.
+SELECT sum(x) OVER (PARTITION BY x, x, a, b ORDER BY x)
+FROM (SELECT y AS x, 'All' AS a, 'All' AS b FROM (VALUES (1), (2), (2)) AS t(y)) AS u

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -257,22 +257,32 @@ bool canPushLeft(velox::core::JoinType joinType, bool leftOnly) {
 
 // Returns the cross-side `Column == Column` equi-pairs reachable on
 // `node` — either explicitly via `leftKeys`/`rightKeys` or as
-// `eq(Column, Column)` conjuncts in the join's filter. The returned
-// pair has equal-length `first` (left columns) and `second` (right
-// columns) vectors.
+// `eq(Column, Column)` conjuncts in the join's filter. Pairs are distinct;
+// the same equality may be written more than once. The returned pair has
+// equal-length `first` (left columns) and `second` (right columns) vectors.
 std::pair<ColumnVector, ColumnVector> collectEquiColumnPairs(
     JoinCP node,
     const PlanObjectSet& leftColumns,
     const PlanObjectSet& rightColumns) {
   ColumnVector leftKeys;
   ColumnVector rightKeys;
+
+  auto addPair = [&](ColumnCP left, ColumnCP right) {
+    for (size_t i = 0; i < leftKeys.size(); ++i) {
+      if (leftKeys[i] == left && rightKeys[i] == right) {
+        return;
+      }
+    }
+    leftKeys.push_back(left);
+    rightKeys.push_back(right);
+  };
+
   for (size_t i = 0; i < node->leftKeys().size(); ++i) {
     ExprCP leftKey = node->leftKeys()[i];
     ExprCP rightKey = node->rightKeys()[i];
     if (leftKey->is(PlanType::kColumnExpr) &&
         rightKey->is(PlanType::kColumnExpr)) {
-      leftKeys.push_back(leftKey->as<Column>());
-      rightKeys.push_back(rightKey->as<Column>());
+      addPair(leftKey->as<Column>(), rightKey->as<Column>());
     }
   }
   if (node->filter().empty()) {
@@ -298,13 +308,11 @@ std::pair<ColumnVector, ColumnVector> collectEquiColumnPairs(
     ColumnCP secondColumn = second->as<Column>();
     if (leftColumns.contains(firstColumn) &&
         rightColumns.contains(secondColumn)) {
-      leftKeys.push_back(firstColumn);
-      rightKeys.push_back(secondColumn);
+      addPair(firstColumn, secondColumn);
     } else if (
         leftColumns.contains(secondColumn) &&
         rightColumns.contains(firstColumn)) {
-      leftKeys.push_back(secondColumn);
-      rightKeys.push_back(firstColumn);
+      addPair(secondColumn, firstColumn);
     }
   }
   return {std::move(leftKeys), std::move(rightKeys)};
@@ -1852,22 +1860,43 @@ class Pushdown : public NodeRewriter<PushdownContext> {
       return false;
     }
 
-    const ExprVector leftAsExprs(leftKeys.begin(), leftKeys.end());
-    const ExprVector rightAsExprs(rightKeys.begin(), rightKeys.end());
+    // A column can be equated to several columns on the other side, as in
+    // `v.b = u.b AND v.b = t.b`, which gives `v.b` two key pairs. A
+    // substitution maps each source once, so a source's n-th pair goes into
+    // the n-th substitution and a conjunct is derived once per substitution,
+    // reaching every equated column.
+    const auto substitutions = [](const ColumnVector& sources,
+                                  const ColumnVector& targets) {
+      std::vector<ExprFactory::ExprSubstitution> result;
+      folly::F14FastMap<ColumnCP, size_t> nth;
+      for (size_t i = 0; i < sources.size(); ++i) {
+        const size_t index = nth[sources[i]]++;
+        if (index == result.size()) {
+          result.emplace_back();
+        }
+        result[index].emplace(sources[i], targets[i]);
+      }
+      return result;
+    };
+
+    const auto toLeft = substitutions(rightKeys, leftKeys);
+    const auto toRight = substitutions(leftKeys, rightKeys);
 
     ExprVector derived;
     for (ExprCP conjunct : pending) {
-      ExprCP leftSubstituted =
-          exprs_.substitute(conjunct, rightKeys, leftAsExprs);
-      if (leftSubstituted != conjunct && !isSelfEquality(leftSubstituted) &&
-          simplifier_.simplifyFilter(leftSubstituted, derived)) {
-        return true;
+      for (const auto& mapping : toLeft) {
+        ExprCP substituted = exprs_.replace(conjunct, mapping);
+        if (substituted != conjunct && !isSelfEquality(substituted) &&
+            simplifier_.simplifyFilter(substituted, derived)) {
+          return true;
+        }
       }
-      ExprCP rightSubstituted =
-          exprs_.substitute(conjunct, leftKeys, rightAsExprs);
-      if (rightSubstituted != conjunct && !isSelfEquality(rightSubstituted) &&
-          simplifier_.simplifyFilter(rightSubstituted, derived)) {
-        return true;
+      for (const auto& mapping : toRight) {
+        ExprCP substituted = exprs_.replace(conjunct, mapping);
+        if (substituted != conjunct && !isSelfEquality(substituted) &&
+            simplifier_.simplifyFilter(substituted, derived)) {
+          return true;
+        }
       }
     }
     appendAll(pending, derived);

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -1144,11 +1144,11 @@ NodeCP Translator::maybeWrapInWindow(
   }
 
   // Pre-translate each lp WindowExpr into its effective spec (partition
-  // keys, order keys). Drop sort keys that duplicate a partition key (every
-  // row in a partition shares that value) or repeat an earlier sort key —
-  // both are redundant. Grouping below compares the effective specs, so two
-  // windows that differ only in a dropped order key — or only in frame, which
-  // is per-function — still share a single `Window` node.
+  // keys, order keys). Drop repeated partition keys, and sort keys that
+  // duplicate a partition key (every row in a partition shares that value) or
+  // repeat an earlier sort key — all are redundant. Grouping below compares
+  // the effective specs, so two windows that differ only in a dropped key — or
+  // only in frame, which is per-function — still share a single `Window` node.
   struct Spec {
     ExprVector partitionKeys;
     ExprVector orderKeys;
@@ -1161,14 +1161,19 @@ NodeCP Translator::maybeWrapInWindow(
     const auto* windowExpr =
         projectExprs[windowIndices[i]]->as<lp::WindowExpr>();
     Spec& spec = specs[i];
+    folly::F14FastSet<ExprCP> seenKeys;
+    spec.partitionKeys.reserve(windowExpr->partitionKeys().size());
     // Subqueries in window partition / order keys / frame bounds would
     // need lifting above the Window's input — left as nullptr until
     // that wiring lands. lp's surface allows them; rare in practice.
-    spec.partitionKeys = translateAll(
-        windowExpr->partitionKeys(), inputScope, /*applyTarget=*/nullptr);
+    for (const auto& partitionKey : windowExpr->partitionKeys()) {
+      ExprCP key =
+          translateExpr(*partitionKey, inputScope, /*applyTarget=*/nullptr);
+      if (seenKeys.insert(key).second) {
+        spec.partitionKeys.push_back(key);
+      }
+    }
 
-    folly::F14FastSet<ExprCP> seenKeys(
-        spec.partitionKeys.begin(), spec.partitionKeys.end());
     spec.orderKeys.reserve(windowExpr->ordering().size());
     spec.orderTypes.reserve(windowExpr->ordering().size());
     for (const auto& field : windowExpr->ordering()) {


### PR DESCRIPTION
Summary:
`deriveTransitive` pushes a conjunct across a join by substituting one side's
equi-key for the other's. It built that substitution from the key pairs as
collected, one per equality, so a column equated to two columns on the other
side appeared twice as a substitution source and planning failed:

  Duplicate substitution source: book_type_code

The shape reaching this is ordinary: a fact table joined to two dimensions
that both carry the same key, `v.b = u.b AND v.b = t.b`.

Build the substitutions once per join rather than per conjunct, splitting a
source's repeated pairs across successive substitutions so a conjunct is
derived for every column its key is equated to. `collectEquiColumnPairs` now
returns distinct pairs, so an equality written twice no longer costs a second
substitution.

Differential Revision: D116721841


