### PR TITLE
fix: Resolve CTE bodies in the scope where the WITH is written (#1740)

### DIFF
--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -730,6 +730,13 @@ class PlanBuilder {
     return outerScope_;
   }
 
+  /// Replaces the enclosing scope. The plan a builder holds outlives the scope
+  /// it was built in when a relation defined in one query, such as a CTE body,
+  /// becomes part of another that resolves the remaining names.
+  void switchOuterScope(Scope scope) {
+    outerScope_ = std::move(scope);
+  }
+
   /// Returns true if the given unqualified name resolves to a column in this
   /// builder's output without chaining to outer scopes.
   bool hasColumn(const std::string& name) const;
@@ -941,7 +948,7 @@ class PlanBuilder {
 
   // Resolves column references from the enclosing query for correlated
   // subqueries. Null for top-level queries.
-  const Scope outerScope_;
+  Scope outerScope_;
 
   // Parses SQL expression strings into Velox expression trees.
   const std::shared_ptr<velox::parse::SqlExpressionsParser> sqlParser_;

--- a/axiom/optimizer/tests/sql/cte.sql
+++ b/axiom/optimizer/tests/sql/cte.sql
@@ -19,3 +19,18 @@ WITH t(a) AS (SELECT 1)
 SELECT * FROM (
   WITH t(b) AS (SELECT a FROM t)
   SELECT * FROM (WITH t(c) AS (SELECT b FROM t) SELECT c AS r FROM t) s2) s1
+----
+-- A CTE body resolves names against its own FROM: `t.u` names the struct
+-- column of `t`, not the same-named relation the referencing query reads.
+WITH s AS (
+  SELECT t.u.k AS k
+  FROM (VALUES (CAST(ROW(1) AS ROW(k BIGINT)))) AS t(u)
+)
+SELECT u.b
+FROM (VALUES (1, 'p'), (2, 'q')) AS u(k, b)
+LEFT JOIN s ON u.k = s.k
+----
+-- A CTE body inside a correlated subquery still reads the correlated column.
+WITH v AS (SELECT a, b FROM t)
+SELECT a FROM v u
+WHERE EXISTS (WITH w AS (SELECT b FROM t WHERE t.a = u.a) SELECT * FROM w)

--- a/axiom/sql/presto/CteScope.h
+++ b/axiom/sql/presto/CteScope.h
@@ -17,11 +17,13 @@
 
 #include <folly/ScopeGuard.h>
 #include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "axiom/common/CatalogSchemaTableName.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/sql/presto/ast/AstNodesAll.h"
 
@@ -45,17 +47,37 @@ namespace lp = facebook::axiom::logical_plan;
 ///
 /// Usage:
 ///   auto scope = ctes.enterScope();   // once per query body
-///   ctes.bind(name, {withQuery, isRecursive});
+///   ctes.bind(name, {withQuery, isRecursive, definingScope});
 ///   if (auto hidden = ctes.hide(name)) { translate hidden.entry()'s body }
 ///
 /// Invariant: a name is a key iff it has a binding in scope.
 class CteScope {
  public:
+  /// What a CTE body resolves names against beyond its own FROM: the scope
+  /// where the WITH is written, captured before the defining query's FROM is
+  /// processed. A body is translated at each reference site, where the
+  /// referencing query's relations are in scope, and those must not resolve
+  /// inside the body.
+  struct DefiningScope {
+    /// Columns of the enclosing queries, for a correlated reference.
+    lp::PlanBuilder::Scope columns;
+
+    /// Base tables reachable by a suffix of their qualified name.
+    folly::F14FastMap<std::string, facebook::axiom::CatalogSchemaTableName>
+        relations;
+
+    /// Qualifiers naming more than one relation, which resolve nothing.
+    folly::F14FastSet<std::string> ambiguousRelations;
+  };
+
   /// One CTE binding. 'isRecursive' is true when the body refers to itself.
   /// A recursive body is re-translated at each reference site.
   struct Entry {
     std::shared_ptr<WithQuery> withQuery;
     bool isRecursive{false};
+
+    /// Never null. Shared by every reference to this CTE.
+    std::shared_ptr<const DefiningScope> definingScope;
   };
 
   /// Hides a name's in-scope binding for the guard's lifetime, so the

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -506,13 +506,34 @@ class RelationPlanner : public AstVisitor {
     return guard;
   }
 
+  // Restores the relations in scope when the guard dies. 'from' replaces them
+  // for the guard's lifetime; without it they only need restoring, which is
+  // what a nested query that adds its own relations wants.
+  [[nodiscard]] auto scopedRelations(
+      const CteScope::DefiningScope* from = nullptr) {
+    auto guard =
+        folly::makeGuard([this,
+                          savedRelations = scopeRelations_,
+                          savedAmbiguous = ambiguousScopeRelations_]() mutable {
+          scopeRelations_ = std::move(savedRelations);
+          ambiguousScopeRelations_ = std::move(savedAmbiguous);
+        });
+    if (from != nullptr) {
+      scopeRelations_ = from->relations;
+      ambiguousScopeRelations_ = from->ambiguousRelations;
+    }
+    return guard;
+  }
+
   // Translates a recursive CTE into a fresh FixedPointNode subtree rooted
-  // in the caller's builder_. Anchor sees 'outerScope' (LATERAL resolves);
-  // step does not (correlated refs across the boundary fail). Each outer
-  // reference run this to produce new FixedPointNodes.
+  // in the caller's builder_. The anchor sees the scope where the WITH is
+  // written; the step sees no outer scope, so a correlated reference across
+  // the boundary fails. Each outer reference runs this to produce new
+  // FixedPointNodes.
   void translateRecursiveCteReference(
       const WithQuery& withEntry,
-      const std::string& cteName) {
+      const std::string& cteName,
+      const CteScope::DefiningScope& definingScope) {
     AXIOM_PRESTO_SYNTAX_CHECK(
         !ctes_.hasAnchors(),
         withEntry.location(),
@@ -522,10 +543,7 @@ class RelationPlanner : public AstVisitor {
         presto::RecursiveCteValidator::extractAndValidateRecursiveUnion(
             withEntry, cteName);
 
-    // Translate the anchor on a fresh builder inheriting the outer scope
-    // (LATERAL refs resolve through it).
-    auto outerScope = builder_->scope();
-    builder_ = newBuilder(outerScope);
+    builder_ = newBuilder(definingScope.columns);
     {
       auto guard = scopedResetLastNames();
       processQueryBody(unionExpr->left());
@@ -625,9 +643,18 @@ class RelationPlanner : public AstVisitor {
 
     if (auto hidden = ctes_.hide(name)) {
       const auto& entry = hidden.entry();
+      VELOX_CHECK_NOT_NULL(entry.definingScope);
+      const auto& definingScope = *entry.definingScope;
+      auto relationsGuard = scopedRelations(&definingScope);
+      // The body resolves in the scope where the WITH is written. The relation
+      // it yields belongs to the referencing query, which resolves the rest of
+      // its own names, correlated ones included, in its own scope.
+      auto referencingScope = builder_->outerScope();
+
       if (entry.isRecursive) {
-        translateRecursiveCteReference(*entry.withQuery, name);
+        translateRecursiveCteReference(*entry.withQuery, name, definingScope);
       } else {
+        builder_ = newBuilder(definingScope.columns);
         processQuery(entry.withQuery->query().get());
 
         // Apply CTE column-alias list, e.g. 'WITH t(a, b) AS (...)' renames
@@ -637,6 +664,7 @@ class RelationPlanner : public AstVisitor {
           applyColumnAliases(*columnAliases, entry.withQuery->location(), name);
         }
       }
+      builder_->switchOuterScope(std::move(referencingScope));
       finalizeCteReference(name);
       return true;
     }
@@ -768,12 +796,7 @@ class RelationPlanner : public AstVisitor {
   void processAliasedRelation(const AliasedRelation& aliasedRelation) {
     // The alias replaces the relation's name, so its qualified name no longer
     // resolves: `nation AS n` makes `default.nation.x` an error.
-    auto savedScopeRelations = scopeRelations_;
-    auto savedAmbiguousRelations = ambiguousScopeRelations_;
-    SCOPE_EXIT {
-      scopeRelations_ = std::move(savedScopeRelations);
-      ambiguousScopeRelations_ = std::move(savedAmbiguousRelations);
-    };
+    auto relationsGuard = scopedRelations();
     processFrom(aliasedRelation.relation());
 
     auto alias = canonicalizeIdentifier(*aliasedRelation.alias());
@@ -1518,18 +1541,16 @@ class RelationPlanner : public AstVisitor {
     // The relations this query puts in scope leave with it. Entries from
     // enclosing queries stay visible, so a correlated subquery can still name
     // an outer relation.
-    auto savedScopeRelations = scopeRelations_;
-    auto savedAmbiguousRelations = ambiguousScopeRelations_;
-    SCOPE_EXIT {
-      scopeRelations_ = std::move(savedScopeRelations);
-      ambiguousScopeRelations_ = std::move(savedAmbiguousRelations);
-    };
+    auto relationsGuard = scopedRelations();
 
     // lastNames is scoped per query; reset so names from a sibling relation
     // in the enclosing scope cannot leak in.
     displayNames_.lastNames.clear();
 
     if (const auto& with = query->with()) {
+      auto definingScope = std::make_shared<const CteScope::DefiningScope>(
+          builder_->outerScope(), scopeRelations_, ambiguousScopeRelations_);
+
       // Names must be unique within a single WITH list. A nested WITH may
       // still reuse an enclosing name -- that is shadowing, handled below.
       std::unordered_set<std::string> namesInList;
@@ -1548,7 +1569,9 @@ class RelationPlanner : public AstVisitor {
           selfReferential = presto::RecursiveCteValidator::referencesCte(
               *withQuery->query(), cteName);
         }
-        ctes_.bind(cteName, CteScope::Entry{withQuery, selfReferential});
+        ctes_.bind(
+            cteName,
+            CteScope::Entry{withQuery, selfReferential, definingScope});
       }
     }
 

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -519,6 +519,40 @@ TEST_F(PrestoParserTest, withNoLeaking) {
       "Table not found: t");
 }
 
+TEST_F(PrestoParserTest, withBodyResolvesInDefiningScope) {
+  // A CTE body names only what its own FROM and the WITH's scope offer. The
+  // referencing query reads a table 'u', which must not answer the qualifier
+  // 'u' inside the body: there 'u' is the struct column of 's', so 's.u.k' is
+  // a field access.
+  connector_->addTable("s", ROW("u", ROW("k", BIGINT())));
+  connector_->addTable("u", ROW({"k", "b"}, {BIGINT(), VARCHAR()}));
+
+  testSelect(
+      "WITH c AS (SELECT s.u.k AS k FROM s) "
+      "SELECT u.b FROM u LEFT JOIN c ON u.k = c.k",
+      matchScan()
+          .join(matchScan().project({"u.k"}).build())
+          .project({"b"})
+          .output({"b"}));
+
+  // Neither a relation nor a column of the body's own FROM answers 'u', even
+  // though the referencing query reads a table by that name.
+  VELOX_ASSERT_THROW(
+      parseSql(
+          "WITH c AS (SELECT u.b AS b FROM nation) "
+          "SELECT u.b FROM u LEFT JOIN c ON u.k = 1"),
+      "Cannot resolve column: u");
+
+  // A schema-qualified name reaches the tables in scope, which are the body's
+  // own. 'default.u' names the referencing query's table, so it resolves
+  // nothing here even though the body has a column 'u'.
+  VELOX_ASSERT_THROW(
+      parseSql(
+          "WITH c AS (SELECT default.u.k AS k FROM s) "
+          "SELECT u.b FROM u LEFT JOIN c ON u.k = c.k"),
+      "Cannot resolve column");
+}
+
 TEST_F(PrestoParserTest, withShadowingBaseTable) {
   // CTE with the same name as a base table it references. The inner reference
   // to 'nation' inside the CTE body must resolve to the base table, not recurse

--- a/axiom/sql/presto/tests/WithRecursiveTest.cpp
+++ b/axiom/sql/presto/tests/WithRecursiveTest.cpp
@@ -28,6 +28,38 @@ namespace {
 
 class WithRecursiveTest : public PrestoParserTestBase {};
 
+TEST_F(WithRecursiveTest, anchorResolvesInDefiningScope) {
+  // The anchor resolves in the scope where the WITH is written: 'u' there is
+  // the struct column of 's', not the same-named table the query referencing
+  // the CTE reads.
+  connector_->addTable("s", ROW("u", ROW("k", BIGINT())));
+  connector_->addTable("u", ROW({"k", "b"}, {BIGINT(), VARCHAR()}));
+
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("c")
+                  .filter()
+                  .project()
+                  .build();
+  testSelect(
+      R"(
+        WITH RECURSIVE c(k) AS (
+          SELECT s.u.k FROM s
+          UNION ALL
+          SELECT k + 1 FROM c WHERE k < 2
+        )
+        SELECT u.b FROM u LEFT JOIN c ON u.k = c.k
+      )",
+      matchScan()
+          .join(
+              matchScan()
+                  .project({"u.k"})
+                  .project()
+                  .fixedPoint(step, {"k"})
+                  .build())
+          .project({"b"})
+          .output({"b"}));
+}
+
 TEST_F(WithRecursiveTest, simpleCounter) {
   // Self-contained recursion — no base table needed.
   auto step = lp::test::LogicalPlanMatcherBuilder()


### PR DESCRIPTION
Summary:

A CTE body was planned into the builder made for the site referencing it, so a
qualified name the body's own columns did not answer fell through to the
relations of the referencing query:

  WITH c AS (SELECT s.u.k AS k FROM s)
  SELECT u.b FROM u LEFT JOIN c ON u.k = c.k

Inside the body `u` is the struct column of `s`, but `u.k` resolved against the
table `u` that the outer query reads, yielding a plan whose Project reads a
column its input does not have. v2 rejected it with `Column not found in
scope`, v1 failed later in `SubfieldTracker`, and a shape where the leaked name
exists on both sides read the wrong column instead.

Capture what the WITH itself can name -- the enclosing correlation scope and
the relations in scope, both taken before the defining query's FROM is
processed -- and translate the body against it, recursive anchors included. The
relation the body yields then belongs to the referencing query, which resolves
the rest of its own names, correlated ones included, in its own scope, so
`PlanBuilder` grows `switchOuterScope` for that hand-off.

Reviewed By: amitkdutta

Differential Revision: D116728065


