### PR TITLE
fix(v2): Plan a subquery in an outer join's ON clause (#1754)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -875,7 +875,7 @@ std::vector<presto::SqlStatementPtr> SqlQueryRunner::parseMultiple(
       collectConnectorProperties(*sessionConfig_));
   auto prestoParser = std::make_unique<presto::PrestoParser>(
       defaultConnectorId, defaultSchema, std::move(parserSession));
-  return prestoParser->parseMultiple(sql, /*enableTracing=*/options.debugMode);
+  return prestoParser->parseMultiple(sql, /*enableTracing=*/false);
 }
 
 presto::SqlStatementPtr SqlQueryRunner::parseSingle(

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -394,6 +394,30 @@ inline auto in(
         << _axiom_plan_->toString(true);             \
   }
 
+// Asserts the plan shape under v1 only, for suites that dual-run before their
+// v2 shapes are pinned: under v2 the query still has to plan, which the call
+// producing `plan` verifies, but its shape is not compared. Reads `useV2_`
+// from the fixture. Replace with `AXIOM_ASSERT_PLAN` once the v2 expectation
+// is written.
+#define AXIOM_ASSERT_PLAN_V1(plan, matcher)       \
+  {                                               \
+    auto _axiom_plan_ = (plan);                   \
+    if (!useV2_) {                                \
+      ASSERT_TRUE((matcher)->match(_axiom_plan_)) \
+          << _axiom_plan_->toString(true, true);  \
+    }                                             \
+  }
+
+// AXIOM_ASSERT_DISTRIBUTED_PLAN under the same terms.
+#define AXIOM_ASSERT_DISTRIBUTED_PLAN_V1(plan, matcher) \
+  {                                                     \
+    auto _axiom_plan_ = (plan);                         \
+    if (!useV2_) {                                      \
+      ASSERT_TRUE((matcher)->match(*_axiom_plan_))      \
+          << _axiom_plan_->toString(true);              \
+    }                                                   \
+  }
+
 // Instantiates a value-parameterized (`TEST_P`) suite for both optimizers,
 // producing `V1/<suite>.<case>/_` and `V2/<suite>.<case>/_`. The fixture must
 // derive from `WithParamInterface<bool>` and set `useV2_ = GetParam()` in

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -27,8 +27,14 @@ namespace {
 using namespace velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class SubqueryTest : public test::HiveQueriesTestBase {
+class SubqueryTest : public test::HiveQueriesTestBase,
+                     public ::testing::WithParamInterface<bool> {
  protected:
+  void SetUp() override {
+    useV2_ = GetParam();
+    test::HiveQueriesTestBase::SetUp();
+  }
+
   static void SetUpTestCase() {
     test::HiveQueriesTestBase::SetUpTestCase();
     createTpchTables(
@@ -40,7 +46,7 @@ class SubqueryTest : public test::HiveQueriesTestBase {
   }
 };
 
-TEST_F(SubqueryTest, uncorrelatedScalar) {
+TEST_P(SubqueryTest, uncorrelatedScalar) {
   // = <subquery>
   {
     auto query =
@@ -120,7 +126,7 @@ TEST_F(SubqueryTest, uncorrelatedScalar) {
 }
 
 // IN list mixing subqueries with non-subquery expressions.
-TEST_F(SubqueryTest, inListWithMixedSubqueries) {
+TEST_P(SubqueryTest, inListWithMixedSubqueries) {
   // IN list with a scalar subquery and a literal. The scalar subquery is
   // extracted, cross-joined, and the IN becomes in(n_regionkey, max, 2).
   {
@@ -138,7 +144,7 @@ TEST_F(SubqueryTest, inListWithMixedSubqueries) {
             .project()
             .build();
 
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // IN list with two scalar subqueries. Both are extracted, cross-joined, and
@@ -161,14 +167,14 @@ TEST_F(SubqueryTest, inListWithMixedSubqueries) {
             .project()
             .build();
 
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
 
 // IN with a constant (table-less) left side over a real source. With no table
 // to anchor the constant on, the optimizer materializes it as a one-row Values
 // relation and runs the IN as a null-aware semi-join against the source.
-TEST_F(SubqueryTest, uncorrelatedInConstantLeftSide) {
+TEST_P(SubqueryTest, uncorrelatedInConstantLeftSide) {
   auto query = "SELECT 1 IN (SELECT r_regionkey FROM region)";
   SCOPED_TRACE(query);
 
@@ -181,10 +187,10 @@ TEST_F(SubqueryTest, uncorrelatedInConstantLeftSide) {
                      .build();
 
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
-TEST_F(SubqueryTest, correlatedExists) {
+TEST_P(SubqueryTest, correlatedExists) {
   {
     auto query =
         "SELECT * FROM nation WHERE "
@@ -199,7 +205,7 @@ TEST_F(SubqueryTest, correlatedExists) {
     {
       SCOPED_TRACE(query);
       auto plan = toSingleNodePlan(query);
-      AXIOM_ASSERT_PLAN(plan, matcher);
+      AXIOM_ASSERT_PLAN_V1(plan, matcher);
     }
 
     query =
@@ -209,7 +215,7 @@ TEST_F(SubqueryTest, correlatedExists) {
     {
       SCOPED_TRACE(query);
       auto plan = toSingleNodePlan(query);
-      AXIOM_ASSERT_PLAN(plan, matcher);
+      AXIOM_ASSERT_PLAN_V1(plan, matcher);
     }
 
     // EXISTS with DISTINCT. DISTINCT is semantically unnecessary for EXISTS
@@ -222,7 +228,7 @@ TEST_F(SubqueryTest, correlatedExists) {
     {
       SCOPED_TRACE(query);
       auto plan = toSingleNodePlan(query);
-      AXIOM_ASSERT_PLAN(plan, matcher);
+      AXIOM_ASSERT_PLAN_V1(plan, matcher);
     }
   }
 
@@ -241,7 +247,7 @@ TEST_F(SubqueryTest, correlatedExists) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   {
@@ -258,7 +264,7 @@ TEST_F(SubqueryTest, correlatedExists) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Correlated conjuncts referencing multiple tables.
@@ -278,11 +284,11 @@ TEST_F(SubqueryTest, correlatedExists) {
     {
       SCOPED_TRACE(query);
       auto plan = toSingleNodePlan(query);
-      AXIOM_ASSERT_PLAN(plan, matcher);
+      AXIOM_ASSERT_PLAN_V1(plan, matcher);
     }
   }
 }
-TEST_F(SubqueryTest, uncorrelatedProject) {
+TEST_P(SubqueryTest, uncorrelatedProject) {
   // Uncorrelated scalar subquery in projection.
   {
     auto query =
@@ -301,7 +307,7 @@ TEST_F(SubqueryTest, uncorrelatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Uncorrelated scalar subquery in projection with global aggregation in the
@@ -324,7 +330,7 @@ TEST_F(SubqueryTest, uncorrelatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Uncorrelated scalar subquery in projection with GROUP BY aggregation in the
@@ -348,7 +354,7 @@ TEST_F(SubqueryTest, uncorrelatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // IN <subquery> in projection.
@@ -371,7 +377,7 @@ TEST_F(SubqueryTest, uncorrelatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // NOT IN <subquery> in projection.
@@ -394,7 +400,7 @@ TEST_F(SubqueryTest, uncorrelatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Uncorrelated EXISTS in projection.
@@ -414,7 +420,7 @@ TEST_F(SubqueryTest, uncorrelatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Uncorrelated NOT EXISTS in projection.
@@ -435,11 +441,11 @@ TEST_F(SubqueryTest, uncorrelatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
 
-TEST_F(SubqueryTest, correlatedIn) {
+TEST_P(SubqueryTest, correlatedIn) {
   // Find customers with at least one order.
   {
     auto query =
@@ -458,7 +464,7 @@ TEST_F(SubqueryTest, correlatedIn) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Find customers with no orders.
@@ -482,7 +488,7 @@ TEST_F(SubqueryTest, correlatedIn) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Correlated IN subquery with non-equality filter in the SELECT list produces
@@ -514,13 +520,13 @@ TEST_F(SubqueryTest, correlatedIn) {
                        .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
 
 // Correlated IN subquery where the correlation predicate is an equality
 // on different columns than the IN equality.
-TEST_F(SubqueryTest, correlatedInWithCorrelationFilter) {
+TEST_P(SubqueryTest, correlatedInWithCorrelationFilter) {
   testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
   testConnector_->addTable("u", ROW({"x", "y", "z"}, BIGINT()));
 
@@ -541,7 +547,7 @@ TEST_F(SubqueryTest, correlatedInWithCorrelationFilter) {
             .project()
             .build();
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Two correlation equalities.
@@ -562,13 +568,13 @@ TEST_F(SubqueryTest, correlatedInWithCorrelationFilter) {
                        .project()
                        .build();
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
 
 // Correlated IN subquery with both equality and non-equality correlation
 // predicates.
-TEST_F(SubqueryTest, correlatedInWithMixedCorrelationFilter) {
+TEST_P(SubqueryTest, correlatedInWithMixedCorrelationFilter) {
   testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
   testConnector_->addTable("u", ROW({"x", "y", "z"}, BIGINT()));
 
@@ -588,11 +594,11 @@ TEST_F(SubqueryTest, correlatedInWithMixedCorrelationFilter) {
                      .project()
                      .build();
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
 // Correlated IN subquery where the correlation equality duplicates the IN key.
-TEST_F(SubqueryTest, correlatedInWithRedundantCorrelationFilter) {
+TEST_P(SubqueryTest, correlatedInWithRedundantCorrelationFilter) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
   testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()));
 
@@ -610,12 +616,12 @@ TEST_F(SubqueryTest, correlatedInWithRedundantCorrelationFilter) {
                      .project()
                      .build();
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
 // IN subquery whose correlation predicate references a sibling of the IN's
 // outer table: t and u join into a single source feeding the SEMI on v.
-TEST_F(SubqueryTest, correlatedInOnSibling) {
+TEST_P(SubqueryTest, correlatedInOnSibling) {
   testConnector_->addTable("t", ROW("a", BIGINT()));
   testConnector_->addTable("u", ROW("k", BIGINT()));
   testConnector_->addTable("v", ROW({"k", "b"}, BIGINT()));
@@ -630,11 +636,11 @@ TEST_F(SubqueryTest, correlatedInOnSibling) {
           .hashJoin(matchScan("v").project(), core::JoinType::kLeftSemiFilter)
           .build();
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
 // IN subquery where the left-side expression references multiple tables.
-TEST_F(SubqueryTest, multiTableInSubquery) {
+TEST_P(SubqueryTest, multiTableInSubquery) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
   testConnector_->addTable("u", ROW({"c", "d"}, BIGINT()));
   testConnector_->addTable("v", ROW({"e", "f"}, BIGINT()));
@@ -654,10 +660,10 @@ TEST_F(SubqueryTest, multiTableInSubquery) {
           .build();
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
-TEST_F(SubqueryTest, correlatedScalar) {
+TEST_P(SubqueryTest, correlatedScalar) {
   // Correlated scalar subquery with aggregation in filter.
   {
     auto query =
@@ -679,7 +685,7 @@ TEST_F(SubqueryTest, correlatedScalar) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   {
@@ -703,7 +709,7 @@ TEST_F(SubqueryTest, correlatedScalar) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   {
@@ -724,11 +730,11 @@ TEST_F(SubqueryTest, correlatedScalar) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
 
-TEST_F(SubqueryTest, correlatedProject) {
+TEST_P(SubqueryTest, correlatedProject) {
   auto matchAggNation = [&]() {
     return matchHiveScan("nation").singleAggregation().project();
   };
@@ -749,7 +755,7 @@ TEST_F(SubqueryTest, correlatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Correlated scalar subquery in projection with SUM aggregation.
@@ -766,7 +772,7 @@ TEST_F(SubqueryTest, correlatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Multiple scalar subqueries in projection.
@@ -787,7 +793,7 @@ TEST_F(SubqueryTest, correlatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // EXISTS <subquery> in projection.
@@ -809,7 +815,7 @@ TEST_F(SubqueryTest, correlatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Correlated IN <subquery> in projection.
@@ -831,7 +837,7 @@ TEST_F(SubqueryTest, correlatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Correlated NOT IN <subquery> in projection.
@@ -853,11 +859,11 @@ TEST_F(SubqueryTest, correlatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
 
-TEST_F(SubqueryTest, uncorrelatedExists) {
+TEST_P(SubqueryTest, uncorrelatedExists) {
   // Uncorrelated EXISTS: returns all rows if subquery has rows.
   {
     auto query = "SELECT * FROM region WHERE EXISTS (SELECT 1 FROM nation)";
@@ -874,7 +880,7 @@ TEST_F(SubqueryTest, uncorrelatedExists) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Uncorrelated NOT EXISTS: returns all rows if subquery has no rows.
@@ -893,11 +899,11 @@ TEST_F(SubqueryTest, uncorrelatedExists) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
 
-TEST_F(SubqueryTest, correlatedNotExists) {
+TEST_P(SubqueryTest, correlatedNotExists) {
   // NOT EXISTS with equality correlation in filter.
   {
     auto query =
@@ -913,7 +919,7 @@ TEST_F(SubqueryTest, correlatedNotExists) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // NOT EXISTS with non-equality correlation in filter.
@@ -934,7 +940,7 @@ TEST_F(SubqueryTest, correlatedNotExists) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // NOT EXISTS in projection.
@@ -956,11 +962,11 @@ TEST_F(SubqueryTest, correlatedNotExists) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
 
-TEST_F(SubqueryTest, unnest) {
+TEST_P(SubqueryTest, unnest) {
   testConnector_->addTable("t", ROW({"a"}, ARRAY(BIGINT())));
   testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()));
   testConnector_->addTable("v", ROW({"n", "m"}, BIGINT()));
@@ -973,7 +979,7 @@ TEST_F(SubqueryTest, unnest) {
     auto matcher = matchScan("t").unnest().hashJoin(matchScan("u")).build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   {
@@ -984,7 +990,7 @@ TEST_F(SubqueryTest, unnest) {
     auto matcher = matchScan("t").unnest().hashJoin(matchScan("u")).build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   {
@@ -1000,11 +1006,11 @@ TEST_F(SubqueryTest, unnest) {
             .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
 
-TEST_F(SubqueryTest, enforceSingleRow) {
+TEST_P(SubqueryTest, enforceSingleRow) {
   auto query =
       "SELECT * FROM region "
       "WHERE r_regionkey > (SELECT n_regionkey FROM nation)";
@@ -1019,7 +1025,7 @@ TEST_F(SubqueryTest, enforceSingleRow) {
             .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
 
     VELOX_ASSERT_THROW(runVelox(plan), "Expected single row of input.");
   }
@@ -1035,11 +1041,11 @@ TEST_F(SubqueryTest, enforceSingleRow) {
             .build();
 
     auto distributedPlan = planVelox(logicalPlan);
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN_V1(distributedPlan.plan, matcher);
   }
 }
 
-TEST_F(SubqueryTest, enforceSingleRowInProjection) {
+TEST_P(SubqueryTest, enforceSingleRowInProjection) {
   auto query =
       "SELECT (SELECT r_regionkey FROM region WHERE r_name = 'AFRICA') "
       "FROM nation";
@@ -1053,7 +1059,7 @@ TEST_F(SubqueryTest, enforceSingleRowInProjection) {
                        .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   {
@@ -1071,11 +1077,11 @@ TEST_F(SubqueryTest, enforceSingleRowInProjection) {
             .build();
 
     auto distributedPlan = planVelox(logicalPlan);
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN_V1(distributedPlan.plan, matcher);
   }
 }
 
-TEST_F(SubqueryTest, uncorrelatedGroupingKey) {
+TEST_P(SubqueryTest, uncorrelatedGroupingKey) {
   auto query =
       "SELECT r_name, (SELECT count(*) FROM nation) FROM region GROUP BY 1, 2";
   SCOPED_TRACE(query);
@@ -1086,10 +1092,10 @@ TEST_F(SubqueryTest, uncorrelatedGroupingKey) {
                      .build();
 
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
-TEST_F(SubqueryTest, correlatedGroupingKey) {
+TEST_P(SubqueryTest, correlatedGroupingKey) {
   auto query =
       "SELECT r_name, (SELECT count(*) FROM nation WHERE n_regionkey = r_regionkey) + 1 "
       "FROM region GROUP BY 1, 2";
@@ -1104,10 +1110,10 @@ TEST_F(SubqueryTest, correlatedGroupingKey) {
                      .build();
 
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
-TEST_F(SubqueryTest, nonEquiCorrelatedScalar) {
+TEST_P(SubqueryTest, nonEquiCorrelatedScalar) {
   // Correlated scalar subquery with non-equi correlation condition.
   {
     auto query =
@@ -1137,7 +1143,7 @@ TEST_F(SubqueryTest, nonEquiCorrelatedScalar) {
                          .build();
 
       auto plan = toSingleNodePlan(logicalPlan);
-      AXIOM_ASSERT_PLAN(plan, matcher);
+      AXIOM_ASSERT_PLAN_V1(plan, matcher);
     }
 
     {
@@ -1162,7 +1168,7 @@ TEST_F(SubqueryTest, nonEquiCorrelatedScalar) {
                          .build();
 
       auto distributedPlan = planVelox(logicalPlan);
-      AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+      AXIOM_ASSERT_DISTRIBUTED_PLAN_V1(distributedPlan.plan, matcher);
     }
   }
 
@@ -1196,7 +1202,7 @@ TEST_F(SubqueryTest, nonEquiCorrelatedScalar) {
                          .build();
 
       auto plan = toSingleNodePlan(logicalPlan);
-      AXIOM_ASSERT_PLAN(plan, matcher);
+      AXIOM_ASSERT_PLAN_V1(plan, matcher);
     }
   }
 }
@@ -1205,7 +1211,7 @@ TEST_F(SubqueryTest, nonEquiCorrelatedScalar) {
 // CTE with GROUP BY). The subquery's own aggregation (COUNT(*)) is stacked on
 // top of the inner aggregation, producing two AggregateNode levels. The
 // correlation predicates include a non-equi condition (BETWEEN).
-TEST_F(SubqueryTest, nonEquiCorrelatedScalarWithNestedAggregation) {
+TEST_P(SubqueryTest, nonEquiCorrelatedScalarWithNestedAggregation) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
   testConnector_->addTable("u", ROW({"c", "d"}, BIGINT()));
 
@@ -1239,10 +1245,10 @@ TEST_F(SubqueryTest, nonEquiCorrelatedScalarWithNestedAggregation) {
           .build();
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
-TEST_F(SubqueryTest, nonEquiCorrelatedProject) {
+TEST_P(SubqueryTest, nonEquiCorrelatedProject) {
   // Correlated scalar subquery with non-equi correlation condition.
   {
     auto query =
@@ -1270,7 +1276,7 @@ TEST_F(SubqueryTest, nonEquiCorrelatedProject) {
                          .build();
 
       auto plan = toSingleNodePlan(logicalPlan);
-      AXIOM_ASSERT_PLAN(plan, matcher);
+      AXIOM_ASSERT_PLAN_V1(plan, matcher);
     }
 
     {
@@ -1294,7 +1300,7 @@ TEST_F(SubqueryTest, nonEquiCorrelatedProject) {
                          .build();
 
       auto distributedPlan = planVelox(logicalPlan);
-      AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+      AXIOM_ASSERT_DISTRIBUTED_PLAN_V1(distributedPlan.plan, matcher);
     }
   }
 }
@@ -1304,7 +1310,7 @@ TEST_F(SubqueryTest, nonEquiCorrelatedProject) {
 // aggregation on top of the previous one. A single AssignUniqueId at the
 // base feeds every aggregation as its grouping key; each aggregation
 // carries forward the prior subqueries' results via arbitrary().
-TEST_F(SubqueryTest, multipleNonEquiCorrelatedScalars) {
+TEST_P(SubqueryTest, multipleNonEquiCorrelatedScalars) {
   // Two subqueries against distinct inner tables.
   {
     auto query =
@@ -1342,7 +1348,7 @@ TEST_F(SubqueryTest, multipleNonEquiCorrelatedScalars) {
                        .build();
 
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Three subqueries against distinct inner tables: each successive
@@ -1397,13 +1403,13 @@ TEST_F(SubqueryTest, multipleNonEquiCorrelatedScalars) {
                        .build();
 
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
 
 // Uncorrelated scalar (max) followed by a non-equi correlated scalar
 // (count(*)) in the same SELECT.
-TEST_F(SubqueryTest, uncorrelatedThenNonEquiCorrelatedScalar) {
+TEST_P(SubqueryTest, uncorrelatedThenNonEquiCorrelatedScalar) {
   auto query =
       "SELECT "
       "  (SELECT max(s_suppkey) FROM supplier) AS x, "
@@ -1431,12 +1437,12 @@ TEST_F(SubqueryTest, uncorrelatedThenNonEquiCorrelatedScalar) {
                      .build();
 
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
 // Non-equi correlated scalar (count(*)) followed by a correlated EXISTS
 // in the same SELECT.
-TEST_F(SubqueryTest, nonEquiCorrelatedScalarThenCorrelatedExists) {
+TEST_P(SubqueryTest, nonEquiCorrelatedScalarThenCorrelatedExists) {
   auto query =
       "SELECT "
       "  (SELECT count(*) FROM nation WHERE n_regionkey > r_regionkey) AS x, "
@@ -1464,12 +1470,12 @@ TEST_F(SubqueryTest, nonEquiCorrelatedScalarThenCorrelatedExists) {
                      .build();
 
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
 // Non-equi correlated scalar (count(*)) followed by an uncorrelated
 // scalar (max) in the same SELECT.
-TEST_F(SubqueryTest, nonEquiCorrelatedThenUncorrelatedScalar) {
+TEST_P(SubqueryTest, nonEquiCorrelatedThenUncorrelatedScalar) {
   auto query =
       "SELECT "
       "  (SELECT count(*) FROM nation WHERE n_regionkey > r_regionkey) AS x, "
@@ -1497,11 +1503,11 @@ TEST_F(SubqueryTest, nonEquiCorrelatedThenUncorrelatedScalar) {
                      .build();
 
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
 // Correlated EXISTS combined with an uncorrelated IN in the same SELECT.
-TEST_F(SubqueryTest, correlatedExistsThenUncorrelatedIn) {
+TEST_P(SubqueryTest, correlatedExistsThenUncorrelatedIn) {
   auto query =
       "SELECT "
       "  EXISTS (SELECT 1 FROM nation WHERE n_regionkey > r_regionkey) AS x, "
@@ -1521,12 +1527,12 @@ TEST_F(SubqueryTest, correlatedExistsThenUncorrelatedIn) {
           .build();
 
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
 // Correlated scalar subqueries without aggregation.
 // These require EnforceDistinct to validate single-row semantics.
-TEST_F(SubqueryTest, correlatedScalarWithoutAggregation) {
+TEST_P(SubqueryTest, correlatedScalarWithoutAggregation) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
   testConnector_->addTable("u", ROW({"c", "d"}, BIGINT()));
 
@@ -1544,7 +1550,7 @@ TEST_F(SubqueryTest, correlatedScalarWithoutAggregation) {
                        .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   {
@@ -1559,7 +1565,7 @@ TEST_F(SubqueryTest, correlatedScalarWithoutAggregation) {
                        .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Non-equi correlation: d < b.
@@ -1578,7 +1584,7 @@ TEST_F(SubqueryTest, correlatedScalarWithoutAggregation) {
                        .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   {
@@ -1595,11 +1601,11 @@ TEST_F(SubqueryTest, correlatedScalarWithoutAggregation) {
                        .build();
 
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
 
-TEST_F(SubqueryTest, innerJoinOnSubquery) {
+TEST_P(SubqueryTest, innerJoinOnSubquery) {
   // Subqueries in inner join ON clauses are processed as cross join + filter,
   // reusing the WHERE clause subquery infrastructure.
   const std::string baseJoin =
@@ -1621,7 +1627,7 @@ TEST_F(SubqueryTest, innerJoinOnSubquery) {
             .build();
 
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // IN subquery in ON clause.
@@ -1639,7 +1645,7 @@ TEST_F(SubqueryTest, innerJoinOnSubquery) {
             .build();
 
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // NOT IN subquery in ON clause.
@@ -1659,7 +1665,7 @@ TEST_F(SubqueryTest, innerJoinOnSubquery) {
             .build();
 
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // EXISTS subquery in ON clause.
@@ -1678,7 +1684,7 @@ TEST_F(SubqueryTest, innerJoinOnSubquery) {
             .build();
 
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // NOT EXISTS subquery in ON clause.
@@ -1699,7 +1705,7 @@ TEST_F(SubqueryTest, innerJoinOnSubquery) {
             .build();
 
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Correlated scalar
@@ -1721,7 +1727,7 @@ TEST_F(SubqueryTest, innerJoinOnSubquery) {
             .build();
 
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Uncorrelated scalar subquery referencing both sides of the join.
@@ -1743,11 +1749,11 @@ TEST_F(SubqueryTest, innerJoinOnSubquery) {
             .build();
 
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
 
-TEST_F(SubqueryTest, leftJoinOnSubquery) {
+TEST_P(SubqueryTest, leftJoinOnSubquery) {
   // Subqueries in LEFT JOIN ON clauses are supported when they reference only
   // the right (null-supplying) side. See Subqueries.md.
   const std::string baseJoin =
@@ -1767,8 +1773,7 @@ TEST_F(SubqueryTest, leftJoinOnSubquery) {
                            core::JoinType::kLeft)
                        .build();
 
-    auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(toSingleNodePlan(query), matcher);
   }
 
   // Uncorrelated scalar subquery in LEFT JOIN ON clause.
@@ -1791,7 +1796,7 @@ TEST_F(SubqueryTest, leftJoinOnSubquery) {
             .build();
 
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // NOT IN subquery in LEFT JOIN ON clause.
@@ -1814,8 +1819,7 @@ TEST_F(SubqueryTest, leftJoinOnSubquery) {
                            core::JoinType::kLeft)
                        .build();
 
-    auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(toSingleNodePlan(query), matcher);
   }
 
   // All conjuncts contain subqueries (no non-subquery condition remains).
@@ -1834,8 +1838,7 @@ TEST_F(SubqueryTest, leftJoinOnSubquery) {
                            core::JoinType::kLeft)
                        .build();
 
-    auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(toSingleNodePlan(query), matcher);
   }
 
   // Correlated EXISTS referencing the right (null-supplying) side.
@@ -1854,8 +1857,7 @@ TEST_F(SubqueryTest, leftJoinOnSubquery) {
                            core::JoinType::kLeft)
                        .build();
 
-    auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(toSingleNodePlan(query), matcher);
   }
 
   // Correlated NOT EXISTS referencing the right (null-supplying) side.
@@ -1877,8 +1879,7 @@ TEST_F(SubqueryTest, leftJoinOnSubquery) {
                            core::JoinType::kLeft)
                        .build();
 
-    auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(toSingleNodePlan(query), matcher);
   }
 
   // Correlated scalar subquery referencing the right (null-supplying) side.
@@ -1908,14 +1909,13 @@ TEST_F(SubqueryTest, leftJoinOnSubquery) {
                 core::JoinType::kLeft)
             .build();
 
-    auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(toSingleNodePlan(query), matcher);
   }
 }
 
 // Non-equi LEFT JOIN where the left side contains a scalar subquery. The
 // scalar subquery cross-join adds an extra table to the left side's DT.
-TEST_F(SubqueryTest, nonEquiLeftJoinWithScalarSubquery) {
+TEST_P(SubqueryTest, nonEquiLeftJoinWithScalarSubquery) {
   testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}));
   testConnector_->addTable("u", ROW({"c", "d"}, {BIGINT(), BIGINT()}));
   testConnector_->addTable("v", ROW({"e"}, {BIGINT()}));
@@ -1939,12 +1939,12 @@ TEST_F(SubqueryTest, nonEquiLeftJoinWithScalarSubquery) {
           .project()
           .build();
 
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
 // LEFT JOIN with a post-join WHERE equality referencing both sides, where one
 // operand is not default-null propagating.
-TEST_F(SubqueryTest, leftJoinFilterWithNonDefaultNullEquality) {
+TEST_P(SubqueryTest, leftJoinFilterWithNonDefaultNullEquality) {
   auto query =
       "SELECT a.x FROM (VALUES 1) a(x) "
       "LEFT JOIN (VALUES 1) b(y) ON a.x = b.y "
@@ -1964,10 +1964,10 @@ TEST_F(SubqueryTest, leftJoinFilterWithNonDefaultNullEquality) {
                      .build();
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
-TEST_F(SubqueryTest, rightJoinOnSubquery) {
+TEST_P(SubqueryTest, rightJoinOnSubquery) {
   // RIGHT JOIN is normalized to LEFT JOIN. Subqueries referencing the
   // null-supplying side (left in SQL, right after normalization) are supported.
   // A final Project reorders columns to match the original SQL column order.
@@ -1990,7 +1990,7 @@ TEST_F(SubqueryTest, rightJoinOnSubquery) {
                        .build();
 
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // Correlated EXISTS referencing the null-supplying side.
@@ -2011,37 +2011,94 @@ TEST_F(SubqueryTest, rightJoinOnSubquery) {
                        .build();
 
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
 
-TEST_F(SubqueryTest, unsupportedSubqueryInJoin) {
+TEST_P(SubqueryTest, subqueryInOuterJoinOn) {
   // Left-side subquery in LEFT JOIN ON clause.
-  VELOX_ASSERT_THROW(
-      toSingleNodePlan(
-          "SELECT * FROM nation n LEFT JOIN region r "
-          "ON r.r_regionkey = n.n_regionkey "
-          "AND n.n_regionkey > (SELECT min(s_nationkey) FROM supplier)"),
-      "Unsupported subqueries in the ON clause of a LEFT or RIGHT join");
+  {
+    auto query =
+        "SELECT * FROM nation n LEFT JOIN region r "
+        "ON r.r_regionkey = n.n_regionkey "
+        "AND n.n_regionkey > (SELECT min(s_nationkey) FROM supplier)";
+    SCOPED_TRACE(query);
+
+    if (useV2_) {
+      // The uncorrelated aggregate joins the preserved side first, so the ON
+      // condition reads it as an ordinary column.
+      auto matcher =
+          matchHiveScan("nation")
+              .nestedLoopJoin(matchHiveScan("supplier").aggregation())
+              .hashJoinLeft(
+                  matchHiveScan("region"),
+                  {.keys = {{"n_regionkey = r_regionkey"}},
+                   .filter = "n_regionkey > min"})
+              .build();
+      AXIOM_ASSERT_PLAN(toSingleNodePlan(query), matcher);
+    } else {
+      VELOX_ASSERT_THROW(
+          toSingleNodePlan(query),
+          "Unsupported subqueries in the ON clause of a LEFT or RIGHT join");
+    }
+  }
 
   // Right-side (preserved) subquery in RIGHT JOIN ON clause.
-  VELOX_ASSERT_THROW(
-      toSingleNodePlan(
-          "SELECT * FROM region r RIGHT JOIN nation n "
-          "ON r.r_regionkey = n.n_regionkey "
-          "AND n.n_regionkey > (SELECT min(s_nationkey) FROM supplier)"),
-      "Unsupported subqueries in the ON clause of a LEFT or RIGHT join");
+  {
+    auto query =
+        "SELECT * FROM region r RIGHT JOIN nation n "
+        "ON r.r_regionkey = n.n_regionkey "
+        "AND n.n_regionkey > (SELECT min(s_nationkey) FROM supplier)";
+    SCOPED_TRACE(query);
+
+    if (useV2_) {
+      // RIGHT JOIN becomes a LEFT JOIN with the sides swapped, and the
+      // subquery still joins the input whose column the ON condition reads.
+      auto matcher =
+          matchHiveScan("nation")
+              .nestedLoopJoin(matchHiveScan("supplier").aggregation())
+              .hashJoinLeft(
+                  matchHiveScan("region"),
+                  {.keys = {{"n_regionkey = r_regionkey"}},
+                   .filter = "n_regionkey > min"})
+              .build();
+      AXIOM_ASSERT_PLAN(toSingleNodePlan(query), matcher);
+    } else {
+      VELOX_ASSERT_THROW(
+          toSingleNodePlan(query),
+          "Unsupported subqueries in the ON clause of a LEFT or RIGHT join");
+    }
+  }
 
   // Subquery in FULL JOIN ON clause.
-  VELOX_ASSERT_THROW(
-      toSingleNodePlan(
-          "SELECT * FROM nation n FULL JOIN region r "
-          "ON r.r_regionkey = n.n_regionkey "
-          "AND r.r_name IN (SELECT s_name FROM supplier)"),
-      "Unexpected expression: Subquery");
+  {
+    auto query =
+        "SELECT * FROM nation n FULL JOIN region r "
+        "ON r.r_regionkey = n.n_regionkey "
+        "AND r.r_name IN (SELECT s_name FROM supplier)";
+    SCOPED_TRACE(query);
+
+    if (useV2_) {
+      // The mark reads only the null-supplying side, so it is computed
+      // there and the FULL join's ON condition consumes it.
+      auto matcher =
+          matchHiveScan("nation")
+              .hashJoinFull(
+                  matchHiveScan("supplier")
+                      .hashJoinRightSemiProject(
+                          matchHiveScan("region"),
+                          {.nullAware = true, .keys = {{"s_name = r_name"}}}),
+                  {.keys = {{"n_regionkey = r_regionkey"}}})
+              .build();
+      AXIOM_ASSERT_PLAN(toSingleNodePlan(query), matcher);
+    } else {
+      VELOX_ASSERT_THROW(
+          toSingleNodePlan(query), "Unexpected expression: Subquery");
+    }
+  }
 }
 
-TEST_F(SubqueryTest, inSubqueryInsideAggregate) {
+TEST_P(SubqueryTest, inSubqueryInsideAggregate) {
   auto matchJoin = [&]() {
     return matchHiveScan("nation").hashJoin(
         matchHiveScan("region"),
@@ -2059,7 +2116,7 @@ TEST_F(SubqueryTest, inSubqueryInsideAggregate) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
   // IN <subquery> inside an aggregate FILTER clause.
@@ -2072,11 +2129,11 @@ TEST_F(SubqueryTest, inSubqueryInsideAggregate) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN(plan, matcher);
+    AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
 
-TEST_F(SubqueryTest, nestedInSubqueries) {
+TEST_P(SubqueryTest, nestedInSubqueries) {
   // IN subquery on a column derived from another IN subquery. The inner IN
   // produces a mark column used to compute 'flag'. The outer IN uses 'flag'
   // as its left key. The optimizer wraps the inner semi-join in a child DT
@@ -2103,13 +2160,13 @@ TEST_F(SubqueryTest, nestedInSubqueries) {
 
   SCOPED_TRACE(query);
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
 // EXISTS (SELECT 1 WHERE <condition>) with no FROM clause is equivalent to
 // just <condition>. The optimizer should simplify this and not attempt
 // subquery decorrelation.
-TEST_F(SubqueryTest, existsWithNoFromClause) {
+TEST_P(SubqueryTest, existsWithNoFromClause) {
   testConnector_->addTable("t", ROW("a", BIGINT()));
   testConnector_->addTable("u", ROW("x", BIGINT()));
 
@@ -2128,23 +2185,23 @@ TEST_F(SubqueryTest, existsWithNoFromClause) {
           .build();
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
 // EXISTS (SELECT ... LIMIT 0) should fold to false because the subquery
 // produces zero rows.
-TEST_F(SubqueryTest, existsWithLimitZero) {
+TEST_P(SubqueryTest, existsWithLimitZero) {
   auto plan = toSingleNodePlan("SELECT EXISTS (SELECT 1 LIMIT 0)");
 
   auto matcher = matchValues(ROW({})).project({"false"}).build();
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
 // IN subquery in a projection combined with a correlated NOT EXISTS in the
 // WHERE clause. The IN subquery creates a semi-join inside the join input,
 // which triggers DT wrapping (excludeOuterJoins). The NOT EXISTS subquery
 // must still be processed correctly.
-TEST_F(SubqueryTest, inSubqueryWithCorrelatedNotExists) {
+TEST_P(SubqueryTest, inSubqueryWithCorrelatedNotExists) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
   testConnector_->addTable("u", ROW("x", BIGINT()));
   testConnector_->addTable("v", ROW("y", BIGINT()));
@@ -2174,7 +2231,7 @@ TEST_F(SubqueryTest, inSubqueryWithCorrelatedNotExists) {
           .build();
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
 // Verifies that the distributed plan for IN / NOT IN subqueries sets
@@ -2183,7 +2240,7 @@ TEST_F(SubqueryTest, inSubqueryWithCorrelatedNotExists) {
 // one worker, producing wrong results:
 //   NOT IN: workers missing the NULL incorrectly return rows.
 //   IN: workers missing the NULL produce false instead of NULL for the mark.
-TEST_F(SubqueryTest, inReplicateNullsAndAny) {
+TEST_P(SubqueryTest, inReplicateNullsAndAny) {
   // replicateNullsAndAny only appears on a hash-partitioned build. Cap the
   // broadcast size limit low so the build is hash partitioned regardless of its
   // size.
@@ -2216,7 +2273,7 @@ TEST_F(SubqueryTest, inReplicateNullsAndAny) {
             .build();
 
     auto distributedPlan = planVelox(parseSelect(query, kTestConnectorId));
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN_V1(distributedPlan.plan, matcher);
   }
 
   // IN in projection: stays as kLeftSemiProject with null-aware. The build
@@ -2238,7 +2295,7 @@ TEST_F(SubqueryTest, inReplicateNullsAndAny) {
             .build();
 
     auto distributedPlan = planVelox(parseSelect(query, kTestConnectorId));
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN_V1(distributedPlan.plan, matcher);
   }
 
   // IN in projection with reversed table sizes — exercises joinByHashRight.
@@ -2257,11 +2314,11 @@ TEST_F(SubqueryTest, inReplicateNullsAndAny) {
                        .build();
 
     auto distributedPlan = planVelox(parseSelect(query, kTestConnectorId));
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN_V1(distributedPlan.plan, matcher);
   }
 }
 
-TEST_F(SubqueryTest, constantFoldingWithoutExecutor) {
+TEST_P(SubqueryTest, constantFoldingWithoutExecutor) {
   auto& ctx = getQueryCtx();
   ctx = velox::core::QueryCtx::create(nullptr, velox::core::QueryConfig{{}});
 
@@ -2271,6 +2328,8 @@ TEST_F(SubqueryTest, constantFoldingWithoutExecutor) {
   auto plan = planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
   EXPECT_EQ(3, plan.plan->fragments().size());
 }
+
+AXIOM_INSTANTIATE_V1_V2(SubqueryTest);
 
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -311,6 +311,39 @@ FROM t
 SELECT t.a, (SELECT u.a FROM u WHERE u.a > t.a AND u.a IN (SELECT v.a FROM v)) AS b
 FROM t
 ----
+-- EXISTS whose body joins a correlated relation to another under an ON
+-- predicate: existence is a property of the pair, not of either side.
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
+SELECT t.a, EXISTS (SELECT 1 FROM (SELECT u.a FROM u WHERE u.a = t.a) q JOIN v ON q.a = v.a) AS e
+FROM t
+----
+-- The same where several pairs match.
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
+SELECT t.a, EXISTS (SELECT 1 FROM (SELECT u.a FROM u WHERE u.a <= t.a) q JOIN v ON q.a <= v.a) AS e
+FROM t
+----
+-- A predicate above the join inside the subquery narrows which pairs count.
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
+SELECT t.a, EXISTS (SELECT 1 FROM (SELECT u.a FROM u WHERE u.a <= t.a) q JOIN v ON q.a <= v.a WHERE v.a > 4) AS e
+FROM t
+----
+-- A NULL join key never matches, so the outer holding it reads false.
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
+SELECT t.a,
+  EXISTS (SELECT 1 FROM (SELECT u.a FROM u WHERE u.a = t.a) q
+          JOIN (VALUES (2), (CAST(NULL AS BIGINT))) AS n(a) ON q.a = n.a) AS e
+FROM t
+----
+-- No row of the join's correlated side belongs to the outer at all.
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
+SELECT t.a, EXISTS (SELECT 1 FROM (SELECT u.a FROM u WHERE u.a = t.a + 100) q JOIN v ON q.a = v.a) AS e
+FROM t
+----
+-- NOT EXISTS over the same body.
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
+SELECT t.a, NOT EXISTS (SELECT 1 FROM (SELECT u.a FROM u WHERE u.a = t.a) q JOIN v ON q.a = v.a) AS e
+FROM t
+----
 -- An IN whose subquery reads an outer column.
 -- error_v1: Join filter references column from unplaced non-single-row table
 SELECT t.a, (SELECT count(*) FROM u WHERE u.a = t.a AND u.a IN (SELECT v.a + t.a FROM v)) AS n

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -349,6 +349,47 @@ FROM t
 SELECT t.a, (SELECT count(*) FROM u WHERE u.a = t.a AND u.a IN (SELECT v.a + t.a FROM v)) AS n
 FROM t
 ----
+-- An IN subquery in a LEFT JOIN's ON clause reading the null-supplying side:
+-- a row whose only match the IN rejects is kept, NULL-padded.
+WITH n(a) AS (VALUES (1), (2), (3)),
+     m(a) AS (VALUES (1), (2), (3)),
+     w(a) AS (VALUES (2), (4))
+SELECT n.a, m.a FROM n LEFT JOIN m ON m.a = n.a AND m.a IN (SELECT a FROM w)
+----
+-- The same for a correlated EXISTS.
+WITH n(a) AS (VALUES (1), (2), (3)),
+     m(a) AS (VALUES (1), (2), (3)),
+     w(a) AS (VALUES (2), (4))
+SELECT n.a, m.a
+FROM n LEFT JOIN m ON m.a = n.a AND EXISTS (SELECT 1 FROM w WHERE w.a = m.a)
+----
+-- A RIGHT JOIN whose ON clause reads its preserved side: a preserved row the
+-- IN rejects matches nothing. DuckDB rejects a subquery in a non-inner
+-- join's ON clause, so the result is spelled out.
+-- error_v1: Failed to place a table
+-- duckdb: VALUES (1, NULL), (2, 2), (3, NULL)
+WITH n(a) AS (VALUES (1), (2), (3)),
+     m(a) AS (VALUES (1), (2), (3)),
+     w(a) AS (VALUES (2), (4))
+SELECT n.a, m.a FROM m RIGHT JOIN n ON m.a = n.a AND n.a IN (SELECT a FROM w)
+----
+-- A FULL JOIN keeps the unmatched rows of both sides.
+-- error_v1: Unexpected expression: Subquery
+-- duckdb: VALUES (1, NULL), (2, 2), (3, NULL), (NULL, 1), (NULL, 3)
+WITH n(a) AS (VALUES (1), (2), (3)),
+     m(a) AS (VALUES (1), (2), (3)),
+     w(a) AS (VALUES (2), (4))
+SELECT n.a, m.a FROM n FULL JOIN m ON m.a = n.a AND m.a IN (SELECT a FROM w)
+----
+-- A NULL in the IN list makes the mark NULL, which is not a match, so only
+-- the value the list names can match.
+-- error_v1: Unexpected expression: Subquery
+-- duckdb: VALUES (1, NULL), (2, 2), (3, NULL), (NULL, 1), (NULL, 3)
+WITH n(a) AS (VALUES (1), (2), (3)), m(a) AS (VALUES (1), (2), (3))
+SELECT n.a, m.a
+FROM n FULL JOIN m
+  ON m.a = n.a AND m.a IN (SELECT w.a FROM (VALUES (2), (CAST(NULL AS INTEGER))) AS w(a))
+----
 -- Correlated IN subquery with single correlation equality.
 SELECT t.a IN (SELECT t2.a FROM t t2 WHERE t2.b = t.b) FROM t
 ----
@@ -1085,10 +1126,10 @@ SELECT l.a, r.a FROM (VALUES 1, 2) l(a)
 LEFT JOIN (VALUES 10, 15, 20) r(a)
   ON r.a = (SELECT max(x) FROM (VALUES 10, 15) s(x) WHERE x > l.a)
 ----
--- Scalar subquery in an outer join's ON condition correlated to the right input
--- is unsupported.
+-- Scalar subquery in an outer join's ON condition reading both inputs is
+-- unsupported: it cannot be lifted onto either one.
 -- error_v1: Unsupported subqueries in the ON clause of a LEFT or RIGHT join
--- error_v2: Correlated subquery referencing the right side of an outer join's ON clause is not supported
+-- error_v2: Subquery in an outer join's ON clause referencing both inputs
 SELECT l.a, r.a FROM (VALUES 1, 2) l(a)
 LEFT JOIN (VALUES 10, 15, 20) r(a)
   ON l.a = (SELECT max(x) FROM (VALUES 10, 15) s(x) WHERE x > r.a)

--- a/axiom/optimizer/v2/DecorrelatePass.cpp
+++ b/axiom/optimizer/v2/DecorrelatePass.cpp
@@ -676,57 +676,20 @@ class Decorrelator : public NodeRewriter<> {
     // (the LEFT JOIN's ON condition); kLeft pad on no match preserves
     // the body LEFT JOIN's semantics.
 
-    // applyA: input = L, body = leftSide.
     ColumnCP applyAIncludeMarker = makeIncludeColumn();
-    ColumnVector applyAOutputs;
-    applyAOutputs.reserve(
-        input->outputColumns().size() + leftSide->outputColumns().size() + 1);
-    appendAll(applyAOutputs, input->outputColumns());
-    appendUnique(applyAOutputs, leftSide->outputColumns());
-    applyAOutputs.push_back(applyAIncludeMarker);
-
-    ColumnVector applyACorrelations =
-        recomputeCorrelations(leftSide, input->outputColumns());
-
-    NodeCP applyA = builder().make<Apply>(Apply::Key{
+    NodeCP applyA = makeLeftLeg(
         input,
         leftSide,
-        std::move(applyACorrelations),
-        velox::core::JoinType::kLeft,
         /*filter=*/ExprVector{},
         node->enforceSingleRow(),
-        /*markColumn=*/nullptr,
-        /*inLhs=*/nullptr,
-        /*inBodyKey=*/nullptr,
-        applyAIncludeMarker,
-        std::move(applyAOutputs),
-    });
+        applyAIncludeMarker);
 
-    // applyB: input = applyA, body = rightSide.
-    ColumnCP applyBIncludeMarker = makeIncludeColumn();
-    ColumnVector applyBOutputs;
-    applyBOutputs.reserve(
-        applyA->outputColumns().size() + rightSide->outputColumns().size() + 1);
-    appendAll(applyBOutputs, applyA->outputColumns());
-    appendUnique(applyBOutputs, rightSide->outputColumns());
-    applyBOutputs.push_back(applyBIncludeMarker);
-
-    ColumnVector applyBCorrelations =
-        recomputeCorrelations(rightSide, applyA->outputColumns());
-
-    NodeCP applyB = builder().make<Apply>(Apply::Key{
+    NodeCP applyB = makeLeftLeg(
         applyA,
         rightSide,
-        std::move(applyBCorrelations),
-        velox::core::JoinType::kLeft,
         std::move(applyBFilter),
         node->enforceSingleRow(),
-        /*markColumn=*/nullptr,
-        /*inLhs=*/nullptr,
-        /*inBodyKey=*/nullptr,
-        applyBIncludeMarker,
-        std::move(applyBOutputs),
-    });
+        makeIncludeColumn());
 
     NodeCP decorrelatedChain = rewrite(applyB);
 
@@ -812,53 +775,20 @@ class Decorrelator : public NodeRewriter<> {
     // cardinality assertion until after the collapse.
     const bool collapse = !markFilter.empty();
     ColumnCP rowId = collapse ? makeIdColumn() : nullptr;
-    NodeCP chainInput = collapse
-        ? builder().make<AssignUniqueId>(AssignUniqueId::Key{input, rowId})
-        : input;
+    NodeCP chainInput = collapse ? tagOuterRows(input, rowId) : input;
 
     ColumnCP applyAIncludeMarker = makeIncludeColumn();
-    ColumnVector applyAOutputs;
-    applyAOutputs.reserve(
-        chainInput->outputColumns().size() + leftSide->outputColumns().size() +
-        1);
-    appendAll(applyAOutputs, chainInput->outputColumns());
-    appendUnique(applyAOutputs, leftSide->outputColumns());
-    applyAOutputs.push_back(applyAIncludeMarker);
-
-    NodeCP applyA = builder().make<Apply>(Apply::Key{
+    NodeCP applyA = makeLeftLeg(
         chainInput,
         leftSide,
-        recomputeCorrelations(leftSide, chainInput->outputColumns()),
-        velox::core::JoinType::kLeft,
         std::move(rowFilter),
         collapse ? false : node->enforceSingleRow(),
-        /*markColumn=*/nullptr,
-        /*inLhs=*/nullptr,
-        /*inBodyKey=*/nullptr,
-        applyAIncludeMarker,
-        std::move(applyAOutputs),
-    });
+        applyAIncludeMarker);
 
     // Semi projection is one row in, one row out, so A's rows are neither
     // multiplied nor dropped by the existence test.
-    ColumnVector applyBOutputs;
-    applyBOutputs.reserve(applyA->outputColumns().size() + 1);
-    appendAll(applyBOutputs, applyA->outputColumns());
-    applyBOutputs.push_back(mark);
-
-    NodeCP applyB = builder().make<Apply>(Apply::Key{
-        applyA,
-        rightSide,
-        recomputeCorrelations(rightSide, applyA->outputColumns()),
-        velox::core::JoinType::kLeftSemiProject,
-        std::move(applyBFilter),
-        /*enforceSingleRow=*/false,
-        mark,
-        inLhs,
-        inBodyKey,
-        /*includeMarker=*/nullptr,
-        std::move(applyBOutputs),
-    });
+    NodeCP applyB = makeSemiLeg(
+        applyA, rightSide, std::move(applyBFilter), mark, inLhs, inBodyKey);
 
     NodeCP chain = rewrite(applyB);
 
@@ -901,54 +831,26 @@ class Decorrelator : public NodeRewriter<> {
       NodeCP rightSide,
       ExprVector applyBFilter) {
     ColumnCP rowId = makeIdColumn();
-    NodeCP taggedInput =
-        builder().make<AssignUniqueId>(AssignUniqueId::Key{input, rowId});
+    NodeCP taggedInput = tagOuterRows(input, rowId);
 
     // Legs never enforce single row: an empty side makes the cross join
     // empty (a valid 0-row scalar), which a per-leg check would misread
     // as the other side's rows. ESR is applied once after the collapse.
     ColumnCP markA = makeIncludeColumn();
-    ColumnVector applyAOutputs;
-    applyAOutputs.reserve(
-        taggedInput->outputColumns().size() + leftSide->outputColumns().size() +
-        1);
-    appendAll(applyAOutputs, taggedInput->outputColumns());
-    appendUnique(applyAOutputs, leftSide->outputColumns());
-    applyAOutputs.push_back(markA);
-    NodeCP applyA = builder().make<Apply>(Apply::Key{
+    NodeCP applyA = makeLeftLeg(
         taggedInput,
         leftSide,
-        recomputeCorrelations(leftSide, taggedInput->outputColumns()),
-        velox::core::JoinType::kLeft,
         /*filter=*/ExprVector{},
         /*enforceSingleRow=*/false,
-        /*markColumn=*/nullptr,
-        /*inLhs=*/nullptr,
-        /*inBodyKey=*/nullptr,
-        markA,
-        std::move(applyAOutputs),
-    });
+        markA);
 
     ColumnCP markB = makeIncludeColumn();
-    ColumnVector applyBOutputs;
-    applyBOutputs.reserve(
-        applyA->outputColumns().size() + rightSide->outputColumns().size() + 1);
-    appendAll(applyBOutputs, applyA->outputColumns());
-    appendUnique(applyBOutputs, rightSide->outputColumns());
-    applyBOutputs.push_back(markB);
-    NodeCP applyB = builder().make<Apply>(Apply::Key{
+    NodeCP applyB = makeLeftLeg(
         applyA,
         rightSide,
-        recomputeCorrelations(rightSide, applyA->outputColumns()),
-        velox::core::JoinType::kLeft,
         std::move(applyBFilter),
         /*enforceSingleRow=*/false,
-        /*markColumn=*/nullptr,
-        /*inLhs=*/nullptr,
-        /*inBodyKey=*/nullptr,
-        markB,
-        std::move(applyBOutputs),
-    });
+        markB);
 
     NodeCP chain = rewrite(applyB);
 
@@ -967,34 +869,18 @@ class Decorrelator : public NodeRewriter<> {
       NodeCP chain,
       ColumnCP rowId,
       ExprCP matchedExpr) {
-    // Leg markers read `true` on a match and NULL on a pad, so fold to a
-    // clean boolean before the window: `bool_or` over all-NULL markers would
-    // otherwise yield NULL and drop the pad row. Materialize it as a column
-    // so the window and filter can reference it.
-    ColumnCP matched = makeIncludeColumn();
-    NodeCP marked = appendColumn(
-        chain,
-        matched,
-        exprFactory_.makeCoalesce(matchedExpr, builder().makeBoolean(false)));
-
-    // Per-outer window: `anyMatch` over the whole partition, and a
-    // `padOrdinal` row_number to designate the single pad row to keep.
-    ColumnCP anyMatch = Column::createBoolean("__any_match");
-    ColumnCP padOrdinal = makeIdColumn("__pad_rn");
-    NodeCP windowed =
-        addPadCollapseWindow(marked, rowId, matched, anyMatch, padOrdinal);
+    PerOuterMatch perOuter = markPerOuter(chain, rowId, matchedExpr);
+    ColumnCP matched = perOuter.matched;
 
     // Keep real rows; for a match-less outer keep only its first row (a
     // pad) and drop the duplicate pads.
-    ExprCP one = builder().makeLiteral(
-        velox::Variant(static_cast<int64_t>(1)), toType(velox::BIGINT()));
     ExprCP keep = exprFactory_.makeOr(
         matched,
         exprFactory_.makeAnd(
-            exprFactory_.makeNot(anyMatch),
-            exprFactory_.makeEq(padOrdinal, one)));
+            exprFactory_.makeNot(perOuter.anyMatch),
+            isFirstRowOfOuter(perOuter.padOrdinal)));
     NodeCP filtered =
-        builder().make<Filter>(Filter::Key{windowed, ExprVector{keep}});
+        builder().make<Filter>(Filter::Key{perOuter.node, ExprVector{keep}});
 
     NodeCP enforced = node->enforceSingleRow()
         ? enforceScalarSingleRow(filtered, rowId)
@@ -1026,6 +912,115 @@ class Decorrelator : public NodeRewriter<> {
         std::move(finalExprs),
         node->outputColumns(),
     });
+  }
+
+  // Tags each 'input' row with a fresh id, so a later window can group a
+  // chain's rows by the outer they came from.
+  NodeCP tagOuterRows(NodeCP input, ColumnCP rowId) {
+    return builder().make<AssignUniqueId>(AssignUniqueId::Key{input, rowId});
+  }
+
+  // A fresh BOOLEAN column for a kLeftSemiProject leg's mark. Each leg of a
+  // chain names its own, so a plan dump tells them apart.
+  static ColumnCP makeMarkColumn(std::string_view name) {
+    return Column::createBoolean(name);
+  }
+
+  // A kLeft Apply leg over 'body': every 'input' row survives, padded when
+  // the body has no row for it, and 'marker' tells the two apart.
+  NodeCP makeLeftLeg(
+      NodeCP input,
+      NodeCP body,
+      ExprVector filter,
+      bool enforceSingleRow,
+      ColumnCP marker) {
+    ColumnVector outputs;
+    outputs.reserve(
+        input->outputColumns().size() + body->outputColumns().size() + 1);
+    appendAll(outputs, input->outputColumns());
+    appendUnique(outputs, body->outputColumns());
+    outputs.push_back(marker);
+
+    return builder().make<Apply>(Apply::Key{
+        input,
+        body,
+        recomputeCorrelations(body, input->outputColumns()),
+        velox::core::JoinType::kLeft,
+        std::move(filter),
+        enforceSingleRow,
+        /*markColumn=*/nullptr,
+        /*inLhs=*/nullptr,
+        /*inBodyKey=*/nullptr,
+        marker,
+        std::move(outputs),
+    });
+  }
+
+  // A kLeftSemiProject Apply leg over 'body': one row out per 'input' row,
+  // with 'mark' saying whether 'body' had a row the filter accepts. 'inLhs'
+  // and 'inBodyKey' carry an IN equality, which makes the leg null-aware.
+  NodeCP makeSemiLeg(
+      NodeCP input,
+      NodeCP body,
+      ExprVector filter,
+      ColumnCP mark,
+      ExprCP inLhs,
+      ExprCP inBodyKey) {
+    ColumnVector outputs;
+    outputs.reserve(input->outputColumns().size() + 1);
+    appendAll(outputs, input->outputColumns());
+    outputs.push_back(mark);
+
+    return builder().make<Apply>(Apply::Key{
+        input,
+        body,
+        recomputeCorrelations(body, input->outputColumns()),
+        velox::core::JoinType::kLeftSemiProject,
+        std::move(filter),
+        /*enforceSingleRow=*/false,
+        mark,
+        inLhs,
+        inBodyKey,
+        /*includeMarker=*/nullptr,
+        std::move(outputs),
+    });
+  }
+
+  // A chain's rows seen per outer: 'matched' says whether the row counts,
+  // 'anyMatch' whether any row of the same outer does, and 'padOrdinal'
+  // numbers an outer's rows so exactly one can be singled out.
+  struct PerOuterMatch {
+    NodeCP node;
+    ColumnCP matched;
+    ColumnCP anyMatch;
+    ColumnCP padOrdinal;
+  };
+
+  // Leg markers read `true` on a match and NULL on a pad, so 'matchedExpr'
+  // folds to a clean boolean before the window: `bool_or` over all-NULL
+  // markers would yield NULL rather than false.
+  PerOuterMatch markPerOuter(NodeCP chain, ColumnCP rowId, ExprCP matchedExpr) {
+    ColumnCP matched = makeIncludeColumn();
+    NodeCP marked = appendColumn(
+        chain,
+        matched,
+        exprFactory_.makeCoalesce(matchedExpr, builder().makeBoolean(false)));
+
+    ColumnCP anyMatch = Column::createBoolean("__any_match");
+    ColumnCP padOrdinal = makeIdColumn("__pad_rn");
+    return {
+        addPadCollapseWindow(marked, rowId, matched, anyMatch, padOrdinal),
+        matched,
+        anyMatch,
+        padOrdinal};
+  }
+
+  // Reads `padOrdinal = 1`, which picks one row of each outer.
+  ExprCP isFirstRowOfOuter(ColumnCP padOrdinal) {
+    return exprFactory_.makeEq(
+        padOrdinal,
+        builder().makeLiteral(
+            velox::Variant(static_cast<int64_t>(1)), toType(velox::BIGINT())));
   }
 
   // Returns a Project that passes `input`'s columns through unchanged
@@ -1104,59 +1099,45 @@ class Decorrelator : public NodeRewriter<> {
           "Decorrelate joinPeel: outer kLeftSemiProject IN over Join "
           "body not yet implemented");
     }
-    if (!joinBody->isInner() || !joinPredicate.empty()) {
+    if (!joinBody->isInner()) {
       VELOX_NYI(
-          "Decorrelate joinPeel: outer kLeftSemiProject EXISTS requires an "
-          "unpredicated kInner body: joinType={}, numPredicates={}",
-          joinBody->joinTypeName(),
-          joinPredicate.size());
+          "Decorrelate joinPeel: outer kLeftSemiProject EXISTS requires a "
+          "kInner body: joinType={}",
+          joinBody->joinTypeName());
+    }
+
+    if (!joinPredicate.empty()) {
+      // A predicate ties the two sides together, so existence is not the
+      // conjunction of each side's own.
+      return joinPeelSemiInnerWithPredicate(
+          node,
+          input,
+          joinBody,
+          std::move(joinPredicate),
+          std::move(accumulatedFilter));
     }
 
     // Cross-join EXISTS: mark = (∃a) AND (∃b).
     NodeCP leftSide = joinBody->left();
     NodeCP rightSide = joinBody->right();
 
-    ColumnCP markA = Column::createBoolean("_join_chain_markA");
-    ColumnVector applyAOutputs;
-    applyAOutputs.reserve(input->outputColumns().size() + 1);
-    appendAll(applyAOutputs, input->outputColumns());
-    applyAOutputs.push_back(markA);
-    ColumnVector applyACorrelations =
-        recomputeCorrelations(leftSide, input->outputColumns());
-    NodeCP applyA = builder().make<Apply>(Apply::Key{
+    ColumnCP markA = makeMarkColumn("_join_chain_markA");
+    NodeCP applyA = makeSemiLeg(
         input,
         leftSide,
-        std::move(applyACorrelations),
-        velox::core::JoinType::kLeftSemiProject,
         /*filter=*/ExprVector{},
-        /*enforceSingleRow=*/false,
         markA,
         /*inLhs=*/nullptr,
-        /*inBodyKey=*/nullptr,
-        /*includeMarker=*/nullptr,
-        std::move(applyAOutputs),
-    });
+        /*inBodyKey=*/nullptr);
 
-    ColumnCP markB = Column::createBoolean("_join_chain_markB");
-    ColumnVector applyBOutputs;
-    applyBOutputs.reserve(applyA->outputColumns().size() + 1);
-    appendAll(applyBOutputs, applyA->outputColumns());
-    applyBOutputs.push_back(markB);
-    ColumnVector applyBCorrelations =
-        recomputeCorrelations(rightSide, applyA->outputColumns());
-    NodeCP applyB = builder().make<Apply>(Apply::Key{
+    ColumnCP markB = makeMarkColumn("_join_chain_markB");
+    NodeCP applyB = makeSemiLeg(
         applyA,
         rightSide,
-        std::move(applyBCorrelations),
-        velox::core::JoinType::kLeftSemiProject,
-        /*filter=*/std::move(accumulatedFilter),
-        /*enforceSingleRow=*/false,
+        std::move(accumulatedFilter),
         markB,
         /*inLhs=*/nullptr,
-        /*inBodyKey=*/nullptr,
-        /*includeMarker=*/nullptr,
-        std::move(applyBOutputs),
-    });
+        /*inBodyKey=*/nullptr);
 
     NodeCP decorrelatedChain = rewrite(applyB);
 
@@ -1173,6 +1154,77 @@ class Decorrelator : public NodeRewriter<> {
     }
     return builder().make<Project>(Project::Key{
         decorrelatedChain,
+        std::move(finalExprs),
+        node->outputColumns(),
+    });
+  }
+
+  // Outer kLeftSemiProject EXISTS over a body kInner Join carrying a
+  // predicate. The mark asks whether the outer has any (a, b) pair the
+  // predicate accepts, which a per-outer `bool_or` over the chain's rows
+  // answers. The chain then collapses to the one row per outer the outer
+  // Apply's contract calls for.
+  NodeCP joinPeelSemiInnerWithPredicate(
+      ApplyCP node,
+      NodeCP input,
+      JoinCP joinBody,
+      ExprVector joinPredicate,
+      ExprVector accumulatedFilter) {
+    NodeCP leftSide = joinBody->left();
+    NodeCP rightSide = joinBody->right();
+
+    ColumnCP rowId = makeIdColumn();
+    NodeCP taggedInput = tagOuterRows(input, rowId);
+
+    // applyA keeps every a row, padded when the outer has none, so applyB can
+    // test each against B under the predicate.
+    ColumnCP markA = makeIncludeColumn();
+    NodeCP applyA = makeLeftLeg(
+        taggedInput,
+        leftSide,
+        /*filter=*/ExprVector{},
+        /*enforceSingleRow=*/false,
+        markA);
+
+    ExprVector applyBFilter = std::move(joinPredicate);
+    appendAll(applyBFilter, accumulatedFilter);
+
+    ColumnCP markB = makeMarkColumn("_join_chain_markB");
+    NodeCP applyB = makeSemiLeg(
+        applyA,
+        rightSide,
+        std::move(applyBFilter),
+        markB,
+        /*inLhs=*/nullptr,
+        /*inBodyKey=*/nullptr);
+
+    // A pad row of applyA reads markA NULL, and applyB's existence test over
+    // its NULL columns reads markB false, so neither can make a pad row count
+    // as a match. markPerOuter folds the NULL away before the window.
+    PerOuterMatch perOuter = markPerOuter(
+        rewrite(applyB), rowId, exprFactory_.makeAnd(markA, markB));
+
+    // Any row of an outer serves: `anyMatch` reads the whole partition, and
+    // the rest of the output is outer columns, which the partition shares.
+    NodeCP filtered = builder().make<Filter>(Filter::Key{
+        perOuter.node, ExprVector{isFirstRowOfOuter(perOuter.padOrdinal)}});
+
+    PlanObjectSet outerColumns =
+        PlanObjectSet::fromObjects(input->outputColumns());
+    ExprVector finalExprs;
+    finalExprs.reserve(node->outputColumns().size());
+    for (ColumnCP outputColumn : node->outputColumns()) {
+      if (outputColumn == node->markColumn()) {
+        finalExprs.push_back(perOuter.anyMatch);
+        continue;
+      }
+      VELOX_CHECK(
+          outerColumns.contains(outputColumn),
+          "kLeftSemiProject Apply must output only outer columns and its mark");
+      finalExprs.push_back(outputColumn);
+    }
+    return builder().make<Project>(Project::Key{
+        filtered,
         std::move(finalExprs),
         node->outputColumns(),
     });

--- a/axiom/optimizer/v2/DecorrelatePass.cpp
+++ b/axiom/optimizer/v2/DecorrelatePass.cpp
@@ -728,16 +728,8 @@ class Decorrelator : public NodeRewriter<> {
       ExprVector accumulatedFilter) {
     NodeCP leftSide = joinBody->left();
     NodeCP rightSide = joinBody->right();
-    // A kLeftSemiProject Join projects its mark as the last output column;
-    // every other output comes from the preserved side. Reading a data column
-    // as the mark would misroute the filter split below.
-    VELOX_CHECK(
-        !joinBody->outputColumns().empty(),
-        "kLeftSemiProject Join must project a mark");
-    ColumnCP mark = joinBody->outputColumns().back();
-    VELOX_CHECK(
-        !PlanObjectSet::fromObjects(leftSide->outputColumns()).contains(mark),
-        "kLeftSemiProject Join must project its mark last");
+    ColumnCP mark = joinBody->markColumn();
+    VELOX_CHECK_NOT_NULL(mark);
 
     ExprVector markFilter;
     ExprVector rowFilter;
@@ -1169,7 +1161,7 @@ class Decorrelator : public NodeRewriter<> {
       NodeCP input,
       JoinCP joinBody,
       ExprVector joinPredicate,
-      ExprVector accumulatedFilter) {
+      const ExprVector& accumulatedFilter) {
     NodeCP leftSide = joinBody->left();
     NodeCP rightSide = joinBody->right();
 

--- a/axiom/optimizer/v2/HypergraphBuilder.cpp
+++ b/axiom/optimizer/v2/HypergraphBuilder.cpp
@@ -558,13 +558,10 @@ JoinHypergraph HypergraphBuilder::build(
       // column. Emit reads it back via JoinEdge::markColumn to thread the
       // mark through reordering. The filtering forms (kLeftSemiFilter /
       // kAnti) carry no mark.
-      ColumnCP markColumn = nullptr;
-      if (leaves.joinType == velox::core::JoinType::kLeftSemiProject) {
-        VELOX_CHECK(
-            !join->outputColumns().empty(),
-            "kLeftSemiProject join must output its mark column");
-        markColumn = join->outputColumns().back();
-      }
+      ColumnCP markColumn =
+          leaves.joinType == velox::core::JoinType::kLeftSemiProject
+          ? join->markColumn()
+          : nullptr;
 
       graph.addEdge(
           JoinEdge{

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -1427,6 +1427,15 @@ bool UnionAll::KeyEq::operator()(const UnionAll* node, const Key& key) const {
   return (*this)(key, node);
 }
 
+namespace {
+// Semi-project joins pass the preserved side through and add a mark saying
+// whether the other side had a match.
+bool projectsMark(velox::core::JoinType joinType) {
+  return joinType == velox::core::JoinType::kLeftSemiProject ||
+      joinType == velox::core::JoinType::kRightSemiProject;
+}
+} // namespace
+
 Join::Join(Key key)
     : Node(
           NodeType::kJoin,
@@ -1466,6 +1475,26 @@ Join::Join(Key key)
   VELOX_CHECK(
       !(nullAware_ && nullAsValue_),
       "nullAware and nullAsValue are mutually exclusive");
+
+  if (projectsMark(joinType_)) {
+    VELOX_CHECK(
+        !outputColumns().empty(),
+        "A semi-project join must output its mark: {}",
+        joinTypeName());
+    VELOX_CHECK_EQ(
+        outputColumns().back()->value().type->kind(),
+        velox::TypeKind::BOOLEAN,
+        "A semi-project join must output its mark last: {}",
+        joinTypeName());
+  }
+}
+
+ColumnCP Join::markColumn() const {
+  VELOX_CHECK(
+      projectsMark(joinType_),
+      "Only a semi-project join projects a mark: {}",
+      joinTypeName());
+  return outputColumns().back();
 }
 
 size_t Join::KeyHash::operator()(const Join* node) const {

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -1191,6 +1191,15 @@ class Join : public Node {
     return joinType_ == velox::core::JoinType::kFull;
   }
 
+  bool isLeftSemiProject() const {
+    return joinType_ == velox::core::JoinType::kLeftSemiProject;
+  }
+
+  /// Returns the BOOLEAN mark this semi-project join adds to the preserved
+  /// side's columns, which is its last output column. Only semi-project joins
+  /// project one.
+  ColumnCP markColumn() const;
+
   const ExprVector& leftKeys() const {
     return leftKeys_;
   }

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -75,13 +75,14 @@ bool isClusterable(const Join* join) {
 void collectCluster(
     NodeCP node,
     JoinCluster& cluster,
-    bool dissolveCrossJoins) {
+    bool dissolveCrossJoins,
+    const folly::F14FastSet<const Join*>& opaqueJoins = {}) {
   if (node->is(NodeType::kJoin)) {
     const auto* join = node->as<Join>();
-    if (isClusterable(join)) {
+    if (isClusterable(join) && !opaqueJoins.contains(join)) {
       cluster.joins.push_back(join);
-      collectCluster(join->left(), cluster, dissolveCrossJoins);
-      collectCluster(join->right(), cluster, dissolveCrossJoins);
+      collectCluster(join->left(), cluster, dissolveCrossJoins, opaqueJoins);
+      collectCluster(join->right(), cluster, dissolveCrossJoins, opaqueJoins);
       return;
     }
     // A bare keyless inner join (no keys, no filter) is a comma-join cross
@@ -92,8 +93,8 @@ void collectCluster(
     // join; leave it an opaque leaf so its semantics are preserved.
     if (dissolveCrossJoins && join->isInner() && join->leftKeys().empty() &&
         join->filter().empty()) {
-      collectCluster(join->left(), cluster, dissolveCrossJoins);
-      collectCluster(join->right(), cluster, dissolveCrossJoins);
+      collectCluster(join->left(), cluster, dissolveCrossJoins, opaqueJoins);
+      collectCluster(join->right(), cluster, dissolveCrossJoins, opaqueJoins);
       return;
     }
   }
@@ -104,13 +105,41 @@ void collectCluster(
     // relation of the cluster; the Unnest emits it as its own input.
     NodeCP input = unnest->input();
     if (!input->outputColumns().empty()) {
-      collectCluster(input, cluster, dissolveCrossJoins);
+      collectCluster(input, cluster, dissolveCrossJoins, opaqueJoins);
     }
     // Preserve JoinCluster's post-order invariant.
     cluster.unnests.push_back(unnest);
     return;
   }
   cluster.leaves.push_back(node);
+}
+
+// A kLeftSemiProject join projects a mark, which is a column of no cluster
+// leaf. Another join in the cluster whose predicate reads that mark has no
+// relation set to resolve it against, so the producing join stays an opaque
+// leaf and the mark becomes one of that leaf's columns.
+folly::F14FastSet<const Join*> markProducersReadInCluster(
+    const JoinCluster& cluster) {
+  PlanObjectSet predicateColumns;
+  for (JoinCP join : cluster.joins) {
+    auto add = [&](const ExprVector& exprs) {
+      for (ExprCP expr : exprs) {
+        predicateColumns.unionSet(expr->columns());
+      }
+    };
+    add(join->leftKeys());
+    add(join->rightKeys());
+    add(join->filter());
+  }
+
+  folly::F14FastSet<const Join*> opaqueJoins;
+  for (JoinCP join : cluster.joins) {
+    if (join->isLeftSemiProject() &&
+        predicateColumns.contains(join->markColumn())) {
+      opaqueJoins.insert(join);
+    }
+  }
+  return opaqueJoins;
 }
 
 // True if some relation appears in an edge's TES but in no edge's left/right
@@ -355,6 +384,14 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
       return rewriteUnclusteredJoin(node, context);
     }
 
+    const folly::F14FastSet<const Join*> opaqueJoins =
+        markProducersReadInCluster(cluster);
+    if (!opaqueJoins.empty()) {
+      cluster = JoinCluster{};
+      cluster.root = node;
+      collectCluster(node, cluster, /*dissolveCrossJoins=*/true, opaqueJoins);
+    }
+
     std::vector<NodeCP> rewrittenLeaves;
     auto buildGraph = [&]() {
       rewrittenLeaves.clear();
@@ -376,7 +413,7 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
     if (hasEndpointStrandedRelation(graph)) {
       cluster = JoinCluster{};
       cluster.root = node;
-      collectCluster(node, cluster, /*dissolveCrossJoins=*/false);
+      collectCluster(node, cluster, /*dissolveCrossJoins=*/false, opaqueJoins);
       graph = buildGraph();
     }
 

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -187,11 +187,8 @@ std::optional<MarkFusion> fuseMarkFilter(
   if (node->joinType() != velox::core::JoinType::kLeftSemiProject) {
     return std::nullopt;
   }
-  // The mark is the last output column of a kLeftSemiProject join.
-  VELOX_CHECK(
-      !node->outputColumns().empty(),
-      "kLeftSemiProject join must produce a mark column");
-  ColumnCP mark = node->outputColumns().back();
+  ColumnCP mark = node->markColumn();
+  VELOX_CHECK_NOT_NULL(mark);
 
   // A consumer strictly above keeps the mark live; fusion drops it.
   if (requiredAbove.contains(mark)) {
@@ -865,7 +862,7 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     if (auto fusion =
             fuseMarkFilter(node, context.pending, context.requiredAbove)) {
       newKind = fusion->joinType;
-      fusedMark = node->outputColumns().back();
+      fusedMark = node->markColumn();
       fusedNullAware =
           newKind == velox::core::JoinType::kAnti && node->nullAware();
       ExprVector remaining;

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -2075,17 +2075,44 @@ velox::core::JoinType toVeloxJoinType(lp::JoinType type) {
   VELOX_UNREACHABLE();
 }
 
-// True if a subquery lifted onto the left input correlates to a column of
-// 'right'. Such a correlation can't be satisfied by an Apply on the left input.
-bool correlatesToRight(NodeCP lifted, NodeCP leftBeforeLift, NodeCP right) {
-  const PlanObjectSet rightColumns =
-      PlanObjectSet::fromObjects(right->outputColumns());
-  for (NodeCP node = lifted; node != leftBeforeLift; node = node->inputs()[0]) {
+// True when every conjunct of 'condition' that carries a subquery reads
+// columns of the right input and none of the left, which makes the right the
+// only input the subquery can be lifted onto.
+bool subqueryReadsOnlyRight(
+    const logical_plan::Expr& condition,
+    const velox::RowType& leftType,
+    const velox::RowType& rightType) {
+  std::vector<const logical_plan::Expr*> conjuncts;
+  flattenAndConjuncts(condition, conjuncts);
+
+  LpNameSet names;
+  for (const auto* conjunct : conjuncts) {
+    if (containsSubquery(*conjunct)) {
+      collectUsedNames(*conjunct, names);
+    }
+  }
+
+  bool readsRight = false;
+  for (const auto& name : names) {
+    if (leftType.containsChild(name)) {
+      return false;
+    }
+    readsRight |= rightType.containsChild(name);
+  }
+  return readsRight;
+}
+
+// True when the Apply chain 'lifted' added on top of 'beforeLift' correlates
+// to 'otherSide', whose columns it cannot read from where it now sits.
+bool correlatesToOtherSide(NodeCP lifted, NodeCP beforeLift, NodeCP otherSide) {
+  const PlanObjectSet otherSideColumns =
+      PlanObjectSet::fromObjects(otherSide->outputColumns());
+  for (NodeCP node = lifted; node != beforeLift; node = node->inputs()[0]) {
     if (node->nodeType() != NodeType::kApply) {
       continue;
     }
     for (ColumnCP column : node->as<Apply>()->correlationColumns()) {
-      if (rightColumns.contains(column)) {
+      if (otherSideColumns.contains(column)) {
         return true;
       }
     }
@@ -2182,17 +2209,24 @@ Translated Translator::translateJoin(
 
   JoinCondition::Split split;
   if (join.condition() != nullptr) {
-    // Lift a subquery in the condition onto the left input; the condition then
-    // references the lifted result column.
-    NodeCP leftBeforeLift = left.node;
+    // Lift a subquery in the condition onto one input; the condition then
+    // references the lifted result column. It goes on the side whose columns
+    // the subquery reads -- `r.name IN (...)` reads the right input, and an
+    // Apply on the left could not key on `r.name`.
+    const bool liftOntoRight = conditionHasSubquery &&
+        subqueryReadsOnlyRight(*join.condition(), leftType, rightType);
+    NodeCP& liftTarget = liftOntoRight ? right.node : left.node;
+    NodeCP otherSide = liftOntoRight ? left.node : right.node;
+
+    NodeCP beforeLift = liftTarget;
     ExprCP condition =
-        translateExpr(*join.condition(), merged, /*applyTarget=*/&left.node);
-    // A subquery correlated to the right input, lifted onto the left,
-    // references a column the left can't provide.
-    if (correlatesToRight(left.node, leftBeforeLift, right.node)) {
+        translateExpr(*join.condition(), merged, /*applyTarget=*/&liftTarget);
+    // A subquery correlated to the input it was not lifted onto references a
+    // column that input cannot provide.
+    if (correlatesToOtherSide(liftTarget, beforeLift, otherSide)) {
       VELOX_NYI(
-          "Correlated subquery referencing the right side of an outer join's "
-          "ON clause is not supported");
+          "Subquery in an outer join's ON clause referencing both inputs is "
+          "not supported");
     }
 
     split = JoinCondition::splitEquiKeys(

--- a/axiom/optimizer/v2/docs/Decorrelate-join-rules.md
+++ b/axiom/optimizer/v2/docs/Decorrelate-join-rules.md
@@ -68,7 +68,7 @@ whether `applyB` pads on no-match (kLeft pad) or projects a mark
 
 | `joinKind` | `kindForB` | Outer envelope addition |
 |---|---|---|
-| `kInner` | `kLeft` | per-rn pad-collapse: drop `applyB` pad rows, keeping exactly one pad per outer with no match — see §"INNER pad-row drop" |
+| `kInner` | `kLeft`, or `kLeftSemiProject` under an outer `kLeftSemiProject` | per-rn pad-collapse: drop `applyB` pad rows, keeping exactly one pad per outer with no match — see §"INNER pad-row drop" |
 | `kLeft` | `kLeft` | none — `kLeft` pad maps to `A LEFT JOIN B`'s pad |
 | `kRight` | swap to `kLeft` with sides reversed (`applyA=B, applyB=A`) | none — symmetry |
 | `kFull` | NYI | needs both sides' unmatched rows; tree-only can't express without re-evaluating one side. Loud NYI. |
@@ -153,11 +153,17 @@ produces ≥1 row.
 - Mark composition: chain's `applyB` is kLeftSemiProject → emits its
   own mark per outer. Outer `markColumn` then equals the chained mark
   (possibly composed with applyA's mark if both contribute).
-- For body kInner+kSemi: mark = `applyA.mark AND applyB.mark`
-  (∃ a ∧ ∃ matching b).
-- For body kLeft: mark = `applyA.mark` (B doesn't gate existence —
-  unmatched B still emits via pad).
-- For body kSemi (in body) / kAnti: mark composes per kind.
+- For an unpredicated kInner body: mark = `applyA.mark AND applyB.mark`
+  (∃a ∧ ∃b), since with no predicate the two existences are independent.
+- For a kInner body carrying a predicate, that formula is wrong: existence
+  is a property of the (a, b) pair. `AssignUniqueId` tags each outer,
+  `applyA` is kLeft over A (so an outer with no a row still reaches the
+  window), `applyB` is kLeftSemiProject over B carrying the predicate and
+  the accumulated filter, and a `bool_or(applyA.mark AND applyB.mark)`
+  window over the outer's id answers the mark. One row per outer survives,
+  chosen by `padOrdinal = 1`; that is legal because `bool_or` reads the
+  whole partition and every remaining output column is an outer column.
+- Body kLeft, kLeftSemiFilter, kLeftSemiProject and kAnti: NYI loud.
 
 ### outerKind = `kLeftSemiProject` IN (inLhs != nullptr, inBodyKey set)
 
@@ -255,7 +261,8 @@ Combinations across (outerKind, joinKind):
 | kLeft (ESR=false) | kFull | NYI loud |
 | kLeft (ESR=false) | kLeftSemiProject | **in scope** |
 | kLeft (ESR=false) | kLeftSemiFilter / kAnti | NYI loud |
-| kLeftSemiProject EXISTS | any non-kFull | **in scope** (mark composes per §"outerKind = kLeftSemiProject EXISTS") |
+| kLeftSemiProject EXISTS | kInner, with or without predicate | **in scope** (mark composes per §"outerKind = kLeftSemiProject EXISTS") |
+| kLeftSemiProject EXISTS | kLeft / kLeftSemi* / kAnti | NYI loud |
 | kLeftSemiProject IN | any non-kFull | **in scope** (IN equi routed per `inBodyKey` reference site) |
 | any | kFull | NYI loud — needs DAG / re-evaluation of one side |
 


### PR DESCRIPTION
Summary:

A subquery in an outer join's ON clause that reads the null-supplying side failed to plan under v2:

    SELECT * FROM n LEFT JOIN r ON r.k = n.k AND r.name IN (SELECT s FROM u)

    Expression references a column not produced by any cluster leaf: mark6

Such a subquery was always lifted onto the join's left input, which built a semi join keyed on `r.name` — a column neither of that join's inputs produces. The malformed node planned quietly and failed much later, where the join graph could not resolve the key.

A subquery now joins the input whose columns it reads, and the guard that rejects one reaching across the join reads an `IN`'s left operand as well as its correlations. That operand is a key rather than a correlation column, which is why the reach went unnoticed.

The mark is the other half of the failure. A semi join projects it, so it belongs to no leaf of a join cluster, and a cluster whose other join reads it has nothing to resolve it against. Such a producer now stays an opaque leaf, which puts the mark among that leaf's columns.

Adds `Join::markColumn()`, since four places derived the mark from the output list on their own. The constructor now checks that a semi-project join ends with a boolean mark, so a malformed one fails where it is built.

`SubqueryTest` runs under both optimizers now — covering v1 alone is what let this shape reach a production query. Its assertions are v1 plan shapes, and v2's are not pinned yet: `AXIOM_ASSERT_PLAN_V1` compares the shape under v1 and requires only that v2 produces a plan, which is what catches an unsupported shape or an internal error. Each is meant to become a plain `AXIOM_ASSERT_PLAN` as a v2 expectation is written, as `subqueryInOuterJoinOn` already is.

Reviewed By: amitkdutta

Differential Revision: D117012823
