### PR TITLE
feat(cli): Add a hook to reject plans before execution (#1764)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -263,6 +263,7 @@ void SqlQueryRunner::initialize(
     const std::function<std::pair<std::string, std::string>()>&
         initializeConnectors,
     PermissionCheck permissionCheck,
+    LogicalPlanCheck logicalPlanCheck,
     std::function<std::string()> queryIdGenerator) {
   static folly::once_flag kInitialized;
 
@@ -296,6 +297,7 @@ void SqlQueryRunner::initialize(
   defaultSchema_ = std::move(defaultSchema);
 
   permissionCheck_ = std::move(permissionCheck);
+  logicalPlanCheck_ = std::move(logicalPlanCheck);
 
   if (queryIdGenerator) {
     queryIdGenerator_ = std::move(queryIdGenerator);
@@ -973,6 +975,7 @@ SqlQueryRunner::co_runExplainStatement(
 
   logical_plan::LogicalPlanNodePtr logicalPlan;
   std::shared_ptr<connector::SchemaResolver> schemaResolver;
+  const presto::CreateTableAsSelectStatement* ctas{nullptr};
 
   if (statement->isSelect()) {
     logicalPlan = statement->as<presto::SelectStatement>()->plan();
@@ -981,16 +984,8 @@ SqlQueryRunner::co_runExplainStatement(
   } else if (statement->isDelete()) {
     logicalPlan = statement->as<presto::DeleteStatement>()->plan();
   } else if (statement->isCreateTableAsSelect()) {
-    const auto* ctas = statement->as<presto::CreateTableAsSelectStatement>();
+    ctas = statement->as<presto::CreateTableAsSelectStatement>();
     logicalPlan = ctas->plan();
-
-    // EXPLAIN ANALYZE runs the query for real, so createTable must not
-    // be in explain mode. Regular EXPLAIN must be side-effect-free.
-    auto table = createTable(queryId, *ctas, /*explain=*/!explain.isAnalyze());
-    schemaResolver = std::make_shared<connector::SchemaResolver>(
-        connector::ConnectorMetadataRegistry::global());
-    schemaResolver->setTargetTable(
-        ctas->connectorId(), ctas->tableName(), table);
   } else if (statement->isCreateTable()) {
     const auto* create = statement->as<presto::CreateTableStatement>();
     createTable(queryId, *create, /*explain=*/true);
@@ -1083,6 +1078,18 @@ SqlQueryRunner::co_runExplainStatement(
     VELOX_NYI("Unsupported EXPLAIN query: {}", statement->kindName());
   }
 
+  // EXPLAIN ANALYZE is the only EXPLAIN that runs the query. The others are
+  // side-effect-free: they skip the check so they stay usable for diagnosing a
+  // rejected query, and create the target table in explain mode.
+  if (explain.isAnalyze()) {
+    checkLogicalPlan(*logicalPlan);
+  }
+
+  if (ctas != nullptr) {
+    schemaResolver =
+        createTargetTable(queryId, *ctas, /*explain=*/!explain.isAnalyze());
+  }
+
   if (explain.type() == presto::ExplainStatement::Type::kIo) {
     co_yield SqlResultChunk{runExplainIo(
         *statement,
@@ -1122,15 +1129,10 @@ SqlQueryRunner::co_runPlanStatement(
   logical_plan::LogicalPlanNodePtr logicalPlan;
   std::shared_ptr<connector::SchemaResolver> schemaResolver;
   velox::RowTypePtr emptyResultType;
+  const presto::CreateTableAsSelectStatement* ctas{nullptr};
 
   if (sqlStatement.isCreateTableAsSelect()) {
-    const auto* ctas = sqlStatement.as<presto::CreateTableAsSelectStatement>();
-    auto table = createTable(queryId, *ctas);
-
-    schemaResolver = std::make_shared<connector::SchemaResolver>(
-        connector::ConnectorMetadataRegistry::global());
-    schemaResolver->setTargetTable(
-        ctas->connectorId(), ctas->tableName(), table);
+    ctas = sqlStatement.as<presto::CreateTableAsSelectStatement>();
     logicalPlan = ctas->plan();
   } else if (sqlStatement.isInsert()) {
     logicalPlan = sqlStatement.as<presto::InsertStatement>()->plan();
@@ -1141,6 +1143,14 @@ SqlQueryRunner::co_runPlanStatement(
     emptyResultType = logicalPlan->outputType();
   } else {
     VELOX_UNREACHABLE("Unexpected plan statement: {}", sqlStatement.kindName());
+  }
+
+  // Runs before the CTAS below creates its target table, so a rejected CTAS
+  // leaves nothing behind.
+  checkLogicalPlan(*logicalPlan);
+
+  if (ctas != nullptr) {
+    schemaResolver = createTargetTable(queryId, *ctas, /*explain=*/false);
   }
 
   auto generator = co_runLogicalPlan(
@@ -1560,6 +1570,8 @@ SqlQueryRunner::executeSelectOrInsert(
         statement.kindName());
   }
 
+  checkLogicalPlan(*logicalPlan);
+
   auto queryCtx = newQuery(options);
   auto planAndStats = optimize(logicalPlan, queryCtx, options);
   return makeLocalRunner(planAndStats, queryCtx, options, noopRuntimeStats_);
@@ -1812,6 +1824,24 @@ SqlQueryRunner::makeOptimizerSession(
       std::move(connectorProperties));
 }
 
+void SqlQueryRunner::checkLogicalPlan(
+    const logical_plan::LogicalPlanNode& logicalPlan) const {
+  if (logicalPlanCheck_) {
+    logicalPlanCheck_(logicalPlan);
+  }
+}
+
+std::shared_ptr<connector::SchemaResolver> SqlQueryRunner::createTargetTable(
+    std::string_view queryId,
+    const presto::CreateTableAsSelectStatement& ctas,
+    bool explain) {
+  auto table = createTable(queryId, ctas, explain);
+  auto schemaResolver = std::make_shared<connector::SchemaResolver>(
+      connector::ConnectorMetadataRegistry::global());
+  schemaResolver->setTargetTable(ctas.connectorId(), ctas.tableName(), table);
+  return schemaResolver;
+}
+
 optimizer::PlanAndStats SqlQueryRunner::optimize(
     const logical_plan::LogicalPlanNodePtr& logicalPlan,
     const std::shared_ptr<velox::core::QueryCtx>& queryCtx,
@@ -1961,6 +1991,9 @@ SqlQueryRunner::co_showSession(
   // destroys co_await-operand temporaries at the suspension point.
   auto plan = showSessionPlan(*sessionConfig_, defaultConnectorId_, statement);
   auto resultType = plan->outputType();
+  // Not checked: this plan is built from the session config rather than parsed
+  // from the statement, so a blocklist match would name a feature the user did
+  // not write and cannot rephrase.
   auto generator = co_runLogicalPlan(plan, options, timing, planString);
   bool yieldedBatch{false};
   while (auto batch = co_await generator.next()) {

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -50,6 +50,21 @@ using PermissionCheck =
         const facebook::axiom::logical_plan::ReferencedTables&
             referencedTables)>;
 
+/// Validates a logical plan before optimization and throws to reject a query
+/// the deployment cannot execute. Runs before the optimizer, so it observes
+/// expressions the optimizer would later constant-fold away.
+///
+/// Offered every statement that executes a plan the user wrote: SELECT,
+/// INSERT, DELETE, CREATE TABLE AS SELECT, and EXPLAIN ANALYZE. Not offered
+/// EXPLAIN in any other form, which does not execute and stays usable for
+/// diagnosing a rejected query, nor SHOW SESSION, whose plan the runner builds
+/// from the session config rather than parsing it from the statement.
+///
+/// An empty value disables checking. A single instance serves every query and
+/// is called from planner threads, so implementations must be thread-safe.
+using LogicalPlanCheck =
+    std::function<void(const facebook::axiom::logical_plan::LogicalPlanNode&)>;
+
 /// Holds query metadata captured at query start time.
 struct QueryStartInfo {
   /// Unique identifier for this query execution.
@@ -222,13 +237,15 @@ class SqlQueryRunner {
     return progressScheduler_ != nullptr;
   }
 
-  /// Initializes the runner with connectors, an optional permission check, and
-  /// a query ID generator (defaults to QueryIdGenerator if not provided).
-  /// Call once before running queries.
+  /// Initializes the runner with connectors, an optional permission check, an
+  /// optional logical plan check that rejects plans the deployment cannot
+  /// execute, and a query ID generator (defaults to QueryIdGenerator if not
+  /// provided). Call once before running queries.
   void initialize(
       const std::function<std::pair<std::string, std::string>()>&
           initializeConnectors,
       PermissionCheck permissionCheck = {},
+      LogicalPlanCheck logicalPlanCheck = {},
       std::function<std::string()> queryIdGenerator = {});
 
   struct RunOptions {
@@ -414,8 +431,9 @@ class SqlQueryRunner {
   SqlResult run(std::string_view sql, const RunOptions& options);
 
   /// Runs a single parsed SQL statement without lifecycle hooks (no permission
-  /// check, no callbacks). Use run(string_view, RunOptions) for the full
-  /// lifecycle.
+  /// check, no callbacks). The logical plan check still applies: it is a
+  /// correctness gate rather than a lifecycle hook, so no entry point skips
+  /// it. Use run(string_view, RunOptions) for the full lifecycle.
   SqlResult runUnchecked(
       const presto::SqlStatement& statement,
       const RunOptions& options);
@@ -526,6 +544,21 @@ class SqlQueryRunner {
       QueryCompletionInfo& completionInfo,
       const presto::ViewMap& views,
       const facebook::axiom::logical_plan::ReferencedTables& referencedTables);
+
+  // Invokes the configured LogicalPlanCheck, which see for the statements
+  // that reach it. Called before CTAS creates its target table, so a rejected
+  // query leaves nothing behind. No-op when no check is installed.
+  void checkLogicalPlan(
+      const facebook::axiom::logical_plan::LogicalPlanNode& logicalPlan) const;
+
+  // Creates the CTAS target table and returns a SchemaResolver pointed at it.
+  // 'explain' makes the creation a dry run, for the EXPLAIN forms that do not
+  // run the query. Callers that execute must call checkLogicalPlan() first: a
+  // rejected CTAS must not leave an empty table behind.
+  std::shared_ptr<facebook::axiom::connector::SchemaResolver> createTargetTable(
+      std::string_view queryId,
+      const presto::CreateTableAsSelectStatement& ctas,
+      bool explain);
 
   std::shared_ptr<facebook::velox::core::QueryCtx> newQuery(
       const RunOptions& options);
@@ -684,6 +717,9 @@ class SqlQueryRunner {
 
   // Permission check callback invoked before query execution.
   PermissionCheck permissionCheck_;
+
+  // Logical plan check invoked before execution. Empty installs no check.
+  LogicalPlanCheck logicalPlanCheck_;
 
   // Generates unique query IDs.
   std::function<std::string()> queryIdGenerator_;

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -1355,6 +1355,65 @@ TEST_F(SqlQueryRunnerTest, call) {
       "Cannot coerce procedure argument from VARCHAR to BIGINT");
 }
 
+TEST_F(SqlQueryRunnerTest, logicalPlanCheck) {
+  using facebook::axiom::logical_plan::LogicalPlanNode;
+  using facebook::axiom::logical_plan::NodeKind;
+
+  // Rejects a plan that still names TIMESTAMP WITH TIME ZONE, which the
+  // optimizer folds away, or that writes a table.
+  int32_t numChecks{0};
+  runner_ = makeRunner(
+      "plan_check",
+      /*queryIdGenerator=*/{},
+      /*permissionCheck=*/{},
+      [&](const LogicalPlanNode& plan) {
+        ++numChecks;
+        if (plan.toString().find("TIMESTAMP WITH TIME ZONE") !=
+                std::string::npos ||
+            plan.is(NodeKind::kTableWrite)) {
+          VELOX_USER_FAIL("blocked by test check");
+        }
+      });
+
+  for (const auto* sql : {"SELECT 1", "EXPLAIN ANALYZE SELECT 1"}) {
+    SCOPED_TRACE(sql);
+    numChecks = 0;
+    run(sql);
+    EXPECT_EQ(numChecks, 1);
+  }
+
+  // The cast reaches the check, so the rejection makes it back to the caller.
+  // The optimized plan carries only the folded literal.
+  numChecks = 0;
+  VELOX_ASSERT_THROW(
+      run("SELECT to_unixtime(TIMESTAMP '2026-07-28 18:30:00 Asia/Bangkok')"),
+      "blocked by test check");
+  EXPECT_EQ(numChecks, 1);
+
+  // A rejected CTAS leaves no target table, on the plain path and on the
+  // EXPLAIN ANALYZE one, which creates the table for real. SHOW TABLES carries
+  // neither trigger, so it answers on its own merits.
+  for (const auto* sql :
+       {"CREATE TABLE t AS SELECT 1 AS x",
+        "EXPLAIN ANALYZE CREATE TABLE t AS SELECT 1 AS x"}) {
+    SCOPED_TRACE(sql);
+    VELOX_ASSERT_THROW(run(sql), "blocked by test check");
+    // SHOW TABLES yields no batches at all when the schema is empty.
+    EXPECT_THAT(run("SHOW TABLES").results, testing::IsEmpty());
+  }
+
+  numChecks = 0;
+  for (const auto* sql :
+       {"EXPLAIN SELECT 1",
+        "EXPLAIN (TYPE IO) SELECT 1",
+        "EXPLAIN CREATE TABLE t3 AS SELECT 1 AS x",
+        "SHOW SESSION"}) {
+    SCOPED_TRACE(sql);
+    run(sql);
+    EXPECT_EQ(numChecks, 0);
+  }
+}
+
 } // namespace
 } // namespace axiom::sql
 

--- a/axiom/cli/tests/SqlQueryRunnerTestBase.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTestBase.cpp
@@ -45,7 +45,8 @@ void SqlQueryRunnerTestBase::TearDown() {
 std::unique_ptr<SqlQueryRunner> SqlQueryRunnerTestBase::makeRunner(
     const std::string& connectorId,
     std::function<std::string()> queryIdGenerator,
-    PermissionCheck permissionCheck) {
+    PermissionCheck permissionCheck,
+    LogicalPlanCheck logicalPlanCheck) {
   return makeRunner(
       [&]() {
         testConnector_ =
@@ -61,18 +62,23 @@ std::unique_ptr<SqlQueryRunner> SqlQueryRunnerTestBase::makeRunner(
         return std::make_pair(testConnector_->connectorId(), kDefaultSchema);
       },
       std::move(queryIdGenerator),
-      std::move(permissionCheck));
+      std::move(permissionCheck),
+      std::move(logicalPlanCheck));
 }
 
 std::unique_ptr<SqlQueryRunner> SqlQueryRunnerTestBase::makeRunner(
     const std::function<std::pair<std::string, std::string>()>& initConnectors,
     std::function<std::string()> queryIdGenerator,
-    PermissionCheck permissionCheck) {
+    PermissionCheck permissionCheck,
+    LogicalPlanCheck logicalPlanCheck) {
   auto runner = std::make_unique<SqlQueryRunner>(
       "test_user", &progressScheduler_, useV2_);
 
   runner->initialize(
-      initConnectors, std::move(permissionCheck), std::move(queryIdGenerator));
+      initConnectors,
+      std::move(permissionCheck),
+      std::move(logicalPlanCheck),
+      std::move(queryIdGenerator));
 
   return runner;
 }

--- a/axiom/cli/tests/SqlQueryRunnerTestBase.h
+++ b/axiom/cli/tests/SqlQueryRunnerTestBase.h
@@ -55,7 +55,8 @@ class SqlQueryRunnerTestBase : public ::testing::Test,
   std::unique_ptr<SqlQueryRunner> makeRunner(
       const std::string& connectorId = "test",
       std::function<std::string()> queryIdGenerator = {},
-      PermissionCheck permissionCheck = {});
+      PermissionCheck permissionCheck = {},
+      LogicalPlanCheck logicalPlanCheck = {});
 
   // Builds a SqlQueryRunner over the connectors 'initConnectors' registers; it
   // returns the connector id and schema to use by default. The caller
@@ -64,7 +65,8 @@ class SqlQueryRunnerTestBase : public ::testing::Test,
       const std::function<std::pair<std::string, std::string>()>&
           initConnectors,
       std::function<std::string()> queryIdGenerator = {},
-      PermissionCheck permissionCheck = {});
+      PermissionCheck permissionCheck = {},
+      LogicalPlanCheck logicalPlanCheck = {});
 
   // Runs 'sql' on runner_ with default options.
   SqlQueryRunner::SqlResult run(std::string_view sql);


### PR DESCRIPTION
Summary:

Axiom evaluates through Velox, which differs from Presto on constructs like TIMESTAMP WITH TIME ZONE. A query using one returns a plausible but wrong answer instead of failing. That is the worst outcome, because the result looks fine. Adds the hook a deployment uses to refuse such a query before it runs. Nothing is installed here, so behavior is unchanged.

`LogicalPlanCheck` is an optional callback on `initialize()`, next to `permissionCheck`. It takes the logical plan rather than the optimized one because the optimizer constant-folds. For

    SELECT to_unixtime(TIMESTAMP '2026-07-28 18:30:00 Asia/Bangkok')

the logical plan still carries the cast to TIMESTAMP WITH TIME ZONE, while the optimized plan carries only the folded `DOUBLE` literal `1785238200`. Folding does not make the expression safe: it was evaluated at plan time with Velox semantics and baked in. A check on the optimized plan would pass a query it should reject.

Every statement that executes a plan the user wrote is offered to the check. EXPLAIN other than ANALYZE is not, so it stays usable for diagnosing a rejected query. Neither is SHOW SESSION, whose plan the runner builds from the session config rather than parsing it. The call precedes `createTargetTable()`, because a rejected CREATE TABLE AS SELECT must not leave an empty table behind.

Reviewed By: mbasmanova

Differential Revision: D116740875


