### PR TITLE
fix(cli): Log the failure source file and line (#1751)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -593,7 +593,9 @@ class QueryFinalizer {
         .message = error.what(),
         .messageTemplate = messageTemplateOf(error),
         .errorCode = error.errorCode(),
-        .errorSource = error.errorSource()};
+        .errorSource = error.errorSource(),
+        .file = error.file() != nullptr ? error.file() : "",
+        .line = error.line()};
     finalize();
   }
 

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -88,6 +88,13 @@ struct ErrorInfo {
   /// Raw Velox error source (e.g. "USER", "RUNTIME", "SYSTEM", "EXTERNAL") from
   /// the caught VeloxException. Empty for non-Velox exceptions.
   std::string errorSource;
+
+  /// Source file the failure was raised from. Empty for exceptions that carry
+  /// no throw site, such as PrestoSqlError.
+  std::string file;
+
+  /// Line within `file`. Meaningful only when `file` is set.
+  size_t line{0};
 };
 
 /// Thrown by co_run() when a query is stopped by an external cancellation. A

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -722,6 +722,42 @@ TEST_F(SqlQueryRunnerTest, completionCapturesFailureMessageTemplate) {
   EXPECT_NE(captured.errorInfo->messageTemplate, captured.errorInfo->message);
 }
 
+// Captures the throw site of a Velox failure so telemetry can point at the
+// code that raised it.
+TEST_F(SqlQueryRunnerTest, completionCapturesFailureSourceLocation) {
+  QueryCompletionInfo captured;
+
+  EXPECT_THROW(
+      runner_->run(
+          "SELECT 1 / 0",
+          {.onComplete =
+               [&](const QueryCompletionInfo& info) { captured = info; }}),
+      std::exception);
+
+  ASSERT_TRUE(captured.errorInfo.has_value());
+  // The path itself is build-specific, so assert only that a location is
+  // captured.
+  EXPECT_FALSE(captured.errorInfo->file.empty());
+  EXPECT_GT(captured.errorInfo->line, 0);
+}
+
+// A PrestoSqlError carries no throw site, so the location stays unset rather
+// than reporting a misleading zero line against an empty file.
+TEST_F(SqlQueryRunnerTest, completionHasNoSourceLocationForSqlError) {
+  QueryCompletionInfo captured;
+
+  EXPECT_THROW(
+      runner_->run(
+          "SELECT * FROM nonexistent_table",
+          {.onComplete =
+               [&](const QueryCompletionInfo& info) { captured = info; }}),
+      std::exception);
+
+  ASSERT_TRUE(captured.errorInfo.has_value());
+  EXPECT_TRUE(captured.errorInfo->file.empty());
+  EXPECT_EQ(captured.errorInfo->line, 0);
+}
+
 TEST(MessageTemplateOfTest, veloxExceptionUsesTemplate) {
   try {
     VELOX_USER_FAIL("Not supported: {}", "rank");


### PR DESCRIPTION
Summary:

`ErrorInfo` gains `file` and `line`, populated from `VeloxException::file()`/`line()` in the Velox `fail()` overload, so a caller can report where a failure was raised.

Reviewed By: kKPulla

Differential Revision: D116909051


