### PR TITLE
fix(optimizer): Bound planning cost of long join chains

### DIFF
--- a/axiom/connectors/tests/README.md
+++ b/axiom/connectors/tests/README.md
@@ -38,6 +38,9 @@ The Test connector is designed for three use cases:
 - User-specified statistics: row counts and per-column stats can be set
   explicitly without adding actual data, enabling optimizer testing with
   controlled cost estimates (see [Setting Statistics Without Data](#setting-statistics-without-data)).
+- Suppressed statistics: a table can be created to report none at all, so the
+  optimizer sees a table it cannot cost (see
+  [Tables Without Statistics](#tables-without-statistics)).
 
 **Supported:**
 - Hash bucketing. Tables can be created bucketed via the C++ API
@@ -140,6 +143,20 @@ When all columns share the same type, use `ROW(names, type)` instead of
 `ROW(names, {type, type, ...})`.
 
 `setStats()` and `addData()` cannot be combined on the same table.
+
+### Tables Without Statistics
+
+A table created with `collect_statistics = false` reports no statistics at all:
+no row count and no per-column statistics, however much data it holds. Use it
+to test what the optimizer does with a table the metastore knows nothing
+about, such as falling back to the written join order because no join over it
+can be costed.
+
+```sql
+CREATE TABLE events (a BIGINT, b BIGINT) WITH (collect_statistics = false);
+```
+
+The data is still there and still queried; only the statistics are withheld.
 
 ### Bucketed Tables
 

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -134,6 +134,13 @@ std::vector<std::unique_ptr<const Column>> makeTestTableColumns(
       makeColumnsWithExplainIo(schema, extractExplainIoColumns(options)),
       hiddenColumns);
 }
+
+bool extractCollectStatistics(
+    const folly::F14FastMap<std::string, velox::Variant>& options) {
+  const auto it =
+      options.find(std::string{TestConnectorMetadata::kCollectStatistics});
+  return it == options.end() ? true : it->second.value<bool>();
+}
 } // namespace
 
 TestTable::TestTable(
@@ -148,6 +155,7 @@ TestTable::TestTable(
           makeTestTableColumns(schema, hiddenColumns, options),
           options),
       connector_(connector),
+      collectStatistics_(extractCollectStatistics(options)),
       bucketSpec_(std::move(bucketSpec)) {
   const auto& label = this->name().table;
   if (bucketSpec_.has_value()) {
@@ -199,6 +207,10 @@ void TestTable::setStats(
       0,
       "Cannot use both setStats and addData on table '{}'.",
       name());
+  VELOX_CHECK(
+      collectStatistics_,
+      "Cannot use setStats on a table that reports no statistics: {}",
+      name().table);
   numRows_ = numRows;
 
   // Set or clear stats for all columns.
@@ -313,7 +325,7 @@ void TestTable::addData(
   }
   dataRows_ += data->size();
 
-  if (!collectColumnStatistics) {
+  if (!collectColumnStatistics || !collectStatistics_) {
     return;
   }
 
@@ -805,7 +817,7 @@ TablePtr TestConnectorMetadata::createTable(
 
   for (const auto& [key, value] : options) {
     VELOX_USER_CHECK(
-        key == kHidden || key == kExplainIo,
+        key == kHidden || key == kExplainIo || key == kCollectStatistics,
         "TestConnector does not support CREATE TABLE property: {}",
         key);
   }
@@ -1093,7 +1105,7 @@ std::unique_ptr<velox::connector::DataSink> TestConnector::createDataSink(
       table,
       "cannot create data sink for nonexistent table {}",
       testHandle->tableName().toString());
-  auto collectColumnStatistics =
+  const auto collectColumnStatistics =
       connectorQueryCtx->sessionProperties()->get<bool>(
           TestConfigProvider::kCollectColumnStatistics, true);
   return std::make_unique<TestDataSink>(table, collectColumnStatistics);

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -168,6 +168,10 @@ class TestTableLayout : public TableLayout {
 /// data is copied inside an internal memory pool associated with
 /// the table. Row count is determined dynamically using a summation
 /// of row counts for RowVectors currently stored within the table.
+///
+/// A table created with `collect_statistics = false` is the exception: it
+/// holds its data but reports no row count and no column statistics, modeling
+/// a table the metastore has no statistics for. setStats() is then rejected.
 class TestTable : public Table {
  public:
   TestTable(
@@ -183,6 +187,9 @@ class TestTable : public Table {
   }
 
   std::optional<uint64_t> numRows() const override {
+    if (!collectStatistics_) {
+      return std::nullopt;
+    }
     return data_.empty() ? numRows_ : dataRows_;
   }
 
@@ -202,9 +209,11 @@ class TestTable : public Table {
   /// Appends a RowVector to the table's data. Each appended vector generates
   /// a separate TestConnectorSplit. Data is copied into the table's internal
   /// memory pool. When 'collectColumnStatistics' is true, computes per-column
-  /// statistics incrementally (numDistinct, min/max, nullPct, maxLength).
-  /// Cannot be combined with setStats on the same table. For bucketed tables,
-  /// each non-empty bucket of the input becomes one entry in 'data'.
+  /// statistics incrementally (numDistinct, min/max, nullPct, maxLength);
+  /// `collect_statistics = false` on the table overrides the argument and
+  /// collects none. Cannot be combined with setStats on the same table. For
+  /// bucketed tables, each non-empty bucket of the input becomes one entry in
+  /// 'data'.
   void addData(
       const velox::RowVectorPtr& data,
       bool collectColumnStatistics = true);
@@ -247,6 +256,7 @@ class TestTable : public Table {
   std::vector<int32_t> dataBucketIds_;
   uint64_t numRows_{0};
   uint64_t dataRows_{0};
+  bool collectStatistics_{true};
   std::vector<ColumnTracker> columnTrackers_;
 
   std::optional<TestBucketSpec> bucketSpec_;
@@ -509,6 +519,12 @@ class TestConnectorMetadata : public ConnectorMetadata {
   /// CREATE TABLE property to mark columns for EXPLAIN IO output.
   /// Example: WITH (explain_io = ARRAY['ds']).
   static constexpr std::string_view kExplainIo = "explain_io";
+
+  /// CREATE TABLE property. When false, the table reports no row count and no
+  /// column statistics regardless of the data it holds, modeling a table the
+  /// metastore has no statistics for. Defaults to true.
+  /// Example: WITH (collect_statistics = false).
+  static constexpr std::string_view kCollectStatistics = "collect_statistics";
 
   explicit TestConnectorMetadata(TestConnector* connector)
       : connector_(connector),

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -730,6 +730,13 @@ class PlanBuilder {
     return outerScope_;
   }
 
+  /// Replaces the enclosing scope. The plan a builder holds outlives the scope
+  /// it was built in when a relation defined in one query, such as a CTE body,
+  /// becomes part of another that resolves the remaining names.
+  void switchOuterScope(Scope scope) {
+    outerScope_ = std::move(scope);
+  }
+
   /// Returns true if the given unqualified name resolves to a column in this
   /// builder's output without chaining to outer scopes.
   bool hasColumn(const std::string& name) const;
@@ -941,7 +948,7 @@ class PlanBuilder {
 
   // Resolves column references from the enclosing query for correlated
   // subqueries. Null for top-level queries.
-  const Scope outerScope_;
+  Scope outerScope_;
 
   // Parses SQL expression strings into Velox expression trees.
   const std::shared_ptr<velox::parse::SqlExpressionsParser> sqlParser_;

--- a/axiom/optimizer/tests/sql/common_setup.sql
+++ b/axiom/optimizer/tests/sql/common_setup.sql
@@ -1,4 +1,5 @@
--- Shared table 't' used by the .sql test files.
+-- Shared tables used by the .sql test files: 't', and 't_no_stats' for
+-- queries that need a table the optimizer cannot cost.
 -- Three INSERT statements produce three TestConnector splits.
 
 CREATE TABLE t (a BIGINT, b BIGINT, c DOUBLE)
@@ -23,3 +24,13 @@ INSERT INTO t VALUES
   (1, 130, 13.5),
   (2, 140, 14.5),
   (3, 150, 15.5)
+----
+-- The first five rows of 't', in a table that reports no statistics.
+CREATE TABLE t_no_stats (a BIGINT, b BIGINT, c DOUBLE) WITH (collect_statistics = false)
+----
+INSERT INTO t_no_stats VALUES
+  (1, 10, 1.5),
+  (2, 20, 2.5),
+  (3, 30, 3.5),
+  (1, 40, 4.5),
+  (2, 50, 5.5)

--- a/axiom/optimizer/tests/sql/cte.sql
+++ b/axiom/optimizer/tests/sql/cte.sql
@@ -19,3 +19,18 @@ WITH t(a) AS (SELECT 1)
 SELECT * FROM (
   WITH t(b) AS (SELECT a FROM t)
   SELECT * FROM (WITH t(c) AS (SELECT b FROM t) SELECT c AS r FROM t) s2) s1
+----
+-- A CTE body resolves names against its own FROM: `t.u` names the struct
+-- column of `t`, not the same-named relation the referencing query reads.
+WITH s AS (
+  SELECT t.u.k AS k
+  FROM (VALUES (CAST(ROW(1) AS ROW(k BIGINT)))) AS t(u)
+)
+SELECT u.b
+FROM (VALUES (1, 'p'), (2, 'q')) AS u(k, b)
+LEFT JOIN s ON u.k = s.k
+----
+-- A CTE body inside a correlated subquery still reads the correlated column.
+WITH v AS (SELECT a, b FROM t)
+SELECT a FROM v u
+WHERE EXISTS (WITH w AS (SELECT b FROM t WHERE t.a = u.a) SELECT * FROM w)

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -194,6 +194,35 @@ JOIN t t18 ON t17.b = t18.b
 JOIN t t19 ON t18.b = t19.b
 JOIN t t20 ON t19.b = t20.b
 ----
+-- 20-way FULL JOIN of an aggregate over a table with no statistics, on a key
+-- USING coalesces. Verifies the chain plans and returns the matched rows.
+WITH base AS (
+  SELECT a, b, count(*) AS n
+  FROM t_no_stats
+  GROUP BY 1, 2
+)
+SELECT b, t1.n AS n1, t2.n AS n2, t3.n AS n3, t4.n AS n4, t5.n AS n5, t6.n AS n6, t7.n AS n7, t8.n AS n8, t9.n AS n9, t10.n AS n10, t11.n AS n11, t12.n AS n12, t13.n AS n13, t14.n AS n14, t15.n AS n15, t16.n AS n16, t17.n AS n17, t18.n AS n18, t19.n AS n19, t20.n AS n20
+FROM base t1
+FULL JOIN base t2 USING (b)
+FULL JOIN base t3 USING (b)
+FULL JOIN base t4 USING (b)
+FULL JOIN base t5 USING (b)
+FULL JOIN base t6 USING (b)
+FULL JOIN base t7 USING (b)
+FULL JOIN base t8 USING (b)
+FULL JOIN base t9 USING (b)
+FULL JOIN base t10 USING (b)
+FULL JOIN base t11 USING (b)
+FULL JOIN base t12 USING (b)
+FULL JOIN base t13 USING (b)
+FULL JOIN base t14 USING (b)
+FULL JOIN base t15 USING (b)
+FULL JOIN base t16 USING (b)
+FULL JOIN base t17 USING (b)
+FULL JOIN base t18 USING (b)
+FULL JOIN base t19 USING (b)
+FULL JOIN base t20 USING (b)
+----
 -- Greedy join enumeration (>= 5 tables) driven by a UNION ALL subquery.
 SELECT b.v, s.k
 FROM (SELECT k FROM (VALUES (1)) AS t (k) UNION ALL SELECT k FROM (VALUES (1)) AS t (k)) AS s

--- a/axiom/optimizer/v2/NodeRewriter.h
+++ b/axiom/optimizer/v2/NodeRewriter.h
@@ -33,14 +33,25 @@ struct NoContext {};
 /// Stateless passes inherit `NodeRewriter<>`. State-bearing passes
 /// parameterize on a `TContext` that is threaded by reference through
 /// dispatch.
+///
+/// Nodes are interned, so one subtree can hang off several parents and a
+/// hook can be called on the same node more than once. A hook must not
+/// depend on how many times, or in what position, it is reached. A hook
+/// that updates rewriter state on every visit is not safe under an override
+/// of rewrite() that caches, unless that update is idempotent.
 template <typename TContext = NoContext>
 class NodeRewriter {
  public:
   explicit NodeRewriter(Builder& builder) : builder_(builder) {}
   virtual ~NodeRewriter() = default;
 
-  /// Dispatches by `node->nodeType()` to the matching `rewriteX` hook.
-  NodeCP rewrite(NodeCP node, TContext& context) {
+  /// Dispatches by `node->nodeType()` to the matching `rewriteX` hook. The
+  /// hooks recurse through this, so an override wraps the entire descent —
+  /// for example to memoize per node. An override must be deterministic per
+  /// node, and must not skip a hook whose effect depends on running at every
+  /// occurrence. An override hides the single-argument `rewrite(NodeCP)`;
+  /// re-expose it with `using NodeRewriter::rewrite;`.
+  virtual NodeCP rewrite(NodeCP node, TContext& context) {
     switch (node->nodeType()) {
       case NodeType::kScan:
         return rewriteScan(node->as<Scan>(), context);

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -21,6 +21,8 @@
 #include <numeric>
 #include <vector>
 
+#include <folly/container/F14Map.h>
+
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/optimizer/v2/CostModel.h"
 #include "axiom/optimizer/v2/DPhyp.h"
@@ -266,6 +268,21 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
         numWorkers_{numWorkers},
         numDrivers_{numDrivers},
         exprFactory_{builder} {}
+
+  // Re-exposes the rewrite(NodeCP) overload hidden by the override below.
+  using NodeRewriter<>::rewrite;
+
+  // Rewriting a node is a pure function of the node, so descend each node
+  // once.
+  NodeCP rewrite(NodeCP node, NoContext& context) override {
+    const auto it = rewrittenNodes_.find(node);
+    if (it != rewrittenNodes_.end()) {
+      return it->second;
+    }
+    NodeCP rewritten = NodeRewriter<>::rewrite(node, context);
+    rewrittenNodes_.emplace(node, rewritten);
+    return rewritten;
+  }
 
  protected:
   // Rebuilds a join that DPhyp does not plan (non-clusterable cross / theta /
@@ -1199,6 +1216,9 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
   // Shared across all clusters of this query so a leaf (or hash-consed
   // duplicate) subtree is estimated once.
   EstimateProvider estimateProvider_;
+
+  // Keys stay valid for the query: Builder owns interned nodes.
+  folly::F14FastMap<NodeCP, NodeCP> rewrittenNodes_;
 };
 
 } // namespace

--- a/axiom/sql/presto/CteScope.h
+++ b/axiom/sql/presto/CteScope.h
@@ -17,11 +17,13 @@
 
 #include <folly/ScopeGuard.h>
 #include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "axiom/common/CatalogSchemaTableName.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/sql/presto/ast/AstNodesAll.h"
 
@@ -45,17 +47,37 @@ namespace lp = facebook::axiom::logical_plan;
 ///
 /// Usage:
 ///   auto scope = ctes.enterScope();   // once per query body
-///   ctes.bind(name, {withQuery, isRecursive});
+///   ctes.bind(name, {withQuery, isRecursive, definingScope});
 ///   if (auto hidden = ctes.hide(name)) { translate hidden.entry()'s body }
 ///
 /// Invariant: a name is a key iff it has a binding in scope.
 class CteScope {
  public:
+  /// What a CTE body resolves names against beyond its own FROM: the scope
+  /// where the WITH is written, captured before the defining query's FROM is
+  /// processed. A body is translated at each reference site, where the
+  /// referencing query's relations are in scope, and those must not resolve
+  /// inside the body.
+  struct DefiningScope {
+    /// Columns of the enclosing queries, for a correlated reference.
+    lp::PlanBuilder::Scope columns;
+
+    /// Base tables reachable by a suffix of their qualified name.
+    folly::F14FastMap<std::string, facebook::axiom::CatalogSchemaTableName>
+        relations;
+
+    /// Qualifiers naming more than one relation, which resolve nothing.
+    folly::F14FastSet<std::string> ambiguousRelations;
+  };
+
   /// One CTE binding. 'isRecursive' is true when the body refers to itself.
   /// A recursive body is re-translated at each reference site.
   struct Entry {
     std::shared_ptr<WithQuery> withQuery;
     bool isRecursive{false};
+
+    /// Never null. Shared by every reference to this CTE.
+    std::shared_ptr<const DefiningScope> definingScope;
   };
 
   /// Hides a name's in-scope binding for the guard's lifetime, so the

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -506,13 +506,34 @@ class RelationPlanner : public AstVisitor {
     return guard;
   }
 
+  // Restores the relations in scope when the guard dies. 'from' replaces them
+  // for the guard's lifetime; without it they only need restoring, which is
+  // what a nested query that adds its own relations wants.
+  [[nodiscard]] auto scopedRelations(
+      const CteScope::DefiningScope* from = nullptr) {
+    auto guard =
+        folly::makeGuard([this,
+                          savedRelations = scopeRelations_,
+                          savedAmbiguous = ambiguousScopeRelations_]() mutable {
+          scopeRelations_ = std::move(savedRelations);
+          ambiguousScopeRelations_ = std::move(savedAmbiguous);
+        });
+    if (from != nullptr) {
+      scopeRelations_ = from->relations;
+      ambiguousScopeRelations_ = from->ambiguousRelations;
+    }
+    return guard;
+  }
+
   // Translates a recursive CTE into a fresh FixedPointNode subtree rooted
-  // in the caller's builder_. Anchor sees 'outerScope' (LATERAL resolves);
-  // step does not (correlated refs across the boundary fail). Each outer
-  // reference run this to produce new FixedPointNodes.
+  // in the caller's builder_. The anchor sees the scope where the WITH is
+  // written; the step sees no outer scope, so a correlated reference across
+  // the boundary fails. Each outer reference runs this to produce new
+  // FixedPointNodes.
   void translateRecursiveCteReference(
       const WithQuery& withEntry,
-      const std::string& cteName) {
+      const std::string& cteName,
+      const CteScope::DefiningScope& definingScope) {
     AXIOM_PRESTO_SYNTAX_CHECK(
         !ctes_.hasAnchors(),
         withEntry.location(),
@@ -522,10 +543,7 @@ class RelationPlanner : public AstVisitor {
         presto::RecursiveCteValidator::extractAndValidateRecursiveUnion(
             withEntry, cteName);
 
-    // Translate the anchor on a fresh builder inheriting the outer scope
-    // (LATERAL refs resolve through it).
-    auto outerScope = builder_->scope();
-    builder_ = newBuilder(outerScope);
+    builder_ = newBuilder(definingScope.columns);
     {
       auto guard = scopedResetLastNames();
       processQueryBody(unionExpr->left());
@@ -625,9 +643,18 @@ class RelationPlanner : public AstVisitor {
 
     if (auto hidden = ctes_.hide(name)) {
       const auto& entry = hidden.entry();
+      VELOX_CHECK_NOT_NULL(entry.definingScope);
+      const auto& definingScope = *entry.definingScope;
+      auto relationsGuard = scopedRelations(&definingScope);
+      // The body resolves in the scope where the WITH is written. The relation
+      // it yields belongs to the referencing query, which resolves the rest of
+      // its own names, correlated ones included, in its own scope.
+      auto referencingScope = builder_->outerScope();
+
       if (entry.isRecursive) {
-        translateRecursiveCteReference(*entry.withQuery, name);
+        translateRecursiveCteReference(*entry.withQuery, name, definingScope);
       } else {
+        builder_ = newBuilder(definingScope.columns);
         processQuery(entry.withQuery->query().get());
 
         // Apply CTE column-alias list, e.g. 'WITH t(a, b) AS (...)' renames
@@ -637,6 +664,7 @@ class RelationPlanner : public AstVisitor {
           applyColumnAliases(*columnAliases, entry.withQuery->location(), name);
         }
       }
+      builder_->switchOuterScope(std::move(referencingScope));
       finalizeCteReference(name);
       return true;
     }
@@ -768,12 +796,7 @@ class RelationPlanner : public AstVisitor {
   void processAliasedRelation(const AliasedRelation& aliasedRelation) {
     // The alias replaces the relation's name, so its qualified name no longer
     // resolves: `nation AS n` makes `default.nation.x` an error.
-    auto savedScopeRelations = scopeRelations_;
-    auto savedAmbiguousRelations = ambiguousScopeRelations_;
-    SCOPE_EXIT {
-      scopeRelations_ = std::move(savedScopeRelations);
-      ambiguousScopeRelations_ = std::move(savedAmbiguousRelations);
-    };
+    auto relationsGuard = scopedRelations();
     processFrom(aliasedRelation.relation());
 
     auto alias = canonicalizeIdentifier(*aliasedRelation.alias());
@@ -1518,18 +1541,16 @@ class RelationPlanner : public AstVisitor {
     // The relations this query puts in scope leave with it. Entries from
     // enclosing queries stay visible, so a correlated subquery can still name
     // an outer relation.
-    auto savedScopeRelations = scopeRelations_;
-    auto savedAmbiguousRelations = ambiguousScopeRelations_;
-    SCOPE_EXIT {
-      scopeRelations_ = std::move(savedScopeRelations);
-      ambiguousScopeRelations_ = std::move(savedAmbiguousRelations);
-    };
+    auto relationsGuard = scopedRelations();
 
     // lastNames is scoped per query; reset so names from a sibling relation
     // in the enclosing scope cannot leak in.
     displayNames_.lastNames.clear();
 
     if (const auto& with = query->with()) {
+      auto definingScope = std::make_shared<const CteScope::DefiningScope>(
+          builder_->outerScope(), scopeRelations_, ambiguousScopeRelations_);
+
       // Names must be unique within a single WITH list. A nested WITH may
       // still reuse an enclosing name -- that is shadowing, handled below.
       std::unordered_set<std::string> namesInList;
@@ -1548,7 +1569,9 @@ class RelationPlanner : public AstVisitor {
           selfReferential = presto::RecursiveCteValidator::referencesCte(
               *withQuery->query(), cteName);
         }
-        ctes_.bind(cteName, CteScope::Entry{withQuery, selfReferential});
+        ctes_.bind(
+            cteName,
+            CteScope::Entry{withQuery, selfReferential, definingScope});
       }
     }
 

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -519,6 +519,40 @@ TEST_F(PrestoParserTest, withNoLeaking) {
       "Table not found: t");
 }
 
+TEST_F(PrestoParserTest, withBodyResolvesInDefiningScope) {
+  // A CTE body names only what its own FROM and the WITH's scope offer. The
+  // referencing query reads a table 'u', which must not answer the qualifier
+  // 'u' inside the body: there 'u' is the struct column of 's', so 's.u.k' is
+  // a field access.
+  connector_->addTable("s", ROW("u", ROW("k", BIGINT())));
+  connector_->addTable("u", ROW({"k", "b"}, {BIGINT(), VARCHAR()}));
+
+  testSelect(
+      "WITH c AS (SELECT s.u.k AS k FROM s) "
+      "SELECT u.b FROM u LEFT JOIN c ON u.k = c.k",
+      matchScan()
+          .join(matchScan().project({"u.k"}).build())
+          .project({"b"})
+          .output({"b"}));
+
+  // Neither a relation nor a column of the body's own FROM answers 'u', even
+  // though the referencing query reads a table by that name.
+  VELOX_ASSERT_THROW(
+      parseSql(
+          "WITH c AS (SELECT u.b AS b FROM nation) "
+          "SELECT u.b FROM u LEFT JOIN c ON u.k = 1"),
+      "Cannot resolve column: u");
+
+  // A schema-qualified name reaches the tables in scope, which are the body's
+  // own. 'default.u' names the referencing query's table, so it resolves
+  // nothing here even though the body has a column 'u'.
+  VELOX_ASSERT_THROW(
+      parseSql(
+          "WITH c AS (SELECT default.u.k AS k FROM s) "
+          "SELECT u.b FROM u LEFT JOIN c ON u.k = c.k"),
+      "Cannot resolve column");
+}
+
 TEST_F(PrestoParserTest, withShadowingBaseTable) {
   // CTE with the same name as a base table it references. The inner reference
   // to 'nation' inside the CTE body must resolve to the base table, not recurse

--- a/axiom/sql/presto/tests/WithRecursiveTest.cpp
+++ b/axiom/sql/presto/tests/WithRecursiveTest.cpp
@@ -28,6 +28,38 @@ namespace {
 
 class WithRecursiveTest : public PrestoParserTestBase {};
 
+TEST_F(WithRecursiveTest, anchorResolvesInDefiningScope) {
+  // The anchor resolves in the scope where the WITH is written: 'u' there is
+  // the struct column of 's', not the same-named table the query referencing
+  // the CTE reads.
+  connector_->addTable("s", ROW("u", ROW("k", BIGINT())));
+  connector_->addTable("u", ROW({"k", "b"}, {BIGINT(), VARCHAR()}));
+
+  auto step = lp::test::LogicalPlanMatcherBuilder()
+                  .recursiveRef("c")
+                  .filter()
+                  .project()
+                  .build();
+  testSelect(
+      R"(
+        WITH RECURSIVE c(k) AS (
+          SELECT s.u.k FROM s
+          UNION ALL
+          SELECT k + 1 FROM c WHERE k < 2
+        )
+        SELECT u.b FROM u LEFT JOIN c ON u.k = c.k
+      )",
+      matchScan()
+          .join(
+              matchScan()
+                  .project({"u.k"})
+                  .project()
+                  .fixedPoint(step, {"k"})
+                  .build())
+          .project({"b"})
+          .output({"b"}));
+}
+
 TEST_F(WithRecursiveTest, simpleCounter) {
   // Self-contained recursion — no base table needed.
   auto step = lp::test::LogicalPlanMatcherBuilder()


### PR DESCRIPTION
Summary:
Planning a query that joins the same aggregate many times over a table with no statistics ran out of memory. Every join added to the chain doubled the work: a 15-join chain planned in a few seconds, adding one more exhausted 16GB, and the query that hit this in production failed with `Exceeded memory allocator limit of 205.00GB` before planning finished.

The v2 physical-plan pass descends a node once while building the join hypergraph, then descends it again when a join it cannot cost falls back to the written order. Nothing remembered the first descent, and each one allocated fresh columns in the query-graph arena, which lives until the query ends. The pass now caches the rewrite of each node.

Adds a `collect_statistics` CREATE TABLE property to the test connector. A table created with `collect_statistics = false` reports no row count and no column statistics, which is the condition that leaves a join uncostable and was otherwise not expressible in a test.

Differential Revision: D116730916


