### PR TITLE
fix(tests): Call folly::Init in system connector tests

### DIFF
--- a/axiom/connectors/system/tests/InformationSchemaTest.cpp
+++ b/axiom/connectors/system/tests/InformationSchemaTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <folly/init/Init.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -111,3 +112,11 @@ TEST_F(InformationSchemaTest, viewColumns) {
 
 } // namespace
 } // namespace facebook::axiom::connector::system
+
+// Queries run here, and Velox execution reaches folly singletons that a
+// gtest-provided main leaves uninitialized.
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:
`axiom_system_connector_test` aborted in the OSS build before gtest printed a single line:

    Singleton folly::Timekeeper requested before registrationComplete() call.
    This usually means that either main() never called folly::init

CMake links every system-connector test file into one binary against `gtest_main`, so nothing calls `folly::Init`. Tests that only build plans survive that; the information_schema tests execute queries, and Velox execution reaches a folly singleton on that path. Buck hides the difference by giving each test its own initializing main.

Adds that main to `InformationSchemaTest.cpp`, the way `PlanTest.cpp` carries it for the combined optimizer test binary.

Differential Revision: D116952654


