### PR TITLE
feat(connectors): Add information_schema relations (#1749)

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -175,15 +175,20 @@ class Column {
   /// @param hidden If true, the column doesn't appear in the output of SELECT *
   /// FROM t query. Still, the column can be accessed by name: SELECT ...,
   /// foo,... FROM t.
+  /// @param extraInfo What the connector says about the column's role beyond
+  /// its name and type, in its own words, e.g. 'partition key'. Reported to a
+  /// client as given.
   Column(
       std::string name,
       velox::TypePtr type,
       bool hidden,
-      bool includeInExplainIo = false)
+      bool includeInExplainIo = false,
+      std::optional<std::string> extraInfo = std::nullopt)
       : name_{std::move(name)},
         type_{std::move(type)},
         hidden_{hidden},
         includeInExplainIo_{includeInExplainIo},
+        extraInfo_{std::move(extraInfo)},
         defaultValue_{velox::Variant::null(type_->kind())} {
     VELOX_CHECK_NOT_NULL(type_);
     VELOX_CHECK(!name_.empty());
@@ -195,11 +200,13 @@ class Column {
       velox::TypePtr type,
       bool hidden,
       velox::Variant defaultValue,
-      bool includeInExplainIo = false)
+      bool includeInExplainIo = false,
+      std::optional<std::string> extraInfo = std::nullopt)
       : name_{std::move(name)},
         type_{std::move(type)},
         hidden_{hidden},
         includeInExplainIo_{includeInExplainIo},
+        extraInfo_{std::move(extraInfo)},
         defaultValue_{std::move(defaultValue)} {
     VELOX_CHECK_NOT_NULL(type_);
     VELOX_CHECK(!name_.empty());
@@ -242,6 +249,13 @@ class Column {
     return defaultValue_;
   }
 
+  /// What the connector says about the column's role beyond its name and
+  /// type, in its own words, e.g. 'partition key'. std::nullopt when it says
+  /// nothing.
+  const std::optional<std::string>& extraInfo() const {
+    return extraInfo_;
+  }
+
   /// Returns true if this column should appear in EXPLAIN IO output.
   /// Set by connectors for columns relevant to IO (e.g., partition columns).
   /// Only VARCHAR and integer types (TINYINT, SMALLINT, INTEGER, BIGINT) are
@@ -265,6 +279,7 @@ class Column {
   const velox::TypePtr type_;
   const bool hidden_;
   const bool includeInExplainIo_;
+  const std::optional<std::string> extraInfo_;
   const velox::Variant defaultValue_;
 
   // The latest element added to 'allStats_'.

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -106,6 +106,10 @@ std::string HivePartitionType::toString() const {
 
 namespace {
 
+// What a Hive-family connector says about a column the table is partitioned
+// by.
+constexpr std::string_view kPartitionKey = "partition key";
+
 std::vector<std::unique_ptr<const connector::Column>> makeColumns(
     const velox::RowTypePtr& type,
     bool bucketed,
@@ -118,12 +122,16 @@ std::vector<std::unique_ptr<const connector::Column>> makeColumns(
   columns.reserve(type->size() + 2 + (bucketed ? 1 : 0));
 
   for (auto i = 0; i < type->size(); i++) {
+    const bool isPartitionColumn = partitionColumns.contains(type->nameOf(i));
     columns.emplace_back(
         std::make_unique<connector::Column>(
             type->nameOf(i),
             type->childAt(i),
             /*hidden=*/false,
-            /*includeInExplainIo=*/partitionColumns.contains(type->nameOf(i))));
+            /*includeInExplainIo=*/isPartitionColumn,
+            /*extraInfo=*/
+            isPartitionColumn ? std::optional<std::string>(kPartitionKey)
+                              : std::nullopt));
   }
 
   if (includeHiddenColumns) {

--- a/axiom/connectors/system/CMakeLists.txt
+++ b/axiom/connectors/system/CMakeLists.txt
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(axiom_system_connector SystemConnector.cpp SystemConnectorMetadata.cpp)
+add_library(
+  axiom_system_connector
+  InformationSchema.cpp
+  SystemConnector.cpp
+  SystemConnectorMetadata.cpp
+)
 
 target_link_libraries(
   axiom_system_connector

--- a/axiom/connectors/system/InformationSchema.cpp
+++ b/axiom/connectors/system/InformationSchema.cpp
@@ -1,0 +1,810 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/connectors/system/InformationSchema.h"
+
+#include <boost/algorithm/string/case_conv.hpp>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/system/SystemConnector.h"
+#include "velox/core/Expressions.h"
+#include "velox/expression/ExprToSubfieldFilter.h"
+#include "velox/type/Filter.h"
+
+namespace facebook::axiom::connector::system {
+namespace {
+
+velox::Variant nullVarchar() {
+  return velox::Variant::null(velox::TypeKind::VARCHAR);
+}
+
+velox::Variant nullBigint() {
+  return velox::Variant::null(velox::TypeKind::BIGINT);
+}
+
+// A type is reported in lower case, e.g. 'bigint'. A decimal is spelled
+// without a space, as a client comparing the text expects.
+std::string dataTypeName(const velox::TypePtr& type) {
+  if (type->isDecimal()) {
+    const auto [precision, scale] = velox::getDecimalPrecisionScale(*type);
+    return fmt::format("decimal({},{})", precision, scale);
+  }
+
+  // A complex type's rendering carries its field names, which lower-casing
+  // would rewrite, so only a scalar's name is lower-cased.
+  if (!type->isPrimitiveType()) {
+    return type->toString();
+  }
+
+  return boost::to_lower_copy(type->toString());
+}
+
+// Number of digits a numeric type holds: the count its range allows for
+// integers, the mantissa bits for floating point, and the declared precision
+// for decimals. Null for every other type.
+velox::Variant precisionOf(const velox::TypePtr& type) {
+  if (type->isDecimal()) {
+    return velox::Variant(
+        static_cast<int64_t>(velox::getDecimalPrecisionScale(*type).first));
+  }
+
+  switch (type->kind()) {
+    case velox::TypeKind::TINYINT:
+      return velox::Variant(static_cast<int64_t>(3));
+    case velox::TypeKind::SMALLINT:
+      return velox::Variant(static_cast<int64_t>(5));
+    case velox::TypeKind::INTEGER:
+      return velox::Variant(static_cast<int64_t>(10));
+    case velox::TypeKind::BIGINT:
+      return velox::Variant(static_cast<int64_t>(19));
+    case velox::TypeKind::REAL:
+      return velox::Variant(static_cast<int64_t>(24));
+    case velox::TypeKind::DOUBLE:
+      return velox::Variant(static_cast<int64_t>(53));
+    default:
+      return nullBigint();
+  }
+}
+
+velox::Variant scaleOf(const velox::TypePtr& type) {
+  if (type->isDecimal()) {
+    return velox::Variant(
+        static_cast<int64_t>(velox::getDecimalPrecisionScale(*type).second));
+  }
+  return nullBigint();
+}
+
+// Marks how far a scan has read. Holds the (schema, table) pair being read,
+// the table or view it resolved to, and, for kColumns, the column within it.
+struct RowPosition {
+  const InformationSchemaTableHandle* handle{nullptr};
+  size_t schemaIndex{0};
+  size_t tableIndex{0};
+  size_t columnIndex{0};
+  TablePtr table;
+  ViewPtr view;
+
+  const std::string& catalog() const {
+    return handle->catalog();
+  }
+
+  // Report the name the query asked for, not the catalog's own spelling. The
+  // scan consumes the filters naming it, so a row spelling it differently
+  // would not pass the query's predicate.
+  const std::string& schema() const {
+    return handle->schemas()[schemaIndex];
+  }
+
+  const std::string& tableName() const {
+    return handle->tables()[tableIndex];
+  }
+
+  // True once a named table has resolved to a table or a view.
+  bool resolved() const {
+    return table != nullptr || view != nullptr;
+  }
+
+  // Columns of the table being described.
+  const velox::RowTypePtr& rowType() const {
+    VELOX_CHECK(resolved(), "No table to describe");
+    return table != nullptr ? table->type() : view->type();
+  }
+};
+
+// A relation's column: its name and type, and how its value is read.
+struct RelationColumn {
+  std::string_view name;
+  velox::TypePtr type;
+  velox::Variant (*read)(const RowPosition&);
+};
+
+// Adapters matching RelationColumn::read for the columns every relation has.
+velox::Variant catalogOf(const RowPosition& position) {
+  return velox::Variant(position.catalog());
+}
+
+velox::Variant schemaOf(const RowPosition& position) {
+  return velox::Variant(position.schema());
+}
+
+velox::Variant tableNameOf(const RowPosition& position) {
+  return velox::Variant(position.tableName());
+}
+
+velox::Variant alwaysNull(const RowPosition& /*at*/) {
+  return nullVarchar();
+}
+
+const std::vector<RelationColumn>& tablesColumns() {
+  static const std::vector<RelationColumn> kRelation{
+      {"table_catalog", velox::VARCHAR(), catalogOf},
+      {"table_schema", velox::VARCHAR(), schemaOf},
+      {"table_name", velox::VARCHAR(), tableNameOf},
+      {"table_type",
+       velox::VARCHAR(),
+       [](const RowPosition& position) {
+         return velox::Variant(
+             std::string(
+                 position.table != nullptr ? InformationSchema::kBaseTableType
+                                           : InformationSchema::kViewType));
+       }},
+  };
+  return kRelation;
+}
+
+const std::vector<RelationColumn>& viewsColumns() {
+  static const std::vector<RelationColumn> kRelation{
+      {"table_catalog", velox::VARCHAR(), catalogOf},
+      {"table_schema", velox::VARCHAR(), schemaOf},
+      {"table_name", velox::VARCHAR(), tableNameOf},
+      // Ownership is not tracked.
+      {"view_owner", velox::VARCHAR(), alwaysNull},
+      {"view_definition",
+       velox::VARCHAR(),
+       [](const RowPosition& position) {
+         return velox::Variant(position.view->text());
+       }},
+  };
+  return kRelation;
+}
+
+const std::vector<RelationColumn>& columnsColumns() {
+  static const std::vector<RelationColumn> kRelation{
+      {"table_catalog", velox::VARCHAR(), catalogOf},
+      {"table_schema", velox::VARCHAR(), schemaOf},
+      {"table_name", velox::VARCHAR(), tableNameOf},
+      {"column_name",
+       velox::VARCHAR(),
+       [](const RowPosition& position) {
+         return velox::Variant(
+             position.rowType()->nameOf(position.columnIndex));
+       }},
+      {"ordinal_position",
+       velox::BIGINT(),
+       [](const RowPosition& position) {
+         return velox::Variant(static_cast<int64_t>(position.columnIndex + 1));
+       }},
+      // Defaults apply to writes and are not reported.
+      {"column_default", velox::VARCHAR(), alwaysNull},
+      {"is_nullable",
+       velox::VARCHAR(),
+       [](const RowPosition& /*at*/) {
+         // Nullability is not tracked, so every column reports as nullable.
+         return velox::Variant(std::string("YES"));
+       }},
+      {"data_type",
+       velox::VARCHAR(),
+       [](const RowPosition& position) {
+         return velox::Variant(
+             dataTypeName(position.rowType()->childAt(position.columnIndex)));
+       }},
+      // Comments are not tracked.
+      {"comment", velox::VARCHAR(), alwaysNull},
+      {"extra_info",
+       velox::VARCHAR(),
+       [](const RowPosition& position) {
+         if (position.table == nullptr) {
+           // A view's columns have no connector-assigned role.
+           return nullVarchar();
+         }
+
+         // The connector says what a column's role is, if anything.
+         const auto& name = position.rowType()->nameOf(position.columnIndex);
+         const auto* column = position.table->findColumn(name);
+         VELOX_CHECK_NOT_NULL(column, "Column not found: {}", name);
+         return column->extraInfo().has_value()
+             ? velox::Variant(column->extraInfo().value())
+             : nullVarchar();
+       }},
+      {"precision",
+       velox::BIGINT(),
+       [](const RowPosition& position) {
+         return precisionOf(position.rowType()->childAt(position.columnIndex));
+       }},
+      {"scale",
+       velox::BIGINT(),
+       [](const RowPosition& position) {
+         return scaleOf(position.rowType()->childAt(position.columnIndex));
+       }},
+      // A length is the declared width of a character type, which the type
+      // system does not carry.
+      {"length",
+       velox::BIGINT(),
+       [](const RowPosition& /*at*/) { return nullBigint(); }},
+  };
+  return kRelation;
+}
+
+// Returns the columns of the relation 'name', or nullptr if no relation goes
+// by that name.
+const std::vector<RelationColumn>* findRelation(std::string_view name) {
+  if (name == InformationSchema::kTables) {
+    return &tablesColumns();
+  }
+  if (name == InformationSchema::kViews) {
+    return &viewsColumns();
+  }
+  if (name == InformationSchema::kColumns) {
+    return &columnsColumns();
+  }
+  return nullptr;
+}
+
+const std::vector<RelationColumn>& relationColumns(std::string_view name) {
+  const auto* columns = findRelation(name);
+  VELOX_CHECK_NOT_NULL(
+      columns, "No such information_schema relation: {}", name);
+  return *columns;
+}
+
+// Returns the values 'filter' restricts a column to, or std::nullopt if it
+// does not restrict it to a finite set. Equality arrives as a single-value
+// range and IN as a value set; a wider range, e.g. table_name > 't', names no
+// tables to read and so leaves the query unbounded.
+//
+// Whether the filter also admits null is ignored: it is read only for
+// table_schema and table_name, whose values are the names the query gave, so
+// no row carries a null there and admitting one matches nothing more.
+std::optional<std::vector<std::string>> filterValues(
+    const velox::common::Filter& filter) {
+  if (filter.kind() == velox::common::FilterKind::kAlwaysFalse) {
+    // No value passes, so the query names no tables and reads nothing.
+    return std::vector<std::string>{};
+  }
+
+  if (filter.kind() == velox::common::FilterKind::kBytesValues) {
+    const auto& values =
+        static_cast<const velox::common::BytesValues&>(filter).values();
+    // The filter holds a set, whose order varies between processes. Sorting
+    // keeps the handle and the plan text it prints stable.
+    std::vector<std::string> sorted{values.begin(), values.end()};
+    std::sort(sorted.begin(), sorted.end());
+    return sorted;
+  }
+
+  if (filter.kind() == velox::common::FilterKind::kBytesRange) {
+    const auto& range = static_cast<const velox::common::BytesRange&>(filter);
+    if (range.isSingleValue()) {
+      return std::vector<std::string>{range.lower()};
+    }
+  }
+
+  return std::nullopt;
+}
+
+// Layout of an information_schema relation. Accepts the filters that name the
+// tables to describe and rejects the rest, and fails a query those filters
+// leave unbounded.
+class InformationSchemaTableLayout : public TableLayout {
+ public:
+  InformationSchemaTableLayout(
+      Table* table,
+      velox::connector::Connector* connector,
+      std::vector<const Column*> columns)
+      : TableLayout(
+            "default",
+            table,
+            connector,
+            std::move(columns),
+            /*partitionColumns=*/{},
+            /*orderColumns=*/{},
+            /*sortOrder=*/{},
+            /*lookupKeys=*/{},
+            /*supportsScan=*/true) {}
+
+  bool supportsSampling() const override {
+    return false;
+  }
+
+  // The rows come from catalog metadata, which only the coordinator can read.
+  bool runsOnCoordinator() const override {
+    return true;
+  }
+
+  velox::connector::ColumnHandlePtr createColumnHandle(
+      const ConnectorSessionPtr& /*session*/,
+      const std::string& columnName,
+      std::vector<velox::common::Subfield> /*subfields*/,
+      std::optional<velox::TypePtr> /*castToType*/,
+      SubfieldMapping /*subfieldMapping*/) const override {
+    return std::make_shared<SystemColumnHandle>(columnName);
+  }
+
+  velox::connector::ConnectorTableHandlePtr createTableHandle(
+      const ConnectorSessionPtr& session,
+      std::vector<velox::connector::ColumnHandlePtr> columnHandles,
+      velox::core::ExpressionEvaluator& evaluator,
+      std::vector<velox::core::TypedExprPtr> filters,
+      std::vector<int32_t>& rejectedFilterIndices,
+      velox::RowTypePtr dataColumns,
+      std::optional<LookupKeys> lookupKeys) const override;
+};
+
+// An information_schema relation of one catalog.
+class InformationSchemaTable : public Table {
+ public:
+  // 'serving' is the connector that serves the relations, not the catalog
+  // being described.
+  InformationSchemaTable(
+      const SchemaTableName& tableName,
+      const velox::RowTypePtr& schema,
+      velox::connector::Connector* serving)
+      : Table(tableName, Table::makeColumns(schema)) {
+    layout_ = std::make_unique<InformationSchemaTableLayout>(
+        this, serving, allColumns());
+    layouts_.push_back(layout_.get());
+  }
+
+  const std::vector<const TableLayout*>& layouts() const override {
+    return layouts_;
+  }
+
+  std::optional<uint64_t> numRows() const override {
+    return std::nullopt;
+  }
+
+ private:
+  std::vector<const TableLayout*> layouts_;
+  std::unique_ptr<InformationSchemaTableLayout> layout_;
+};
+
+velox::connector::ConnectorTableHandlePtr
+InformationSchemaTableLayout::createTableHandle(
+    const ConnectorSessionPtr& session,
+    std::vector<velox::connector::ColumnHandlePtr> /*columnHandles*/,
+    velox::core::ExpressionEvaluator& evaluator,
+    std::vector<velox::core::TypedExprPtr> filters,
+    std::vector<int32_t>& rejectedFilterIndices,
+    velox::RowTypePtr /*dataColumns*/,
+    std::optional<LookupKeys> lookupKeys) const {
+  VELOX_USER_CHECK(
+      !lookupKeys.has_value(),
+      "information_schema does not support index lookups");
+
+  // Take filters on these columns: they decide how much metadata the scan
+  // reads. Reject every other filter; it only removes rows the scan would
+  // produce anyway, so the caller applies it above the scan.
+  constexpr std::string_view kTableSchemaColumn = "table_schema";
+  constexpr std::string_view kTableNameColumn = "table_name";
+
+  std::optional<std::vector<std::string>> schemas;
+  std::optional<std::vector<std::string>> tables;
+  const auto& parser = velox::exec::ExprToSubfieldFilterParser::getInstance();
+  for (size_t i = 0; i < filters.size(); ++i) {
+    auto subfieldFilter = filters[i]->isCallKind()
+        ? parser->leafCallToSubfieldFilter(
+              *filters[i]->asUnchecked<velox::core::CallTypedExpr>(),
+              &evaluator)
+        : std::nullopt;
+
+    if (!subfieldFilter.has_value()) {
+      rejectedFilterIndices.push_back(static_cast<int32_t>(i));
+      continue;
+    }
+
+    const std::string columnName = subfieldFilter->first.toString();
+    if (columnName != kTableSchemaColumn && columnName != kTableNameColumn) {
+      rejectedFilterIndices.push_back(static_cast<int32_t>(i));
+      continue;
+    }
+
+    // A column named by two conjuncts is taken from the first; the rest
+    // narrow the rows further, which the caller does above the scan.
+    auto& pinned = columnName == kTableSchemaColumn ? schemas : tables;
+    if (pinned.has_value()) {
+      rejectedFilterIndices.push_back(static_cast<int32_t>(i));
+      continue;
+    }
+
+    auto values = filterValues(*subfieldFilter->second);
+    if (!values.has_value()) {
+      rejectedFilterIndices.push_back(static_cast<int32_t>(i));
+      continue;
+    }
+
+    pinned = std::move(values);
+  }
+
+  const auto& relation = table().name().table;
+  VELOX_USER_CHECK(
+      schemas.has_value(),
+      "Querying information_schema.{} requires a filter naming table_schema, e.g. table_schema = 's'",
+      relation);
+  VELOX_USER_CHECK(
+      tables.has_value(),
+      "Querying information_schema.{} requires a filter naming table_name, e.g. table_name = 't'",
+      relation);
+
+  // A schema the catalog does not have describes nothing. Dropping it here
+  // keeps the scan from asking the catalog about it, which a catalog may
+  // answer with an error rather than an empty result.
+  const auto catalog = InformationSchema::catalog(table().name().schema);
+  const auto metadata =
+      ConnectorMetadataRegistry::get(std::string{catalog.value()});
+  std::vector<std::string> existing;
+  for (auto& schema : schemas.value()) {
+    if (metadata->schemaExists(session, schema)) {
+      existing.push_back(std::move(schema));
+    }
+  }
+
+  return std::make_shared<InformationSchemaTableHandle>(
+      connectorId(),
+      table().name(),
+      std::move(existing),
+      std::move(tables).value());
+}
+
+// Reads the rows of an information_schema relation from the metadata of the
+// catalog its handle names.
+class InformationSchemaDataSource : public velox::connector::DataSource {
+ public:
+  InformationSchemaDataSource(
+      const velox::RowTypePtr& outputType,
+      std::shared_ptr<const InformationSchemaTableHandle> tableHandle,
+      const velox::connector::ColumnHandleMap& columnHandles,
+      velox::memory::MemoryPool* pool)
+      : outputType_{outputType},
+        tableHandle_{std::move(tableHandle)},
+        relation_{relationColumns(tableHandle_->relation())},
+        metadata_{ConnectorMetadataRegistry::get(tableHandle_->catalog())},
+        outputColumns_{findOutputColumns(outputType, columnHandles)},
+        position_{.handle = tableHandle_.get()},
+        pool_{pool} {}
+
+  void addSplit(
+      std::shared_ptr<velox::connector::ConnectorSplit> split) override {
+    VELOX_CHECK_NOT_NULL(split);
+    hasSplit_ = true;
+  }
+
+  std::optional<velox::RowVectorPtr> next(
+      uint64_t size,
+      velox::ContinueFuture& future) override;
+
+  void addDynamicFilter(
+      velox::column_index_t,
+      const std::shared_ptr<velox::common::Filter>&) override {
+    VELOX_UNSUPPORTED("information_schema does not support dynamic filters");
+  }
+
+  uint64_t getCompletedBytes() override {
+    return 0;
+  }
+
+  uint64_t getCompletedRows() override {
+    return completedRows_;
+  }
+
+  std::unordered_map<std::string, velox::RuntimeMetric> getRuntimeStats()
+      override {
+    return {};
+  }
+
+ private:
+  // The relation's columns a query selects, in output order. A query that
+  // selects none, e.g. count(*), still describes each named table but reads
+  // nothing from it.
+  std::vector<const RelationColumn*> findOutputColumns(
+      const velox::RowTypePtr& outputType,
+      const velox::connector::ColumnHandleMap& columnHandles) const;
+
+  // Moves to the row the relation describes next and returns false once every
+  // named table has been described. A named table that does not exist
+  // contributes no rows.
+  bool advance();
+
+  // Advances to the next table to describe, resolving it in the catalog.
+  // Returns false when there are none left.
+  bool nextTable();
+
+  const velox::RowTypePtr outputType_;
+  const std::shared_ptr<const InformationSchemaTableHandle> tableHandle_;
+  const std::vector<RelationColumn>& relation_;
+  const std::shared_ptr<ConnectorMetadata> metadata_;
+  const std::vector<const RelationColumn*> outputColumns_;
+
+  RowPosition position_;
+  // Whether a named table has been visited, so the next one is the one after
+  // it rather than the first.
+  bool visitedTable_{false};
+  bool exhausted_{false};
+
+  velox::memory::MemoryPool* const pool_;
+  bool hasSplit_{false};
+  uint64_t completedRows_{0};
+};
+
+std::vector<const RelationColumn*>
+InformationSchemaDataSource::findOutputColumns(
+    const velox::RowTypePtr& outputType,
+    const velox::connector::ColumnHandleMap& columnHandles) const {
+  std::vector<const RelationColumn*> columns;
+  columns.reserve(outputType->size());
+  for (const auto& outputName : outputType->names()) {
+    // An output column names the relation's column through its handle.
+    const auto handle = columnHandles.find(outputName);
+    VELOX_CHECK(
+        handle != columnHandles.end(),
+        "No column handle for output column: {}",
+        outputName);
+    const auto& name = handle->second->name();
+    const auto it = std::find_if(
+        relation_.begin(), relation_.end(), [&](const RelationColumn& column) {
+          return column.name == name;
+        });
+    VELOX_CHECK(
+        it != relation_.end(),
+        "No such column in information_schema.{}: {}",
+        tableHandle_->relation(),
+        name);
+    columns.push_back(&*it);
+  }
+  return columns;
+}
+
+bool InformationSchemaDataSource::nextTable() {
+  const auto& schemas = tableHandle_->schemas();
+  const auto& tables = tableHandle_->tables();
+
+  if (visitedTable_) {
+    ++position_.tableIndex;
+    if (position_.tableIndex == tables.size()) {
+      position_.tableIndex = 0;
+      ++position_.schemaIndex;
+    }
+  }
+
+  for (; position_.schemaIndex < schemas.size(); ++position_.schemaIndex) {
+    for (; position_.tableIndex < tables.size(); ++position_.tableIndex) {
+      const SchemaTableName name{
+          schemas[position_.schemaIndex], tables[position_.tableIndex]};
+      position_.table = metadata_->findTable(name);
+      position_.view =
+          position_.table == nullptr ? metadata_->findView(name) : nullptr;
+      position_.columnIndex = 0;
+      visitedTable_ = true;
+
+      // A table with no columns contributes no rows to 'columns'.
+      if (position_.resolved() &&
+          (tableHandle_->relation() != InformationSchema::kColumns ||
+           position_.rowType()->size() > 0)) {
+        return true;
+      }
+    }
+    position_.tableIndex = 0;
+  }
+
+  return false;
+}
+
+bool InformationSchemaDataSource::advance() {
+  if (exhausted_) {
+    return false;
+  }
+
+  const auto& relation = tableHandle_->relation();
+
+  if (relation == InformationSchema::kColumns && position_.resolved() &&
+      ++position_.columnIndex < position_.rowType()->size()) {
+    // A table contributes a row per column, so the source stays on it.
+    return true;
+  }
+
+  // 'views' describes views only, so a table in the list is stepped over.
+  do {
+    if (!nextTable()) {
+      exhausted_ = true;
+      return false;
+    }
+  } while (relation == InformationSchema::kViews && position_.view == nullptr);
+
+  return true;
+}
+
+std::optional<velox::RowVectorPtr> InformationSchemaDataSource::next(
+    uint64_t size,
+    velox::ContinueFuture& /*future*/) {
+  VELOX_CHECK(hasSplit_, "No split added");
+
+  std::vector<std::vector<velox::Variant>> columns(outputColumns_.size());
+  for (auto& column : columns) {
+    column.reserve(size);
+  }
+
+  velox::vector_size_t numRows = 0;
+  for (uint64_t i = 0; i < size && advance(); ++i) {
+    for (size_t column = 0; column < outputColumns_.size(); ++column) {
+      columns[column].push_back(outputColumns_[column]->read(position_));
+    }
+    ++numRows;
+  }
+
+  if (numRows == 0) {
+    return nullptr;
+  }
+
+  std::vector<velox::VectorPtr> children;
+  children.reserve(columns.size());
+  for (size_t column = 0; column < columns.size(); ++column) {
+    children.push_back(
+        velox::BaseVector::createFromVariants(
+            outputType_->childAt(column), columns[column], pool_));
+  }
+
+  completedRows_ += numRows;
+  return std::make_shared<velox::RowVector>(
+      pool_, outputType_, nullptr, numRows, std::move(children));
+}
+
+} // namespace
+
+std::string InformationSchema::schemaName(std::string_view catalog) {
+  return fmt::format("{}{}", kPrefix, catalog);
+}
+
+std::optional<std::string_view> InformationSchema::catalog(
+    std::string_view schemaName) {
+  if (!schemaName.starts_with(kPrefix)) {
+    return std::nullopt;
+  }
+
+  const auto catalog = schemaName.substr(kPrefix.size());
+  if (catalog.empty()) {
+    return std::nullopt;
+  }
+  return catalog;
+}
+
+const std::vector<std::string>& InformationSchema::tableNames() {
+  static const std::vector<std::string> kNames{
+      std::string{InformationSchema::kColumns},
+      std::string{InformationSchema::kTables},
+      std::string{InformationSchema::kViews}};
+  return kNames;
+}
+
+const velox::RowTypePtr& InformationSchema::tableSchema(
+    std::string_view tableName) {
+  static const velox::RowTypePtr kNone;
+  static const folly::F14FastMap<std::string_view, velox::RowTypePtr> kSchemas =
+      [] {
+        folly::F14FastMap<std::string_view, velox::RowTypePtr> schemas;
+        for (const auto& name :
+             {InformationSchema::kTables,
+              InformationSchema::kViews,
+              InformationSchema::kColumns}) {
+          std::vector<std::string> names;
+          std::vector<velox::TypePtr> types;
+          for (const auto& column : relationColumns(name)) {
+            names.emplace_back(column.name);
+            types.push_back(column.type);
+          }
+          schemas.emplace(name, velox::ROW(std::move(names), std::move(types)));
+        }
+        return schemas;
+      }();
+
+  const auto it = kSchemas.find(tableName);
+  return it == kSchemas.end() ? kNone : it->second;
+}
+
+namespace {
+std::string catalogOrFail(std::string_view schemaName) {
+  auto catalog = InformationSchema::catalog(schemaName);
+  VELOX_CHECK(
+      catalog.has_value(), "Not an information_schema name: {}", schemaName);
+  return std::string{catalog.value()};
+}
+} // namespace
+
+InformationSchemaTableHandle::InformationSchemaTableHandle(
+    const std::string& connectorId,
+    SchemaTableName schemaTableName,
+    std::vector<std::string> schemas,
+    std::vector<std::string> tables)
+    : ConnectorTableHandle(connectorId),
+      schemaTableName_{std::move(schemaTableName)},
+      catalog_{catalogOrFail(schemaTableName_.schema)},
+      qualifiedName_{fmt::format(
+          "{}.{}",
+          schemaTableName_.schema,
+          schemaTableName_.table)},
+      schemas_{std::move(schemas)},
+      tables_{std::move(tables)} {}
+
+folly::dynamic InformationSchemaTableHandle::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = InformationSchemaTableHandle::getClassName();
+  obj["connectorId"] = connectorId();
+  obj["schemaName"] = schemaTableName_.schema;
+  obj["tableName"] = schemaTableName_.table;
+  obj["schemas"] = folly::dynamic::array(schemas_.begin(), schemas_.end());
+  obj["tables"] = folly::dynamic::array(tables_.begin(), tables_.end());
+
+  return obj;
+}
+
+velox::connector::ConnectorTableHandlePtr InformationSchemaTableHandle::create(
+    const folly::dynamic& obj,
+    void* /*context*/) {
+  const auto toStrings = [](const folly::dynamic& array) {
+    std::vector<std::string> values;
+    values.reserve(array.size());
+    for (const auto& value : array) {
+      values.push_back(value.asString());
+    }
+    return values;
+  };
+
+  return std::make_shared<InformationSchemaTableHandle>(
+      obj["connectorId"].asString(),
+      SchemaTableName{
+          obj["schemaName"].asString(), obj["tableName"].asString()},
+      toStrings(obj["schemas"]),
+      toStrings(obj["tables"]));
+}
+
+TablePtr InformationSchema::findTable(
+    const SchemaTableName& tableName,
+    velox::connector::Connector* serving) {
+  if (!catalog(tableName.schema).has_value()) {
+    return nullptr;
+  }
+
+  const auto& schema = tableSchema(tableName.table);
+  if (schema == nullptr) {
+    return nullptr;
+  }
+
+  // A catalog nobody registered describes nothing, which reads as no such
+  // table rather than a failure when the scan starts.
+  if (ConnectorMetadataRegistry::tryGet(
+          std::string{catalog(tableName.schema).value()}) == nullptr) {
+    return nullptr;
+  }
+
+  return std::make_shared<InformationSchemaTable>(tableName, schema, serving);
+}
+
+std::unique_ptr<velox::connector::DataSource> InformationSchema::makeDataSource(
+    const std::shared_ptr<const InformationSchemaTableHandle>& tableHandle,
+    const velox::RowTypePtr& outputType,
+    const velox::connector::ColumnHandleMap& columnHandles,
+    velox::memory::MemoryPool* pool) {
+  return std::make_unique<InformationSchemaDataSource>(
+      outputType, tableHandle, columnHandles, pool);
+}
+
+} // namespace facebook::axiom::connector::system

--- a/axiom/connectors/system/InformationSchema.h
+++ b/axiom/connectors/system/InformationSchema.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/connectors/ConnectorMetadata.h"
+
+namespace facebook::axiom::connector::system {
+
+/// Table handle for an information_schema relation. Carries the tables the
+/// scan describes: a scan is accepted only when its filters name them, so the
+/// set is known once the filters are pushed, and reading is a lookup of each
+/// name in the source catalog.
+///
+/// A scan of the 'columns' relation of catalog 'hive', whose filters pin
+/// table_schema to 'sales' and table_name to 'orders' and 'lineitem', carries
+/// catalog() = 'hive', relation() = 'columns', schemas() = {'sales'} and
+/// tables() = {'lineitem', 'orders'}, and describes each (schema, table)
+/// pair.
+class InformationSchemaTableHandle
+    : public velox::connector::ConnectorTableHandle {
+ public:
+  InformationSchemaTableHandle(
+      const std::string& connectorId,
+      SchemaTableName schemaTableName,
+      std::vector<std::string> schemas,
+      std::vector<std::string> tables);
+
+  const std::string& name() const override {
+    return qualifiedName_;
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  /// Catalog whose metadata produces the rows.
+  const std::string& catalog() const {
+    return catalog_;
+  }
+
+  /// Relation being read: 'tables', 'views' or 'columns'.
+  const std::string& relation() const {
+    return schemaTableName_.table;
+  }
+
+  /// Schemas the query names, in the source catalog. Empty when its filters
+  /// admit no name, which describes nothing.
+  const std::vector<std::string>& schemas() const {
+    return schemas_;
+  }
+
+  /// Table names the query names, empty on the same terms as schemas(). Every
+  /// (schema, table) pair is described; a pair no table answers to
+  /// contributes no rows.
+  const std::vector<std::string>& tables() const {
+    return tables_;
+  }
+
+  folly::dynamic serialize() const override;
+
+  static velox::connector::ConnectorTableHandlePtr create(
+      const folly::dynamic& obj,
+      void* context);
+
+  static void registerSerDe() {
+    velox::registerDeserializerWithContext<InformationSchemaTableHandle>();
+  }
+
+  VELOX_DEFINE_CLASS_NAME(InformationSchemaTableHandle)
+
+ private:
+  const SchemaTableName schemaTableName_;
+  const std::string catalog_;
+  const std::string qualifiedName_;
+  const std::vector<std::string> schemas_;
+  const std::vector<std::string> tables_;
+};
+
+/// The information_schema relations — 'tables', 'views' and 'columns' — as
+/// served for one catalog.
+class InformationSchema {
+ public:
+  /// Prefix under which a catalog's relations live in this connector's schema
+  /// namespace: the relations of catalog 'foo' are the tables of schema
+  /// '$info_schema@foo', so the catalog whose metadata produces the rows is
+  /// named by the schema. The prefix is reserved, which keeps a catalog name
+  /// clear of the connector's own schemas. Whoever resolves a name for a
+  /// catalog maps it onto this schema.
+  static constexpr std::string_view kPrefix = "$info_schema@";
+
+  /// The relations, one per kind of object described.
+  static constexpr std::string_view kTables = "tables";
+  static constexpr std::string_view kViews = "views";
+  static constexpr std::string_view kColumns = "columns";
+
+  /// Values of kTables.table_type.
+  static constexpr std::string_view kBaseTableType = "BASE TABLE";
+  static constexpr std::string_view kViewType = "VIEW";
+
+  /// Returns the schema the relations of 'catalog' live in, e.g. 'foo' ->
+  /// '$info_schema@foo'.
+  static std::string schemaName(std::string_view catalog);
+
+  /// Returns the catalog a schema name refers to, as a view into
+  /// 'schemaName', or std::nullopt if it is not an information_schema name.
+  static std::optional<std::string_view> catalog(std::string_view schemaName);
+
+  /// Names of the relations, sorted.
+  static const std::vector<std::string>& tableNames();
+
+  /// Returns the row type of a relation, or nullptr if 'tableName' names none.
+  static const velox::RowTypePtr& tableSchema(std::string_view tableName);
+
+  /// Returns the relation 'tableName' names, or nullptr when it names none or
+  /// its catalog is not registered.
+  ///
+  /// @param serving The connector that serves the relations. Not the catalog
+  /// being described, which 'tableName''s schema names.
+  static TablePtr findTable(
+      const SchemaTableName& tableName,
+      velox::connector::Connector* serving);
+
+  /// Returns a data source reading the relation 'tableHandle' names from the
+  /// metadata of the catalog it names. Rows come in batches of the size the
+  /// scan asks for: a relation may describe many tables, and kColumns returns
+  /// a row per column of each.
+  static std::unique_ptr<velox::connector::DataSource> makeDataSource(
+      const std::shared_ptr<const InformationSchemaTableHandle>& tableHandle,
+      const velox::RowTypePtr& outputType,
+      const velox::connector::ColumnHandleMap& columnHandles,
+      velox::memory::MemoryPool* pool);
+};
+
+} // namespace facebook::axiom::connector::system

--- a/axiom/connectors/system/README.md
+++ b/axiom/connectors/system/README.md
@@ -7,6 +7,10 @@ active queries, session properties, and other operational state. The
 application registers it under a catalog name of its choice (the CLI
 uses `system`).
 
+It also serves the `information_schema` relations of every other
+catalog, since those describe schemas, tables and columns rather than
+belonging to any one connector.
+
 ## Schemas and Tables
 
 ### system.metadata
@@ -18,6 +22,82 @@ signatures.
 |-------|-------------|
 | `session_properties` | All registered session properties with current values, defaults, and descriptions. |
 | `functions` | All registered function signatures with types, arguments, and metadata. |
+
+### <catalog>.information_schema
+
+What a catalog contains: its tables, its views, and their columns. A
+query names these per catalog, as `hive.information_schema.columns`.
+The parser resolves that to this connector, carrying the catalog in the
+schema: `system."$info_schema@hive".columns`. Nobody types the resolved
+name; `$info_schema@` is reserved so a catalog name cannot collide with
+`runtime` or `metadata`.
+
+| Table | Description |
+|-------|-------------|
+| `tables` | One row per table or view, with its type. |
+| `views` | One row per view, with the text it was defined with. |
+| `columns` | One row per column of a table or view. |
+
+#### What a query may ask
+
+**A query must name the tables to describe.** Its filters have to pin
+`table_schema` and `table_name`, and only these forms name them:
+
+| Form | Example |
+|------|---------|
+| Equality | `table_name = 'orders'` |
+| `IN` list | `table_name IN ('orders', 'lineitem')` |
+
+Anything else leaves the query unbounded and fails at planning, with a
+message naming the filter to add:
+
+```
+Querying information_schema.columns requires a filter naming table_name,
+e.g. table_name = 't'
+```
+
+Unbounded forms include a pattern (`table_name LIKE 'o%'`), a range
+(`table_name > 'o'`), a name that reaches the scan through an `OR` or a
+subquery, and naming only one of the two columns. Naming neither fails
+on `table_schema` first.
+
+Filters on any other column — `data_type`, `table_catalog`, `is_nullable`
+— narrow the result but name nothing, so they are applied above the scan
+and never make a query servable on their own.
+
+A named table the catalog does not have, or a named schema it does not
+have, contributes no rows rather than failing. So does a filter no value
+passes, such as `table_name IN ()`.
+
+This is a deliberate divergence from Presto, which answers an unfiltered
+query by listing every table in a schema and reading each one's
+metadata. That does not hold up on a large catalog, so Axiom asks the
+catalog only about names a query gives it.
+
+#### Other restrictions
+
+- Served for the v2 optimizer. The v1 optimizer offers a connector one
+  filter at a time, so a query never names both the schema and the
+  table, and it fails as unbounded.
+- `DESCRIBE`, `SHOW COLUMNS` and `SHOW TABLES` resolve these relations
+  like any other table, so `SHOW TABLES FROM hive.information_schema`
+  lists them.
+- `data_type` is spelled the way the type system spells it, lower-cased.
+  A decimal reads as `decimal(10,2)`; complex types do not match
+  Presto's spelling.
+- `view_owner`, `column_default`, `comment` and `length` are always
+  null: ownership, defaults, comments and declared widths are not
+  tracked.
+- A query reports the relation it scanned as a table of this connector,
+  e.g. `system."$info_schema@hive".columns`, not as a table of the
+  catalog it describes. Anything reading a query's referenced tables,
+  such as an access check, sees that name.
+- The rows are read through the catalog's globally registered metadata,
+  with a session of this connector rather than of the catalog being
+  described.
+
+The rows come from catalog metadata, which only the coordinator can
+read, so these scans are placed there.
 
 ### system.runtime
 
@@ -51,6 +131,22 @@ WHERE is_variadic ORDER BY 1;
 -- List all active queries.
 SELECT query_id, state, query, elapsed_time_ms
 FROM system.runtime.queries;
+
+-- Columns of one table, as a client introspecting a schema asks for them.
+SELECT column_name, data_type, ordinal_position
+FROM information_schema.columns
+WHERE table_schema = 'sales' AND table_name = 'orders'
+ORDER BY ordinal_position;
+
+-- Whether a name is a table or a view.
+SELECT table_name, table_type
+FROM hive.information_schema.tables
+WHERE table_schema = 'sales' AND table_name IN ('orders', 'daily_orders');
+
+-- The text a view was defined with.
+SELECT view_definition
+FROM information_schema.views
+WHERE table_schema = 'sales' AND table_name = 'daily_orders';
 ```
 
 ## Table Schemas
@@ -118,6 +214,43 @@ One row per function signature (overload).
 
 </details>
 
+### <catalog>.information_schema.tables
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `table_catalog` | VARCHAR | Catalog the table belongs to. |
+| `table_schema` | VARCHAR | Schema the table belongs to. |
+| `table_name` | VARCHAR | Name of the table. |
+| `table_type` | VARCHAR | `BASE TABLE` or `VIEW`. |
+
+### <catalog>.information_schema.views
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `table_catalog` | VARCHAR | Catalog the view belongs to. |
+| `table_schema` | VARCHAR | Schema the view belongs to. |
+| `table_name` | VARCHAR | Name of the view. |
+| `view_owner` | VARCHAR | Always null; ownership is not tracked. |
+| `view_definition` | VARCHAR | The text the view was defined with. |
+
+### <catalog>.information_schema.columns
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `table_catalog` | VARCHAR | Catalog the column's table belongs to. |
+| `table_schema` | VARCHAR | Schema the column's table belongs to. |
+| `table_name` | VARCHAR | Table the column belongs to. |
+| `column_name` | VARCHAR | Name of the column. |
+| `ordinal_position` | BIGINT | Position of the column, counting from one. |
+| `column_default` | VARCHAR | Always null; defaults apply to writes. |
+| `is_nullable` | VARCHAR | Always `YES`; nullability is not tracked. |
+| `data_type` | VARCHAR | Type of the column, in lower case. |
+| `comment` | VARCHAR | Always null; comments are not tracked. |
+| `extra_info` | VARCHAR | What the connector says about the column's role, e.g. `partition key`. |
+| `precision` | BIGINT | Digits an integer or decimal type holds, mantissa bits for a floating-point one; null for other types. |
+| `scale` | BIGINT | Scale of a decimal; null for other types. |
+| `length` | BIGINT | Always null; types carry no declared width. |
+
 ## Architecture
 
 The system connector has two layers:
@@ -158,4 +291,19 @@ Query time:
     → connector dispatches to SessionPropertiesDataSource
     → data source calls SessionPropertiesProvider::getSessionProperties()
     → returns rows
+```
+
+The information_schema relations take the same path but read another
+catalog rather than a provider:
+
+```
+Query time:
+  SQL "SELECT ... FROM hive.information_schema.columns WHERE ..."
+    → parser resolves it to system."$info_schema@hive".columns
+    → optimizer offers the filters to createTableHandle(), which takes the
+      ones naming schemas and tables and rejects the rest, failing the
+      query if what it took does not name the tables to describe
+    → runner calls SystemConnector::createDataSource()
+    → data source looks up each named table in the hive catalog's ConnectorMetadata
+      and describes it, a batch of rows at a time
 ```

--- a/axiom/connectors/system/SystemConnector.cpp
+++ b/axiom/connectors/system/SystemConnector.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/connectors/system/SystemConnector.h"
+#include "axiom/connectors/system/InformationSchema.h"
 
 #include <algorithm>
 
@@ -865,11 +866,28 @@ SystemConnector::SystemConnector(
       queryInfoProvider_(queryInfoProvider),
       sessionPropertiesProvider_(sessionPropertiesProvider) {}
 
+void SystemConnector::registerSerDe() {
+  SystemTableHandle::registerSerDe();
+  InformationSchemaTableHandle::registerSerDe();
+  SystemColumnHandle::registerSerDe();
+  SystemSplit::registerSerDe();
+}
+
 std::unique_ptr<velox::connector::DataSource> SystemConnector::createDataSource(
     const velox::RowTypePtr& outputType,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const velox::connector::ColumnHandleMap& columnHandles,
     velox::connector::ConnectorQueryCtx* connectorQueryCtx) {
+  if (auto infoSchemaHandle =
+          std::dynamic_pointer_cast<const InformationSchemaTableHandle>(
+              tableHandle)) {
+    return InformationSchema::makeDataSource(
+        infoSchemaHandle,
+        outputType,
+        columnHandles,
+        connectorQueryCtx->memoryPool());
+  }
+
   auto* systemHandle =
       dynamic_cast<const SystemTableHandle*>(tableHandle.get());
   VELOX_CHECK_NOT_NULL(systemHandle, "Expected SystemTableHandle");

--- a/axiom/connectors/system/SystemConnector.h
+++ b/axiom/connectors/system/SystemConnector.h
@@ -241,11 +241,7 @@ class SystemConnector : public velox::connector::Connector {
   }
 
   /// Registers deserialization functions for all system connector types.
-  static void registerSerDe() {
-    SystemTableHandle::registerSerDe();
-    SystemColumnHandle::registerSerDe();
-    SystemSplit::registerSerDe();
-  }
+  static void registerSerDe();
 
  private:
   const QueryInfoProvider* queryInfoProvider_;

--- a/axiom/connectors/system/SystemConnectorMetadata.cpp
+++ b/axiom/connectors/system/SystemConnectorMetadata.cpp
@@ -18,6 +18,8 @@
 
 #include <numeric>
 
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/system/InformationSchema.h"
 #include "axiom/connectors/system/SystemConnector.h"
 #include "velox/common/base/Exceptions.h"
 
@@ -187,7 +189,44 @@ TablePtr SystemConnectorMetadata::findTable(const SchemaTableName& tableName) {
     return functionsTable_;
   }
 
+  if (InformationSchema::catalog(tableName.schema).has_value()) {
+    return informationSchemaTables_.withWLock([&](auto& tables) -> TablePtr {
+      const auto it = tables.find(tableName);
+      if (it != tables.end()) {
+        return it->second;
+      }
+
+      auto table = InformationSchema::findTable(tableName, connector_);
+      if (table != nullptr) {
+        tables.emplace(tableName, table);
+      }
+      return table;
+    });
+  }
+
   return nullptr;
+}
+
+std::vector<std::string> SystemConnectorMetadata::listSchemaNames(
+    const ConnectorSessionPtr& /*session*/) {
+  std::vector<std::string> names{
+      std::string(kRuntimeSchema), std::string(kMetadataSchema)};
+  for (const auto& catalog : ConnectorMetadataRegistry::allMetadataIds()) {
+    names.push_back(InformationSchema::schemaName(catalog));
+  }
+  return names;
+}
+
+bool SystemConnectorMetadata::schemaExists(
+    const ConnectorSessionPtr& /*session*/,
+    const std::string& schemaName) {
+  if (schemaName == kRuntimeSchema || schemaName == kMetadataSchema) {
+    return true;
+  }
+  auto catalog = InformationSchema::catalog(schemaName);
+  return catalog.has_value() &&
+      ConnectorMetadataRegistry::tryGet(std::string{catalog.value()}) !=
+      nullptr;
 }
 
 std::vector<std::string> SystemConnectorMetadata::listTableNames(
@@ -201,6 +240,9 @@ std::vector<std::string> SystemConnectorMetadata::listTableNames(
         std::string(kSessionPropertiesTable.table),
         std::string(kFunctionsTable.table),
     };
+  }
+  if (InformationSchema::catalog(schemaName).has_value()) {
+    return InformationSchema::tableNames();
   }
   return {};
 }

--- a/axiom/connectors/system/SystemConnectorMetadata.h
+++ b/axiom/connectors/system/SystemConnectorMetadata.h
@@ -16,6 +16,9 @@
 
 #pragma once
 
+#include <folly/Synchronized.h>
+#include <folly/container/F14Map.h>
+
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/system/SystemConnector.h"
 
@@ -139,16 +142,14 @@ class SystemConnectorMetadata : public ConnectorMetadata {
 
   TablePtr findTable(const SchemaTableName& tableName) override;
 
+  /// Returns the connector's own schemas plus one information_schema name per
+  /// registered catalog.
   std::vector<std::string> listSchemaNames(
-      const ConnectorSessionPtr& session) override {
-    return {std::string(kRuntimeSchema), std::string(kMetadataSchema)};
-  }
+      const ConnectorSessionPtr& session) override;
 
   bool schemaExists(
       const ConnectorSessionPtr& session,
-      const std::string& schemaName) override {
-    return schemaName == kRuntimeSchema || schemaName == kMetadataSchema;
-  }
+      const std::string& schemaName) override;
 
   std::vector<std::string> listTableNames(
       const ConnectorSessionPtr& session,
@@ -161,6 +162,10 @@ class SystemConnectorMetadata : public ConnectorMetadata {
  private:
   velox::connector::Connector* connector_;
   std::unique_ptr<SystemSplitManager> splitManager_;
+  // One table object per information_schema relation of a catalog, so a
+  // second lookup of the same name returns the same columns.
+  folly::Synchronized<folly::F14FastMap<SchemaTableName, TablePtr>>
+      informationSchemaTables_;
   std::shared_ptr<SystemTable> queriesTable_;
   std::shared_ptr<SystemTable> sessionPropertiesTable_;
   std::shared_ptr<SystemTable> functionsTable_;

--- a/axiom/connectors/system/tests/CMakeLists.txt
+++ b/axiom/connectors/system/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_executable(
   axiom_system_connector_test
   CoordinatorSchedulingTest.cpp
+  InformationSchemaTest.cpp
   SystemConnectorMetadataTest.cpp
   SystemConnectorSerDeTest.cpp
 )

--- a/axiom/connectors/system/tests/InformationSchemaTest.cpp
+++ b/axiom/connectors/system/tests/InformationSchemaTest.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/system/SystemConnectorMetadata.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+#include "velox/connectors/ConnectorRegistry.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::axiom::connector::system {
+namespace {
+
+using namespace facebook::velox;
+
+constexpr std::string_view kSystemConnectorId = "system";
+
+/// Queries the information_schema relations of the test catalog. The .sql
+/// tests cover the relations over tables; this covers what SQL cannot set up,
+/// a view, since CREATE VIEW is not supported.
+class InformationSchemaTest : public optimizer::test::QueryTestBase {
+ protected:
+  void SetUp() override {
+    useV2_ = true;
+    optimizer::test::QueryTestBase::SetUp();
+
+    systemConnector_ = std::make_shared<SystemConnector>(
+        std::string(kSystemConnectorId),
+        /*queryInfoProvider=*/nullptr,
+        /*sessionPropertiesProvider=*/nullptr);
+    velox::connector::ConnectorRegistry::global().insert(
+        std::string(kSystemConnectorId), systemConnector_);
+    ConnectorMetadataRegistry::global().insert(
+        std::string(kSystemConnectorId),
+        std::make_shared<SystemConnectorMetadata>(systemConnector_.get()));
+
+    testConnector_->createView(
+        SchemaTableName{kDefaultSchema, "nation_names"},
+        ROW("n_name", VARCHAR()),
+        "SELECT n_name FROM nation");
+  }
+
+  void TearDown() override {
+    ConnectorMetadataRegistry::global().erase(std::string(kSystemConnectorId));
+    velox::connector::ConnectorRegistry::global().erase(
+        std::string(kSystemConnectorId));
+    systemConnector_.reset();
+
+    optimizer::test::QueryTestBase::TearDown();
+  }
+
+  std::vector<RowVectorPtr> run(std::string_view sql) {
+    return runVelox(parseSelect(sql, kTestConnectorId)).results;
+  }
+
+  std::shared_ptr<SystemConnector> systemConnector_;
+};
+
+TEST_F(InformationSchemaTest, view) {
+  // A view reports the text it was defined with, and is not a base table.
+  auto results =
+      run("SELECT table_name, table_type FROM information_schema.tables "
+          "WHERE table_schema = 'default' AND table_name = 'nation_names'");
+  velox::test::assertEqualVectors(
+      makeRowVector({
+          makeFlatVector<std::string>({"nation_names"}),
+          makeFlatVector<std::string>({"VIEW"}),
+      }),
+      results.at(0));
+
+  results =
+      run("SELECT view_definition, view_owner FROM information_schema.views "
+          "WHERE table_schema = 'default' AND table_name = 'nation_names'");
+  velox::test::assertEqualVectors(
+      makeRowVector({
+          makeFlatVector<std::string>({"SELECT n_name FROM nation"}),
+          makeNullableFlatVector<std::string>({std::nullopt}),
+      }),
+      results.at(0));
+}
+
+TEST_F(InformationSchemaTest, viewColumns) {
+  // A view's columns are described like a table's, but carry no role.
+  auto results =
+      run("SELECT column_name, data_type, extra_info "
+          "FROM information_schema.columns "
+          "WHERE table_schema = 'default' AND table_name = 'nation_names'");
+  velox::test::assertEqualVectors(
+      makeRowVector({
+          makeFlatVector<std::string>({"n_name"}),
+          makeFlatVector<std::string>({"varchar"}),
+          makeNullableFlatVector<std::string>({std::nullopt}),
+      }),
+      results.at(0));
+}
+
+} // namespace
+} // namespace facebook::axiom::connector::system

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -21,6 +21,7 @@
 
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/system/InformationSchema.h"
 #include "axiom/connectors/system/SystemConnector.h"
 #include "axiom/connectors/system/SystemConnectorMetadata.h"
 #include "velox/connectors/Connector.h"
@@ -499,13 +500,57 @@ TEST_F(SystemConnectorMetadataTest, sessionPropertiesSchema) {
 
 TEST_F(SystemConnectorMetadataTest, schemas) {
   auto session = makeSession();
+  // Every registered catalog also has its information_schema relations here.
   EXPECT_THAT(
       metadata_->listSchemaNames(session),
       testing::UnorderedElementsAre(
-          kQueriesTable.schema, kSessionPropertiesTable.schema));
+          kQueriesTable.schema,
+          kSessionPropertiesTable.schema,
+          InformationSchema::schemaName(kSystemCatalog)));
   EXPECT_TRUE(metadata_->schemaExists(session, kQueriesTable.schema));
   EXPECT_TRUE(metadata_->schemaExists(session, kSessionPropertiesTable.schema));
   EXPECT_FALSE(metadata_->schemaExists(session, "information_schema"));
+}
+
+TEST_F(SystemConnectorMetadataTest, informationSchema) {
+  auto session = makeSession();
+  const auto schema = InformationSchema::schemaName(kSystemCatalog);
+
+  // A catalog's relations resolve under its information_schema name.
+  EXPECT_THAT(
+      metadata_->listTableNames(session, schema),
+      testing::UnorderedElementsAre("columns", "tables", "views"));
+
+  const auto table =
+      metadata_->findTable(SchemaTableName{schema, std::string("columns")});
+  ASSERT_NE(table, nullptr);
+  EXPECT_THAT(
+      table->type()->names(),
+      testing::ElementsAre(
+          "table_catalog",
+          "table_schema",
+          "table_name",
+          "column_name",
+          "ordinal_position",
+          "column_default",
+          "is_nullable",
+          "data_type",
+          "comment",
+          "extra_info",
+          "precision",
+          "scale",
+          "length"));
+
+  // The rows come from catalog metadata, which only the coordinator reads.
+  EXPECT_TRUE(table->layouts().at(0)->runsOnCoordinator());
+
+  // A name that is not a relation is not a table.
+  EXPECT_EQ(
+      metadata_->findTable(SchemaTableName{schema, std::string("schemata")}),
+      nullptr);
+  EXPECT_EQ(
+      metadata_->findTable(SchemaTableName{"information_schema", "columns"}),
+      nullptr);
 }
 
 TEST_F(SystemConnectorMetadataTest, listTableNames) {

--- a/axiom/connectors/system/tests/SystemConnectorSerDeTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorSerDeTest.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 #include "axiom/common/SchemaTableName.h"
+#include "axiom/connectors/system/InformationSchema.h"
 #include "axiom/connectors/system/SystemConnector.h"
 
 namespace facebook::axiom::connector::system {
@@ -57,6 +58,19 @@ class SystemConnectorSerDeTest : public testing::Test {
     }
   }
 
+  static void testSerde(const InformationSchemaTableHandle& handle) {
+    auto obj = handle.serialize();
+    auto clone =
+        velox::ISerializable::deserialize<InformationSchemaTableHandle>(
+            obj, nullptr);
+    ASSERT_EQ(handle.connectorId(), clone->connectorId());
+    ASSERT_EQ(handle.name(), clone->name());
+    ASSERT_EQ(handle.catalog(), clone->catalog());
+    ASSERT_EQ(handle.relation(), clone->relation());
+    ASSERT_EQ(handle.schemas(), clone->schemas());
+    ASSERT_EQ(handle.tables(), clone->tables());
+  }
+
   static void testSerde(const SystemSplit& split) {
     auto obj = split.serialize();
     auto clone = velox::ISerializable::deserialize<SystemSplit>(obj);
@@ -89,6 +103,20 @@ TEST_F(SystemConnectorSerDeTest, tableHandle) {
       SchemaTableName{"metadata", "session_properties"},
       std::move(columns));
   testSerde(handle2);
+}
+
+TEST_F(SystemConnectorSerDeTest, informationSchemaTableHandle) {
+  const std::string connectorId{"system"};
+  const SchemaTableName name{
+      InformationSchema::schemaName("cat"), std::string("columns")};
+
+  testSerde(InformationSchemaTableHandle(connectorId, name, {"s"}, {"t"}));
+
+  testSerde(InformationSchemaTableHandle(
+      connectorId, name, {"s1", "s2"}, {"t1", "t2"}));
+
+  // A filter no value passes names nothing to describe.
+  testSerde(InformationSchemaTableHandle(connectorId, name, {"s"}, {}));
 }
 
 TEST_F(SystemConnectorSerDeTest, connectorSplit) {

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -21,6 +21,7 @@
 #include <filesystem>
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
+#include "axiom/connectors/system/SystemConnectorMetadata.h"
 #include "axiom/optimizer/ConstantExprEvaluator.h"
 #include "axiom/optimizer/tests/SqlFile.h"
 #include "axiom/optimizer/tests/SqlTestBase.h"
@@ -41,6 +42,9 @@
 
 namespace facebook::axiom::optimizer::test {
 namespace {
+
+// Connector that serves information_schema for the catalogs under test.
+constexpr std::string_view kSystemConnectorId = "system";
 
 using namespace facebook::velox;
 
@@ -236,6 +240,19 @@ class SqlTest : public SqlTestBase {
       metadata = suiteConnector_->metadata().get();
     }
 
+    // The system connector serves information_schema for every catalog.
+    suiteSystemConnector_ =
+        std::make_shared<connector::system::SystemConnector>(
+            std::string(kSystemConnectorId),
+            /*queryInfoProvider=*/nullptr,
+            /*sessionPropertiesProvider=*/nullptr);
+    velox::connector::ConnectorRegistry::global().insert(
+        std::string(kSystemConnectorId), suiteSystemConnector_);
+    connector::ConnectorMetadataRegistry::global().insert(
+        std::string(kSystemConnectorId),
+        std::make_shared<connector::system::SystemConnectorMetadata>(
+            suiteSystemConnector_.get()));
+
     for (const auto& statement : setupStatements) {
       suiteDuckDbRunner_->execute(stripTablePropertiesForDuckDb(statement));
       runSetupStatement(
@@ -306,6 +323,14 @@ class SqlTest : public SqlTestBase {
       velox::connector::ConnectorRegistry::global().erase(kTestConnectorId);
       suiteConnector_.reset();
     }
+    if (suiteSystemConnector_ != nullptr) {
+      connector::ConnectorMetadataRegistry::global().erase(
+          std::string(kSystemConnectorId));
+      velox::connector::ConnectorRegistry::global().erase(
+          std::string(kSystemConnectorId));
+      suiteSystemConnector_.reset();
+    }
+
     suiteOptimizerPool_.reset();
     suiteRootPool_.reset();
     suiteExecutor_.reset();
@@ -369,6 +394,8 @@ class SqlTest : public SqlTestBase {
   static std::shared_ptr<memory::MemoryPool> suiteRootPool_;
   static std::shared_ptr<memory::MemoryPool> suiteOptimizerPool_;
   static std::shared_ptr<connector::TestConnector> suiteConnector_;
+  static std::shared_ptr<connector::system::SystemConnector>
+      suiteSystemConnector_;
   static std::unique_ptr<exec::test::DuckDbQueryRunner> suiteDuckDbRunner_;
   static std::shared_ptr<velox::common::testutil::TempDirectoryPath>
       suiteHiveDir_;
@@ -392,6 +419,10 @@ std::shared_ptr<memory::MemoryPool> SqlTest<Name, UseV2>::suiteOptimizerPool_;
 
 template <FileName Name, bool UseV2>
 std::shared_ptr<connector::TestConnector> SqlTest<Name, UseV2>::suiteConnector_;
+
+template <FileName Name, bool UseV2>
+std::shared_ptr<connector::system::SystemConnector>
+    SqlTest<Name, UseV2>::suiteSystemConnector_;
 
 template <FileName Name, bool UseV2>
 std::unique_ptr<exec::test::DuckDbQueryRunner>
@@ -488,6 +519,7 @@ int main(int argc, char** argv) {
   registerQueryFile<"distinctAggregation">();
   registerQueryFile<"filterPushdown">();
   registerQueryFile<"groupingsets">();
+  registerQueryFile<"informationSchema">(/*v2Only=*/true);
   registerQueryFile<"join">();
   registerQueryFile<"limit">();
   registerQueryFile<"metadataAggregate">(/*v2Only=*/true);

--- a/axiom/optimizer/tests/sql/informationSchema.sql
+++ b/axiom/optimizer/tests/sql/informationSchema.sql
@@ -1,0 +1,134 @@
+-- connector: hive
+-- setup
+CREATE TABLE t (a BIGINT, b VARCHAR, c DOUBLE, d DECIMAL(10, 2))
+----
+CREATE TABLE p (v BIGINT, k BIGINT) WITH (partitioned_by = ARRAY['k'])
+-- end_setup
+
+-- A catalog's tables and columns are described by information_schema, for
+-- queries whose filters name the tables to describe.
+
+-- The columns of a table, in declaration order.
+-- ordered
+-- duckdb: VALUES ('a', 'bigint', 1), ('b', 'varchar', 2), ('c', 'double', 3), ('d', 'decimal(10,2)', 4)
+SELECT column_name, data_type, ordinal_position
+FROM information_schema.columns
+WHERE table_schema = 'default' AND table_name = 't'
+ORDER BY ordinal_position
+
+----
+
+-- Every column reports as nullable and carries no default or comment.
+-- count 4
+SELECT column_name
+FROM information_schema.columns
+WHERE table_schema = 'default'
+  AND table_name = 't'
+  AND is_nullable = 'YES'
+  AND column_default IS NULL
+  AND comment IS NULL
+
+----
+
+-- A numeric type reports the digits it holds, a decimal its declared
+-- precision and scale, and a string type neither.
+-- ordered
+-- duckdb: VALUES ('a', 19, NULL), ('b', NULL, NULL), ('c', 53, NULL), ('d', 10, 2)
+SELECT column_name, precision, scale
+FROM information_schema.columns
+WHERE table_schema = 'default' AND table_name = 't'
+ORDER BY ordinal_position
+
+----
+
+-- A column the table is partitioned by says so; the others say nothing.
+-- ordered
+-- duckdb: VALUES ('k', 'partition key'), ('v', NULL)
+SELECT column_name, extra_info
+FROM information_schema.columns
+WHERE table_schema = 'default' AND table_name = 'p'
+ORDER BY column_name
+
+----
+
+-- A filter naming several schemas describes the tables of each it has.
+-- duckdb: VALUES ('default')
+SELECT DISTINCT table_schema
+FROM information_schema.columns
+WHERE table_schema IN ('default', 'absent') AND table_name = 't'
+
+----
+
+-- A filter naming several tables describes each of them.
+-- count 6
+SELECT column_name
+FROM information_schema.columns
+WHERE table_schema = 'default' AND table_name IN ('t', 'p')
+
+----
+
+-- A name no table answers to contributes no rows.
+-- count 0
+SELECT column_name
+FROM information_schema.columns
+WHERE table_schema = 'default' AND table_name = 'absent'
+
+----
+
+-- A table is reported as a base table.
+-- duckdb: VALUES ('t', 'BASE TABLE')
+SELECT table_name, table_type
+FROM information_schema.tables
+WHERE table_schema = 'default' AND table_name = 't'
+
+----
+
+-- A table is not a view, so views describes none of it.
+-- count 0
+SELECT table_name
+FROM information_schema.views
+WHERE table_schema = 'default' AND table_name = 't'
+
+----
+
+-- Counting selects no column of the relation.
+-- duckdb: VALUES (4)
+SELECT count(*)
+FROM information_schema.columns
+WHERE table_schema = 'default' AND table_name = 't'
+
+----
+
+-- A filter on any other column narrows the rows the query returns.
+-- duckdb: VALUES ('c')
+SELECT column_name
+FROM information_schema.columns
+WHERE table_schema = 'default' AND table_name = 't' AND data_type = 'double'
+
+----
+
+-- A query naming no schema describes no tables and fails.
+-- error: requires a filter naming table_schema
+SELECT column_name FROM information_schema.columns
+
+----
+
+-- Naming the schema alone leaves the tables to describe unbounded.
+-- error: requires a filter naming table_name
+SELECT table_name FROM information_schema.tables WHERE table_schema = 'default'
+
+----
+
+-- A pattern does not name the tables to describe.
+-- error: requires a filter naming table_name
+SELECT column_name
+FROM information_schema.columns
+WHERE table_schema = 'default' AND table_name LIKE 't%'
+
+----
+
+-- Neither does a range.
+-- error: requires a filter naming table_name
+SELECT column_name
+FROM information_schema.columns
+WHERE table_schema = 'default' AND table_name > 't'

--- a/axiom/sql/presto/CMakeLists.txt
+++ b/axiom/sql/presto/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(
   axiom_logical_plan_builder
   axiom_sql_presto_ast
   axiom_sql_presto_error
+  axiom_system_connector
   velox_common_base
   velox_common_config
   velox_presto_types

--- a/axiom/sql/presto/ParserOptions.cpp
+++ b/axiom/sql/presto/ParserOptions.cpp
@@ -60,6 +60,12 @@ std::vector<ConfigProperty> buildProperties(
           "a stack overflow.",
       },
       {
+          std::string(ParserOptions::kInformationSchemaConnectorId),
+          ConfigPropertyType::kString,
+          std::string(ParserOptions::kInformationSchemaConnectorIdDefault),
+          "Connector serving the information_schema relations.",
+      },
+      {
           std::string(ParserOptions::kMaxExpressionWidth),
           ConfigPropertyType::kInteger,
           fmt::to_string(ParserOptions::kMaxExpressionWidthDefault),
@@ -110,6 +116,13 @@ ParserOptions ParserOptions::from(
       field = it->second == "true";
     }
   };
+  auto setString = [&](std::string_view key, std::string& field) {
+    auto it = properties.find(key);
+    if (it != properties.end()) {
+      VELOX_USER_CHECK(!it->second.empty(), "{} cannot be empty", key);
+      field = it->second;
+    }
+  };
   auto setUint32 = [&](std::string_view key, uint32_t& field) {
     auto it = properties.find(key);
     if (it != properties.end()) {
@@ -123,6 +136,9 @@ ParserOptions ParserOptions::from(
   setUint32(kMaxExpressionDepth, options.maxExpressionDepth);
   setUint32(kMaxSubqueryDepth, options.maxSubqueryDepth);
   setUint32(kMaxExpressionWidth, options.maxExpressionWidth);
+
+  setString(
+      kInformationSchemaConnectorId, options.informationSchemaConnectorId);
   return options;
 }
 

--- a/axiom/sql/presto/ParserOptions.h
+++ b/axiom/sql/presto/ParserOptions.h
@@ -37,12 +37,16 @@ struct ParserOptions : public facebook::velox::config::ConfigProvider {
   static constexpr std::string_view kMaxExpressionWidth =
       "max_expression_width";
   static constexpr std::string_view kMaxSubqueryDepth = "max_subquery_depth";
+  static constexpr std::string_view kInformationSchemaConnectorId =
+      "information_schema_connector_id";
 
   static constexpr bool kFriendlySqlDefault = true;
   static constexpr bool kParseDecimalLiteralAsDoubleDefault = true;
   static constexpr uint32_t kMaxExpressionDepthDefault = 1024;
   static constexpr uint32_t kMaxExpressionWidthDefault = 100'000;
   static constexpr uint32_t kMaxSubqueryDepthDefault = 1024;
+  static constexpr std::string_view kInformationSchemaConnectorIdDefault =
+      "system";
 
   ParserOptions();
 
@@ -80,6 +84,12 @@ struct ParserOptions : public facebook::velox::config::ConfigProvider {
   /// Maximum subquery nesting depth; deeper nesting is rejected to avoid a
   /// stack overflow.
   uint32_t maxSubqueryDepth{kMaxSubqueryDepthDefault};
+
+  /// Connector serving the information_schema relations. A name like
+  /// 'hive.information_schema.columns' resolves to this connector, with the
+  /// catalog it describes carried in the schema.
+  std::string informationSchemaConnectorId{
+      kInformationSchemaConnectorIdDefault};
 
   /// Constructs options from session property name-value pairs.
   /// Keys are unqualified property names (e.g., "friendly_sql").

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "axiom/sql/presto/PrestoParser.h"
+
+#include <boost/algorithm/string/predicate.hpp>
 #include <folly/ScopeGuard.h>
 #include <folly/container/F14Map.h>
 #include <folly/container/small_vector.h>
@@ -25,6 +27,7 @@
 #include "axiom/common/CatalogSchemaTableName.h"
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/system/InformationSchema.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/sql/presto/ColumnsExpansion.h"
 #include "axiom/sql/presto/CteScope.h"
@@ -207,7 +210,15 @@ class ParserHelper {
   DepthLimitListener depthListener_;
 };
 
-std::pair<std::string, facebook::axiom::SchemaTableName> toConnectorTable(
+// A catalog's information_schema relations are served by another connector,
+// so a name whose schema is information_schema resolves there.
+bool isInformationSchema(std::string_view schema) {
+  static constexpr std::string_view kInformationSchema = "information_schema";
+  return boost::iequals(schema, kInformationSchema);
+}
+
+std::pair<std::string, facebook::axiom::SchemaTableName>
+toConnectorTableInCatalog(
     const QualifiedName& name,
     const std::string& defaultConnectorId,
     const std::string& defaultSchema) {
@@ -227,6 +238,44 @@ std::pair<std::string, facebook::axiom::SchemaTableName> toConnectorTable(
   // connector.schema.name
   VELOX_CHECK_EQ(3, parts.size());
   return {parts[0], {parts[1], parts[2]}};
+}
+
+// The information_schema relations describe a catalog but are served by one
+// connector, so '<catalog>.information_schema.<relation>' resolves to
+// '<that connector>."$info_schema@<catalog>".<relation>'. The catalog travels
+// in the schema, which is where the relation reads its metadata from.
+std::pair<std::string, facebook::axiom::SchemaTableName> toConnectorTable(
+    const QualifiedName& name,
+    const std::string& defaultConnectorId,
+    const std::string& defaultSchema,
+    std::string_view informationSchemaConnectorId) {
+  auto [connectorId, table] =
+      toConnectorTableInCatalog(name, defaultConnectorId, defaultSchema);
+
+  if (!isInformationSchema(table.schema)) {
+    return {std::move(connectorId), std::move(table)};
+  }
+
+  return {
+      std::string(informationSchemaConnectorId),
+      {facebook::axiom::connector::system::InformationSchema::schemaName(
+           connectorId),
+       std::move(table.table)}};
+}
+
+// Statement paths that do not carry the session's options resolve
+// information_schema through the connector it names by default. The id is a
+// deployment-wide setting, so a session that overrides it changes where a
+// SELECT resolves, not where DESCRIBE does.
+std::pair<std::string, facebook::axiom::SchemaTableName> toConnectorTable(
+    const QualifiedName& name,
+    const std::string& defaultConnectorId,
+    const std::string& defaultSchema) {
+  return toConnectorTable(
+      name,
+      defaultConnectorId,
+      defaultSchema,
+      ParserOptions::kInformationSchemaConnectorIdDefault);
 }
 
 // Resolves a column reference against both sides of a JOIN. Raises an error
@@ -688,7 +737,10 @@ class RelationPlanner : public AstVisitor {
 
     // Regular base-table reference.
     const auto [connectorId, connectorTable] = toConnectorTable(
-        name, context_.defaultConnectorId.value(), defaultSchema_);
+        name,
+        context_.defaultConnectorId.value(),
+        defaultSchema_,
+        options_.informationSchemaConnectorId);
 
     auto metadata =
         facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
@@ -3075,6 +3127,15 @@ SqlStatementPtr parseShowTables(
       connectorId = parts[0];
       schema = parts[1];
     }
+  }
+
+  // A catalog's information_schema is served by another connector, with the
+  // catalog carried in the schema.
+  if (isInformationSchema(schema)) {
+    schema = facebook::axiom::connector::system::InformationSchema::schemaName(
+        connectorId);
+    connectorId =
+        std::string(ParserOptions::kInformationSchemaConnectorIdDefault);
   }
 
   auto metadata =

--- a/axiom/sql/presto/tests/CMakeLists.txt
+++ b/axiom/sql/presto/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(
   axiom_logical_plan_matcher
   axiom_logical_plan_builder
   axiom_sql_presto_parser
+  axiom_system_connector
   axiom_test_connector
   GTest::gmock
   glog::glog

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#include <folly/ScopeGuard.h>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/system/InformationSchema.h"
+#include "axiom/connectors/system/SystemConnectorMetadata.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
@@ -26,7 +30,38 @@ namespace lp = facebook::axiom::logical_plan;
 
 namespace {
 
-class PrestoParserTest : public PrestoParserTestBase {};
+namespace connector = facebook::axiom::connector;
+using lp::test::LogicalPlanMatcherBuilder;
+
+class PrestoParserTest : public PrestoParserTestBase {
+ protected:
+  // information_schema names resolve to the system connector, so it must be
+  // registered for them to parse.
+  void SetUp() override {
+    PrestoParserTestBase::SetUp();
+
+    systemConnector_ = std::make_shared<connector::system::SystemConnector>(
+        kSystemConnectorId,
+        /*queryInfoProvider=*/nullptr,
+        /*sessionPropertiesProvider=*/nullptr);
+    connector::ConnectorMetadataRegistry::global().insert(
+        kSystemConnectorId,
+        std::make_shared<connector::system::SystemConnectorMetadata>(
+            systemConnector_.get()));
+  }
+
+  void TearDown() override {
+    connector::ConnectorMetadataRegistry::global().erase(kSystemConnectorId);
+    systemConnector_.reset();
+
+    PrestoParserTestBase::TearDown();
+  }
+
+  const std::string kSystemConnectorId{
+      ParserOptions::kInformationSchemaConnectorIdDefault};
+
+  std::shared_ptr<connector::system::SystemConnector> systemConnector_;
+};
 
 TEST_F(PrestoParserTest, unnest) {
   {
@@ -2199,6 +2234,38 @@ TEST_F(PrestoParserTest, semanticErrorHasMessageTemplate) {
         << "Semantic errors must have a messageTemplate for Scuba grouping";
     EXPECT_EQ(std::string(e.messageTemplate()), "Table not found: {}");
   }
+}
+
+// A catalog's information_schema relations are served by the system connector,
+// so the name resolves there with the catalog carried in the schema.
+TEST_F(PrestoParserTest, informationSchemaRoutesToSystemConnector) {
+  // The schema names the catalog the relations describe.
+  const auto matchInformationSchema = [&](const lp::LogicalPlanNodePtr& node) {
+    const auto* scan = node->as<lp::TableScanNode>();
+    EXPECT_EQ(scan->connectorId(), "system");
+    EXPECT_EQ(scan->tableName().schema, "$info_schema@test");
+    EXPECT_EQ(scan->tableName().table, "columns");
+  };
+
+  auto matcher = LogicalPlanMatcherBuilder()
+                     .tableScan(matchInformationSchema)
+                     .filter()
+                     .project()
+                     .output();
+
+  // The catalog defaults to the session's when the name does not give one.
+  testSelect(
+      "SELECT column_name FROM information_schema.columns "
+      "WHERE table_schema = 's' AND table_name = 't'",
+      matcher);
+
+  // A name that gives the catalog resolves the same way, in any case.
+  testSelect(
+      fmt::format(
+          "SELECT column_name FROM {}.INFORMATION_SCHEMA.columns "
+          "WHERE table_schema = 's' AND table_name = 't'",
+          kConnectorId),
+      matcher);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/axel/pull/265

A query that asks what a catalog contains failed with `Table not found`:

    SELECT view_definition FROM information_schema.views
    WHERE table_schema = 'sf30' AND table_name = 'nation'

`tables`, `views` and `columns` describe a catalog's tables and columns rather than belonging to any one connector, and every catalog has them. They are now served for all of them, as `<catalog>.information_schema.<relation>`.

The system connector hosts the relations, and the parser resolves a name to it, carrying the catalog in the schema: `hive.information_schema.columns` becomes `system."$info_schema@hive".columns`. The rows come from that catalog's `findTable` and `findView`, a batch at a time, computing only the columns a query selects; the scan is placed on the coordinator, which is where metadata can be read. Which connector serves the relations is a session property, `information_schema_connector_id`.

A query is served when its filters name the tables to describe — equality or `IN` on `table_schema` and `table_name`. Anything else, a pattern or a range or naming one of the two, fails at planning with a message naming the filter to add. Presto answers an unfiltered query by listing every table in a schema and reading each one's metadata, which does not finish on a large catalog, so Axiom asks a catalog only about names a query gives it. A filter on any other column narrows the result above the scan. A name no table answers to contributes no rows.

Served for the v2 optimizer: v1 offers a connector one filter at a time, so a query never names both columns and fails as unbounded. `Column` gains `extraInfo`, what a connector says about a column's role, which Hive-family connectors set to `partition key` and `columns` reports.

Reviewed By: amitkdutta, singcha

Differential Revision: D116873991
