### PR TITLE
feat(v2): Decorrelate a subquery unnesting an outer array (#1761)

### DIFF
--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -505,7 +505,20 @@ class UnnestMatcher : public PlanMatcherImpl<UnnestNode> {
 
     AXIOM_TEST_RETURN_IF_FAILURE
 
-    return MatchResult::success();
+    // Only a replicated column keeps its identity across the unnest. An
+    // unnested one names the array below and its element above, so a symbol
+    // bound to it means something else here.
+    std::unordered_set<std::string> replicated;
+    for (const auto& variable : plan.replicateVariables()) {
+      replicated.insert(variable->name());
+    }
+    std::unordered_map<std::string, std::string> passedThrough;
+    for (const auto& [alias, name] : symbols) {
+      if (replicated.contains(name)) {
+        passedThrough.emplace(alias, name);
+      }
+    }
+    return MatchResult::success(std::move(passedThrough));
   }
 
  private:
@@ -1540,10 +1553,17 @@ class WindowMatcher : public PlanMatcherImpl<WindowNode> {
       const core::WindowCallExpr::Frame& expected,
       const std::unordered_map<std::string, std::string>& symbols,
       size_t index) const {
-    EXPECT_EQ(
-        WindowNode::toName(actual.type),
-        WindowNode::toName(toNodeWindowType(expected.type)))
-        << "Frame type mismatch at index " << index;
+    // ROWS and RANGE cover the same rows between unbounded bounds, so SQL
+    // spells such a frame either way and DuckDB keeps neither keyword.
+    const bool betweenUnboundedBounds =
+        actual.startType == WindowNode::BoundType::kUnboundedPreceding &&
+        actual.endType == WindowNode::BoundType::kUnboundedFollowing;
+    if (!betweenUnboundedBounds) {
+      EXPECT_EQ(
+          WindowNode::toName(actual.type),
+          WindowNode::toName(toNodeWindowType(expected.type)))
+          << "Frame type mismatch at index " << index;
+    }
 
     // Verify frame start bound.
     EXPECT_EQ(

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -16,6 +16,7 @@
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
 
 namespace facebook::axiom::optimizer {
 namespace {
@@ -1095,6 +1096,154 @@ TEST_P(UnnestTest, unnestPlacedAboveJoin) {
         planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
     AXIOM_ASSERT_DISTRIBUTED_PLAN(distributed.plan, matcher);
   }
+}
+
+// An UNNEST of the outer row's own array inside a correlated subquery. v1
+// cannot resolve the outer column there.
+TEST_P(UnnestTest, correlatedExists) {
+  testConnector_->addTable("t", ROW({"k", "a"}, {BIGINT(), ARRAY(BIGINT())}));
+
+  auto query =
+      "SELECT k, EXISTS (SELECT 1 FROM UNNEST(a) AS u(e) WHERE e > 15) AS m "
+      "FROM t";
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+
+  if (!useV2_) {
+    VELOX_ASSERT_THROW(
+        toSingleNodePlan(logicalPlan), "Cannot resolve column name: a");
+    return;
+  }
+
+  auto matcher =
+      matchScan("t")
+          .assignUniqueId("row_id")
+          .unnest({"k", "row_id"}, {"a"})
+          .aliases({"k", "row_id", "e", "marker"})
+          .project(
+              {"k", "row_id", "coalesce(marker and e > 15, false) as matched"})
+          .window(
+              {"bool_or(matched) OVER (PARTITION BY row_id) as any_match",
+               "row_number() OVER (PARTITION BY row_id ROWS BETWEEN "
+               "    UNBOUNDED PRECEDING AND CURRENT ROW) as ordinal"})
+          .filter("ordinal = 1")
+          .project({"k", "any_match"})
+          .build();
+
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+}
+
+// A LATERAL subquery unnesting the outer row's array. The subquery's FROM is
+// one empty row, which contributes no join.
+TEST_P(UnnestTest, lateralUnnest) {
+  testConnector_->addTable("t", ROW({"k", "a"}, {BIGINT(), ARRAY(BIGINT())}));
+
+  auto query =
+      "SELECT k, l.e FROM t, LATERAL (SELECT e FROM UNNEST(a) AS u(e) "
+      "WHERE e > 15) AS l";
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+
+  if (!useV2_) {
+    VELOX_ASSERT_THROW(
+        toSingleNodePlan(logicalPlan), "Unsupported PlanNode LATERAL_JOIN");
+    return;
+  }
+
+  auto matcher = matchScan("t").unnest({"k"}, {"a"}).filter("e > 15").build();
+
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+}
+
+// An IN whose subquery unnests the outer row's array is null-aware: an
+// element equal to the left side answers true, and a NULL that could hide a
+// match answers unknown.
+TEST_P(UnnestTest, inOverCorrelatedUnnest) {
+  testConnector_->addTable(
+      "t", ROW({"k", "v", "a"}, {BIGINT(), BIGINT(), ARRAY(BIGINT())}));
+
+  auto query = "SELECT k, v IN (SELECT e FROM UNNEST(a) AS u(e)) AS m FROM t";
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+
+  if (!useV2_) {
+    VELOX_ASSERT_THROW(
+        toSingleNodePlan(logicalPlan), "Cannot resolve column name: a");
+    return;
+  }
+
+  auto matcher =
+      matchScan("t")
+          .assignUniqueId("row_id")
+          .unnest({"k", "v", "row_id"}, {"a"})
+          .aliases({"k", "v", "row_id", "e", "marker"})
+          .project(
+              {"k",
+               "row_id",
+               "coalesce(marker and v = e, false) as matched",
+               "coalesce(marker and (v = e) is null, false) "
+               "as unknown"})
+          .window(
+              {"bool_or(matched) OVER (PARTITION BY row_id) as any_match",
+               "bool_or(unknown) OVER (PARTITION BY row_id) as any_unknown",
+               "row_number() OVER (PARTITION BY row_id ROWS BETWEEN "
+               "    UNBOUNDED PRECEDING AND CURRENT ROW) as ordinal"})
+          .filter("ordinal = 1")
+          .project(
+              {"k",
+               "case when any_match then true when any_unknown then null else false end"})
+          .build();
+
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+}
+
+// A LATERAL that selects only the unnested column. The outer columns reach no
+// consumer, so none is replicated.
+TEST_P(UnnestTest, lateralUnnestNarrowerOutput) {
+  testConnector_->addTable("t", ROW({"k", "a"}, {BIGINT(), ARRAY(BIGINT())}));
+
+  auto query =
+      "SELECT l.e FROM t, LATERAL (SELECT e FROM UNNEST(a) AS u(e)) AS l";
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+
+  if (!useV2_) {
+    VELOX_ASSERT_THROW(
+        toSingleNodePlan(logicalPlan), "Unsupported PlanNode LATERAL_JOIN");
+    return;
+  }
+
+  auto matcher = matchScan("t").unnest({}, {"a"}).build();
+
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+}
+
+// The subquery unnests the outer row's array alongside a relation, so its rows
+// are not one per element of that array. The peel drops the unnest's own
+// input, so it takes only a body that contributes no rows and no columns.
+TEST_P(UnnestTest, existsOverUnnestOfRelationNotSupported) {
+  testConnector_->addTable("t", ROW({"k", "a"}, {BIGINT(), ARRAY(BIGINT())}));
+  testConnector_->addTable("u", ROW("x", BIGINT()));
+
+  auto query =
+      "SELECT k, EXISTS (SELECT 1 FROM u, UNNEST(a) AS w(e) WHERE e > u.x) "
+      "FROM t";
+
+  VELOX_ASSERT_THROW(
+      toSingleNodePlan(parseSelect(query, kTestConnectorId)),
+      useV2_ ? "EXISTS over an Unnest of a relation is not yet implemented"
+             : "Cannot resolve column name: a");
+}
+
+// A LEFT JOIN LATERAL must keep an outer whose array is empty, which the
+// unnest lift does not do.
+TEST_P(UnnestTest, leftJoinLateralUnnestNotSupported) {
+  testConnector_->addTable("t", ROW({"k", "a"}, {BIGINT(), ARRAY(BIGINT())}));
+
+  auto query =
+      "SELECT k, l.e FROM t LEFT JOIN LATERAL "
+      "(SELECT e FROM UNNEST(a) AS u(e)) AS l ON true";
+
+  VELOX_ASSERT_THROW(
+      toSingleNodePlan(parseSelect(query, kTestConnectorId)),
+      useV2_ ? "a kLeft Apply over an Unnest body is not yet implemented"
+             : "Unsupported PlanNode LATERAL_JOIN");
 }
 
 AXIOM_INSTANTIATE_V1_V2(UnnestTest);

--- a/axiom/optimizer/tests/sql/unnest.sql
+++ b/axiom/optimizer/tests/sql/unnest.sql
@@ -111,3 +111,78 @@ FROM arrays AS t
 CROSS JOIN UNNEST(t.nested) AS n(b)
 CROSS JOIN UNNEST(n.b) AS m(c)
 JOIN (VALUES (1)) AS u(x) ON c = u.x
+----
+-- EXISTS over an UNNEST of the outer row's own array asks whether any element
+-- matches. An outer row whose array has no matching element answers false.
+-- error_v1: Cannot resolve column name: ys
+SELECT x, EXISTS (SELECT 1 FROM UNNEST(ys) AS _(y) WHERE y > 25) FROM arrays
+----
+-- The same over an array that is empty or NULL for some rows: those answer
+-- false rather than dropping out. DuckDB spells the empty array literal
+-- differently, so state the rows directly.
+-- error_v1: Cannot resolve column name: a
+-- duckdb: VALUES (1, true), (2, false), (3, false), (4, false)
+SELECT k, EXISTS (SELECT 1 FROM UNNEST(a) AS _(e) WHERE e > 15)
+FROM (VALUES
+  (1, ARRAY[10, 20]),
+  (2, ARRAY[10]),
+  (3, CAST(ARRAY[] AS ARRAY(INTEGER))),
+  (4, CAST(NULL AS ARRAY(INTEGER)))
+) AS s(k, a)
+----
+-- NOT EXISTS over the outer row's array. Only the row whose array holds a
+-- larger element is excluded.
+-- error_v1: Cannot resolve column name: ys
+SELECT x FROM arrays WHERE NOT EXISTS (SELECT 1 FROM UNNEST(ys) AS _(y) WHERE y > 35)
+----
+-- A LATERAL subquery unnesting the outer row's array, filtered on the
+-- unnested column.
+-- error_v1: Unsupported PlanNode LATERAL_JOIN
+SELECT x, y FROM arrays, LATERAL (SELECT e AS y FROM UNNEST(ys) AS _(e) WHERE e > 25) AS l
+----
+-- IN over the outer row's array is null-aware: true when an element equals
+-- the left side, unknown when a NULL element or a NULL left side could be
+-- hiding a match, and false when the array holds nothing at all.
+-- error_v1: Cannot resolve column name: a
+-- duckdb: VALUES (1, false), (2, true), (3, false), (4, NULL), (5, true), (6, NULL), (7, false)
+SELECT k, v IN (SELECT e FROM UNNEST(a) AS _(e))
+FROM (VALUES
+  (1, 99, ARRAY[10, 20]),
+  (2, 20, ARRAY[10, 20]),
+  (3, 5, CAST(ARRAY[] AS ARRAY(INTEGER))),
+  (4, 99, ARRAY[10, NULL]),
+  (5, 20, ARRAY[NULL, 20]),
+  (6, CAST(NULL AS INTEGER), ARRAY[10]),
+  (7, CAST(NULL AS INTEGER), CAST(ARRAY[] AS ARRAY(INTEGER)))
+) AS s(k, v, a)
+----
+-- IN over the outer row's array whose subquery predicate is unknown for some
+-- elements. An element the predicate neither accepts nor rejects is not in the
+-- subquery's result, so it cannot hide a match: the answer is unknown only when
+-- an element the predicate accepts is NULL, or the left side is NULL and the
+-- result holds anything at all. DuckDB unnests a single list only, so state the
+-- rows directly.
+-- error_v1: Cannot resolve column name: a
+-- duckdb: VALUES (1, true), (2, false), (3, NULL), (4, NULL), (5, false)
+SELECT k, v IN (SELECT e FROM UNNEST(a, b) AS _(e, f) WHERE f > 0)
+FROM (VALUES
+  (1, 20, ARRAY[20], ARRAY[1]),
+  (2, 20, ARRAY[20], CAST(ARRAY[NULL] AS ARRAY(INTEGER))),
+  (3, 99, CAST(ARRAY[NULL] AS ARRAY(INTEGER)), ARRAY[1]),
+  (4, CAST(NULL AS INTEGER), ARRAY[10], ARRAY[1]),
+  (5, CAST(NULL AS INTEGER), ARRAY[10], CAST(ARRAY[NULL] AS ARRAY(INTEGER)))
+) AS s(k, v, a, b)
+----
+-- The subquery's predicate reads the ordinality of the unnested element.
+-- DuckDB does not implement WITH ORDINALITY, so state the rows directly.
+-- error_v1: Cannot resolve column name: a
+-- duckdb: VALUES (1, true), (2, false)
+SELECT k, EXISTS (SELECT 1 FROM UNNEST(a) WITH ORDINALITY AS _(e, o) WHERE o = 2)
+FROM (VALUES (1, ARRAY[10, 20]), (2, ARRAY[30])) AS s(k, a)
+----
+-- Two arrays unnested together inside the subquery are zipped. DuckDB unnests
+-- a single list only, so state the rows directly.
+-- error_v1: Cannot resolve column name: a
+-- duckdb: VALUES (1, true), (2, false)
+SELECT k, EXISTS (SELECT 1 FROM UNNEST(a, b) AS _(e, f) WHERE e > f)
+FROM (VALUES (1, ARRAY[10, 20], ARRAY[5, 50]), (2, ARRAY[1], ARRAY[9])) AS s(k, a, b)

--- a/axiom/optimizer/v2/DecorrelatePass.cpp
+++ b/axiom/optimizer/v2/DecorrelatePass.cpp
@@ -141,6 +141,17 @@ bool isNullOnPadRows(ExprCP expr, const PlanObjectSet& bodyColumns) {
       !expr->containsFunction(FunctionSet::kNonDefaultNullBehavior);
 }
 
+// True if `node` is a `Values` with one row and no columns — what the FROM of
+// a subquery that selects only from an UNNEST lowers to. Joining with it
+// neither adds columns nor changes cardinality.
+bool isSingleEmptyRowValues(NodeCP node) {
+  if (!node->is(NodeType::kValues)) {
+    return false;
+  }
+  const Values* values = node->as<Values>();
+  return values->outputColumns().empty() && values->cardinality() == 1;
+}
+
 // Decorrelate pass implementation. The per-Apply loop:
 // recompute `correlationColumns` from body; if empty, hit terminus;
 // otherwise dispatch a peel rule by body's outermost operator and
@@ -203,6 +214,10 @@ class Decorrelator : public NodeRewriter<> {
 
       if (body->is(NodeType::kAssignUniqueId)) {
         return assignUniqueIdPeel(node, input, body, accumulatedFilter);
+      }
+
+      if (body->is(NodeType::kUnnest)) {
+        return unnestPeel(node, input, body, accumulatedFilter);
       }
 
       VELOX_NYI(
@@ -556,6 +571,25 @@ class Decorrelator : public NodeRewriter<> {
         FunctionSet{} | FunctionSet::kNonDeterministic |
             FunctionSet::kNonDefaultNullBehavior);
     return WindowFunction{call, Frame::toCurrentRow(), /*ignoreNulls=*/false};
+  }
+
+  // `bool_or(source)` over the whole partition, reading true when any row of
+  // the partition has it.
+  WindowFunction boolOrWindowFunction(ColumnCP source) {
+    const auto& boolOrName = FunctionRegistry::instance()->boolOr();
+    VELOX_USER_CHECK(
+        boolOrName.has_value(),
+        "Decorrelate requires bool_or registered via "
+        "FunctionRegistry::registerBoolOr");
+
+    // bool_or yields a BOOLEAN (two distinct values).
+    ExprCP call = builder().makeCall(
+        toName(*boolOrName),
+        Value(toType(velox::BOOLEAN()), /*cardinality=*/2),
+        ExprVector{source},
+        source->functions() | FunctionSet::kNonDeterministic |
+            FunctionSet::kNonDefaultNullBehavior);
+    return WindowFunction{call, Frame::wholePartition(), /*ignoreNulls=*/false};
   }
 
   // Wraps 'input' in a Window that emits `row_number() OVER
@@ -1031,20 +1065,28 @@ class Decorrelator : public NodeRewriter<> {
   }
 
   // Returns a Project that passes `input`'s columns through unchanged
-  // and appends `column` computed as `expr`.
-  NodeCP appendColumn(NodeCP input, ColumnCP column, ExprCP expr) {
+  // and appends `columns`, computed as the matching entry of `newExprs`.
+  NodeCP appendColumns(
+      NodeCP input,
+      const ColumnVector& columns,
+      const ExprVector& newExprs) {
+    VELOX_CHECK_EQ(columns.size(), newExprs.size());
     const auto& inputColumns = input->outputColumns();
 
     ExprVector exprs;
     ColumnVector outputs;
-    exprs.reserve(inputColumns.size() + 1);
-    outputs.reserve(inputColumns.size() + 1);
+    exprs.reserve(inputColumns.size() + columns.size());
+    outputs.reserve(inputColumns.size() + columns.size());
     appendAll(exprs, inputColumns);
     appendAll(outputs, inputColumns);
-    exprs.push_back(expr);
-    outputs.push_back(column);
+    appendAll(exprs, newExprs);
+    appendAll(outputs, columns);
     return builder().make<Project>(
         Project::Key{input, std::move(exprs), std::move(outputs)});
+  }
+
+  NodeCP appendColumn(NodeCP input, ColumnCP column, ExprCP expr) {
+    return appendColumns(input, ColumnVector{column}, ExprVector{expr});
   }
 
   // Window over PARTITION BY `partition` computing `anyMatch =
@@ -1056,24 +1098,8 @@ class Decorrelator : public NodeRewriter<> {
       ColumnCP marker,
       ColumnCP anyMatch,
       ColumnCP padOrdinal) {
-    const auto& boolOrName = FunctionRegistry::instance()->boolOr();
-    VELOX_USER_CHECK(
-        boolOrName.has_value(),
-        "Decorrelate kInner cross-join recovery requires bool_or "
-        "registered via FunctionRegistry::registerBoolOr");
-
-    // bool_or yields a BOOLEAN (two distinct values).
-    ExprCP boolOrCall = builder().makeCall(
-        toName(*boolOrName),
-        Value(toType(velox::BOOLEAN()), /*cardinality=*/2),
-        ExprVector{marker},
-        marker->functions() | FunctionSet::kNonDeterministic |
-            FunctionSet::kNonDefaultNullBehavior);
-
     WindowFunctions functions;
-    functions.push_back(
-        WindowFunction{
-            boolOrCall, Frame::wholePartition(), /*ignoreNulls=*/false});
+    functions.push_back(boolOrWindowFunction(marker));
     functions.push_back(rowNumberWindowFunction(padOrdinal));
 
     ColumnVector outputs;
@@ -1232,6 +1258,239 @@ class Decorrelator : public NodeRewriter<> {
     }
     return builder().make<Project>(Project::Key{
         filtered,
+        std::move(finalExprs),
+        node->outputColumns(),
+    });
+  }
+
+  // Rebuilds `unnestBody` over `input`, replicating every column `input`
+  // produces. A non-null `marker` makes it an outer Unnest, which keeps an
+  // input row whose unnested value is empty.
+  NodeCP
+  liftUnnestOver(const Unnest* unnestBody, NodeCP input, ColumnCP marker) {
+    ColumnVector replicated = input->outputColumns();
+    ColumnVector outputs = replicated;
+    for (const auto& columns : unnestBody->unnestColumns()) {
+      appendAll(outputs, columns);
+    }
+    if (unnestBody->withOrdinality()) {
+      outputs.push_back(unnestBody->ordinalityColumn());
+    }
+    if (marker != nullptr) {
+      outputs.push_back(marker);
+    }
+
+    return builder().make<Unnest>(Unnest::Key{
+        input,
+        unnestBody->unnestExpressions(),
+        std::move(replicated),
+        unnestBody->unnestColumns(),
+        unnestBody->ordinalityColumn(),
+        marker,
+        std::move(outputs),
+    });
+  }
+
+  // Unnest peel. An Unnest whose expressions read outer columns produces
+  // rows per outer row, which is what an Apply already means, so the Unnest
+  // lifts above the Apply and replicates the outer columns. Conjuncts
+  // reading a column the Unnest produces cannot go below the lift and stay
+  // above it.
+  //
+  // Only kInner lifts this way, since a plain Unnest drops an outer whose
+  // array is empty. kLeftSemiProject keeps such an outer with an outer Unnest
+  // and reduces per outer; see `unnestPeelSemi`. kLeft is not implemented.
+  NodeCP unnestPeel(
+      ApplyCP node,
+      NodeCP input,
+      NodeCP body,
+      ExprVector accumulatedFilter) {
+    if (node->isLeftSemiProject()) {
+      return unnestPeelSemi(node, input, body, accumulatedFilter);
+    }
+    if (!node->isInner()) {
+      VELOX_NYI(
+          "Decorrelate unnestPeel: a {} Apply over an Unnest body is not yet "
+          "implemented",
+          node->isLeft() ? "kLeft" : "semi-filter or anti");
+    }
+    const Unnest* unnestBody = body->as<Unnest>();
+    NodeCP newBody = unnestBody->input();
+
+    PlanObjectSet unnestedColumns;
+    for (const auto& columns : unnestBody->unnestColumns()) {
+      unnestedColumns.unionObjects(columns);
+    }
+    if (unnestBody->withOrdinality()) {
+      unnestedColumns.add(unnestBody->ordinalityColumn());
+    }
+
+    ExprVector innerFilter;
+    ExprVector liftedFilter;
+    for (ExprCP conjunct : accumulatedFilter) {
+      if (conjunct->columns().hasIntersection(unnestedColumns)) {
+        liftedFilter.push_back(conjunct);
+      } else {
+        innerFilter.push_back(conjunct);
+      }
+    }
+
+    ColumnVector innerOutputColumns;
+    innerOutputColumns.reserve(
+        input->outputColumns().size() + newBody->outputColumns().size());
+    appendAll(innerOutputColumns, input->outputColumns());
+    appendUnique(innerOutputColumns, newBody->outputColumns());
+
+    NodeCP innerApply = builder().make<Apply>(Apply::Key{
+        input,
+        newBody,
+        recomputeCorrelations(newBody, input->outputColumns()),
+        node->kind(),
+        std::move(innerFilter),
+        node->enforceSingleRow(),
+        node->markColumn(),
+        node->inLhs(),
+        node->inBodyKey(),
+        node->includeMarker(),
+        std::move(innerOutputColumns),
+    });
+
+    NodeCP decorrelatedInner = rewrite(innerApply);
+
+    NodeCP lifted = liftUnnestOver(
+        unnestBody, decorrelatedInner, unnestBody->markerColumn());
+    const ColumnVector unnestOutputs = lifted->outputColumns();
+
+    if (!liftedFilter.empty()) {
+      lifted =
+          builder().make<Filter>(Filter::Key{lifted, std::move(liftedFilter)});
+    }
+
+    // The lift carries every column the inner Apply produced, in its own
+    // order; the Apply's schema may differ in either.
+    if (unnestOutputs == node->outputColumns()) {
+      return lifted;
+    }
+    ExprVector finalExprs;
+    appendAll(finalExprs, node->outputColumns());
+    return builder().make<Project>(Project::Key{
+        lifted,
+        std::move(finalExprs),
+        node->outputColumns(),
+    });
+  }
+
+  // Unnest peel for kLeftSemiProject: `EXISTS (SELECT ... FROM UNNEST(a) ...)`
+  // asks whether any element of the outer row's array passes the filter.
+  //
+  // The lift is an outer Unnest, which keeps an outer whose array is empty and
+  // says so in its marker, so every outer reaches the answer. A row counts
+  // when it came from a real element and the filter accepts it; `bool_or` over
+  // an outer's rows turns that into the mark, and one row per outer survives.
+  NodeCP unnestPeelSemi(
+      ApplyCP node,
+      NodeCP input,
+      NodeCP body,
+      const ExprVector& accumulatedFilter) {
+    VELOX_CHECK(
+        !node->enforceSingleRow(),
+        "A kLeftSemiProject Apply does not assert a single row");
+
+    const Unnest* unnestBody = body->as<Unnest>();
+    if (!isSingleEmptyRowValues(unnestBody->input())) {
+      VELOX_NYI(
+          "Decorrelate unnestPeel: EXISTS over an Unnest of a relation is not "
+          "yet implemented; only over the subquery's own row is");
+    }
+
+    ColumnCP rowId = makeIdColumn();
+    NodeCP tagged = tagOuterRows(input, rowId);
+
+    ColumnCP marker = makeIncludeColumn();
+    NodeCP expanded = liftUnnestOver(unnestBody, tagged, marker);
+
+    // A row of `expanded` is an element of this outer's array when the marker
+    // says it came from a value and the subquery's own predicates accept it.
+    ExprCP qualifies = marker;
+    for (ExprCP conjunct : accumulatedFilter) {
+      qualifies = exprFactory_.makeAnd(qualifies, conjunct);
+    }
+
+    if (!node->nullAware()) {
+      PerOuterMatch perOuter = markPerOuter(expanded, rowId, qualifies);
+      return markOnePerOuter(
+          node, perOuter.node, perOuter.padOrdinal, perOuter.anyMatch);
+    }
+
+    // IN is null-aware: true when an element equals the left side, false when
+    // no element does and no comparison was unknown, and unknown otherwise —
+    // a NULL element or a NULL left side could be hiding a match. An empty
+    // array has no comparison at all, so it reads false.
+    ExprCP equality = exprFactory_.makeEq(node->inLhs(), node->inBodyKey());
+    const Literal* falseLiteral = builder().makeBoolean(false);
+    ColumnCP matchRow = Column::createBoolean("__in_match");
+    ColumnCP unknownRow = Column::createBoolean("__in_unknown");
+    NodeCP compared = appendColumns(
+        expanded,
+        ColumnVector{matchRow, unknownRow},
+        ExprVector{
+            exprFactory_.makeCoalesce(
+                exprFactory_.makeAnd(qualifies, equality), falseLiteral),
+            exprFactory_.makeCoalesce(
+                exprFactory_.makeAnd(
+                    qualifies, exprFactory_.makeIsNull(equality)),
+                falseLiteral)});
+
+    ColumnCP anyMatch = Column::createBoolean("__any_match");
+    ColumnCP anyUnknown = Column::createBoolean("__any_unknown");
+    ColumnCP padOrdinal = makeIdColumn("__pad_rn");
+
+    WindowFunctions functions;
+    functions.push_back(boolOrWindowFunction(matchRow));
+    functions.push_back(boolOrWindowFunction(unknownRow));
+    functions.push_back(rowNumberWindowFunction(padOrdinal));
+
+    ColumnVector windowOutputs;
+    windowOutputs.reserve(compared->outputColumns().size() + 3);
+    appendAll(windowOutputs, compared->outputColumns());
+    windowOutputs.push_back(anyMatch);
+    windowOutputs.push_back(anyUnknown);
+    windowOutputs.push_back(padOrdinal);
+
+    NodeCP windowed = builder().make<Window>(Window::Key{
+        compared,
+        std::move(functions),
+        ExprVector{rowId},
+        /*orderKeys=*/{},
+        /*orderTypes=*/{},
+        std::move(windowOutputs),
+    });
+
+    ExprCP mark = exprFactory_.makeSwitch(
+        {{anyMatch, builder().makeBoolean(true)},
+         {anyUnknown, builder().makeNull(toType(velox::BOOLEAN()))}},
+        falseLiteral);
+    return markOnePerOuter(node, windowed, padOrdinal, mark);
+  }
+
+  // Keeps one row per outer and projects the Apply's schema, reading `mark`
+  // for its mark column.
+  NodeCP markOnePerOuter(
+      ApplyCP node,
+      NodeCP input,
+      ColumnCP padOrdinal,
+      ExprCP mark) {
+    NodeCP oneRowPerOuter = builder().make<Filter>(
+        Filter::Key{input, ExprVector{isFirstRowOfOuter(padOrdinal)}});
+
+    ExprVector finalExprs;
+    finalExprs.reserve(node->outputColumns().size());
+    for (ColumnCP outputColumn : node->outputColumns()) {
+      finalExprs.push_back(
+          outputColumn == node->markColumn() ? mark : outputColumn);
+    }
+    return builder().make<Project>(Project::Key{
+        oneRowPerOuter,
         std::move(finalExprs),
         node->outputColumns(),
     });
@@ -2012,8 +2271,17 @@ class Decorrelator : public NodeRewriter<> {
     });
   }
 
-  NodeCP
-  terminusInner(ApplyCP apply, NodeCP input, NodeCP body, ExprVector filter) {
+  NodeCP terminusInner(
+      ApplyCP apply,
+      NodeCP input,
+      NodeCP body,
+      const ExprVector& filter) {
+    // A body that is one empty row contributes nothing to join, so the
+    // Apply is its input.
+    if (filter.empty() && isSingleEmptyRowValues(body)) {
+      return input;
+    }
+
     // Plain INNER JOIN: no cardinality assertion, no include marker. Body and
     // input columns are disjoint (correlation columns live on the Apply, not
     // in body output), so the output is input ++ body with no collision.

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -1531,13 +1531,18 @@ velox::core::PlanNodePtr Emitter::emitUnnest(const Unnest& unnest) {
     ordinalityName = unnest.ordinalityColumn()->outputName();
   }
 
+  std::optional<std::string> markerName;
+  if (unnest.isOuter()) {
+    markerName = unnest.markerColumn()->outputName();
+  }
+
   return std::make_shared<velox::core::UnnestNode>(
       nextId(),
       std::move(replicateVariables),
       std::move(unnestVariables),
       std::move(unnestNames),
       ordinalityName,
-      /*markerName=*/std::nullopt,
+      markerName,
       std::move(input));
 }
 

--- a/axiom/optimizer/v2/ExprFactory.cpp
+++ b/axiom/optimizer/v2/ExprFactory.cpp
@@ -156,6 +156,27 @@ ExprCP ExprFactory::makeIf(ExprCP condition, ExprCP thenExpr, ExprCP elseExpr) {
       ifName, resultValue, std::move(arguments), functions);
 }
 
+ExprCP ExprFactory::makeSwitch(
+    const std::vector<std::pair<ExprCP, ExprCP>>& when,
+    ExprCP elseExpr) {
+  VELOX_CHECK(!when.empty(), "makeSwitch requires at least one condition");
+
+  ExprVector arguments;
+  arguments.reserve(when.size() * 2 + 1);
+  for (const auto& [condition, result] : when) {
+    arguments.push_back(condition);
+    arguments.push_back(result);
+  }
+  arguments.push_back(elseExpr);
+
+  const Name switchName = SpecialFormCallNames::kSwitch;
+  const Value resultValue = when.front().second->value();
+  const FunctionSet functions = Call::unionArgFunctions(
+      functionBits(switchName, /*specialForm=*/true), arguments);
+  return builder_.makeCall(
+      switchName, resultValue, std::move(arguments), functions);
+}
+
 namespace {
 
 // Rebuilds `call` with each argument replaced, sharing the original

--- a/axiom/optimizer/v2/ExprFactory.h
+++ b/axiom/optimizer/v2/ExprFactory.h
@@ -92,6 +92,14 @@ class ExprFactory {
   /// does not verify.
   ExprCP makeIf(ExprCP condition, ExprCP thenExpr, ExprCP elseExpr);
 
+  /// Builds `switch(when[0].first, when[0].second, ..., elseExpr)`, reading
+  /// the result of the first `when` whose condition holds. Every result and
+  /// `elseExpr` must be the same type per Velox's SWITCH rules; the factory
+  /// does not verify. `when` must be non-empty.
+  ExprCP makeSwitch(
+      const std::vector<std::pair<ExprCP, ExprCP>>& when,
+      ExprCP elseExpr);
+
   /// Maps a subexpression to what it should be replaced by.
   using ExprSubstitution = folly::F14FastMap<ExprCP, ExprCP>;
 

--- a/axiom/optimizer/v2/JoinTreeEmitter.cpp
+++ b/axiom/optimizer/v2/JoinTreeEmitter.cpp
@@ -309,6 +309,9 @@ Emitted buildUnnest(const UnnestOp* unnest, Emitted input, EmitState& state) {
   if (origUnnest->ordinalityColumn() != nullptr) {
     outputColumns.push_back(origUnnest->ordinalityColumn());
   }
+  if (origUnnest->isOuter()) {
+    outputColumns.push_back(origUnnest->markerColumn());
+  }
 
   NodeCP node = state.builder.make<Unnest>(Unnest::Key{
       input.node,
@@ -316,6 +319,7 @@ Emitted buildUnnest(const UnnestOp* unnest, Emitted input, EmitState& state) {
       std::move(replicatedColumns),
       origUnnest->unnestColumns(),
       origUnnest->ordinalityColumn(),
+      origUnnest->markerColumn(),
       std::move(outputColumns)});
 
   if (!predicates.empty()) {

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -1096,6 +1096,13 @@ Values::Values(Key key)
   }
 }
 
+size_t Values::cardinality() const {
+  if (rows_ != nullptr) {
+    return rows_->array().size();
+  }
+  return source_ != nullptr ? source_->cardinality() : 0;
+}
+
 size_t Values::KeyHash::operator()(const Values* node) const {
   return hashOf(
       node->source(), node->rows(), node->outputColumns(), node->channels());
@@ -1133,7 +1140,8 @@ Unnest::Unnest(Key key)
       unnestExpressions_(std::move(key.unnestExpressions)),
       replicatedColumns_(std::move(key.replicatedColumns)),
       unnestColumns_(std::move(key.unnestColumns)),
-      ordinalityColumn_(key.ordinalityColumn) {
+      ordinalityColumn_(key.ordinalityColumn),
+      markerColumn_(key.markerColumn) {
   VELOX_CHECK_NOT_NULL(input_);
   VELOX_CHECK(
       !unnestExpressions_.empty(), "Unnest must have at least one expression");
@@ -1177,6 +1185,13 @@ Unnest::Unnest(Key key)
   if (ordinalityColumn_ != nullptr) {
     produced.add(ordinalityColumn_);
   }
+  if (markerColumn_ != nullptr) {
+    VELOX_CHECK_EQ(
+        markerColumn_->value().type->kind(),
+        velox::TypeKind::BOOLEAN,
+        "Unnest markerColumn must be BOOLEAN");
+    produced.add(markerColumn_);
+  }
 
   for (ColumnCP column : this->outputColumns()) {
     VELOX_CHECK(
@@ -1193,6 +1208,9 @@ Unnest::Unnest(Key key)
   VELOX_CHECK(
       ordinalityColumn_ == nullptr || outputSet.contains(ordinalityColumn_),
       "Unnest ordinalityColumn must appear in outputColumns");
+  VELOX_CHECK(
+      markerColumn_ == nullptr || outputSet.contains(markerColumn_),
+      "Unnest markerColumn must appear in outputColumns");
 }
 
 size_t Unnest::KeyHash::operator()(const Unnest* node) const {
@@ -1201,7 +1219,8 @@ size_t Unnest::KeyHash::operator()(const Unnest* node) const {
       node->unnestExpressions(),
       node->outputColumns(),
       node->replicatedColumns(),
-      node->ordinalityColumn());
+      node->ordinalityColumn(),
+      node->markerColumn());
   const auto& unnestColumns = node->unnestColumns();
   for (size_t idx = 0; idx < unnestColumns.size(); ++idx) {
     // Mix idx and inner size to break symmetry across index permutations
@@ -1221,7 +1240,8 @@ size_t Unnest::KeyHash::operator()(const Key& key) const {
       key.unnestExpressions,
       key.outputColumns,
       key.replicatedColumns,
-      key.ordinalityColumn);
+      key.ordinalityColumn,
+      key.markerColumn);
   const auto& unnestColumns = key.unnestColumns;
   for (size_t idx = 0; idx < unnestColumns.size(); ++idx) {
     // Mix idx and inner size to break symmetry across index permutations
@@ -1241,6 +1261,7 @@ bool Unnest::KeyEq::operator()(const Unnest* left, const Unnest* right) const {
       left->replicatedColumns() == right->replicatedColumns() &&
       left->unnestColumns() == right->unnestColumns() &&
       left->ordinalityColumn() == right->ordinalityColumn() &&
+      left->markerColumn() == right->markerColumn() &&
       left->outputColumns() == right->outputColumns();
 }
 
@@ -1250,6 +1271,7 @@ bool Unnest::KeyEq::operator()(const Key& key, const Unnest* node) const {
       key.replicatedColumns == node->replicatedColumns() &&
       key.unnestColumns == node->unnestColumns() &&
       key.ordinalityColumn == node->ordinalityColumn() &&
+      key.markerColumn == node->markerColumn() &&
       key.outputColumns == node->outputColumns();
 }
 

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -926,6 +926,10 @@ class Values : public Node {
     return channels_;
   }
 
+  /// Number of rows this produces, whether they are held as folded row
+  /// `Variant`s or by the logical node.
+  size_t cardinality() const;
+
   std::span<const NodeCP> inputs() const override {
     return {};
   }
@@ -941,12 +945,14 @@ class Values : public Node {
 
 using ValuesCP = const Values*;
 
-/// Expands array / map expressions row-wise. The output has three disjoint
+/// Expands array / map expressions row-wise. The output has four disjoint
 /// kinds of columns, exposed as separate accessors so consumers never need
 /// positional decoding: `replicatedColumns` (pass-through input columns),
-/// `unnestColumns[i]` (per-expression result columns), and the optional
-/// `ordinalityColumn`. `outputColumns()` returns the concatenation in that
-/// order, for downstream consumers that need a single vector view.
+/// `unnestColumns[i]` (per-expression result columns), the optional
+/// `ordinalityColumn`, and the optional `markerColumn`, which keeps an input
+/// row whose unnested value is empty. `outputColumns()` returns the
+/// concatenation in that order, for downstream consumers that need a single
+/// vector view.
 class Unnest : public Node {
  public:
   struct Key {
@@ -962,10 +968,17 @@ class Unnest : public Node {
     /// Optional ordinality column; null when this node does not produce
     /// ordinality.
     ColumnCP ordinalityColumn;
+    /// Optional BOOLEAN marker column. When set, an input row whose unnested
+    /// value is empty or NULL still produces one output row, with the marker
+    /// false and every unnest result column NULL; the marker is true on rows
+    /// that came from a value. When null, such an input row produces no
+    /// output row.
+    ColumnCP markerColumn;
     /// Visible schema. Every `Column*` here is a `replicatedColumns` column, a
-    /// column in some `unnestColumns[i]`, or `ordinalityColumn`. All
-    /// `replicatedColumns` and `ordinalityColumn` must appear; only
-    /// per-expression `unnestColumns` may be pruned out.
+    /// column in some `unnestColumns[i]`, `ordinalityColumn`, or
+    /// `markerColumn`. All `replicatedColumns`, `ordinalityColumn` and
+    /// `markerColumn` must appear; only per-expression `unnestColumns` may be
+    /// pruned out.
     ColumnVector outputColumns;
   };
 
@@ -1010,6 +1023,16 @@ class Unnest : public Node {
     return ordinalityColumn_ != nullptr;
   }
 
+  ColumnCP markerColumn() const {
+    return markerColumn_;
+  }
+
+  /// True if an input row with an empty or NULL unnested value still
+  /// produces an output row. See `Key::markerColumn`.
+  bool isOuter() const {
+    return markerColumn_ != nullptr;
+  }
+
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
@@ -1023,6 +1046,7 @@ class Unnest : public Node {
   const ColumnVector replicatedColumns_;
   const QGVector<ColumnVector> unnestColumns_;
   const ColumnCP ordinalityColumn_;
+  const ColumnCP markerColumn_;
 };
 
 using UnnestCP = const Unnest*;

--- a/axiom/optimizer/v2/NodeRewriter.h
+++ b/axiom/optimizer/v2/NodeRewriter.h
@@ -222,6 +222,7 @@ class NodeRewriter {
          node->replicatedColumns(),
          node->unnestColumns(),
          node->ordinalityColumn(),
+         node->markerColumn(),
          node->outputColumns()});
   }
 

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
@@ -675,14 +675,16 @@ NodeCP Rewriter::rewriteUnnest(const Unnest* unnest, NoContext& context) {
     newUnnestExprs.push_back(precompute.toColumn(expr));
   }
   newInput = std::move(precompute).node();
-  // Structured fields (replicatedColumns / unnestColumns / ordinalityColumn)
-  // are by Column*; precompute preserves Column identity so they stay valid.
+  // Structured fields (replicatedColumns / unnestColumns / ordinalityColumn /
+  // markerColumn) are by Column*; precompute preserves Column identity so they
+  // stay valid.
   return builder().make<Unnest>(
       {newInput,
        std::move(newUnnestExprs),
        unnest->replicatedColumns(),
        unnest->unnestColumns(),
        unnest->ordinalityColumn(),
+       unnest->markerColumn(),
        unnest->outputColumns()});
 }
 

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -1394,12 +1394,20 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     if (node->ordinalityColumn() != nullptr) {
       outputOnlyColumns.add(node->ordinalityColumn());
     }
+    if (node->isOuter()) {
+      outputOnlyColumns.add(node->markerColumn());
+    }
     auto [pushable, blocked] = partition(context.pending, outputOnlyColumns);
 
     // Columns this Unnest must still produce: those the consumer requires plus
-    // the columns read by conjuncts that stay above.
+    // the columns read by conjuncts that stay above. The marker keeps the rows
+    // of an empty unnested value rather than carrying a value of its own, so
+    // dropping it would drop those rows; keep it whether or not it is read.
     PlanObjectSet outputsKept = context.required;
     outputsKept.unionColumns(blocked);
+    if (node->isOuter()) {
+      outputsKept.add(node->markerColumn());
+    }
 
     // Drop the replicated (pass-through) columns and ordinality column the
     // consumer no longer needs. These must leave the replicated/ordinality
@@ -1417,6 +1425,8 @@ class Pushdown : public NodeRewriter<PushdownContext> {
             outputsKept.contains(node->ordinalityColumn())
         ? node->ordinalityColumn()
         : nullptr;
+
+    ColumnCP survivingMarker = node->markerColumn();
 
     PushdownContext childContext =
         makeChildContext(std::move(pushable), context);
@@ -1445,6 +1455,7 @@ class Pushdown : public NodeRewriter<PushdownContext> {
                                       std::move(survivingReplicated),
                                       node->unnestColumns(),
                                       survivingOrdinality,
+                                      survivingMarker,
                                       std::move(survivingOutputs)});
     return maybeWrapFilter(newNode, std::move(blocked));
   }

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -1862,6 +1862,7 @@ Translated Translator::translateUnnest(
        std::move(replicatedColumns),
        std::move(unnestColumns),
        ordinalityColumn,
+       /*markerColumn=*/nullptr,
        std::move(outputColumns)});
   return {unnestNode, std::move(newScope)};
 }


### PR DESCRIPTION
Summary:

A subquery unnesting the outer row's own array failed to plan:

    SELECT x, EXISTS (SELECT 1 FROM UNNEST(ys) AS _(y) WHERE y > 25) FROM arrays

    Correlated reference inside a Unnest branch is not supported yet

An Unnest of an outer array produces rows per outer row, which is what an Apply already means, so the Unnest lifts above the Apply and replicates the outer columns. An `EXISTS` needs one row per outer instead: the lift keeps an outer whose array is empty, `bool_or` over an outer's rows answers the mark, and one row per outer survives. An `IN` asks whether an element equals the left side and answers `NULL` when a NULL element or a NULL left side could be hiding a match, which a second `bool_or` over the unknown comparisons tells apart from a plain miss.

Keeping an outer whose array is empty needs the marker column Velox's `UnnestNode` already accepts, which `Unnest` now models. Pruning keeps that marker whether or not anything reads it, since it decides which rows the unnest emits rather than carrying a value.

Deferred, each failing loud: a `LEFT JOIN LATERAL`, whose outer must survive a filter that empties its array, and an `EXISTS` whose subquery unnests alongside a relation, which the lift cannot drop.

Also collapses a join with a subquery's empty FROM, which is one row of no columns and joins to nothing.

Differential Revision: D117099586


