### PR TITLE
docs: Align the Axel and Axiom coding-style rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -197,7 +197,9 @@ Use conventional commit prefixes with `[Project]` tags:
 ```
 
 Format: `[Project] type(scope): Description`
-- Types: `feat`, `fix`, `refactor`, `test`, `docs`
+- Types: `feat`, `fix`, `perf`, `build`, `test`, `docs`, `refactor`, `misc`
+  (this list is enforced by the `PR Title Format` check in
+  `.github/workflows/preliminary_checks.yml` — keep it in step with that regex)
 - Scope is optional, use for subsystem clarity (e.g., `parser`, `optimizer`)
 - Description starts with a capital letter, no trailing period
 


### PR DESCRIPTION
Summary:
`axel/.llms/rules/coding-style.md` is a copy of Axiom's that was never adapted. It is titled "Axiom Coding Style", tells agents working in axel to consult `axiom/optimizer/docs/DebuggingTips.md` and run `buck run axiom/cli:cli`, and instructs them to keep the file in sync with `axiom/public_tld/.claude/CLAUDE.md`. It had also drifted 168 lines behind, missing the public-class-doc rules, `## Types`, the commit-message body-shape and pre-send checklist, and four Common Mistakes entries.

Rebuilds axel's file from Axiom's so the shared rules are byte-identical, then substitutes only what is genuinely project-specific: the title and intro, the debugging section (now Axel's design and testing overviews, `axel_main`, `presto_cmdline_client` and real `axel/service/tests` targets), the slow-test guidance, and the commit examples. Drops the Axiom-only Dialect Independence rule and the `ExprCP` / `ColumnCP` aliases.

All three files listed five conventional-commit types, while the `PR Title Format` check that both repos ship enforces eight — `feat|fix|perf|build|test|docs|refactor|misc`. That gap is why two submodule bumps landed with different prefixes, one `build(oss)` and one `fix(build)`. Corrects the list in all three and cites the workflow that enforces it so it does not drift again.

Known limitation: both rule files now trip the `LLMSRULES token-count-exceeded` warning — axel at ~5.7k tokens, Axiom at ~5.9k, against a 3k recommendation. Axiom already exceeded it; axel does now as the price of parity. Splitting the shared body into a `deps:`-referenced rule under `.llms/rules/references/` would fix both, and is the better long-term shape than three copies kept in sync by hand.

Reviewed By: mbasmanova

Differential Revision: D116732359


