### PR TITLE
misc: Advance Velox (#1759)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Axiom integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/54eed8163addcfff80649d200c045c7c144ee6fc...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/704b7036907c03ed0325a4a3db0d6bb7ddb4ac54...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that


### PR DESCRIPTION
Summary:

Moves the Velox pin from `82187f392` to `704b70369`, 24 commits.

Most of the range is Nimble work landing after the move into Velox: shared dictionary catalog schema, reader, config, encoding and writer, plus an external dictionary build tool and library, a file-features-to-properties rename, and a sync from fbcode. The rest is a materialized exchange implementation, torchwave CUDA-event stream ordering and common-subexpression elimination, packing `DirectCoalescedLoad` buffers into one shared allocation, and fixes to `RPCOperator::close()` input release, `LIKE` on truncated UTF-8 patterns, KLL sketch sizing, and cuDF batch concat.

Also refreshes the Velox compare link in `README.md`, which `scripts/check-velox-readme.sh` requires to match the submodule SHA. It had drifted to `54eed8163`, two pins behind.

No Axiom code changes.

Differential Revision: D117050982
