### PR TITLE
feat(v2): Decorrelate a semi-join inside a correlated subquery

### DIFF
--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -271,6 +271,51 @@ SELECT
     (SELECT count(*) FROM u WHERE u.a < t.c) AS z
 FROM t
 ----
+
+-- A correlated subquery whose body filters on an IN subquery.
+SELECT t.a, (SELECT count(*) FROM u WHERE u.a = t.a AND u.a IN (SELECT v.a FROM v)) AS n
+FROM t
+----
+-- An outer whose body rows are all rejected by the IN still produces a row.
+SELECT t.a, (SELECT count(*) FROM u WHERE u.a = t.a AND u.a IN (SELECT v.a FROM v WHERE v.a > 100)) AS n
+FROM t
+----
+-- An IN predicate in the subquery's SELECT list rather than its WHERE.
+SELECT t.a, (SELECT max(CAST(u.a IN (SELECT v.a FROM v) AS INTEGER)) FROM u WHERE u.a = t.a) AS m
+FROM t
+----
+-- The same for EXISTS, where no body row belongs to the outer.
+SELECT t.a, (SELECT max(CAST(EXISTS (SELECT 1 FROM v WHERE v.a = u.a) AS INTEGER)) FROM u WHERE u.a = t.a + 1000) AS m
+FROM t
+----
+-- NOT IN over a list holding NULL is never true, so no body row survives.
+SELECT t.a, (SELECT count(*) FROM u WHERE u.a = t.a AND u.a NOT IN (SELECT w.a FROM (VALUES (1), (CAST(NULL AS BIGINT))) AS w(a))) AS n
+FROM t
+----
+-- EXISTS in the body of a correlated subquery.
+SELECT t.a, (SELECT count(*) FROM u WHERE u.a = t.a AND EXISTS (SELECT 1 FROM v WHERE v.a = u.a)) AS n
+FROM t
+----
+-- A body predicate beyond the correlation equality and the IN.
+SELECT t.a, (SELECT count(*) FROM u WHERE u.a = t.a AND u.a > 1 AND u.a IN (SELECT v.a FROM v)) AS n
+FROM t
+----
+-- A subquery returning a value rather than an aggregate: an outer whose body
+-- rows are all rejected by the IN reads NULL.
+SELECT t.a, (SELECT u.a FROM u WHERE u.a = t.a AND u.a IN (SELECT v.a FROM v WHERE v.a > 100)) AS b
+FROM t
+----
+-- More than one body row survives the IN, which a single-value subquery
+-- rejects at runtime.
+-- error: Scalar sub-query has returned multiple rows
+SELECT t.a, (SELECT u.a FROM u WHERE u.a > t.a AND u.a IN (SELECT v.a FROM v)) AS b
+FROM t
+----
+-- An IN whose subquery reads an outer column.
+-- error_v1: Join filter references column from unplaced non-single-row table
+SELECT t.a, (SELECT count(*) FROM u WHERE u.a = t.a AND u.a IN (SELECT v.a + t.a FROM v)) AS n
+FROM t
+----
 -- Correlated IN subquery with single correlation equality.
 SELECT t.a IN (SELECT t2.a FROM t t2 WHERE t2.b = t.b) FROM t
 ----

--- a/axiom/optimizer/v2/DecorrelatePass.cpp
+++ b/axiom/optimizer/v2/DecorrelatePass.cpp
@@ -631,9 +631,9 @@ class Decorrelator : public NodeRewriter<> {
     return conjuncts;
   }
 
-  // Outer Apply is kLeft (scalar). Supports kInner cross-join (no
-  // predicate) and kLeft with predicate. kInner with a Join-node
-  // predicate (requires per-rn pad-collapse over matches) and other
+  // Outer Apply is kLeft (scalar). Supports a kLeftSemiProject body, a kLeft
+  // body with predicate, and a kInner cross-join body with none. kInner with
+  // a predicate (requires per-rn pad-collapse over matches) and the remaining
   // kinds NYI loud.
   NodeCP joinPeelLeft(
       ApplyCP node,
@@ -641,11 +641,16 @@ class Decorrelator : public NodeRewriter<> {
       JoinCP joinBody,
       ExprVector joinPredicate,
       ExprVector accumulatedFilter) {
+    if (joinBody->joinType() == velox::core::JoinType::kLeftSemiProject) {
+      return joinPeelLeftSemiProject(
+          node, input, joinBody, std::move(accumulatedFilter));
+    }
+
     if (!joinBody->isInner() && !joinBody->isLeft()) {
       VELOX_NYI(
-          "Decorrelate joinPeel: outer kLeft over Join.kind={} not yet "
-          "implemented",
-          joinBody->joinType());
+          "Decorrelate joinPeel: outer kLeft over this body Join kind is not "
+          "yet implemented: {}",
+          joinBody->joinTypeName());
     }
     if (joinBody->isInner() && !joinPredicate.empty()) {
       VELOX_NYI(
@@ -746,6 +751,142 @@ class Decorrelator : public NodeRewriter<> {
     });
   }
 
+  // Outer kLeft over a body kLeftSemiProject: the body emits A's rows plus a
+  // mark saying whether any B row matched. applyA carries the outer scalar
+  // Apply's kLeft pad semantics over A, and applyB tests B for existence and
+  // writes the body's own mark.
+  //
+  // A filter reading that mark selects among body rows, and an outer whose
+  // every body row it rejects must still emit one NULL-padded row.
+  NodeCP joinPeelLeftSemiProject(
+      ApplyCP node,
+      NodeCP input,
+      JoinCP joinBody,
+      ExprVector accumulatedFilter) {
+    NodeCP leftSide = joinBody->left();
+    NodeCP rightSide = joinBody->right();
+    // A kLeftSemiProject Join projects its mark as the last output column;
+    // every other output comes from the preserved side. Reading a data column
+    // as the mark would misroute the filter split below.
+    VELOX_CHECK(
+        !joinBody->outputColumns().empty(),
+        "kLeftSemiProject Join must project a mark");
+    ColumnCP mark = joinBody->outputColumns().back();
+    VELOX_CHECK(
+        !PlanObjectSet::fromObjects(leftSide->outputColumns()).contains(mark),
+        "kLeftSemiProject Join must project its mark last");
+
+    ExprVector markFilter;
+    ExprVector rowFilter;
+    for (ExprCP conjunct : accumulatedFilter) {
+      if (conjunct->columns().contains(mark)) {
+        markFilter.push_back(conjunct);
+      } else {
+        rowFilter.push_back(conjunct);
+      }
+    }
+
+    // A null-aware body carries the IN equality as its single equi-pair, and
+    // applyB must keep the two sides apart to stay null-aware.
+    ExprCP inLhs = nullptr;
+    ExprCP inBodyKey = nullptr;
+    ExprVector applyBFilter;
+    if (joinBody->nullAware()) {
+      // A body whose IN key reads outer columns carries the equality in its
+      // filter instead, leaving nothing to hand applyB as the null-aware pair.
+      if (joinBody->leftKeys().size() != 1) {
+        VELOX_NYI(
+            "Decorrelate joinPeel: outer kLeft over a null-aware "
+            "kLeftSemiProject Join without a single equi-pair is not yet "
+            "implemented");
+      }
+      inLhs = joinBody->leftKeys()[0];
+      inBodyKey = joinBody->rightKeys()[0];
+      appendAll(applyBFilter, joinBody->filter());
+    } else {
+      applyBFilter = flattenJoinPredicate(joinBody);
+    }
+
+    // Collapsing keeps the rows the mark filter accepts and one pad row per
+    // outer that has none, which needs a per-outer id and defers the
+    // cardinality assertion until after the collapse.
+    const bool collapse = !markFilter.empty();
+    ColumnCP rowId = collapse ? makeIdColumn() : nullptr;
+    NodeCP chainInput = collapse
+        ? builder().make<AssignUniqueId>(AssignUniqueId::Key{input, rowId})
+        : input;
+
+    ColumnCP applyAIncludeMarker = makeIncludeColumn();
+    ColumnVector applyAOutputs;
+    applyAOutputs.reserve(
+        chainInput->outputColumns().size() + leftSide->outputColumns().size() +
+        1);
+    appendAll(applyAOutputs, chainInput->outputColumns());
+    appendUnique(applyAOutputs, leftSide->outputColumns());
+    applyAOutputs.push_back(applyAIncludeMarker);
+
+    NodeCP applyA = builder().make<Apply>(Apply::Key{
+        chainInput,
+        leftSide,
+        recomputeCorrelations(leftSide, chainInput->outputColumns()),
+        velox::core::JoinType::kLeft,
+        std::move(rowFilter),
+        collapse ? false : node->enforceSingleRow(),
+        /*markColumn=*/nullptr,
+        /*inLhs=*/nullptr,
+        /*inBodyKey=*/nullptr,
+        applyAIncludeMarker,
+        std::move(applyAOutputs),
+    });
+
+    // Semi projection is one row in, one row out, so A's rows are neither
+    // multiplied nor dropped by the existence test.
+    ColumnVector applyBOutputs;
+    applyBOutputs.reserve(applyA->outputColumns().size() + 1);
+    appendAll(applyBOutputs, applyA->outputColumns());
+    applyBOutputs.push_back(mark);
+
+    NodeCP applyB = builder().make<Apply>(Apply::Key{
+        applyA,
+        rightSide,
+        recomputeCorrelations(rightSide, applyA->outputColumns()),
+        velox::core::JoinType::kLeftSemiProject,
+        std::move(applyBFilter),
+        /*enforceSingleRow=*/false,
+        mark,
+        inLhs,
+        inBodyKey,
+        /*includeMarker=*/nullptr,
+        std::move(applyBOutputs),
+    });
+
+    NodeCP chain = rewrite(applyB);
+
+    if (!collapse) {
+      // Without a mark filter the mark is a value on an A row rather than a
+      // reason to keep or drop it, so applyA's marker alone gates inclusion.
+      ExprVector finalExprs;
+      finalExprs.reserve(node->outputColumns().size());
+      for (ColumnCP outputColumn : node->outputColumns()) {
+        finalExprs.push_back(
+            outputColumn == node->includeMarker() ? applyAIncludeMarker
+                                                  : outputColumn);
+      }
+      return builder().make<Project>(Project::Key{
+          chain,
+          std::move(finalExprs),
+          node->outputColumns(),
+      });
+    }
+
+    // A body row counts when A matched and the mark filter accepts it.
+    ExprCP matchedExpr = applyAIncludeMarker;
+    for (ExprCP conjunct : markFilter) {
+      matchedExpr = exprFactory_.makeAnd(matchedExpr, conjunct);
+    }
+    return collapsePadRows(node, input, chain, rowId, matchedExpr);
+  }
+
   // Outer kLeft over a body kInner cross-join. The leg cascade uses
   // kLeft legs so outers and left rows survive, but that over-produces
   // pad rows when one side is empty and the other has >1 rows, which
@@ -811,17 +952,30 @@ class Decorrelator : public NodeRewriter<> {
 
     NodeCP chain = rewrite(applyB);
 
-    // A real body row requires both sides to match. Leg markers are
-    // `true` on a match and NULL on a pad, so fold to a clean boolean
-    // (NULL → false) before the window: `bool_or` over all-NULL markers
-    // would otherwise yield NULL and drop the pad row. Materialize it
-    // as a column so the window and filter can reference it.
+    // A real body row requires both sides to match.
+    return collapsePadRows(
+        node, input, chain, rowId, exprFactory_.makeAnd(markA, markB));
+  }
+
+  // Reduces 'chain' to the outer Apply's contract: every row 'matchedExpr'
+  // accepts survives, and an outer with no such row keeps exactly one
+  // NULL-padded row. 'rowId', from an AssignUniqueId over 'input', identifies
+  // the outer a row belongs to.
+  NodeCP collapsePadRows(
+      ApplyCP node,
+      NodeCP input,
+      NodeCP chain,
+      ColumnCP rowId,
+      ExprCP matchedExpr) {
+    // Leg markers read `true` on a match and NULL on a pad, so fold to a
+    // clean boolean before the window: `bool_or` over all-NULL markers would
+    // otherwise yield NULL and drop the pad row. Materialize it as a column
+    // so the window and filter can reference it.
     ColumnCP matched = makeIncludeColumn();
     NodeCP marked = appendColumn(
         chain,
         matched,
-        exprFactory_.makeCoalesce(
-            exprFactory_.makeAnd(markA, markB), builder().makeBoolean(false)));
+        exprFactory_.makeCoalesce(matchedExpr, builder().makeBoolean(false)));
 
     // Per-outer window: `anyMatch` over the whole partition, and a
     // `padOrdinal` row_number to designate the single pad row to keep.
@@ -846,13 +1000,11 @@ class Decorrelator : public NodeRewriter<> {
         ? enforceScalarSingleRow(filtered, rowId)
         : filtered;
 
-    // Shape to the outer Apply's contract. The kept pad row carries
-    // real left-side values (gated only by applyA's marker), so body
-    // columns must be NULLed when this outer had no match; otherwise a
-    // left-only scalar would leak the pad's value. Outer columns are
-    // valid on a pad and pass through; the matched marker becomes the
-    // outer includeMarker. rowId, leg markers, and window columns drop
-    // here.
+    // The kept pad row carries real body values, so body columns must be
+    // NULLed when this outer had no match; otherwise the scalar would leak
+    // the pad's value. Outer columns are valid on a pad and pass through;
+    // the matched marker becomes the outer includeMarker. rowId, leg
+    // markers, and window columns drop here.
     PlanObjectSet outerColumns =
         PlanObjectSet::fromObjects(input->outputColumns());
     ExprVector finalExprs;
@@ -954,10 +1106,10 @@ class Decorrelator : public NodeRewriter<> {
     }
     if (!joinBody->isInner() || !joinPredicate.empty()) {
       VELOX_NYI(
-          "Decorrelate joinPeel: outer kLeftSemiProject EXISTS over "
-          "Join.kind={} with predicate {} not yet implemented",
-          joinBody->joinType(),
-          joinPredicate.empty() ? "empty" : "non-empty");
+          "Decorrelate joinPeel: outer kLeftSemiProject EXISTS requires an "
+          "unpredicated kInner body: joinType={}, numPredicates={}",
+          joinBody->joinTypeName(),
+          joinPredicate.size());
     }
 
     // Cross-join EXISTS: mark = (∃a) AND (∃b).

--- a/axiom/optimizer/v2/docs/Decorrelate-join-rules.md
+++ b/axiom/optimizer/v2/docs/Decorrelate-join-rules.md
@@ -73,7 +73,7 @@ whether `applyB` pads on no-match (kLeft pad) or projects a mark
 | `kRight` | swap to `kLeft` with sides reversed (`applyA=B, applyB=A`) | none — symmetry |
 | `kFull` | NYI | needs both sides' unmatched rows; tree-only can't express without re-evaluating one side. Loud NYI. |
 | `kLeftSemiFilter` | `kLeftSemiProject` (apply emits per-A mark) | `Filter(mark)` then drop mark; equivalent to A-rows-with-any-matching-B |
-| `kLeftSemiProject` (in body) | `kLeftSemiProject` | mark propagates as a new column; outer's body-cols accordingly |
+| `kLeftSemiProject` (in body) | `kLeftSemiProject` | mark propagates as a new column; a filter reading that mark gates inclusion and triggers the per-rn pad-collapse — see §"outerKind = kLeft (scalar context)" |
 | `kAnti` | `kLeftSemiProject` | `Filter(NOT mark OR mark IS NULL)` |
 
 (Filter expressions in the envelope use `Builder::makeBoolean` /
@@ -113,9 +113,23 @@ semantics). Body's Join output becomes that row's value(s). Outer's
   - Body kLeft: `applyA.includeMarker` alone — the inner LEFT JOIN's
     right-side pad rows ARE real body rows (left preserved with
     NULL right cols), so applyB's marker must not gate inclusion.
-  - Body kSemi*: chain's `applyB.includeMarker` maps to outer's
-    `includeMarker` via the same aliasing the Limit peel uses (see
-    `Decorrelate-limit-rules.md` §"kLeft + count >= 1").
+  - Body kLeftSemiProject: `applyB` is itself kLeftSemiProject and has
+    no `includeMarker`; it writes the body's mark for every row `applyA`
+    produced. With no filter on that mark, `applyA.includeMarker` alone
+    gates inclusion. A filter on the mark (`WHERE x IN (...)` inside the
+    subquery) selects among body rows, so inclusion becomes
+    `COALESCE(applyA.includeMarker AND markFilter, false)` and the chain
+    runs the per-rn pad-collapse of §"INNER pad-row drop" to keep one
+    pad row for an outer whose body rows the filter all rejected.
+    `accumulatedFilter` splits by whether a conjunct reads the mark: the
+    rest reference only A and outer columns and ride on `applyA.filter`.
+  - A null-aware body (`IN` / `NOT IN`) carries the IN equality as its
+    single equi-pair, which must be re-hosted as `applyB`'s
+    `inLhs` / `inBodyKey` — `Apply.nullAware()` is defined as
+    `inLhs != nullptr`, so folding the pair into `applyB.filter` would
+    silently drop null-awareness. A body whose IN key reads outer
+    columns has its equality demoted into the Join filter by
+    `terminusSemi` and so carries no equi-pair; that shape is NYI loud.
 - ESR=true (`enforceSingleRow`) handling depends on body Join kind:
   - Body kLeft: leg-wise ESR on `applyA` (`|A| ≤ 1`) and `applyB`
     (per-A `|B| ≤ 1`) enforces the scalar bound; their conjunction is
@@ -126,6 +140,10 @@ semantics). Body's Join output becomes that row's value(s). Outer's
     the other side's rows. Run the per-rn pad-collapse first, then
     `EnforceDistinct(rn)` over the collapsed stream; see §"INNER
     pad-row drop."
+  - Body kLeftSemiProject: with no mark filter, `applyA` carries the ESR
+    (`|A| ≤ 1`), since semi projection is one row in, one row out. With
+    a mark filter, the legs carry none and `EnforceDistinct(rn)` runs
+    over the collapsed stream, as for kInner.
 
 ### outerKind = `kLeftSemiProject` EXISTS (inLhs == nullptr)
 
@@ -229,12 +247,14 @@ Combinations across (outerKind, joinKind):
 | kLeft (ESR=true) | kLeft | **in scope** |
 | kLeft (ESR=true) | kRight | **in scope** (via swap) |
 | kLeft (ESR=true) | kFull | NYI loud |
-| kLeft (ESR=true) | kLeftSemiFilter / kLeftSemiProject / kAnti | **in scope** |
+| kLeft (ESR=true) | kLeftSemiProject | **in scope** |
+| kLeft (ESR=true) | kLeftSemiFilter / kAnti | NYI loud |
 | kLeft (ESR=false) | kInner cross-join | **in scope** (per-rn pad-collapse; see §"INNER pad-row drop") |
 | kLeft (ESR=false) | kInner with predicate | designed (per-rn pad-collapse; see §"INNER pad-row drop"); **NYI loud** in code |
 | kLeft (ESR=false) | kLeft / kRight | **in scope** |
 | kLeft (ESR=false) | kFull | NYI loud |
-| kLeft (ESR=false) | kLeftSemi* / kAnti | **in scope** |
+| kLeft (ESR=false) | kLeftSemiProject | **in scope** |
+| kLeft (ESR=false) | kLeftSemiFilter / kAnti | NYI loud |
 | kLeftSemiProject EXISTS | any non-kFull | **in scope** (mark composes per §"outerKind = kLeftSemiProject EXISTS") |
 | kLeftSemiProject IN | any non-kFull | **in scope** (IN equi routed per `inBodyKey` reference site) |
 | any | kFull | NYI loud — needs DAG / re-evaluation of one side |


### PR DESCRIPTION
Summary:
A correlated subquery whose body filters on `IN`, `NOT IN`, or `EXISTS` failed to plan under v2:

    SELECT t.a,
      (SELECT count(*) FROM u
       WHERE u.a = t.a AND u.a IN (SELECT v.a FROM v)) AS n
    FROM t

    Decorrelate joinPeel: outer kLeft over LEFT SEMI (PROJECT) join not yet implemented

The nested predicate makes the subquery's body a semi-join, and peeling a Join body handled only inner and left bodies.

A semi-join body emits its left side's rows plus a mark saying whether the right side matched, so the chain keeps the pad semantics on the left leg and turns the right leg into the existence test that writes that mark. A filter reading the mark — the shape `WHERE x IN (...)` produces — selects among body rows, so an outer whose body rows it all rejects must still emit one NULL-padded row; that case reuses the per-outer pad-collapse the inner body already used, now shared between the two.

Deferred: a body whose `IN` key reads an outer column carries no equi-pair to hand the leg, and semi-filter and anti bodies are still untranslated. Both fail loud.

Differential Revision: D116984869
