### PR TITLE
docs: Fix the commit-type list and the keep-in-sync note (#1765)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -197,7 +197,9 @@ Use conventional commit prefixes with `[Project]` tags:
 ```
 
 Format: `[Project] type(scope): Description`
-- Types: `feat`, `fix`, `refactor`, `test`, `docs`
+- Types: `feat`, `fix`, `perf`, `build`, `test`, `docs`, `refactor`, `misc`
+  (this list is enforced by the `PR Title Format` check in
+  `.github/workflows/preliminary_checks.yml` — keep it in step with that regex)
 - Scope is optional, use for subsystem clarity (e.g., `parser`, `optimizer`)
 - Description starts with a capital letter, no trailing period
 


### PR DESCRIPTION
Summary:

Two corrections to the Axiom coding-style rules, both cases of the doc describing something that is no longer true.

Both copies list five conventional-commit types, while the `PR Title Format` check in `.github/workflows/preliminary_checks.yml` accepts eight — `feat|fix|perf|build|test|docs|refactor|misc`. Authors following the doc avoid `build`, `perf` and `misc` even though the check takes them, and two recent submodule bumps landed with different prefixes because of it, one `build(oss)` and one `fix(build)`. Lists all eight and cites the workflow that enforces them.

The keep-in-sync note says these rules live in two files and to "update both". They now live in four — Axel and fb_axiom carry copies of the same shared body. Following the old note leaves two of the four stale, which is how they drifted apart to begin with. Names all four locations.

Differential Revision: D116739191


