### PR TITLE
build: Add iceberg-cpp dependency resolution

### DIFF
--- a/CMake/resolve_dependency_modules/iceberg-cpp.cmake
+++ b/CMake/resolve_dependency_modules/iceberg-cpp.cmake
@@ -1,0 +1,92 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_guard(GLOBAL)
+
+# Iceberg's bundled Avro reader is needed to plan manifest files. Build and
+# install Iceberg separately with scripts/setup-iceberg-cpp.sh, which first
+# installs a Velox-version Arrow/Parquet package and then configures iceberg-cpp
+# to use those package targets instead of its default vendored Arrow.
+find_package(iceberg CONFIG QUIET COMPONENTS REST)
+
+if(TARGET iceberg::iceberg_rest_static)
+  set(AXIOM_ICEBERG_REST_TARGET iceberg::iceberg_rest_static)
+  set(AXIOM_ICEBERG_DATA_TARGET iceberg::iceberg_data_static)
+  set(AXIOM_ICEBERG_BUNDLE_TARGET iceberg::iceberg_bundle_static)
+elseif(TARGET iceberg::iceberg_rest_shared)
+  set(AXIOM_ICEBERG_REST_TARGET iceberg::iceberg_rest_shared)
+  set(AXIOM_ICEBERG_DATA_TARGET iceberg::iceberg_data_shared)
+  set(AXIOM_ICEBERG_BUNDLE_TARGET iceberg::iceberg_bundle_shared)
+else()
+  message(
+    FATAL_ERROR
+    "Axiom's Iceberg connector requires an installed iceberg-cpp package. "
+    "Run scripts/setup-iceberg-cpp.sh, or add its install prefix to "
+    "CMAKE_PREFIX_PATH."
+  )
+endif()
+
+if(TARGET iceberg::arrow_static OR TARGET iceberg::parquet_static)
+  message(
+    FATAL_ERROR
+    "Installed iceberg-cpp package still exports vendored Arrow or Parquet. "
+    "Reinstall it using scripts/setup-iceberg-cpp.sh so iceberg-cpp uses the "
+    "same Arrow package as Velox."
+  )
+endif()
+
+foreach(
+  _iceberg_target
+  IN
+  ITEMS ${AXIOM_ICEBERG_REST_TARGET} ${AXIOM_ICEBERG_DATA_TARGET} ${AXIOM_ICEBERG_BUNDLE_TARGET}
+)
+  if(NOT TARGET ${_iceberg_target})
+    message(
+      FATAL_ERROR
+      "Installed iceberg-cpp package is missing ${_iceberg_target}. "
+      "Axiom requires the REST, data, and bundled Avro libraries to plan "
+      "Iceberg manifests. Reinstall it using scripts/setup-iceberg-cpp.sh."
+    )
+  endif()
+endforeach()
+
+get_target_property(
+  _iceberg_include_dirs
+  ${AXIOM_ICEBERG_REST_TARGET}
+  INTERFACE_INCLUDE_DIRECTORIES
+)
+set(_iceberg_headers_found FALSE)
+foreach(_iceberg_include_dir IN LISTS _iceberg_include_dirs)
+  if(
+    EXISTS "${_iceberg_include_dir}/iceberg/catalog/rest/rest_catalog.h"
+    AND EXISTS "${_iceberg_include_dir}/iceberg/avro/avro_register.h"
+  )
+    set(_iceberg_headers_found TRUE)
+    break()
+  endif()
+endforeach()
+
+if(NOT _iceberg_headers_found)
+  message(
+    FATAL_ERROR
+    "Installed iceberg-cpp package is missing REST or Avro headers. "
+    "Reinstall it using scripts/setup-iceberg-cpp.sh."
+  )
+endif()
+
+message(STATUS "Using iceberg-cpp target ${AXIOM_ICEBERG_REST_TARGET}")
+unset(_iceberg_headers_found)
+unset(_iceberg_include_dir)
+unset(_iceberg_include_dirs)
+unset(_iceberg_target)

--- a/CMake/resolve_dependency_modules/iceberg-cpp/arrow18-compat.patch
+++ b/CMake/resolve_dependency_modules/iceberg-cpp/arrow18-compat.patch
@@ -1,0 +1,51 @@
+diff --git a/src/iceberg/avro/avro_data_util.cc b/src/iceberg/avro/avro_data_util.cc
+index 8c2b6f0..2f09b5f 100644
+--- a/src/iceberg/avro/avro_data_util.cc
++++ b/src/iceberg/avro/avro_data_util.cc
+@@ -22,7 +22,6 @@
+ #include <arrow/array/builder_decimal.h>
+ #include <arrow/array/builder_nested.h>
+ #include <arrow/array/builder_primitive.h>
+ #include <arrow/extension_type.h>
+-#include <arrow/json/from_string.h>
+ #include <arrow/type.h>
+ #include <arrow/util/decimal.h>
+ #include <avro/Generic.hh>
+diff --git a/src/iceberg/parquet/parquet_reader.cc b/src/iceberg/parquet/parquet_reader.cc
+index 51f602b..f1ff631 100644
+--- a/src/iceberg/parquet/parquet_reader.cc
++++ b/src/iceberg/parquet/parquet_reader.cc
+@@ -123,11 +123,12 @@ class ParquetReader::Impl {
+     // Open the Parquet file reader
+     ICEBERG_ASSIGN_OR_RAISE(input_stream_, OpenInputStream(options));
+     auto file_reader =
+         ::parquet::ParquetFileReader::Open(input_stream_, reader_properties);
+-    ICEBERG_ARROW_ASSIGN_OR_RETURN(
+-        reader_, ::parquet::arrow::FileReader::Make(pool_, std::move(file_reader),
+-                                                    arrow_reader_properties));
++    std::unique_ptr<::parquet::arrow::FileReader> reader;
++    ICEBERG_ARROW_RETURN_NOT_OK(::parquet::arrow::FileReader::Make(
++        pool_, std::move(file_reader), arrow_reader_properties, &reader));
++    reader_ = std::move(reader);
+
+     // Project read schema onto the Parquet file schema
+     ICEBERG_ASSIGN_OR_RAISE(projection_, BuildProjection(reader_.get(), *read_schema_));
+     metadata_context_ = {.file_path = options.path,
+@@ -240,13 +241,14 @@ class ParquetReader::Impl {
+
+     // Create the record batch reader
+     if (row_group_indices.empty()) {
+       // None of the row groups are selected, return an empty record batch reader
+       context_->record_batch_reader_ = std::make_unique<EmptyRecordBatchReader>();
+     } else {
+       auto column_indices = SelectedColumnIndices(projection_);
+-      ICEBERG_ARROW_ASSIGN_OR_RETURN(
+-          context_->record_batch_reader_,
+-          reader_->GetRecordBatchReader(row_group_indices, column_indices));
++      std::unique_ptr<::arrow::RecordBatchReader> record_batch_reader;
++      ICEBERG_ARROW_RETURN_NOT_OK(reader_->GetRecordBatchReader(
++          row_group_indices, column_indices, &record_batch_reader));
++      context_->record_batch_reader_ = std::move(record_batch_reader);
+     }
+
+     return {};

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,35 @@ set(VELOX_BUILD_TESTING OFF)
 
 set(VELOX_DEPENDENCY_SOURCE AUTO CACHE STRING "Default dependency source: AUTO SYSTEM or BUNDLED.")
 
+option(
+  AXIOM_PREFER_DEPS_INSTALL
+  "Prefer dependency packages from the local deps-install directory."
+  ON
+)
+
+if(AXIOM_PREFER_DEPS_INSTALL AND EXISTS "${PROJECT_SOURCE_DIR}/deps-install")
+  list(PREPEND CMAKE_PREFIX_PATH "${PROJECT_SOURCE_DIR}/deps-install")
+
+  foreach(_dependency IN ITEMS absl fmt iceberg re2)
+    set(_dependency_dir "${PROJECT_SOURCE_DIR}/deps-install/lib/cmake/${_dependency}")
+    if(EXISTS "${_dependency_dir}")
+      set(${_dependency}_DIR "${_dependency_dir}" CACHE PATH "Path to ${_dependency} package" FORCE)
+    endif()
+  endforeach()
+
+  set(_s2_dir "${PROJECT_SOURCE_DIR}/deps-install/share/s2")
+  if(EXISTS "${_s2_dir}")
+    set(s2_DIR "${_s2_dir}" CACHE PATH "Path to s2 package" FORCE)
+  endif()
+endif()
+
 option(AXIOM_ENABLE_CCACHE "Use ccache if installed." ON)
 option(AXIOM_ENABLE_COLLAGEN "Build Collagen (Spark Connect server)." OFF)
+option(
+  AXIOM_ENABLE_ICEBERG_CPP
+  "Resolve Apache Iceberg C++ REST/catalog dependency for the Iceberg connector."
+  OFF
+)
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
@@ -160,6 +187,10 @@ velox_set_source(antlr4-runtime)
 velox_resolve_dependency(antlr4-runtime)
 
 message(STATUS "Using ANTLR4 runtime from ${ANTLR4_INCLUDE_DIR}")
+
+if(AXIOM_ENABLE_ICEBERG_CPP)
+  include(iceberg-cpp)
+endif()
 
 # Dependencies for the PySpark/Collagen server.
 if(AXIOM_ENABLE_COLLAGEN)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ VELOX_BUILD_SHARED=ON PROMPT_ALWAYS_RESPOND=y velox/scripts/setup-ubuntu.sh
 `VELOX_BUILD_SHARED=ON` ensures dependencies are built for shared linking,
 which is required by the Velox mono library used in Axiom.
 
+The Iceberg connector has an additional Apache iceberg-cpp dependency. Install
+it before building with `AXIOM_ENABLE_ICEBERG_CPP=ON`:
+
+```
+scripts/setup-iceberg-cpp.sh
+```
+
+The script builds the same Arrow version Velox uses, then builds and installs
+iceberg-cpp against that Arrow into `deps-install`, so iceberg-cpp and Velox
+share one Arrow rather than iceberg-cpp vendoring its own. CMake then finds the
+package through `deps-install/lib/cmake/iceberg`.
+
 ### Building
 
 On macOS, pass the path to the installed dependencies via `EXTRA_CMAKE_FLAGS`:

--- a/scripts/setup-iceberg-cpp.sh
+++ b/scripts/setup-iceberg-cpp.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+source "${ROOT_DIR}/velox/scripts/setup-versions.sh"
+
+ICEBERG_CPP_REVISION=87a11de7e83785d925cf3dcc31d84100dccfb62f
+ICEBERG_CPP_SHA256=2167ea59c84db01249888530ebfd8bd30e72edd9fad1c94178f7f9aa0dd8eb4a
+ICEBERG_CPP_URL="https://github.com/apache/iceberg-cpp/archive/${ICEBERG_CPP_REVISION}.tar.gz"
+VELOX_ARROW_SHA256=9c473f2c9914c59ab571761c9497cf0e5cfd3ea335f7782ccc6121f5cb99ae9b
+VELOX_ARROW_URL="https://github.com/apache/arrow/archive/apache-arrow-${ARROW_VERSION}.tar.gz"
+
+INSTALL_PREFIX=${ICEBERG_CPP_INSTALL_PREFIX:-${INSTALL_PREFIX:-"${ROOT_DIR}/deps-install"}}
+BUILD_DIR=${ICEBERG_CPP_BUILD_DIR:-"${ROOT_DIR}/_build/iceberg-cpp"}
+SOURCE_DIR="${BUILD_DIR}/source"
+ARCHIVE_PATH="${BUILD_DIR}/iceberg-cpp.tar.gz"
+NUM_THREADS=${NUM_THREADS:-$(getconf _NPROCESSORS_CONF 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)}
+ARROW_BUILD_DIR="${BUILD_DIR}/arrow"
+ARROW_SOURCE_DIR="${ARROW_BUILD_DIR}/source"
+ARROW_ARCHIVE_PATH="${ARROW_BUILD_DIR}/arrow.tar.gz"
+ARROW_PREFIX=${ARROW_PREFIX:-"${INSTALL_PREFIX}"}
+
+build_velox_arrow_with_parquet() {
+  if [[ -f "${ARROW_PREFIX}/lib/cmake/Arrow/ArrowConfig.cmake" &&
+        -f "${ARROW_PREFIX}/lib/cmake/Parquet/ParquetConfig.cmake" ]]; then
+    return
+  fi
+
+  mkdir -p "${ARROW_BUILD_DIR}"
+  curl --fail --location --silent --show-error "${VELOX_ARROW_URL}" --output "${ARROW_ARCHIVE_PATH}"
+
+  local actual_sha256
+  actual_sha256=$(shasum -a 256 "${ARROW_ARCHIVE_PATH}" | awk '{print $1}')
+  if [[ "${actual_sha256}" != "${VELOX_ARROW_SHA256}" ]]; then
+    echo "Arrow archive checksum does not match Velox's pinned revision" >&2
+    exit 1
+  fi
+
+  rm -rf "${ARROW_SOURCE_DIR}"
+  mkdir -p "${ARROW_SOURCE_DIR}"
+  tar -xzf "${ARROW_ARCHIVE_PATH}" --strip-components=1 -C "${ARROW_SOURCE_DIR}"
+
+  (
+    cd "${ARROW_SOURCE_DIR}" || exit 1
+    patch -p1 -i "${ROOT_DIR}/velox/CMake/resolve_dependency_modules/arrow/arrow-testing-boost.patch"
+    patch -p1 -i "${ROOT_DIR}/velox/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch"
+  )
+
+  cmake \
+    -S "${ARROW_SOURCE_DIR}/cpp" \
+    -B "${ARROW_BUILD_DIR}/build" \
+    -DARROW_PARQUET=ON \
+    -DARROW_IPC=ON \
+    -DARROW_FILESYSTEM=ON \
+    -DARROW_JSON=ON \
+    -DARROW_DEPENDENCY_SOURCE=AUTO \
+    -DARROW_WITH_LZ4=ON \
+    -DARROW_WITH_SNAPPY=ON \
+    -DARROW_WITH_ZLIB=ON \
+    -DARROW_WITH_ZSTD=ON \
+    -DARROW_JEMALLOC=OFF \
+    -DARROW_SIMD_LEVEL=NONE \
+    -DARROW_RUNTIME_SIMD_LEVEL=NONE \
+    -DARROW_WITH_UTF8PROC=OFF \
+    -DARROW_TESTING=ON \
+    -DARROW_BUILD_STATIC=ON \
+    -DARROW_BUILD_SHARED=ON \
+    -DBUILD_WARNING_LEVEL=PRODUCTION \
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    -DCMAKE_INSTALL_PREFIX="${ARROW_PREFIX}" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+    -DARROW_CXXFLAGS=-Wno-documentation \
+    -DBOOST_ROOT="${ROOT_DIR}/deps-install"
+
+  cmake --build "${ARROW_BUILD_DIR}/build" --target install -j "${NUM_THREADS}"
+}
+
+mkdir -p "${BUILD_DIR}"
+curl --fail --location --silent --show-error "${ICEBERG_CPP_URL}" --output "${ARCHIVE_PATH}"
+
+ACTUAL_SHA256=$(shasum -a 256 "${ARCHIVE_PATH}" | awk '{print $1}')
+if [[ "${ACTUAL_SHA256}" != "${ICEBERG_CPP_SHA256}" ]]; then
+  echo "iceberg-cpp archive checksum does not match the pinned revision" >&2
+  exit 1
+fi
+
+rm -rf "${SOURCE_DIR}"
+mkdir -p "${SOURCE_DIR}"
+tar -xzf "${ARCHIVE_PATH}" --strip-components=1 -C "${SOURCE_DIR}"
+(
+  cd "${SOURCE_DIR}" || exit 1
+  patch -p1 -i "${ROOT_DIR}/CMake/resolve_dependency_modules/iceberg-cpp/arrow18-compat.patch"
+)
+
+build_velox_arrow_with_parquet
+
+CONFIGURE_ARGS=(
+  -S "${SOURCE_DIR}"
+  -B "${BUILD_DIR}/build"
+  -DICEBERG_BUILD_STATIC=ON
+  -DICEBERG_BUILD_SHARED=OFF
+  -DICEBERG_BUILD_TESTS=OFF
+  -DICEBERG_BUILD_BENCHMARKS=OFF
+  -DICEBERG_BUILD_REST=ON
+  -DICEBERG_BUILD_REST_INTEGRATION_TESTS=OFF
+  -DICEBERG_BUILD_HIVE=OFF
+  -DICEBERG_BUILD_SQL_CATALOG=OFF
+  -DICEBERG_BUILD_BUNDLE=ON
+  -DICEBERG_BUNDLE_AWSSDK=OFF
+  -DICEBERG_BUNDLE_THRIFT=OFF
+  -DICEBERG_S3=OFF
+  -DICEBERG_SIGV4=OFF
+  -DFETCHCONTENT_TRY_FIND_PACKAGE_MODE=ALWAYS
+  -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON
+  -DArrow_DIR="${ARROW_PREFIX}/lib/cmake/Arrow"
+  -DParquet_DIR="${ARROW_PREFIX}/lib/cmake/Parquet"
+  -DCMAKE_PREFIX_PATH="${ARROW_PREFIX};${ROOT_DIR}/deps-install"
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+  -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS:-} -Wno-deprecated-declarations"
+  -DCMAKE_BUILD_TYPE=Release
+  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}"
+)
+
+if [[ -n "${EXTRA_CMAKE_FLAGS:-}" ]]; then
+  read -r -a EXTRA_ARGS <<<"${EXTRA_CMAKE_FLAGS}"
+  CONFIGURE_ARGS+=("${EXTRA_ARGS[@]}")
+fi
+
+cmake "${CONFIGURE_ARGS[@]}"
+cmake --build "${BUILD_DIR}/build" --target install -j "${NUM_THREADS}"
+
+echo "iceberg-cpp installed to ${INSTALL_PREFIX}"
+echo "Headers are available under ${INSTALL_PREFIX}/include/iceberg"
+echo "Arrow and Parquet are resolved from ${ARROW_PREFIX}"


### PR DESCRIPTION
**Summary**

Add the build plumbing for an Iceberg connector that links Apache iceberg-cpp, ahead of any connector code. A new AXIOM_ENABLE_ICEBERG_CPP option (default OFF) pulls in a resolver that locates an installed iceberg-cpp package and exposes its REST, data, and Avro static targets.

scripts/setup-iceberg-cpp.sh builds the same Arrow version Velox uses and then builds iceberg-cpp against that Arrow, so the two share one Arrow rather than iceberg-cpp vendoring its own. This avoids Arrow symbol clashes when iceberg-cpp and Velox run in one process. The resolver fails fast if an install still exports vendored Arrow or Parquet. With the option OFF the build graph is unchanged, so existing builds are unaffected.

Velox builds and installs Arrow 18.0.0 into deps-install, but its Arrow build sets `DARROW_PARQUET=OFF`. Velox doesn't need Arrow's Parquet; it has its own native Parquet reader. iceberg-cpp, on the other hand, requires Arrow's Parquet, it reads/writes Parquet data files and manifests through parquet::arrow::FileReader. So, the script rebuilds Arrow with `-DARROW_PARQUET=ON`.

Fix https://github.com/facebookincubator/axiom/issues/1763.