### PR TITLE
fix(optimizer): Plan DELETE from a bucketed table

### DIFF
--- a/axiom/optimizer/tests/DeleteTest.cpp
+++ b/axiom/optimizer/tests/DeleteTest.cpp
@@ -114,6 +114,22 @@ TEST_F(DeleteTest, partitionPredicates) {
   EXPECT_EQ(0, runCount("FROM test"));
 }
 
+// Deleting one partition of a bucketed table removes that partition's rows and
+// leaves the rest.
+TEST_F(DeleteTest, bucketedTable) {
+  SCOPE_EXIT {
+    hiveMetadata().dropTableIfExists("test");
+  };
+
+  runCtas(
+      "CREATE TABLE test WITH (bucket_count = 8, "
+      "bucketed_by = ARRAY['n_nationkey'], partitioned_by = ARRAY['pk']) AS "
+      "SELECT n_nationkey, n_nationkey % 3 AS pk FROM nation");
+
+  EXPECT_EQ(9, runDelete("DELETE FROM test WHERE pk = 0"));
+  EXPECT_EQ(16, runCount("FROM test"));
+}
+
 // An unpartitioned table has no partitions to drop, so a delete removes the
 // data files and leaves an empty table rather than dropping it.
 TEST_F(DeleteTest, unpartitionedTable) {

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -1192,15 +1192,15 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
   // single worker, else workers race to create the same bucket file.
   // Repartition the input on the target's partition columns using the target's
   // connector partitioning, unless the input is already compatibly bucketed (a
-  // collocated write) or the query runs on one worker. The within-worker split
-  // is added at emit.
+  // collocated write), the query runs on one worker, or the write is a delete,
+  // which writes no columns and so has no key to shuffle on.
   NodeCP rewriteTableWrite(const TableWrite* node, NoContext& context)
       override {
     NodeCP newInput = rewrite(node->input(), context);
     // A partition key computed for the shuffle is written from that column
     // rather than evaluated a second time.
     ExprFactory::ExprSubstitution materialized;
-    if (numWorkers_ > 1) {
+    if (numWorkers_ > 1 && node->kind() != connector::WriteKind::kDelete) {
       const auto* layout = node->table()->layouts().front();
       const auto& partitionColumns = layout->partitionColumns();
       if (!partitionColumns.empty()) {


### PR DESCRIPTION
Summary:
Deleting from a bucketed table failed to plan on more than one worker:

    DELETE FROM t WHERE ds < '2026-08-24'

failed with

    vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)

The WHERE clause had nothing to do with it — `DELETE FROM t` with no predicate failed the same way.

Physical planning repartitions a write's input on the target's bucket columns so no two workers write the same bucket file. It reads each partitioning key out of the write's per-column expressions by schema position. A delete writes no columns — the connector removes the rows through metadata — so that lookup ran off the end of an empty list. Skips the repartition for a delete.

Differential Revision: D117418109
