### PR TITLE
fix(planner): Unify IN operand types and coerce predicates (#1745)

### DIFF
--- a/axiom/logical_plan/ExprResolver.cpp
+++ b/axiom/logical_plan/ExprResolver.cpp
@@ -241,14 +241,20 @@ ExprPtr tryResolveSpecialForm(
     const std::shared_ptr<velox::core::PlanNodeIdGenerator>&
         planNodeIdGenerator,
     const velox::TypeCoercer* coercer) {
-  if (name == "and") {
-    return std::make_shared<SpecialFormExpr>(
-        velox::BOOLEAN(), SpecialForm::kAnd, resolvedInputs);
-  }
+  if (name == "and" || name == "or") {
+    const bool isAnd = (name == "and");
+    const auto form = isAnd ? SpecialForm::kAnd : SpecialForm::kOr;
 
-  if (name == "or") {
+    if (coercer != nullptr) {
+      return resolveSpecialFormWithCoercions(
+          form,
+          isAnd ? velox::expression::kAnd : velox::expression::kOr,
+          resolvedInputs,
+          *coercer);
+    }
+
     return std::make_shared<SpecialFormExpr>(
-        velox::BOOLEAN(), SpecialForm::kOr, resolvedInputs);
+        velox::BOOLEAN(), form, resolvedInputs);
   }
 
   if (name == "try") {
@@ -328,26 +334,24 @@ ExprPtr tryResolveSpecialForm(
       VELOX_USER_CHECK_GE(
           resolvedInputs.size(), 2, "IN must have at least two inputs");
 
-      auto type = resolvedInputs.at(0)->type();
+      // The left operand and every value in the list share one type: the
+      // least common super type of all of them.
+      velox::TypePtr type = resolvedInputs.at(0)->type();
       for (auto i = 1; i < resolvedInputs.size(); ++i) {
         const auto& newType = resolvedInputs.at(i)->type();
-        if (type->equivalent(*newType)) {
-          continue;
-        }
+        velox::TypePtr commonType =
+            coercer->leastCommonSuperType(type, newType);
+        VELOX_USER_CHECK_NOT_NULL(
+            commonType,
+            "All inputs to IN must be coercible to a single type: {} vs. {}",
+            type->toString(),
+            newType->toString());
+        type = std::move(commonType);
+      }
 
-        if (coercer->coerce(newType, type)) {
-          resolvedInputs[i] =
-              applyCoercion(resolvedInputs[i], type, planNodeIdGenerator);
-          continue;
-        }
-
-        if (coercer->coerce(type, newType)) {
-          type = newType;
-
-          for (auto j = 0; j < i; ++j) {
-            resolvedInputs[j] =
-                applyCoercion(resolvedInputs[j], type, planNodeIdGenerator);
-          }
+      for (auto& input : resolvedInputs) {
+        if (!input->type()->equivalent(*type)) {
+          input = applyCoercion(input, type, planNodeIdGenerator);
         }
       }
     }

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -432,8 +432,35 @@ PlanBuilder& PlanBuilder::filter(const std::string& predicate) {
   return filter(untypedExpr);
 }
 
+namespace {
+// Returns 'predicate' if it is boolean, otherwise coerces it. 'errorLabel'
+// names the predicate in error messages.
+ExprPtr coerceToBoolean(
+    const ExprPtr& predicate,
+    const velox::TypeCoercer* coercer,
+    std::string_view errorLabel) {
+  if (predicate->type()->isBoolean()) {
+    return predicate;
+  }
+
+  VELOX_USER_CHECK_NOT_NULL(
+      coercer,
+      "{} must be boolean: {}",
+      errorLabel,
+      predicate->type()->toString());
+  VELOX_USER_CHECK(
+      coercer->coerce(predicate->type(), velox::BOOLEAN()).has_value(),
+      "{} must be coercible to boolean: {}",
+      errorLabel,
+      predicate->type()->toString());
+
+  return applyCoercion(predicate, velox::BOOLEAN());
+}
+} // namespace
+
 PlanBuilder& PlanBuilder::filter(const ExprApi& predicate) {
-  auto expr = resolveScalarTypes(predicate.expr());
+  auto expr = coerceToBoolean(
+      resolveScalarTypes(predicate.expr()), coercer_, "Filter predicate");
 
   node_ = std::make_shared<FilterNode>(nextId(), node_, std::move(expr));
 
@@ -1232,11 +1259,15 @@ PlanBuilder& PlanBuilder::join(
 
   ExprPtr expr;
   if (condition.has_value()) {
-    expr = resolver_.resolveScalarTypes(
-        condition->expr(), [&](const auto& alias, const auto& name) {
-          return resolveJoinInputName(
-              alias, name, *outputMapping_, inputRowType, outerScope_);
-        });
+    expr = coerceToBoolean(
+        resolver_.resolveScalarTypes(
+            condition->expr(),
+            [&](const auto& alias, const auto& name) {
+              return resolveJoinInputName(
+                  alias, name, *outputMapping_, inputRowType, outerScope_);
+            }),
+        coercer_,
+        "Join condition");
   }
 
   node_ = std::make_shared<JoinNode>(
@@ -1270,11 +1301,15 @@ PlanBuilder& PlanBuilder::lateralJoin(
 
   ExprPtr expr;
   if (condition.has_value()) {
-    expr = resolver_.resolveScalarTypes(
-        condition->expr(), [&](const auto& alias, const auto& name) {
-          return resolveJoinInputName(
-              alias, name, *outputMapping_, inputRowType, outerScope_);
-        });
+    expr = coerceToBoolean(
+        resolver_.resolveScalarTypes(
+            condition->expr(),
+            [&](const auto& alias, const auto& name) {
+              return resolveJoinInputName(
+                  alias, name, *outputMapping_, inputRowType, outerScope_);
+            }),
+        coercer_,
+        "Join condition");
   }
 
   node_ = std::make_shared<LateralJoinNode>(

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -108,6 +108,10 @@ class ThrowingSqlExpressionsParser : public velox::parse::SqlExpressionsParser {
 /// (e.g. INTEGER + BIGINT). Set Context.queryCtx to enable constant folding,
 /// i.e. evaluating constant expressions at plan-build time
 /// (e.g. 1 + 2 becomes 3).
+///
+/// Filter predicates and join conditions must be boolean. Without a coercer,
+/// any other type is an error. With one, a type that coerces to boolean, i.e.
+/// the UNKNOWN type of a NULL literal, is cast.
 class PlanBuilder {
  public:
   /// Shared state across PlanBuilder instances. Pass the same Context to

--- a/axiom/logical_plan/tests/ExprTest.cpp
+++ b/axiom/logical_plan/tests/ExprTest.cpp
@@ -84,22 +84,35 @@ TEST_F(ExprTest, looksConstant) {
   testLooksConstant(Cast(DOUBLE(), Col("a")), false);
 }
 
-TEST_F(ExprTest, conjunctAcceptsUnknownInput) {
-  // Mirror Velox's ConjunctExpr::resolveType, which accepts BOOLEAN or UNKNOWN.
+TEST_F(ExprTest, conjunctInputTypes) {
   auto schema = ROW({"p", "a"}, {BOOLEAN(), BIGINT()});
-  auto resolve = [&](const ExprApi& expr) {
-    return ExprResolver(nullptr, nullptr)
+  auto resolve = [&](const ExprApi& expr, const velox::TypeCoercer* coercer) {
+    return ExprResolver(nullptr, coercer)
         .resolveScalarTypes(expr.expr(), inputResolver(schema));
   };
 
   auto nullLiteral = Lit(Variant::null(TypeKind::UNKNOWN), UNKNOWN());
+  const auto* coercer = &velox::TypeCoercer::defaults();
 
-  EXPECT_EQ(*resolve(Col("p") && nullLiteral)->type(), *BOOLEAN());
-  EXPECT_EQ(*resolve(nullLiteral || Col("p"))->type(), *BOOLEAN());
+  // A null literal input types as UNKNOWN and coerces to boolean.
+  auto expr = resolve(Col("p") && nullLiteral, coercer);
+  EXPECT_EQ(*expr->type(), *BOOLEAN());
+  EXPECT_EQ(*expr->inputAt(1)->type(), *BOOLEAN());
 
-  // Non-boolean, non-unknown inputs remain rejected.
+  EXPECT_EQ(*resolve(nullLiteral || Col("p"), coercer)->type(), *BOOLEAN());
+
+  // Without a coercer, an UNKNOWN input is kept as is. Velox evaluates the
+  // conjunct only if it doesn't short-circuit first.
+  EXPECT_EQ(
+      *resolve(Col("p") && nullLiteral, nullptr)->inputAt(1)->type(),
+      *UNKNOWN());
+
+  // An input of a type that doesn't coerce to boolean is always rejected.
   VELOX_ASSERT_THROW(
-      resolve(Col("p") && Col("a")),
+      resolve(Col("p") && Col("a"), coercer),
+      "Conjunct expression argument is not coercible to BOOLEAN");
+  VELOX_ASSERT_THROW(
+      resolve(Col("p") && Col("a"), nullptr),
       "All inputs to AND and OR must be boolean");
 }
 

--- a/axiom/logical_plan/tests/PlanBuilderTest.cpp
+++ b/axiom/logical_plan/tests/PlanBuilderTest.cpp
@@ -737,5 +737,60 @@ TEST_F(PlanBuilderTest, valuesTypeCoercionErrors) {
       "All values should have equivalent types: BIGINT vs. ROW<x:BOOLEAN>");
 }
 
+namespace {
+// Values with an INTEGER column 'a' and a null literal column, which types as
+// UNKNOWN.
+PlanBuilder makeValuesWithNull(bool enableCoercions = true) {
+  PlanBuilder::Context context;
+  if (enableCoercions) {
+    context.coercer = &velox::TypeCoercer::defaults();
+  }
+  const std::vector<std::vector<std::string>> rows{
+      {"CAST(1 AS integer)", "null"}};
+  return PlanBuilder(context).values({"a", "n"}, rows);
+}
+
+PlanBuilder makeBooleanValues() {
+  PlanBuilder::Context context;
+  context.coercer = &velox::TypeCoercer::defaults();
+  const std::vector<std::vector<std::string>> rows{{"true"}};
+  return PlanBuilder(context).values({"m"}, rows);
+}
+} // namespace
+
+TEST_F(PlanBuilderTest, predicateTypeCoercion) {
+  auto plan = makeValuesWithNull().filter("n").build();
+  EXPECT_EQ(*plan->as<FilterNode>()->predicate()->type(), *BOOLEAN());
+
+  auto joinPlan = makeValuesWithNull()
+                      .join(makeBooleanValues(), "n", JoinType::kLeft)
+                      .build();
+  EXPECT_EQ(*joinPlan->as<JoinNode>()->condition()->type(), *BOOLEAN());
+
+  auto lateralPlan = makeValuesWithNull()
+                         .lateralJoin(makeBooleanValues(), "n", JoinType::kLeft)
+                         .build();
+  EXPECT_EQ(
+      *lateralPlan->as<LateralJoinNode>()->condition()->type(), *BOOLEAN());
+
+  VELOX_ASSERT_THROW(
+      makeValuesWithNull().filter("a"),
+      "Filter predicate must be coercible to boolean: INTEGER");
+
+  VELOX_ASSERT_THROW(
+      makeValuesWithNull(/*enableCoercions=*/false).filter("n"),
+      "Filter predicate must be boolean: UNKNOWN");
+}
+
+TEST_F(PlanBuilderTest, conjunctTypeCoercion) {
+  auto plan = makeValuesWithNull().filter("n AND a = 1").build();
+
+  const auto& predicate = plan->as<FilterNode>()->predicate();
+  ASSERT_EQ(predicate->as<SpecialFormExpr>()->form(), SpecialForm::kAnd);
+  for (const auto& input : predicate->inputs()) {
+    EXPECT_EQ(*input->type(), *BOOLEAN()) << input->toString();
+  }
+}
+
 } // namespace
 } // namespace facebook::axiom::logical_plan

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -1258,6 +1258,24 @@ TEST_F(ExpressionParserTest, lambdaParameterShadowsTableAlias) {
       matchScan().aggregate().project().output());
 }
 
+// The left operand and every row in an IN list are coerced to one common row
+// type, even when a different side of the comparison widens per field.
+TEST_F(ExpressionParserTest, rowInListCoercion) {
+  auto expr = parseExpr(
+      "(integer '1', integer '2') IN ((bigint '3', tinyint '4'), (1, 2))");
+
+  ASSERT_EQ(expr->as<lp::SpecialFormExpr>()->form(), lp::SpecialForm::kIn);
+
+  const auto expectedType = ROW({BIGINT(), INTEGER()});
+  for (const auto& input : expr->inputs()) {
+    EXPECT_EQ(*input->type(), *expectedType) << input->toString();
+  }
+
+  VELOX_ASSERT_THROW(
+      parseExpr("(integer '1', integer '2') IN ((varchar 'x', 2))"),
+      "All inputs to IN must be coercible to a single type");
+}
+
 // Presto allows BIGINT -> REAL coercion: real / bigint returns REAL.
 TEST_F(ExpressionParserTest, bigintToRealCoercion) {
   EXPECT_EQ(*REAL(), *parseExpr("real '1' / bigint '2'")->type());


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/266


Comparing a row of columns against a list of rows failed when the fields needed coercion in opposite directions. For example:

    SELECT * FROM (VALUES (integer '1', integer '2')) t(a, b) WHERE (a, b) IN ((bigint '3', tinyint '4'))

failed with:

    All inputs to IN must have the same type as the left operand: ROW<"":INTEGER,"":INTEGER> vs ROW<"":BIGINT,"":TINYINT>

The first field has to widen to BIGINT and the second one has to widen to INTEGER, and the resolver only tried to coerce one whole operand into the other. It now takes the least common super type of the left operand and every value in the list, then coerces all of them to it. Presto returns `true` for the query above.

A predicate that is not boolean failed as well. `SELECT 1 FROM (SELECT NULL AS x) WHERE x` failed with "Filter predicate must be boolean", and `SELECT x AND true FROM (SELECT NULL AS x)` built a plan that then failed during evaluation. A NULL literal types as UNKNOWN. Filter predicates, join conditions, and AND / OR arguments now coerce to boolean, and UNKNOWN is the only type that coerces. Presto returns no rows for the first query and NULL for the second.

Reviewed By: xiaoxmeng

Differential Revision: D116835652
