### PR TITLE
feat(sql): Support EXPLAIN of session statements (#1743)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -633,6 +633,54 @@ class QueryFinalizer {
   QueryCompletionInfo& completionInfo_;
 };
 
+// Returns the plan SHOW SESSION runs: the session properties as literal rows,
+// filtered by the statement's LIKE pattern.
+logical_plan::LogicalPlanNodePtr showSessionPlan(
+    const SessionConfig& sessionConfig,
+    const std::string& defaultConnectorId,
+    const presto::ShowSessionStatement& statement) {
+  using facebook::velox::config::ConfigPropertyTypeName;
+
+  // Collect and sort entries by qualified name.
+  auto entries = sessionConfig.all();
+  std::sort(
+      entries.begin(), entries.end(), [](const auto& lhs, const auto& rhs) {
+        return std::tie(lhs.prefix, lhs.property.name) <
+            std::tie(rhs.prefix, rhs.property.name);
+      });
+
+  std::vector<velox::Variant> data;
+  data.reserve(entries.size());
+  for (const auto& entry : entries) {
+    auto qualifiedName = entry.prefix + "." + entry.property.name;
+    data.emplace_back(
+        velox::Variant::row({
+            qualifiedName,
+            entry.currentValue.value_or(""),
+            entry.property.defaultValue.value_or(""),
+            std::string(ConfigPropertyTypeName::toName(entry.property.type)),
+            entry.property.description,
+        }));
+  }
+
+  namespace lp = facebook::axiom::logical_plan;
+
+  lp::PlanBuilder::Context context(defaultConnectorId);
+  lp::PlanBuilder builder(context);
+  builder.values(
+      ROW({"Name", "Value", "Default", "Type", "Description"},
+          velox::VARCHAR()),
+      std::move(data));
+
+  if (statement.likePattern().has_value()) {
+    builder.filter(
+        lp::Call(
+            "like", lp::Col("Name"), lp::Lit(statement.likePattern().value())));
+  }
+
+  return builder.build();
+}
+
 } // namespace
 
 SqlQueryRunner::SqlResult SqlQueryRunner::run(
@@ -942,6 +990,38 @@ SqlQueryRunner::co_runExplainStatement(
         add->ifNotExists() ? "IF NOT EXISTS " : "",
         add->columnName(),
         add->columnType()->toString())};
+    co_return;
+  } else if (statement->isShowSession()) {
+    logicalPlan = showSessionPlan(
+        *sessionConfig_,
+        defaultConnectorId_,
+        *statement->as<presto::ShowSessionStatement>());
+  } else if (
+      statement->isSetSession() || statement->isResetSession() ||
+      statement->isUse()) {
+    // These change the session and have no plan: echo the statement without
+    // applying it, and without resolving the property or catalog it names.
+    //
+    // Each message is built before its co_yield. A temporary that a
+    // conditional expression materializes in the yielded expression has to
+    // outlive the suspension, and GCC does not keep it alive.
+    if (statement->isSetSession()) {
+      const auto* setSession = statement->as<presto::SetSessionStatement>();
+      auto message = fmt::format(
+          "SET SESSION {} = {}", setSession->name(), setSession->valueSql());
+      co_yield SqlResultChunk{std::move(message)};
+    } else if (statement->isResetSession()) {
+      const auto* resetSession = statement->as<presto::ResetSessionStatement>();
+      auto message = fmt::format("RESET SESSION {}", resetSession->name());
+      co_yield SqlResultChunk{std::move(message)};
+    } else {
+      VELOX_CHECK_EQ(statement->kind(), presto::SqlStatementKind::kUse);
+      const auto* use = statement->as<presto::UseStatement>();
+      auto message = use->catalog().has_value()
+          ? fmt::format("USE {}.{}", use->catalog().value(), use->schema())
+          : fmt::format("USE {}", use->schema());
+      co_yield SqlResultChunk{std::move(message)};
+    }
     co_return;
   } else if (statement->isCall()) {
     // EXPLAIN must be side-effect-free: echo the resolved call without
@@ -1831,50 +1911,10 @@ folly::coro::AsyncGenerator<velox::RowVectorPtr> SqlQueryRunner::co_showSession(
     const RunOptions& options,
     QueryTiming& timing,
     std::string& planString) {
-  using facebook::velox::config::ConfigPropertyTypeName;
-
-  // Collect and sort entries by qualified name.
-  auto entries = sessionConfig_->all();
-  std::sort(
-      entries.begin(), entries.end(), [](const auto& lhs, const auto& rhs) {
-        return std::tie(lhs.prefix, lhs.property.name) <
-            std::tie(rhs.prefix, rhs.property.name);
-      });
-
-  std::vector<velox::Variant> data;
-  data.reserve(entries.size());
-  for (const auto& entry : entries) {
-    auto qualifiedName = entry.prefix + "." + entry.property.name;
-    data.emplace_back(
-        velox::Variant::row({
-            qualifiedName,
-            entry.currentValue.value_or(""),
-            entry.property.defaultValue.value_or(""),
-            std::string(ConfigPropertyTypeName::toName(entry.property.type)),
-            entry.property.description,
-        }));
-  }
-
-  namespace lp = facebook::axiom::logical_plan;
-
-  lp::PlanBuilder::Context context(defaultConnectorId_);
-  lp::PlanBuilder builder(context);
-  builder.values(
-      ROW({"Name", "Value", "Default", "Type", "Description"},
-          velox::VARCHAR()),
-      std::move(data));
-
-  if (statement.likePattern().has_value()) {
-    builder.filter(
-        lp::Call(
-            "like", lp::Col("Name"), lp::Lit(statement.likePattern().value())));
-  }
-
-  // Materialize the built plan into a local before the await: `build()` returns
-  // by value, and binding that temporary to co_runLogicalPlan's `const&`
-  // parameter would leave it dangling once GCC destroys co_await-operand
-  // temporaries at the suspension point.
-  auto plan = builder.build();
+  // Materialize the plan into a local before the await: co_runLogicalPlan
+  // takes it by const reference, and a temporary would dangle once GCC
+  // destroys co_await-operand temporaries at the suspension point.
+  auto plan = showSessionPlan(*sessionConfig_, defaultConnectorId_, statement);
   auto generator = co_runLogicalPlan(plan, options, timing, planString);
   while (auto batch = co_await generator.next()) {
     co_yield std::move(*batch);

--- a/axiom/cli/tests/ExplainTest.cpp
+++ b/axiom/cli/tests/ExplainTest.cpp
@@ -127,6 +127,70 @@ TEST_P(ExplainTest, explainValidate) {
       "Table not found: nosuchtable");
 }
 
+// USE only changes the session, so EXPLAIN reports the statement itself and
+// resolves nothing: neither form names a catalog or schema that exists here.
+TEST_P(ExplainTest, explainUse) {
+  EXPECT_EQ(run("EXPLAIN USE other").message, "USE other");
+  EXPECT_EQ(run("EXPLAIN USE test.other").message, "USE test.other");
+  EXPECT_EQ(run("EXPLAIN USE nosuchcatalog.s").message, "USE nosuchcatalog.s");
+
+  // EXPLAIN left the session where it was.
+  EXPECT_EQ(runner_->defaultConnectorId(), "test");
+  EXPECT_EQ(runner_->defaultSchema(), "default");
+}
+
+TEST_P(ExplainTest, explainSessionStatements) {
+  // SHOW SESSION reads the properties as rows, so it explains like any query,
+  // with the LIKE pattern as a filter over them.
+  auto explainLines = [&](const std::string& sql) {
+    auto result = run(sql);
+    EXPECT_TRUE(result.message.has_value());
+    std::vector<std::string> lines;
+    folly::split('\n', result.message.value_or(""), lines);
+    return lines;
+  };
+
+  EXPECT_THAT(
+      explainLines("EXPLAIN (TYPE LOGICAL) SHOW SESSION"),
+      ::testing::ElementsAre(
+          ::testing::StartsWith("- Values: "), ::testing::Eq("")));
+
+  EXPECT_THAT(
+      explainLines("EXPLAIN (TYPE LOGICAL) SHOW SESSION LIKE 'optimizer.%'"),
+      ::testing::ElementsAre(
+          ::testing::StartsWith("- Filter: like(Name, optimizer.%) -> ROW<"),
+          ::testing::StartsWith("  - Values: "),
+          ::testing::Eq("")));
+
+  // A statement that only changes the session has no plan; EXPLAIN reports the
+  // statement itself, as written, and leaves the session alone.
+  auto result = run("EXPLAIN SET SESSION optimizer.sample_joins = true");
+  EXPECT_EQ(result.message, "SET SESSION optimizer.sample_joins = true");
+
+  // The value reads back as a SQL literal: a string keeps its quotes,
+  // doubling any it contains, and a number takes its shortest spelling.
+  result = run("EXPLAIN SET SESSION optimizer.sample_joins = 'a''b'");
+  EXPECT_EQ(result.message, "SET SESSION optimizer.sample_joins = 'a''b'");
+
+  result = run("EXPLAIN SET SESSION optimizer.sample_joins = 1.5");
+  EXPECT_EQ(result.message, "SET SESSION optimizer.sample_joins = 1.5");
+
+  result = run("EXPLAIN RESET SESSION optimizer.sample_joins");
+  EXPECT_EQ(result.message, "RESET SESSION optimizer.sample_joins");
+
+  // Neither the property nor the catalog is resolved, as in Presto.
+  result = run("EXPLAIN SET SESSION no.such_property = 1");
+  EXPECT_EQ(result.message, "SET SESSION no.such_property = 1");
+
+  // None of the EXPLAINs above took effect: the property the SET statements
+  // name still holds its default, and the USE statements moved nothing.
+  EXPECT_EQ(
+      runner_->sessionConfig().effectiveValue("optimizer.sample_joins"),
+      "false");
+  EXPECT_EQ(runner_->defaultSchema(), "default");
+  EXPECT_EQ(runner_->defaultConnectorId(), "test");
+}
+
 TEST_P(ExplainTest, explainCreateTable) {
   auto result = run("EXPLAIN CREATE TABLE t(x int)");
   EXPECT_EQ(result.message, R"(CREATE TABLE test."default"."t")");

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -3119,21 +3119,41 @@ SqlStatementPtr parseSetSession(const SetSession* setSession) {
 
   auto* value = setSession->value().get();
   std::string valueString;
+  std::string valueSql;
   if (value->is(NodeType::kStringLiteral)) {
     valueString = value->as<StringLiteral>()->value();
+    std::string escaped;
+    escaped.reserve(valueString.size());
+    for (const char character : valueString) {
+      // SQL writes a quote inside a string literal as two.
+      if (character == '\'') {
+        escaped.push_back(character);
+      }
+      escaped.push_back(character);
+    }
+    valueSql = fmt::format("'{}'", escaped);
   } else if (value->is(NodeType::kLongLiteral)) {
     valueString = std::to_string(value->as<LongLiteral>()->value());
+    valueSql = valueString;
   } else if (value->is(NodeType::kBooleanLiteral)) {
     valueString = value->as<BooleanLiteral>()->value() ? "true" : "false";
+    valueSql = valueString;
   } else if (value->is(NodeType::kDoubleLiteral)) {
-    valueString = std::to_string(value->as<DoubleLiteral>()->value());
+    // Shortest round-trip form: 1.5, not 1.500000.
+    valueString = fmt::format("{}", value->as<DoubleLiteral>()->value());
+    valueSql = valueString;
+  } else if (value->is(NodeType::kDecimalLiteral)) {
+    // A decimal reaches here only when the parser is configured to keep
+    // decimals exact rather than read them as doubles.
+    valueString = value->as<DecimalLiteral>()->value();
+    valueSql = valueString;
   } else {
     AXIOM_PRESTO_SEMANTIC_FAIL(
         value->location(), name, "SET SESSION value must be a literal");
   }
 
   return std::make_shared<SetSessionStatement>(
-      std::move(name), std::move(valueString));
+      std::move(name), std::move(valueString), std::move(valueSql));
 }
 
 // Resolves a procedure's qualified name into a connector id and
@@ -3313,6 +3333,32 @@ SqlStatementPtr doPlan(
     const ParserSessionPtr& parserSession) {
   const auto& user = parserSession->user();
 
+  // Statements that don't reference tables and don't need planning.
+  if (query->is(NodeType::kShowSession)) {
+    auto* showSession = query->as<ShowSession>();
+    return std::make_shared<ShowSessionStatement>(showSession->likePattern());
+  }
+
+  if (query->is(NodeType::kSetSession)) {
+    return parseSetSession(query->as<SetSession>());
+  }
+
+  if (query->is(NodeType::kResetSession)) {
+    auto* resetSession = query->as<ResetSession>();
+    return std::make_shared<ResetSessionStatement>(
+        resetSession->name()->fullyQualifiedName());
+  }
+
+  if (query->is(NodeType::kUse)) {
+    auto* use = query->as<Use>();
+    std::optional<std::string> catalog;
+    if (use->catalog()) {
+      catalog = use->catalog()->value();
+    }
+    return std::make_shared<UseStatement>(
+        std::move(catalog), use->schema()->value());
+  }
+
   if (query->is(NodeType::kInsert)) {
     return parseInsert(
         user,
@@ -3466,32 +3512,6 @@ SqlStatementPtr PrestoParser::doParse(
   };
 
   auto query = parseSql(sql);
-
-  // Statements that don't reference tables and don't need planning.
-  if (query->is(NodeType::kShowSession)) {
-    auto* showSession = query->as<ShowSession>();
-    return std::make_shared<ShowSessionStatement>(showSession->likePattern());
-  }
-
-  if (query->is(NodeType::kSetSession)) {
-    return parseSetSession(query->as<SetSession>());
-  }
-
-  if (query->is(NodeType::kResetSession)) {
-    auto* resetSession = query->as<ResetSession>();
-    return std::make_shared<ResetSessionStatement>(
-        resetSession->name()->fullyQualifiedName());
-  }
-
-  if (query->is(NodeType::kUse)) {
-    auto* use = query->as<Use>();
-    std::optional<std::string> catalog;
-    if (use->catalog()) {
-      catalog = use->catalog()->value();
-    }
-    return std::make_shared<UseStatement>(
-        std::move(catalog), use->schema()->value());
-  }
 
   if (query->is(NodeType::kExplain)) {
     auto* explain = query->as<Explain>();

--- a/axiom/sql/presto/SqlStatement.h
+++ b/axiom/sql/presto/SqlStatement.h
@@ -678,22 +678,31 @@ class ShowSessionStatement : public SqlStatement {
 
 class SetSessionStatement : public SqlStatement {
  public:
-  SetSessionStatement(std::string name, std::string value)
+  SetSessionStatement(std::string name, std::string value, std::string valueSql)
       : SqlStatement(SqlStatementKind::kSetSession),
         name_{std::move(name)},
-        value_{std::move(value)} {}
+        value_{std::move(value)},
+        valueSql_{std::move(valueSql)} {}
 
   const std::string& name() const {
     return name_;
   }
 
+  /// The value to store, with a string literal's quotes stripped.
   const std::string& value() const {
     return value_;
+  }
+
+  /// The value rendered as a SQL literal: a string keeps its quotes, a
+  /// number the shortest spelling that reads back the same.
+  const std::string& valueSql() const {
+    return valueSql_;
   }
 
  private:
   const std::string name_;
   const std::string value_;
+  const std::string valueSql_;
 };
 
 class ResetSessionStatement : public SqlStatement {
@@ -731,5 +740,6 @@ class UseStatement : public SqlStatement {
 
 } // namespace axiom::sql::presto
 
+AXIOM_ENUM_FORMATTER(axiom::sql::presto::SqlStatementKind);
 AXIOM_EMBEDDED_ENUM_FORMATTER(axiom::sql::presto::ExplainStatement, Type);
 AXIOM_EMBEDDED_ENUM_FORMATTER(axiom::sql::presto::ExplainStatement, Format);


### PR DESCRIPTION
Summary:

`EXPLAIN SHOW SESSION` and `EXPLAIN SET SESSION x = 1` failed to parse with
`Unsupported statement type`. The session statements were recognized in
`doParse` ahead of its EXPLAIN branch, and the statement inside an EXPLAIN is
parsed by `doPlan`, which knew nothing of them. Moving them into `doPlan`,
which both paths reach, is all it takes for EXPLAIN to see them.

SHOW SESSION reads the session properties as rows, and the plan it runs is a
`Values` over them under an optional LIKE filter. That plan moves out of
`co_showSession` so EXPLAIN renders the same one, for every type and format,
the way Presto explains its own rewrite of the statement.

A statement that only changes the session has no plan, so EXPLAIN reports the
statement itself and changes nothing, matching Presto:

  presto> explain set session foo = 1;
   SET SESSION foo = 1

RESET SESSION and USE, reachable under EXPLAIN by the same parser change, are
reported the same way. None of them resolves its target, as Presto's own
example above does not resolve `foo`.

Echoing a SET SESSION needs the value as a SQL literal, which the statement
did not keep: it stores the value the session takes, with a string's quotes
stripped. It now carries the literal spelling too, with quotes doubled inside
a string. Rendering it switches doubles from `to_string` to `format`, so a
double-valued property is stored as `0.5` rather than `0.5000000`, and a
decimal literal is now accepted, which it was not when the parser is
configured to keep decimals exact.

Reviewed By: amitkdutta

Differential Revision: D116737572


