### PR TITLE
feat(logical_plan): Derive referenced tables from a logical plan (#1744)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -2066,7 +2066,7 @@ SqlQueryRunner::checkPermission(
     const RunOptions& options,
     QueryCompletionInfo& completionInfo,
     const presto::ViewMap& views,
-    const presto::ReferencedTables& referencedTables) {
+    const logical_plan::ReferencedTables& referencedTables) {
   if (permissionCheck_) {
     velox::MicrosecondTimer timer(&completionInfo.timing.checkPermission);
     return permissionCheck_(

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -47,7 +47,8 @@ using PermissionCheck =
         std::string_view catalog,
         std::optional<std::string_view> schema,
         const presto::ViewMap& views,
-        const presto::ReferencedTables& referencedTables)>;
+        const facebook::axiom::logical_plan::ReferencedTables&
+            referencedTables)>;
 
 /// Holds query metadata captured at query start time.
 struct QueryStartInfo {
@@ -128,7 +129,8 @@ struct QueryCompletionInfo {
   QueryStartInfo startInfo;
 
   /// Tables referenced by the parsed statement. Unset when parsing fails.
-  std::optional<presto::ReferencedTables> referencedTables;
+  std::optional<facebook::axiom::logical_plan::ReferencedTables>
+      referencedTables;
 
   /// Contains error details when the query fails; std::nullopt on success.
   std::optional<ErrorInfo> errorInfo;
@@ -494,7 +496,7 @@ class SqlQueryRunner {
       const RunOptions& options,
       QueryCompletionInfo& completionInfo,
       const presto::ViewMap& views,
-      const presto::ReferencedTables& referencedTables);
+      const facebook::axiom::logical_plan::ReferencedTables& referencedTables);
 
   std::shared_ptr<facebook::velox::core::QueryCtx> newQuery(
       const RunOptions& options);

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -157,7 +157,8 @@ TestTable::TestTable(
       connector_(connector),
       collectStatistics_(extractCollectStatistics(options)),
       bucketSpec_(std::move(bucketSpec)) {
-  const auto& label = this->name().table;
+  VELOX_CHECK_NOT_NULL(connector);
+  const auto& tableName = this->name().table;
   if (bucketSpec_.has_value()) {
     std::vector<const Column*> partitionColumns;
     std::vector<velox::TypePtr> partitionKeyTypes;
@@ -178,7 +179,7 @@ TestTable::TestTable(
             ->create(bucketSpec_->numBuckets, /*localExchange=*/false);
 
     exportedLayout_ = std::make_unique<TestTableLayout>(
-        label,
+        tableName,
         this,
         connector_,
         allColumns(),
@@ -186,13 +187,17 @@ TestTable::TestTable(
         std::move(partitionType));
   } else {
     exportedLayout_ = std::make_unique<TestTableLayout>(
-        label, this, connector_, allColumns());
+        tableName, this, connector_, allColumns());
   }
   layouts_.push_back(exportedLayout_.get());
   // Use the connector's parent pool if one was supplied (suite-scoped
   // fixtures with a standalone MemoryManager); otherwise fall back to the
   // global singleton.
   auto* tableRootPool = connector->tableRootPool();
+  // Pool names must be unique within the parent, and the same table name may
+  // occur in more than one schema or connector.
+  const auto label = fmt::format(
+      "{}.{}.{}", connector->connectorId(), this->name().schema, tableName);
   pool_ = tableRootPool != nullptr
       ? tableRootPool->addLeafChild(label + "_table")
       : velox::memory::memoryManager()->addLeafPool(label + "_table");

--- a/axiom/logical_plan/CMakeLists.txt
+++ b/axiom/logical_plan/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
   ExprResolver.cpp
   LogicalPlanNode.cpp
   PlanPrinter.cpp
+  ReferencedTableCollector.cpp
   ExprApi.cpp
 )
 

--- a/axiom/logical_plan/ReferencedTableCollector.cpp
+++ b/axiom/logical_plan/ReferencedTableCollector.cpp
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/logical_plan/ReferencedTableCollector.h"
+#include "axiom/logical_plan/ExprVisitor.h"
+#include "axiom/logical_plan/PlanNodeVisitor.h"
+
+namespace facebook::axiom::logical_plan {
+namespace {
+
+void collectFromPlan(const LogicalPlanNode& plan, ReferencedTables& tables);
+
+// Reaches the plan a subquery expression carries. Every other case is there to
+// walk through the expression trees that may hold one.
+class SubqueryTableVisitor : public ExprVisitor {
+ public:
+  struct Context : public ExprVisitorContext {
+    explicit Context(ReferencedTables& tables) : tables{tables} {}
+
+    ReferencedTables& tables;
+  };
+
+  void visit(const SubqueryExpr& expr, ExprVisitorContext& ctx) const override {
+    collectFromPlan(*expr.subquery(), static_cast<Context&>(ctx).tables);
+  }
+
+  void visit(const InputReferenceExpr& expr, ExprVisitorContext& ctx)
+      const override {
+    visitInputs(expr, ctx);
+  }
+
+  void visit(const ConstantExpr& expr, ExprVisitorContext& ctx) const override {
+    visitInputs(expr, ctx);
+  }
+
+  void visit(const CallExpr& expr, ExprVisitorContext& ctx) const override {
+    visitInputs(expr, ctx);
+  }
+
+  void visit(const SpecialFormExpr& expr, ExprVisitorContext& ctx)
+      const override {
+    visitInputs(expr, ctx);
+  }
+
+  void visit(const AggregateExpr& expr, ExprVisitorContext& ctx)
+      const override {
+    visitAggregate(expr, ctx);
+  }
+
+  void visit(const SpecialFormAggExpr& expr, ExprVisitorContext& ctx)
+      const override {
+    visitAggregate(expr, ctx);
+  }
+
+  void visit(const WindowExpr& expr, ExprVisitorContext& ctx) const override {
+    for (const auto& key : expr.partitionKeys()) {
+      key->accept(*this, ctx);
+    }
+    visitOrdering(expr.ordering(), ctx);
+    if (expr.frame().startValue != nullptr) {
+      expr.frame().startValue->accept(*this, ctx);
+    }
+    if (expr.frame().endValue != nullptr) {
+      expr.frame().endValue->accept(*this, ctx);
+    }
+    visitInputs(expr, ctx);
+  }
+
+  void visit(const LambdaExpr& expr, ExprVisitorContext& ctx) const override {
+    expr.body()->accept(*this, ctx);
+  }
+
+ private:
+  void visitOrdering(
+      const std::vector<SortingField>& ordering,
+      ExprVisitorContext& ctx) const {
+    for (const auto& field : ordering) {
+      field.expression->accept(*this, ctx);
+    }
+  }
+
+  void visitAggregate(const AggregateExpr& expr, ExprVisitorContext& ctx)
+      const {
+    if (expr.filter() != nullptr) {
+      expr.filter()->accept(*this, ctx);
+    }
+    visitOrdering(expr.ordering(), ctx);
+    visitInputs(expr, ctx);
+  }
+};
+
+class TableVisitor : public PlanNodeVisitor {
+ public:
+  struct Context : public PlanNodeVisitorContext {
+    explicit Context(ReferencedTables& tables) : tables{tables} {}
+
+    ReferencedTables& tables;
+  };
+
+  void visit(const ValuesNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    if (const auto* rows = std::get_if<ValuesNode::Exprs>(&node.data())) {
+      for (const auto& row : *rows) {
+        visitExprs(row, ctx);
+      }
+    }
+  }
+
+  void visit(const TableScanNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    static_cast<Context&>(ctx).tables.inputTables.insert(
+        {.catalogName = node.connectorId(),
+         .schemaTableName = node.tableName()});
+  }
+
+  void visit(const FilterNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    visitExpr(*node.predicate(), ctx);
+    visitInputs(node, ctx);
+  }
+
+  void visit(const ProjectNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    visitExprs(node.expressions(), ctx);
+    visitInputs(node, ctx);
+  }
+
+  void visit(const AggregateNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    visitExprs(node.groupingKeys(), ctx);
+    for (const auto& aggregate : node.aggregates()) {
+      visitExpr(*aggregate, ctx);
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const JoinNode& node, PlanNodeVisitorContext& ctx) const override {
+    visitCondition(node.condition(), ctx);
+    visitInputs(node, ctx);
+  }
+
+  void visit(const LateralJoinNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    visitCondition(node.condition(), ctx);
+    visitInputs(node, ctx);
+  }
+
+  void visit(const SortNode& node, PlanNodeVisitorContext& ctx) const override {
+    for (const auto& field : node.ordering()) {
+      visitExpr(*field.expression, ctx);
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const LimitNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    visitInputs(node, ctx);
+  }
+
+  void visit(const SetNode& node, PlanNodeVisitorContext& ctx) const override {
+    visitInputs(node, ctx);
+  }
+
+  void visit(const UnnestNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    visitExprs(node.unnestExpressions(), ctx);
+    visitInputs(node, ctx);
+  }
+
+  void visit(const TableWriteNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    auto& tables = static_cast<Context&>(ctx).tables;
+    CatalogSchemaTableName outputTable{
+        .catalogName = node.connectorId(), .schemaTableName = node.tableName()};
+
+    // A node rejects a write as its input, so the only way a second write
+    // reaches here is through the plan a subquery expression carries.
+    VELOX_USER_CHECK(
+        !tables.outputTable.has_value(),
+        "Plan cannot write more than one table: {} and {}",
+        tables.outputTable.value(),
+        outputTable);
+
+    tables.outputTable = std::move(outputTable);
+    visitExprs(node.columnExpressions(), ctx);
+    visitInputs(node, ctx);
+  }
+
+  void visit(const SampleNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    visitExpr(*node.percentage(), ctx);
+    visitInputs(node, ctx);
+  }
+
+  void visit(const OutputNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    visitInputs(node, ctx);
+  }
+
+  void visit(const FixedPointNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    visitInputs(node, ctx);
+  }
+
+  void visit(
+      const RecursiveReferenceNode& /*node*/,
+      PlanNodeVisitorContext& /*ctx*/) const override {
+    // Stands for the rows of the enclosing fixed point, not for a table.
+  }
+
+ private:
+  static void visitCondition(
+      const ExprPtr& condition,
+      PlanNodeVisitorContext& ctx) {
+    if (condition != nullptr) {
+      visitExpr(*condition, ctx);
+    }
+  }
+
+  static void visitExpr(const Expr& expr, PlanNodeVisitorContext& ctx) {
+    const SubqueryTableVisitor visitor;
+    SubqueryTableVisitor::Context exprContext{
+        static_cast<Context&>(ctx).tables};
+    expr.accept(visitor, exprContext);
+  }
+
+  static void visitExprs(
+      const std::vector<ExprPtr>& exprs,
+      PlanNodeVisitorContext& ctx) {
+    for (const auto& expr : exprs) {
+      visitExpr(*expr, ctx);
+    }
+  }
+};
+
+void collectFromPlan(const LogicalPlanNode& plan, ReferencedTables& tables) {
+  const TableVisitor visitor;
+  TableVisitor::Context context{tables};
+  plan.accept(visitor, context);
+}
+
+} // namespace
+
+// static
+ReferencedTables ReferencedTableCollector::collect(
+    const LogicalPlanNode& plan) {
+  ReferencedTables tables;
+  collectFromPlan(plan, tables);
+  return tables;
+}
+
+} // namespace facebook::axiom::logical_plan

--- a/axiom/logical_plan/ReferencedTableCollector.h
+++ b/axiom/logical_plan/ReferencedTableCollector.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/logical_plan/ReferencedTables.h"
+
+namespace facebook::axiom::logical_plan {
+
+/// Derives the tables a query references from its plan, for queries that never
+/// pass a SQL parser.
+class ReferencedTableCollector {
+ public:
+  /// Returns the tables 'plan' reads and writes. Every TableScan is an input
+  /// table, including scans reached through a subquery expression. A TableWrite
+  /// is the output table.
+  ///
+  /// Fails if the plan writes more than one table, rather than reporting one of
+  /// them: a caller checking permissions or recording lineage must see every
+  /// table written.
+  static ReferencedTables collect(const LogicalPlanNode& plan);
+};
+
+} // namespace facebook::axiom::logical_plan

--- a/axiom/logical_plan/ReferencedTables.h
+++ b/axiom/logical_plan/ReferencedTables.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <optional>
+#include <unordered_set>
+#include "axiom/common/CatalogSchemaTableName.h"
+
+namespace facebook::axiom::logical_plan {
+
+/// Tables referenced by a query, extracted from its SQL text or its logical
+/// plan.
+///
+/// Each table is a CatalogSchemaTableName with three parts:
+///   - catalogName: the connector ID (e.g., "prism", "impulse", "tpch").
+///   - schemaTableName.schema: the schema or namespace (e.g., "di", "default").
+///   - schemaTableName.table: the table name (e.g., "orders", "lineitem").
+///
+/// Both fields are complete: empty means the query touches nothing, never that
+/// the producer could not tell. A producer that cannot name everything a query
+/// reads or writes must fail instead of reporting less.
+struct ReferencedTables {
+  /// Every table the query reads.
+  std::unordered_set<CatalogSchemaTableName> inputTables;
+
+  /// The table the query writes.
+  std::optional<CatalogSchemaTableName> outputTable;
+};
+
+} // namespace facebook::axiom::logical_plan

--- a/axiom/logical_plan/tests/CMakeLists.txt
+++ b/axiom/logical_plan/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   ExprApiTest.cpp
   PlanBuilderTest.cpp
   PlanPrinterTest.cpp
+  ReferencedTableCollectorTest.cpp
 )
 
 add_test(axiom_logical_plan_tests axiom_logical_plan_tests)

--- a/axiom/logical_plan/tests/ReferencedTableCollectorTest.cpp
+++ b/axiom/logical_plan/tests/ReferencedTableCollectorTest.cpp
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/logical_plan/ReferencedTableCollector.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/ConnectorRegistry.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook::velox;
+
+namespace facebook::axiom::logical_plan {
+namespace {
+
+using ::testing::IsEmpty;
+using ::testing::UnorderedElementsAre;
+
+class ReferencedTableCollectorTest : public testing::Test {
+ protected:
+  static constexpr auto kConnectorId = "test";
+  static constexpr auto kOtherConnectorId = "other";
+  static constexpr auto kSchema = connector::TestConnector::kDefaultSchema;
+  static constexpr auto kOtherSchema = "archive";
+
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    functions::prestosql::registerAllScalarFunctions();
+    aggregate::prestosql::registerAllAggregateFunctions();
+
+    connector_ = addConnector(kConnectorId);
+    otherConnector_ = addConnector(kOtherConnectorId);
+
+    const auto ordersType = ROW({"id", "amount"}, BIGINT());
+    connector_->addTable("orders", ordersType);
+    connector_->addTable("orders_copy", ordersType);
+    connector_->addTable("lineitem", ROW({"id", "quantity"}, BIGINT()));
+    connector_->addTable({std::string(kOtherSchema), "orders"}, ordersType);
+    otherConnector_->addTable("orders", ordersType);
+  }
+
+  void TearDown() override {
+    removeConnector(kOtherConnectorId);
+    removeConnector(kConnectorId);
+    connector_.reset();
+    otherConnector_.reset();
+  }
+
+  static CatalogSchemaTableName table(
+      std::string_view name,
+      std::string_view catalogName = kConnectorId,
+      std::string_view schema = kSchema) {
+    return {
+        .catalogName = std::string{catalogName},
+        .schemaTableName = {
+            .schema = std::string{schema}, .table = std::string{name}}};
+  }
+
+  PlanBuilder planBuilder() {
+    return PlanBuilder(context_, /*allowAmbiguousOutputNames=*/true);
+  }
+
+  static ReferencedTables collect(const LogicalPlanNodePtr& plan) {
+    return ReferencedTableCollector::collect(*plan);
+  }
+
+  std::shared_ptr<connector::TestConnector> connector_;
+  std::shared_ptr<connector::TestConnector> otherConnector_;
+
+  PlanBuilder::Context context_{
+      std::string(kConnectorId),
+      std::string(kSchema)};
+
+ private:
+  static std::shared_ptr<connector::TestConnector> addConnector(
+      std::string_view connectorId) {
+    auto connector =
+        std::make_shared<connector::TestConnector>(std::string(connectorId));
+    velox::connector::ConnectorRegistry::global().insert(
+        std::string(connectorId), connector);
+    connector::ConnectorMetadataRegistry::global().insert(
+        std::string(connectorId), connector->metadata());
+    return connector;
+  }
+
+  static void removeConnector(std::string_view connectorId) {
+    connector::ConnectorMetadataRegistry::global().erase(
+        std::string(connectorId));
+    velox::connector::ConnectorRegistry::global().erase(
+        std::string(connectorId));
+  }
+};
+
+TEST_F(ReferencedTableCollectorTest, scanIsAnInputTable) {
+  auto plan = planBuilder().tableScan("orders").build();
+
+  const auto referenced = collect(plan);
+
+  EXPECT_THAT(referenced.inputTables, UnorderedElementsAre(table("orders")));
+  EXPECT_FALSE(referenced.outputTable.has_value());
+}
+
+TEST_F(ReferencedTableCollectorTest, joinCollectsBothSides) {
+  auto plan = planBuilder()
+                  .tableScan("orders")
+                  .as("o")
+                  .join(
+                      planBuilder().tableScan("lineitem").as("l"),
+                      "o.id = l.id",
+                      JoinType::kInner)
+                  .build();
+
+  const auto referenced = collect(plan);
+
+  EXPECT_THAT(
+      referenced.inputTables,
+      UnorderedElementsAre(table("orders"), table("lineitem")));
+}
+
+TEST_F(ReferencedTableCollectorTest, selfJoinCollectsOneTable) {
+  auto plan = planBuilder()
+                  .tableScan("orders")
+                  .as("o1")
+                  .join(
+                      planBuilder().tableScan("orders").as("o2"),
+                      "o1.id = o2.id",
+                      JoinType::kInner)
+                  .build();
+
+  const auto referenced = collect(plan);
+
+  EXPECT_THAT(referenced.inputTables, UnorderedElementsAre(table("orders")));
+}
+
+TEST_F(ReferencedTableCollectorTest, unionCollectsEveryBranchOnce) {
+  auto plan = planBuilder()
+                  .tableScan("orders", {"id"})
+                  .unionAll(planBuilder().tableScan("lineitem", {"id"}))
+                  .unionAll(planBuilder().tableScan("orders", {"id"}))
+                  .build();
+
+  const auto referenced = collect(plan);
+
+  EXPECT_THAT(
+      referenced.inputTables,
+      UnorderedElementsAre(table("orders"), table("lineitem")));
+}
+
+TEST_F(ReferencedTableCollectorTest, sameTableNameInTwoCatalogsStaysApart) {
+  auto plan = planBuilder()
+                  .tableScan("orders")
+                  .unionAll(
+                      planBuilder().tableScan(
+                          std::string(kOtherConnectorId),
+                          std::string(kSchema),
+                          std::string("orders")))
+                  .build();
+
+  const auto referenced = collect(plan);
+
+  EXPECT_THAT(
+      referenced.inputTables,
+      UnorderedElementsAre(
+          table("orders"), table("orders", kOtherConnectorId)));
+}
+
+TEST_F(ReferencedTableCollectorTest, sameTableNameInTwoSchemasStaysApart) {
+  auto plan = planBuilder()
+                  .tableScan("orders")
+                  .unionAll(
+                      planBuilder().tableScan(
+                          std::string(kOtherSchema), std::string("orders")))
+                  .build();
+
+  const auto referenced = collect(plan);
+
+  EXPECT_THAT(
+      referenced.inputTables,
+      UnorderedElementsAre(
+          table("orders"), table("orders", kConnectorId, kOtherSchema)));
+}
+
+TEST_F(ReferencedTableCollectorTest, subqueryTableIsAnInputTable) {
+  auto plan =
+      planBuilder()
+          .tableScan("orders")
+          .filter(Exists(Subquery(planBuilder().tableScan("lineitem").build())))
+          .build();
+
+  const auto referenced = collect(plan);
+
+  EXPECT_THAT(
+      referenced.inputTables,
+      UnorderedElementsAre(table("orders"), table("lineitem")));
+}
+
+TEST_F(ReferencedTableCollectorTest, insertSeparatesSourceFromTarget) {
+  auto plan =
+      planBuilder()
+          .tableScan("orders")
+          .tableWrite("orders_copy", WriteKind::kInsert, {"id", "amount"})
+          .build();
+
+  const auto referenced = collect(plan);
+
+  EXPECT_THAT(referenced.inputTables, UnorderedElementsAre(table("orders")));
+  EXPECT_EQ(referenced.outputTable, table("orders_copy"));
+}
+
+TEST_F(ReferencedTableCollectorTest, deleteTargetIsBothReadAndWritten) {
+  // Matches what the Presto parser records for DELETE, where the target is
+  // scanned to find the rows to remove.
+  auto plan = planBuilder().tableScan("orders").tableDelete("orders").build();
+
+  const auto referenced = collect(plan);
+
+  EXPECT_THAT(referenced.inputTables, UnorderedElementsAre(table("orders")));
+  EXPECT_EQ(referenced.outputTable, table("orders"));
+}
+
+TEST_F(ReferencedTableCollectorTest, secondWriteFails) {
+  // A write reaches the collector twice only through a subquery, since a node
+  // rejects a write as its input.
+  auto write =
+      planBuilder()
+          .tableScan("orders")
+          .tableWrite("orders_copy", WriteKind::kInsert, {"id", "amount"})
+          .build();
+
+  auto plan = planBuilder()
+                  .tableScan("orders")
+                  .filter(Exists(Subquery(write)))
+                  .tableWrite("orders", WriteKind::kInsert, {"id", "amount"})
+                  .build();
+
+  VELOX_ASSERT_USER_THROW(
+      collect(plan),
+      "Plan cannot write more than one table: "
+      "test.default.orders and test.default.orders_copy");
+}
+
+TEST_F(ReferencedTableCollectorTest, planWithoutTablesReferencesNothing) {
+  auto plan =
+      planBuilder()
+          .values(
+              ROW({"id"}, BIGINT()), std::vector<Variant>{Variant::row({1LL})})
+          .build();
+
+  const auto referenced = collect(plan);
+
+  EXPECT_THAT(referenced.inputTables, IsEmpty());
+  EXPECT_FALSE(referenced.outputTable.has_value());
+}
+
+} // namespace
+} // namespace facebook::axiom::logical_plan

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2402,7 +2402,7 @@ SqlStatementPtr parseShowCatalogs(
   }
 
   return std::make_shared<SelectStatement>(
-      builder.build(), ViewMap{}, ReferencedTables{});
+      builder.build(), ViewMap{}, lp::ReferencedTables{});
 }
 
 SqlStatementPtr parseShowColumns(
@@ -2440,7 +2440,7 @@ SqlStatementPtr parseShowColumns(
           .values(ROW({"column", "type"}, VARCHAR()), data)
           .build(),
       ViewMap{},
-      ReferencedTables{
+      lp::ReferencedTables{
           {facebook::axiom::CatalogSchemaTableName{
               connectorId, connectorTable}},
           std::nullopt,
@@ -2535,7 +2535,7 @@ SqlStatementPtr parseShowCreateTable(
           .values(ROW({"Create Table"}, VARCHAR()), {Variant::row({ddl.str()})})
           .build(),
       ViewMap{},
-      ReferencedTables{
+      lp::ReferencedTables{
           {facebook::axiom::CatalogSchemaTableName{
               connectorId, schemaTableName}},
           std::nullopt,
@@ -2567,7 +2567,7 @@ SqlStatementPtr parseShowCreateView(
           .values(ROW({"Create View"}, VARCHAR()), {Variant::row({ddl})})
           .build(),
       ViewMap{},
-      ReferencedTables{
+      lp::ReferencedTables{
           {facebook::axiom::CatalogSchemaTableName{
               connectorId, schemaTableName}},
           std::nullopt,
@@ -2629,7 +2629,7 @@ SqlStatementPtr parseShowStats(
           .values(ShowStatsBuilder::outputType(), builder.rows())
           .build(),
       ViewMap{},
-      ReferencedTables{
+      lp::ReferencedTables{
           {facebook::axiom::CatalogSchemaTableName{
               connectorId, connectorTable}},
           std::nullopt,
@@ -2703,7 +2703,7 @@ SqlStatementPtr parseShowFunctions(
   }
 
   return std::make_shared<SelectStatement>(
-      builder.build(), ViewMap{}, ReferencedTables{});
+      builder.build(), ViewMap{}, lp::ReferencedTables{});
 };
 
 std::vector<lp::ExprApi> toColumnExprs(
@@ -2769,7 +2769,7 @@ SqlStatementPtr parseInsert(
   return std::make_shared<InsertStatement>(
       planner.plan(),
       planner.views(),
-      ReferencedTables{
+      lp::ReferencedTables{
           planner.inputTables(),
           facebook::axiom::CatalogSchemaTableName{connectorId, connectorTable},
       });
@@ -2795,7 +2795,7 @@ SqlStatementPtr parseDelete(
   return std::make_shared<DeleteStatement>(
       planner.plan(),
       planner.views(),
-      ReferencedTables{
+      lp::ReferencedTables{
           planner.inputTables(),
           facebook::axiom::CatalogSchemaTableName{connectorId, connectorTable},
       });
@@ -3101,7 +3101,7 @@ SqlStatementPtr parseShowSchemas(
   }
 
   return std::make_shared<SelectStatement>(
-      builder.build(), ViewMap{}, ReferencedTables{});
+      builder.build(), ViewMap{}, lp::ReferencedTables{});
 }
 
 SqlStatementPtr parseShowTables(
@@ -3171,7 +3171,7 @@ SqlStatementPtr parseShowTables(
   }
 
   return std::make_shared<SelectStatement>(
-      builder.build(), ViewMap{}, ReferencedTables{});
+      builder.build(), ViewMap{}, lp::ReferencedTables{});
 }
 
 // Extracts the literal value from a SET SESSION statement.
@@ -3520,7 +3520,7 @@ SqlStatementPtr doPlan(
     auto innerStatement = std::make_shared<SelectStatement>(
         planner.plan(),
         planner.views(),
-        ReferencedTables{planner.inputTables(), std::nullopt});
+        lp::ReferencedTables{planner.inputTables(), std::nullopt});
     return std::make_shared<ShowStatsForQueryStatement>(
         std::move(innerStatement));
   }
@@ -3540,7 +3540,7 @@ SqlStatementPtr doPlan(
     return std::make_shared<SelectStatement>(
         planner.plan(),
         planner.views(),
-        ReferencedTables{planner.inputTables(), std::nullopt});
+        lp::ReferencedTables{planner.inputTables(), std::nullopt});
   }
 
   AXIOM_PRESTO_SYNTAX_FAIL(

--- a/axiom/sql/presto/SqlStatement.cpp
+++ b/axiom/sql/presto/SqlStatement.cpp
@@ -125,7 +125,7 @@ CreateTableStatement::CreateTableStatement(
     : SqlStatement(
           SqlStatementKind::kCreateTable,
           /*views=*/{},
-          ReferencedTables{
+          lp::ReferencedTables{
               /*inputTables=*/{},
               facebook::axiom::CatalogSchemaTableName{connectorId, tableName}}),
       connectorId_{std::move(connectorId)},
@@ -165,7 +165,7 @@ CreateTableAsSelectStatement::CreateTableAsSelectStatement(
     : SqlStatement(
           SqlStatementKind::kCreateTableAsSelect,
           std::move(views),
-          ReferencedTables{
+          lp::ReferencedTables{
               std::move(inputTables),
               facebook::axiom::CatalogSchemaTableName{connectorId, tableName}}),
       connectorId_{std::move(connectorId)},

--- a/axiom/sql/presto/SqlStatement.h
+++ b/axiom/sql/presto/SqlStatement.h
@@ -20,6 +20,7 @@
 #include "axiom/common/Enums.h"
 #include "axiom/common/SchemaProcedureName.h"
 #include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/logical_plan/ReferencedTables.h"
 #include "velox/type/Variant.h"
 
 namespace facebook::axiom::connector {
@@ -53,24 +54,6 @@ enum class SqlStatementKind {
 };
 
 AXIOM_DECLARE_ENUM_NAME(SqlStatementKind);
-
-/// Tables referenced by a SQL statement, extracted during parsing.
-/// Each table is a CatalogSchemaTableName with three parts:
-///   - catalogName: the connector ID (e.g., "prism", "impulse", "tpch").
-///   - schemaTableName.schema: the schema or namespace (e.g., "di", "default").
-///   - schemaTableName.table: the table name (e.g., "orders", "lineitem").
-///
-/// Uses the same CatalogSchemaTableName format as ViewMap keys.
-struct ReferencedTables {
-  /// Tables read by the query (e.g., FROM, JOIN, subquery sources),
-  /// or empty if the query does not read any tables.
-  std::unordered_set<facebook::axiom::CatalogSchemaTableName> inputTables;
-
-  /// Table or view modified by the query (e.g., INSERT INTO, CREATE TABLE AS
-  /// SELECT, CREATE VIEW, DROP VIEW), or nullopt if the query does not target
-  /// any table or view.
-  std::optional<facebook::axiom::CatalogSchemaTableName> outputTable;
-};
 
 class SqlStatement {
  public:
@@ -161,7 +144,8 @@ class SqlStatement {
   /// Tables referenced by this statement. Each table is identified by
   /// connector ID (catalogName), schema, and table name — the same
   /// CatalogSchemaTableName format used as ViewMap keys.
-  const ReferencedTables& referencedTables() const {
+  const facebook::axiom::logical_plan::ReferencedTables& referencedTables()
+      const {
     return referencedTables_;
   }
 
@@ -172,7 +156,7 @@ class SqlStatement {
   explicit SqlStatement(
       SqlStatementKind kind,
       ViewMap views,
-      ReferencedTables referencedTables)
+      facebook::axiom::logical_plan::ReferencedTables referencedTables)
       : kind_{kind},
         views_{std::move(views)},
         referencedTables_{std::move(referencedTables)} {}
@@ -181,7 +165,7 @@ class SqlStatement {
   const SqlStatementKind kind_;
   const ViewMap views_;
   // Tables referenced by this statement, populated during construction.
-  const ReferencedTables referencedTables_;
+  const facebook::axiom::logical_plan::ReferencedTables referencedTables_;
 };
 
 using SqlStatementPtr = std::shared_ptr<const SqlStatement>;
@@ -191,7 +175,7 @@ class SelectStatement : public SqlStatement {
   SelectStatement(
       facebook::axiom::logical_plan::LogicalPlanNodePtr plan,
       ViewMap views,
-      ReferencedTables referencedTables)
+      facebook::axiom::logical_plan::ReferencedTables referencedTables)
       : SqlStatement(
             SqlStatementKind::kSelect,
             std::move(views),
@@ -211,7 +195,7 @@ class InsertStatement : public SqlStatement {
   InsertStatement(
       facebook::axiom::logical_plan::LogicalPlanNodePtr plan,
       ViewMap views,
-      ReferencedTables referencedTables)
+      facebook::axiom::logical_plan::ReferencedTables referencedTables)
       : SqlStatement(
             SqlStatementKind::kInsert,
             std::move(views),
@@ -233,7 +217,7 @@ class DeleteStatement : public SqlStatement {
   DeleteStatement(
       facebook::axiom::logical_plan::LogicalPlanNodePtr plan,
       ViewMap views,
-      ReferencedTables referencedTables)
+      facebook::axiom::logical_plan::ReferencedTables referencedTables)
       : SqlStatement(
             SqlStatementKind::kDelete,
             std::move(views),
@@ -378,10 +362,11 @@ class DropTableStatement : public SqlStatement {
       : SqlStatement(
             SqlStatementKind::kDropTable,
             /*views=*/{},
-            ReferencedTables{/*inputTables=*/{},
-                             facebook::axiom::CatalogSchemaTableName{
-                                 connectorId,
-                                 tableName}}),
+            facebook::axiom::logical_plan::ReferencedTables{
+                /*inputTables=*/{},
+                facebook::axiom::CatalogSchemaTableName{
+                    connectorId,
+                    tableName}}),
         connectorId_{std::move(connectorId)},
         tableName_{std::move(tableName)},
         ifExists_{ifExists} {}
@@ -416,10 +401,11 @@ class AddColumnStatement : public SqlStatement {
       : SqlStatement(
             SqlStatementKind::kAddColumn,
             /*views=*/{},
-            ReferencedTables{/*inputTables=*/{},
-                             facebook::axiom::CatalogSchemaTableName{
-                                 connectorId,
-                                 tableName}}),
+            facebook::axiom::logical_plan::ReferencedTables{
+                /*inputTables=*/{},
+                facebook::axiom::CatalogSchemaTableName{
+                    connectorId,
+                    tableName}}),
         connectorId_{std::move(connectorId)},
         tableName_{std::move(tableName)},
         columnName_{std::move(columnName)},


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/axel/pull/263

Permission checks and lineage need the set of tables a query touches, and today that set exists only as a byproduct of parsing Presto SQL: `PrestoParser` records each table as it resolves it and hands the result to the checkers on `SqlStatement`. Not every query comes from SQL — a query submitted as a logical plan, or built from a dataframe, never passes the parser, so `CliPermissionChecker`, `PermissionBypassUtils`, `LineageBypassUtils`, and the axel `PermissionChecker` and query logger have no table set for it at all.

`ReferencedTableCollector::collect()` builds the same struct by walking a plan. Every `TableScan` contributes an input table, including scans reached through a `SubqueryExpr`, which carries a plan of its own. The `TableWrite` becomes the output table: a plan cannot contain more than one, so a plan that carries a second is malformed and the collector fails instead of silently reporting one of them. The result matches what `PrestoParser` records for the equivalent SQL: the parser also lists base tables only — a view goes to the `ViewMap` and the tables in its body to `inputTables` — and a `DELETE` names its target as both an input and the output.

`ReferencedTables` moves out of the parser's header into `axiom/logical_plan/ReferencedTables.h` under `facebook::axiom::logical_plan`, so callers that only want the table list drop their dependency on `axiom/sql/presto`. It is removed from `axiom::sql::presto` outright, with no compatibility alias, so every reference moves with it.

Views reach a checker only on the SQL path, where the parser hands it a `ViewMap` next to the tables. A plan records that base tables were read and nothing about a view that expanded into them, so a permission check on a submitted plan authorizes the base tables; plan-submitted queries carry no views.

Reviewed By: mbasmanova

Differential Revision: D116716762


