### PR TITLE
fix: Answer an IN that repeats its correlation as EXISTS (#1757)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -4088,11 +4088,16 @@ ExprCP ToGraph::processCorrelatedInPredicate(
 
   // Only the IN equality should be a null-aware join key. Correlation
   // equalities are standard WHERE clause predicates with different null
-  // semantics, so they belong in the filter. Correlation equalities that match
-  // the IN key are redundant and dropped.
+  // semantics, so they belong in the filter.
+  //
+  // A correlation repeating the IN equality makes the IN an EXISTS: the
+  // subquery holds only rows equal to the left side, so neither the repeated
+  // predicate nor a null-aware key is needed.
+  bool repeatsInEquality = false;
   for (auto i = 0; i < decorrelated.leftKeys.size(); ++i) {
     if (!inRightHasOuter && decorrelated.leftKeys[i] == leftKey &&
         decorrelated.rightKeys[i] == inRightKey) {
+      repeatsInEquality = true;
       continue;
     }
     decorrelated.filter.push_back(
@@ -4108,7 +4113,7 @@ ExprCP ToGraph::processCorrelatedInPredicate(
       subqueryDt,
       markColumn,
       std::move(decorrelated.filter),
-      /*nullAwareIn=*/true);
+      /*nullAwareIn=*/!repeatsInEquality);
   currentDt_->joins.push_back(edge);
 
   if (!inRightHasOuter) {

--- a/axiom/optimizer/tests/OrderByTest.cpp
+++ b/axiom/optimizer/tests/OrderByTest.cpp
@@ -62,6 +62,20 @@ TEST_P(OrderByTest, aggregationDropsPrecedingOrderBy) {
           .build());
 }
 
+TEST_P(OrderByTest, orderByOfUnreadRowsDrops) {
+  // Nothing reads a column of the ordered rows, so their order cannot be
+  // observed: `SELECT 1 FROM t ORDER BY x` is `SELECT 1 FROM t`. v1 keeps the
+  // ORDER BY.
+  auto plan = scan("nation").orderBy({"n_nationkey"}).project({"1 as one"});
+
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(plan.build()),
+      matchScan("nation")
+          .orderByIf(!useV2_, {"n_nationkey ASC NULLS LAST"})
+          .project({"1 as one"})
+          .build());
+}
+
 AXIOM_INSTANTIATE_V1_V2(OrderByTest);
 
 } // namespace

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -337,6 +337,12 @@ class PlanMatcherBuilder {
   /// Matches any single (non-distributed) Aggregation node.
   PlanMatcherBuilder& singleAggregation();
 
+  /// Adds a single Aggregation matcher (see singleAggregation()) only when
+  /// 'condition' is true; otherwise a no-op.
+  PlanMatcherBuilder& singleAggregationIf(bool condition) {
+    return condition ? singleAggregation() : *this;
+  }
+
   /// Matches a single (non-distributed) Aggregation node with the specified
   /// grouping keys and aggregate expressions.
   /// @param groupingKeys Columns to group by.
@@ -345,6 +351,15 @@ class PlanMatcherBuilder {
   PlanMatcherBuilder& singleAggregation(
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates);
+
+  /// Adds a single Aggregation matcher (see singleAggregation()) only when
+  /// 'condition' is true; otherwise a no-op.
+  PlanMatcherBuilder& singleAggregationIf(
+      bool condition,
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates) {
+    return condition ? singleAggregation(groupingKeys, aggregates) : *this;
+  }
 
   /// Matches any partial Aggregation node.
   PlanMatcherBuilder& partialAggregation();
@@ -630,6 +645,14 @@ class PlanMatcherBuilder {
   /// omitted null ordering to `NULLS LAST`. So "c" means "c ASC NULLS LAST" and
   /// "c DESC" means "c DESC NULLS LAST".
   PlanMatcherBuilder& orderBy(const std::vector<std::string>& ordering);
+
+  /// Adds an OrderBy matcher (see orderBy()) only when 'condition' is true;
+  /// otherwise a no-op.
+  PlanMatcherBuilder& orderByIf(
+      bool condition,
+      const std::vector<std::string>& ordering) {
+    return condition ? orderBy(ordering) : *this;
+  }
 
   /// Matches any TableWrite node.
   PlanMatcherBuilder& tableWrite();

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -335,7 +335,7 @@ TEST_P(SubqueryTest, uncorrelatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
   // Uncorrelated scalar subquery in projection with global aggregation in the
@@ -358,7 +358,7 @@ TEST_P(SubqueryTest, uncorrelatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
   // Uncorrelated scalar subquery in projection with GROUP BY aggregation in the
@@ -382,7 +382,7 @@ TEST_P(SubqueryTest, uncorrelatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
   // IN <subquery> in projection.
@@ -405,7 +405,7 @@ TEST_P(SubqueryTest, uncorrelatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
   // NOT IN <subquery> in projection.
@@ -428,7 +428,7 @@ TEST_P(SubqueryTest, uncorrelatedProject) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
   // Uncorrelated EXISTS in projection.
@@ -438,17 +438,22 @@ TEST_P(SubqueryTest, uncorrelatedProject) {
         "   EXISTS (SELECT 1 FROM nation) AS has_nations "
         "FROM region";
 
-    // Uncorrelated EXISTS in projection uses cross join with count check.
-    auto matcher = matchHiveScan("region")
-                       .nestedLoopJoin(
-                           matchHiveScan("nation").limit().singleAggregation(),
-                           velox::core::JoinType::kInner)
-                       .project()
-                       .build();
+    // One subquery row settles existence, so both optimizers cap the subquery
+    // at one row. The projection reading that answer is spelled with a
+    // generated name under either, so it stays unasserted.
+    auto matcher =
+        matchHiveScan("region")
+            .nestedLoopJoin(
+                matchHiveScan("nation").finalLimit(0, 1).singleAggregationIf(
+                    !useV2_),
+                useV2_ ? velox::core::JoinType::kLeftSemiProject
+                       : velox::core::JoinType::kInner)
+            .project()
+            .build();
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
   // Uncorrelated NOT EXISTS in projection.
@@ -458,18 +463,21 @@ TEST_P(SubqueryTest, uncorrelatedProject) {
         "   NOT EXISTS (SELECT 1 FROM nation) AS no_nations "
         "FROM region";
 
-    // Uncorrelated NOT EXISTS in projection uses cross join with count = 0
-    // check.
-    auto matcher = matchHiveScan("region")
-                       .nestedLoopJoin(
-                           matchHiveScan("nation").limit().singleAggregation(),
-                           velox::core::JoinType::kInner)
-                       .project()
-                       .build();
+    // One row of the subquery settles existence, which the limit reads. v1
+    // then counts that row; v2 marks each outer row against it.
+    auto matcher =
+        matchHiveScan("region")
+            .nestedLoopJoin(
+                matchHiveScan("nation").finalLimit(0, 1).singleAggregationIf(
+                    !useV2_),
+                useV2_ ? velox::core::JoinType::kLeftSemiProject
+                       : velox::core::JoinType::kInner)
+            .project()
+            .build();
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
 
@@ -575,7 +583,7 @@ TEST_P(SubqueryTest, correlatedInWithCorrelationFilter) {
             .project()
             .build();
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
   // Two correlation equalities.
@@ -596,7 +604,7 @@ TEST_P(SubqueryTest, correlatedInWithCorrelationFilter) {
                        .project()
                        .build();
     auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
 
@@ -622,7 +630,7 @@ TEST_P(SubqueryTest, correlatedInWithMixedCorrelationFilter) {
                      .project()
                      .build();
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-  AXIOM_ASSERT_PLAN_V1(plan, matcher);
+  AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 // Correlated IN subquery where the correlation equality duplicates the IN key.
@@ -688,7 +696,7 @@ TEST_P(SubqueryTest, multiTableInSubquery) {
           .build();
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-  AXIOM_ASSERT_PLAN_V1(plan, matcher);
+  AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 TEST_P(SubqueryTest, correlatedScalar) {
@@ -896,38 +904,48 @@ TEST_P(SubqueryTest, uncorrelatedExists) {
   {
     auto query = "SELECT * FROM region WHERE EXISTS (SELECT 1 FROM nation)";
 
-    // EXISTS uses NOT(count = 0) to check if any rows exist.
-    auto matcher = matchHiveScan("region")
-                       .nestedLoopJoin(
-                           matchHiveScan("nation")
-                               .finalLimit(0, 1)
-                               .singleAggregation({}, {"count(*) as c"})
-                               .filter("not(eq(c, 0))"),
-                           velox::core::JoinType::kInner)
-                       .build();
+    // One subquery row settles existence, so the subquery is capped at one
+    // row. v1 then counts that row and tests the count below the join; v2
+    // marks the outer row and filters on the mark above it, under a name it
+    // generates.
+    auto matcher =
+        matchHiveScan("region")
+            .nestedLoopJoin(
+                matchHiveScan("nation")
+                    .finalLimit(0, 1)
+                    .singleAggregationIf(!useV2_, {}, {"count(*) as c"})
+                    .filterIf(!useV2_, "not(eq(c, 0))"),
+                useV2_ ? velox::core::JoinType::kLeftSemiProject
+                       : velox::core::JoinType::kInner)
+            .filterIf(useV2_)
+            .projectIf(useV2_)
+            .build();
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
   // Uncorrelated NOT EXISTS: returns all rows if subquery has no rows.
   {
     auto query = "SELECT * FROM region WHERE NOT EXISTS (SELECT 1 FROM nation)";
 
-    // NOT EXISTS uses NOT(NOT(count = 0)) to check if no rows exist.
-    auto matcher = matchHiveScan("region")
-                       .nestedLoopJoin(
-                           matchHiveScan("nation")
-                               .finalLimit(0, 1)
-                               .singleAggregation({}, {"count(*) as c"})
-                               .filter("not(not(eq(c, 0)))"),
-                           velox::core::JoinType::kInner)
-                       .build();
+    auto matcher =
+        matchHiveScan("region")
+            .nestedLoopJoin(
+                matchHiveScan("nation")
+                    .finalLimit(0, 1)
+                    .singleAggregationIf(!useV2_, {}, {"count(*) as c"})
+                    .filterIf(!useV2_, "not(not(eq(c, 0)))"),
+                useV2_ ? velox::core::JoinType::kLeftSemiProject
+                       : velox::core::JoinType::kInner)
+            .filterIf(useV2_)
+            .projectIf(useV2_)
+            .build();
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
 
@@ -947,7 +965,7 @@ TEST_P(SubqueryTest, correlatedNotExists) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
   // NOT EXISTS with non-equality correlation in filter.
@@ -968,7 +986,7 @@ TEST_P(SubqueryTest, correlatedNotExists) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
   // NOT EXISTS in projection.
@@ -990,7 +1008,7 @@ TEST_P(SubqueryTest, correlatedNotExists) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
 
@@ -1120,7 +1138,7 @@ TEST_P(SubqueryTest, uncorrelatedGroupingKey) {
                      .build();
 
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN_V1(plan, matcher);
+  AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 TEST_P(SubqueryTest, correlatedGroupingKey) {
@@ -1992,7 +2010,7 @@ TEST_P(SubqueryTest, leftJoinFilterWithNonDefaultNullEquality) {
                      .build();
 
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-  AXIOM_ASSERT_PLAN_V1(plan, matcher);
+  AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 TEST_P(SubqueryTest, rightJoinOnSubquery) {
@@ -2144,7 +2162,7 @@ TEST_P(SubqueryTest, inSubqueryInsideAggregate) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
   // IN <subquery> inside an aggregate FILTER clause.
@@ -2157,7 +2175,7 @@ TEST_P(SubqueryTest, inSubqueryInsideAggregate) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
 
@@ -2188,7 +2206,7 @@ TEST_P(SubqueryTest, nestedInSubqueries) {
 
   SCOPED_TRACE(query);
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN_V1(plan, matcher);
+  AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 // EXISTS (SELECT 1 WHERE <condition>) with no FROM clause is equivalent to
@@ -2301,7 +2319,7 @@ TEST_P(SubqueryTest, inReplicateNullsAndAny) {
             .build();
 
     auto distributedPlan = planVelox(parseSelect(query, kTestConnectorId));
-    AXIOM_ASSERT_DISTRIBUTED_PLAN_V1(distributedPlan.plan, matcher);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
   }
 
   // IN in projection: stays as kLeftSemiProject with null-aware. The build
@@ -2323,7 +2341,7 @@ TEST_P(SubqueryTest, inReplicateNullsAndAny) {
             .build();
 
     auto distributedPlan = planVelox(parseSelect(query, kTestConnectorId));
-    AXIOM_ASSERT_DISTRIBUTED_PLAN_V1(distributedPlan.plan, matcher);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
   }
 
   // IN in projection with reversed table sizes — exercises joinByHashRight.
@@ -2342,7 +2360,7 @@ TEST_P(SubqueryTest, inReplicateNullsAndAny) {
                        .build();
 
     auto distributedPlan = planVelox(parseSelect(query, kTestConnectorId));
-    AXIOM_ASSERT_DISTRIBUTED_PLAN_V1(distributedPlan.plan, matcher);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, matcher);
   }
 }
 

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -511,13 +511,13 @@ TEST_P(SubqueryTest, correlatedIn) {
         "  SELECT o.o_custkey FROM orders AS o "
         "  WHERE o.o_custkey = c.c_custkey)";
 
-    // Correlated NOT IN subquery creates a RIGHT SEMI PROJECT join with
-    // mark column, then filters and projects.
+    // The correlation repeats the IN equality, so membership is existence:
+    // the join carries a mark but needs no null-aware key.
     auto matcher = matchHiveScan("orders")
                        .hashJoin(
                            matchHiveScan("customer"),
                            core::JoinType::kRightSemiProject,
-                           {.nullAware = true})
+                           {.nullAware = false})
                        .filter()
                        .project()
                        .build();
@@ -633,26 +633,29 @@ TEST_P(SubqueryTest, correlatedInWithMixedCorrelationFilter) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-// Correlated IN subquery where the correlation equality duplicates the IN key.
-TEST_P(SubqueryTest, correlatedInWithRedundantCorrelationFilter) {
+TEST_P(SubqueryTest, correlatedInWithCorrelationOnInKey) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
   testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()));
 
+  // The correlation holds the subquery to rows equal to the left side, so the
+  // IN asks only whether the subquery has a row: no repeated predicate and no
+  // null-aware key.
   auto query =
       "SELECT t.a IN ("
       "  SELECT u.x FROM u "
       "  WHERE u.x = t.a"
       ") FROM t";
 
-  auto matcher = matchScan("t")
-                     .hashJoin(
-                         matchScan("u"),
-                         core::JoinType::kLeftSemiProject,
-                         {.nullAware = true, .keys = {{"a = x"}}, .filter = ""})
-                     .project()
-                     .build();
+  auto matcher =
+      matchScan("t")
+          .hashJoin(
+              matchScan("u"),
+              core::JoinType::kLeftSemiProject,
+              {.nullAware = false, .keys = {{"a = x"}}, .filter = ""})
+          .project()
+          .build();
   auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-  AXIOM_ASSERT_PLAN_V1(plan, matcher);
+  AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 // IN subquery whose correlation predicate references a sibling of the IN's
@@ -861,13 +864,13 @@ TEST_P(SubqueryTest, correlatedProject) {
         "   n_regionkey IN (SELECT r_regionkey FROM region WHERE r_regionkey = n_regionkey) AS in_region "
         "FROM nation";
 
-    // Correlated IN subquery in projection is transformed into a LEFT SEMI
-    // PROJECT join with a mark column.
+    // The correlation repeats the IN equality, so membership is existence and
+    // the key is not null-aware, as for the EXISTS above.
     auto matcher = matchHiveScan("nation")
                        .hashJoin(
                            core::PlanMatcherBuilder().hiveScan("region", {}),
                            velox::core::JoinType::kLeftSemiProject,
-                           {.nullAware = true})
+                           {.nullAware = false})
                        .project()
                        .build();
 
@@ -889,7 +892,7 @@ TEST_P(SubqueryTest, correlatedProject) {
                        .hashJoin(
                            core::PlanMatcherBuilder().hiveScan("region", {}),
                            velox::core::JoinType::kLeftSemiProject,
-                           {.nullAware = true})
+                           {.nullAware = false})
                        .project()
                        .build();
 

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -128,27 +128,31 @@ TEST_P(SubqueryTest, uncorrelatedScalar) {
 // IN list mixing subqueries with non-subquery expressions.
 TEST_P(SubqueryTest, inListWithMixedSubqueries) {
   // IN list with a scalar subquery and a literal. The scalar subquery is
-  // extracted, cross-joined, and the IN becomes in(n_regionkey, max, 2).
+  // extracted and cross-joined, and the IN reads its result as a column: v2
+  // evaluates it as the cross join's condition, v1 as a filter above it.
   {
     auto query =
         "SELECT * FROM nation WHERE n_regionkey IN "
         "((SELECT max(r_regionkey) FROM region), 2)";
     SCOPED_TRACE(query);
 
+    const std::string inPredicate = "\"in\"(n_regionkey, max_key, 2)";
     auto plan = toSingleNodePlan(query);
-    auto matcher =
-        matchHiveScan("nation")
-            .nestedLoopJoin(matchHiveScan("region").singleAggregation(
-                {}, {"max(r_regionkey) as max_key"}))
-            .filter("\"in\"(n_regionkey, max_key, 2)")
-            .project()
-            .build();
+    auto matcher = matchHiveScan("nation")
+                       .nestedLoopJoin(
+                           matchHiveScan("region").singleAggregation(
+                               {}, {"max(r_regionkey) as max_key"}),
+                           core::JoinType::kInner,
+                           useV2_ ? inPredicate : "")
+                       .filterIf(!useV2_, inPredicate)
+                       .projectIf(!useV2_)
+                       .build();
 
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
-  // IN list with two scalar subqueries. Both are extracted, cross-joined, and
-  // the IN becomes in(n_regionkey, max_key, min_key).
+  // IN list with two scalar subqueries. Both are extracted and cross-joined,
+  // and the IN reads both results as columns.
   {
     auto query =
         "SELECT * FROM nation WHERE n_regionkey IN "
@@ -156,38 +160,62 @@ TEST_P(SubqueryTest, inListWithMixedSubqueries) {
         "(SELECT min(r_regionkey) FROM region))";
     SCOPED_TRACE(query);
 
+    const std::string inPredicate = "\"in\"(n_regionkey, max_key, min_key)";
     auto plan = toSingleNodePlan(query);
     auto matcher =
         matchHiveScan("nation")
             .nestedLoopJoin(matchHiveScan("region").singleAggregation(
                 {}, {"max(r_regionkey) as max_key"}))
-            .nestedLoopJoin(matchHiveScan("region").singleAggregation(
-                {}, {"min(r_regionkey_2) as min_key"}))
-            .filter("\"in\"(n_regionkey, max_key, min_key)")
-            .project()
+            .nestedLoopJoin(
+                matchHiveScan("region").singleAggregation(
+                    {}, {"min(r_regionkey_2) as min_key"}),
+                core::JoinType::kInner,
+                useV2_ ? inPredicate : "")
+            .filterIf(!useV2_, inPredicate)
+            .projectIf(!useV2_)
             .build();
 
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
 
-// IN with a constant (table-less) left side over a real source. With no table
-// to anchor the constant on, the optimizer materializes it as a one-row Values
-// relation and runs the IN as a null-aware semi-join against the source.
 TEST_P(SubqueryTest, uncorrelatedInConstantLeftSide) {
   auto query = "SELECT 1 IN (SELECT r_regionkey FROM region)";
   SCOPED_TRACE(query);
 
+  // v1 makes the one-row build side by cross-joining two one-row relations,
+  // which is wasted work this pins only because v1 still emits it.
+  auto constantSide = useV2_ ? matchValues().project({"1"})
+                             : matchValues().nestedLoopJoin(matchValues());
   auto matcher = matchHiveScan("region")
                      .hashJoin(
-                         matchValues().nestedLoopJoin(matchValues()),
+                         constantSide,
                          velox::core::JoinType::kRightSemiProject,
                          {.nullAware = true})
                      .project()
                      .build();
 
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN_V1(plan, matcher);
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  // The join preserves its build side, so that side is partitioned rather
+  // than replicated to every worker.
+  auto distributedConstantSide = useV2_
+      ? matchValues().project({"1"}).shuffle()
+      : matchValues().nestedLoopJoin(matchValues().broadcast()).shuffle();
+  auto distributedMatcher =
+      matchHiveScan("region")
+          .shuffle({"r_regionkey"}, /*replicateNullsAndAny=*/true)
+          .hashJoin(
+              distributedConstantSide,
+              velox::core::JoinType::kRightSemiProject,
+              {.nullAware = true})
+          .project()
+          .gather()
+          .build();
+
+  auto distributedPlan = planVelox(parseSelect(query));
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
 }
 
 TEST_P(SubqueryTest, correlatedExists) {
@@ -205,7 +233,7 @@ TEST_P(SubqueryTest, correlatedExists) {
     {
       SCOPED_TRACE(query);
       auto plan = toSingleNodePlan(query);
-      AXIOM_ASSERT_PLAN_V1(plan, matcher);
+      AXIOM_ASSERT_PLAN(plan, matcher);
     }
 
     query =
@@ -215,7 +243,7 @@ TEST_P(SubqueryTest, correlatedExists) {
     {
       SCOPED_TRACE(query);
       auto plan = toSingleNodePlan(query);
-      AXIOM_ASSERT_PLAN_V1(plan, matcher);
+      AXIOM_ASSERT_PLAN(plan, matcher);
     }
 
     // EXISTS with DISTINCT. DISTINCT is semantically unnecessary for EXISTS
@@ -228,7 +256,7 @@ TEST_P(SubqueryTest, correlatedExists) {
     {
       SCOPED_TRACE(query);
       auto plan = toSingleNodePlan(query);
-      AXIOM_ASSERT_PLAN_V1(plan, matcher);
+      AXIOM_ASSERT_PLAN(plan, matcher);
     }
   }
 
@@ -247,7 +275,7 @@ TEST_P(SubqueryTest, correlatedExists) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
   {
@@ -264,7 +292,7 @@ TEST_P(SubqueryTest, correlatedExists) {
 
     SCOPED_TRACE(query);
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
   // Correlated conjuncts referencing multiple tables.
@@ -284,7 +312,7 @@ TEST_P(SubqueryTest, correlatedExists) {
     {
       SCOPED_TRACE(query);
       auto plan = toSingleNodePlan(query);
-      AXIOM_ASSERT_PLAN_V1(plan, matcher);
+      AXIOM_ASSERT_PLAN(plan, matcher);
     }
   }
 }

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -736,6 +736,20 @@ SELECT x FROM (SELECT x, sum(x) AS sx FROM s GROUP BY x) WHERE sx > 0
 -- IN with a constant left-hand side over a no-FROM subquery.
 SELECT 1 WHERE 1 IN (SELECT 1)
 ----
+-- The same read as a value rather than a filter, over a matching list, a
+-- non-matching one, and one holding only NULL.
+SELECT 1 IN (SELECT 1) AS a, 1 IN (SELECT 2) AS b,
+       1 IN (SELECT CAST(NULL AS INTEGER)) AS c
+----
+-- A constant left-hand side alongside a relation the subquery does not name.
+SELECT x FROM UNNEST(ARRAY[1, 2]) AS t(x)
+WHERE 1 IN (SELECT c FROM (VALUES (1), (2)) AS s(c))
+----
+-- The negated form keeps no row.
+-- count 0
+SELECT x FROM UNNEST(ARRAY[1, 2]) AS t(x)
+WHERE 1 NOT IN (SELECT c FROM (VALUES (1), (2)) AS s(c))
+----
 -- Scalar subquery in aggregate ORDER BY expression.
 SELECT array_agg(a ORDER BY a + (SELECT 1)) AS vals FROM t
 ----

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -417,11 +417,20 @@ SELECT t.a <> ALL (SELECT t2.a FROM t t2 WHERE t2.b = t.b) FROM t
 -- Correlated NOT IN subquery with mixed equality and non-equality correlation.
 SELECT t.a NOT IN (SELECT t2.a FROM t t2 WHERE t2.b = t.b AND t2.c < t.c) FROM t
 ----
--- Correlated IN subquery where correlation equality is redundant with IN key.
+-- Correlated IN subquery whose correlation repeats the IN equality.
 SELECT t.a IN (SELECT t2.a FROM t t2 WHERE t2.a = t.a) FROM t
 ----
--- Correlated NOT IN subquery where correlation equality is redundant with IN key.
+-- Correlated NOT IN subquery whose correlation repeats the IN equality.
 SELECT t.a NOT IN (SELECT t2.a FROM t t2 WHERE t2.a = t.a) FROM t
+----
+-- The same over a source holding NULLs, which is what tells the answer apart
+-- from an unknown one: a row whose subquery is empty is not in it.
+WITH n(a) AS (VALUES (1), (2), (CAST(NULL AS INTEGER))),
+     m(x) AS (VALUES (2), (CAST(NULL AS INTEGER)))
+SELECT n.a,
+       n.a IN (SELECT m.x FROM m WHERE m.x = n.a) AS present,
+       n.a NOT IN (SELECT m.x FROM m WHERE m.x = n.a) AS absent
+FROM n
 ----
 -- Correlated IN subquery with reversed operand order in correlation.
 SELECT t.a IN (SELECT t2.a FROM t t2 WHERE t.b = t2.b) FROM t

--- a/axiom/optimizer/v2/DecorrelatePass.cpp
+++ b/axiom/optimizer/v2/DecorrelatePass.cpp
@@ -2596,12 +2596,13 @@ class Decorrelator : public NodeRewriter<> {
   terminusSemi(ApplyCP apply, NodeCP input, NodeCP body, ExprVector filter) {
     ExprVector leftKeys;
     ExprVector rightKeys;
+    bool bodyKeyHasOuter = false;
     if (apply->inLhs() != nullptr) {
       // Equi-keys must each resolve on a single join side. When the
       // body key references outer columns, demote the IN equality
       // into the join filter; `nullAware=true` preserves null-aware
       // semi-project semantics.
-      const bool bodyKeyHasOuter =
+      bodyKeyHasOuter =
           apply->inBodyKey()->columns().containsAny(input->outputColumns());
       if (bodyKeyHasOuter) {
         filter.push_back(
@@ -2618,8 +2619,18 @@ class Decorrelator : public NodeRewriter<> {
     // Null-aware semantics apply only to the IN equality. Keep
     // correlation equi-conditions in the residual so they execute
     // under standard `=`.
+    //
+    // A correlation repeating the IN equality makes the IN an EXISTS: the body
+    // holds only rows equal to the left side, so neither the repeated
+    // predicate nor a null-aware key is needed.
+    bool repeatsInEquality = false;
     if (apply->nullAware()) {
       for (size_t i = 0; i < split.leftKeys.size(); ++i) {
+        if (!bodyKeyHasOuter && split.leftKeys[i] == apply->inLhs() &&
+            split.rightKeys[i] == apply->inBodyKey()) {
+          repeatsInEquality = true;
+          continue;
+        }
         split.residual.push_back(
             exprFactory_.makeEq(split.leftKeys[i], split.rightKeys[i]));
       }
@@ -2634,7 +2645,7 @@ class Decorrelator : public NodeRewriter<> {
         std::move(leftKeys),
         std::move(rightKeys),
         std::move(split.residual),
-        apply->nullAware(),
+        apply->nullAware() && !repeatsInEquality,
         /*nullAsValue=*/false,
         apply->outputColumns(),
     });

--- a/axiom/optimizer/v2/HypergraphBuilder.cpp
+++ b/axiom/optimizer/v2/HypergraphBuilder.cpp
@@ -59,6 +59,27 @@ RelationSet unionExpressionRelations(
   return result;
 }
 
+// The relations an edge's side reads: those its 'keys' name, or 'operand' --
+// the whole side -- when a key names none, as the constant side of
+// `1 IN (SELECT ...)` does. The operand is a superset of what any key of that
+// side can read, and a larger edge side only forbids reorderings, so
+// substituting it cannot admit a wrong one. It does cost plan space: the join
+// is then pinned above everything its operand covers.
+RelationSet keyRelationsOrOperand(
+    const ExprVector& keys,
+    const folly::F14FastMap<ColumnCP, int8_t>& columnToLeaf,
+    const RelationSet& operand) {
+  RelationSet fromKeys = unionExpressionRelations(keys, columnToLeaf);
+  if (!fromKeys.empty()) {
+    return fromKeys;
+  }
+  VELOX_CHECK(
+      !operand.empty(),
+      "A join edge side must read some relation, but neither its keys nor its "
+      "operand do");
+  return operand;
+}
+
 // Per-Join leaf covers of left and right operands, with the
 // kRight-to-kLeft normalization baked in: for an IR `kRight`
 // join, `left`/`right` are swapped and `joinType` is `kLeft`.
@@ -76,24 +97,27 @@ struct JoinLeaves {
 RelationSet populateJoinLeaves(
     NodeCP node,
     const folly::F14FastMap<NodeCP, int8_t>& leafIds,
+    const folly::F14FastMap<UnnestCP, int8_t>& unnestIds,
     folly::F14FastMap<JoinCP, JoinLeaves>& leaves) {
   const auto it = leafIds.find(node);
   if (it != leafIds.end()) {
     return RelationSet::singleton(it->second);
   }
   if (node->is(NodeType::kUnnest)) {
-    // The cluster does not contain the input of an Unnest of a constant.
-    NodeCP input = node->onlyInput();
+    // The cluster does not contain the input of an Unnest of a constant, so
+    // the Unnest's own relation is all its subtree contributes.
+    const auto* unnest = node->as<Unnest>();
+    NodeCP input = unnest->input();
     if (input->outputColumns().empty()) {
-      return RelationSet{};
+      return RelationSet::singleton(unnestIds.at(unnest));
     }
-    return populateJoinLeaves(input, leafIds, leaves);
+    return populateJoinLeaves(input, leafIds, unnestIds, leaves);
   }
   const auto* join = node->as<Join>();
   const RelationSet leftLeaves =
-      populateJoinLeaves(join->left(), leafIds, leaves);
+      populateJoinLeaves(join->left(), leafIds, unnestIds, leaves);
   const RelationSet rightLeaves =
-      populateJoinLeaves(join->right(), leafIds, leaves);
+      populateJoinLeaves(join->right(), leafIds, unnestIds, leaves);
   // Normalize right-form joins to their left form by swapping operands.
   // kRight, kRightSemiFilter and kRightSemiProject each map to the
   // matching left-form type; the rest of the pipeline never sees a
@@ -420,7 +444,7 @@ JoinHypergraph HypergraphBuilder::build(
   }
 
   folly::F14FastMap<JoinCP, JoinLeaves> joinLeaves;
-  populateJoinLeaves(cluster.root, leafIds, joinLeaves);
+  populateJoinLeaves(cluster.root, leafIds, unnestIds, joinLeaves);
 
   for (JoinCP join : cluster.joins) {
     const auto& leaves = joinLeaves.at(join);
@@ -449,9 +473,9 @@ JoinHypergraph HypergraphBuilder::build(
           rightKeys.push_back(join->rightKeys()[i]);
         }
         const RelationSet leftSet{
-            unionExpressionRelations(leftKeys, columnToLeaf)};
+            keyRelationsOrOperand(leftKeys, columnToLeaf, leaves.left)};
         const RelationSet rightSet{
-            unionExpressionRelations(rightKeys, columnToLeaf)};
+            keyRelationsOrOperand(rightKeys, columnToLeaf, leaves.right)};
         RelationSet ses{leftSet};
         ses.unionSet(rightSet);
         RelationSet tes{ses};
@@ -502,9 +526,9 @@ JoinHypergraph HypergraphBuilder::build(
       NodeCP normalizedRightChild = flip ? join->left() : join->right();
 
       const RelationSet leftSet{
-          unionExpressionRelations(edgeLeftKeys, columnToLeaf)};
+          keyRelationsOrOperand(edgeLeftKeys, columnToLeaf, leaves.left)};
       const RelationSet rightSet{
-          unionExpressionRelations(edgeRightKeys, columnToLeaf)};
+          keyRelationsOrOperand(edgeRightKeys, columnToLeaf, leaves.right)};
       RelationSet ses{leftSet};
       ses.unionSet(rightSet);
       for (ExprCP conjunct : join->filter()) {

--- a/axiom/optimizer/v2/LimitAndOrderPass.cpp
+++ b/axiom/optimizer/v2/LimitAndOrderPass.cpp
@@ -66,6 +66,20 @@ LimitBound collapse(const LimitBound& outer, const LimitBound& inner) {
   return {offset, count};
 }
 
+// True when the join's only question of its right side is whether it has a
+// row: a semi or anti join with nothing to match on. A key or a filter would
+// make the surviving row matter, so only an unconditional one qualifies.
+// Null-aware semantics are defined over equi-keys, so a null-aware join never
+// reaches this shape; the term states that rather than relying on it.
+bool readsRightForExistenceOnly(const Join* join) {
+  using velox::core::JoinType;
+  const auto joinType = join->joinType();
+  const bool existenceSideIsRight = joinType == JoinType::kLeftSemiFilter ||
+      joinType == JoinType::kLeftSemiProject || joinType == JoinType::kAnti;
+  return existenceSideIsRight && join->leftKeys().empty() &&
+      join->filter().empty() && !join->nullAware();
+}
+
 // State threaded top-down.
 struct LimitContext {
   // The row bound the consumer imposes on the current node's output, placed as
@@ -205,7 +219,7 @@ class LimitAndOrderRewriter : public NodeRewriter<LimitContext> {
   // rewrite the inputs with no pending bound. 'preservesOrder' says whether the
   // node passes its input's order through (drives the bare-Sort drop below).
   //
-  // The multi-input barriers (Join, Apply) delegate to the base rewriter, which
+  // The multi-input barrier (Apply) delegates to the base rewriter, which
   // rewrites all inputs with this one shared context. That is safe because the
   // macro clears `pending` (via the std::exchange below) and sets
   // `orderPreserved` false *before* delegating, so no input is rewritten with
@@ -227,13 +241,44 @@ class LimitAndOrderRewriter : public NodeRewriter<LimitContext> {
   // Unnest emits each input row's unnested rows in input order, so it passes
   // its input's order through: a Sort below it stays observable.
   LIMIT_BARRIER(Unnest, rewriteUnnest, true)
-  LIMIT_BARRIER(Join, rewriteJoin, false)
   LIMIT_BARRIER(Apply, rewriteApply, false)
   LIMIT_BARRIER(EnforceDistinct, rewriteEnforceDistinct, false)
   LIMIT_BARRIER(TopNRowNumber, rewriteTopNRowNumber, false)
   LIMIT_BARRIER(Exchange, rewriteExchange, false)
 
 #undef LIMIT_BARRIER
+
+  // A Join is a barrier like the nodes above, with one addition: when it asks
+  // only whether its right side has any row — a semi or anti join with no keys
+  // and no filter — one row answers that, so the right side is rewritten under
+  // a bound of one.
+  NodeCP rewriteJoin(const Join* node, LimitContext& context) override {
+    const auto pending = std::exchange(context.pending, std::nullopt);
+    context.orderPreserved = false;
+
+    NodeCP newLeft = rewrite(node->left(), context);
+
+    LimitContext rightContext;
+    rightContext.orderPreserved = false;
+    if (readsRightForExistenceOnly(node)) {
+      rightContext.pending = LimitBound{/*offset=*/0, /*count=*/1};
+    }
+    NodeCP newRight = rewrite(node->right(), rightContext);
+
+    NodeCP newJoin = newLeft == node->left() && newRight == node->right()
+        ? node
+        : builder().make<Join>(
+              {newLeft,
+               newRight,
+               node->joinType(),
+               node->leftKeys(),
+               node->rightKeys(),
+               node->filter(),
+               node->nullAware(),
+               node->nullAsValue(),
+               node->outputColumns()});
+    return materialize(pending, newJoin);
+  }
 
   // Window: a bound above it counts the rows it emits, which is its input's
   // rows, but the values its functions compute read the whole partition — so a

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -37,32 +37,12 @@ namespace facebook::axiom::optimizer::v2 {
 
 namespace {
 
-// True if every expression in 'keys' references at least one column.
-bool allKeysReferenceColumns(const ExprVector& keys) {
-  for (ExprCP key : keys) {
-    if (key->columns().empty()) {
-      return false;
-    }
-  }
-  return true;
-}
-
 // Reorder limit: inner / LEFT / RIGHT / FULL equi-joins,
 // plus filtering semijoin (kLeftSemiFilter), antijoin (kAnti), and
 // mark-preserving semijoin (kLeftSemiProject).
 bool isClusterable(const Join* join) {
   using velox::core::JoinType;
   if (join->leftKeys().empty()) {
-    return false;
-  }
-  // A hyperedge needs a non-empty relation set on both sides: the edge's
-  // left/right relation sets are the cluster leaves referenced by the
-  // left/right keys (HypergraphBuilder::unionExpressionRelations). A
-  // degenerate equi-key that references no column (e.g. the `1 = 1` a
-  // `1 IN (SELECT 1)` decorrelates to) would yield an empty side and trip
-  // the JoinEdge invariant, so such a join stays an opaque cluster leaf.
-  if (!allKeysReferenceColumns(join->leftKeys()) ||
-      !allKeysReferenceColumns(join->rightKeys())) {
     return false;
   }
   const auto kind = join->joinType();

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -1224,6 +1224,12 @@ class Pushdown : public NodeRewriter<PushdownContext> {
   // Sort: pending passes through unchanged — order has no row-set
   // effect. The sort keys must survive in the child's outputs.
   NodeCP rewriteSort(const Sort* node, PushdownContext& context) override {
+    // With no column of this node read above, its rows are indistinguishable
+    // and their order cannot be observed: `SELECT 1 FROM t ORDER BY x` is
+    // `SELECT 1 FROM t`. Dropping the Sort also frees its keys to be pruned.
+    if (!context.requiredAbove.containsAny(node->outputColumns())) {
+      return rewrite(node->input(), context);
+    }
     context.required.unionColumns(node->orderKeys());
     context.requiredAbove.unionColumns(node->orderKeys());
     // A Sort outputs its input's columns, so it is not the consumer the flag
@@ -1272,7 +1278,15 @@ class Pushdown : public NodeRewriter<PushdownContext> {
   // TopN: a filter barrier like Limit (its bound depends on the row set), and
   // its order keys must survive in the child like Sort.
   NodeCP rewriteTopN(const TopN* node, PushdownContext& context) override {
+    // As in rewriteSort, with no column read above only the row count the
+    // TopN keeps is observable, which a Limit keeps as well.
+    const bool rowsUnread =
+        !context.requiredAbove.containsAny(node->outputColumns());
     return blockAt(context, [&](PushdownContext& empty) -> NodeCP {
+      if (rowsUnread) {
+        return builder().make<Limit>(
+            {rewrite(node->input(), empty), node->offset(), node->count()});
+      }
       empty.required.unionColumns(node->orderKeys());
       empty.requiredAbove.unionColumns(node->orderKeys());
 


### PR DESCRIPTION
Summary:

`SELECT t.a IN (SELECT u.x FROM u WHERE u.x = t.a) FROM t` answered `NULL` under v1 where Presto answers `false`, for an outer row whose subquery holds nothing.

The correlation holds the subquery to rows equal to the left side, so the left side is in the subquery exactly when the subquery has a row, and a NULL of the source never survives to make the answer unknown. The whole expression is `EXISTS (SELECT 1 FROM u WHERE u.x = t.a)`, which needs neither the repeated predicate as a join filter nor a null-aware key.

v1 recognized the repetition and dropped the predicate, but kept the key null-aware — and it is null-awareness that then reads a NULL of the unfiltered source and reports the answer as unknown. The two go together: both are now dropped when the correlation is the IN equality, in v1 and in v2, which kept both and paid for a filter that decides nothing.

Beyond the answer, the join loses work: the repeated predicate no longer runs per matching row, and without a null-aware key a distributed probe no longer replicates its nulls to every worker.

Differential Revision: D117034272


