### PR TITLE
misc: Advance Velox

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Axiom integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/704b7036907c03ed0325a4a3db0d6bb7ddb4ac54...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/eb846b0fd042c8fcb145c693a5bc21f8f22d17ad...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that


### PR DESCRIPTION
Summary:
Moves the Velox pin from `704b70369` to `eb846b0fd`, 24 commits.

Nimble dominates the range: a shared integer dictionary encoding, encoding evaluation extracted into a common library, Nimble file dictionary conversion, fuzzer verification of writer metadata and column statistics, FOR made read-only while PFOR stays writable, and perf work on scratch-buffer reuse, uncompressed chunk stripping and stream location lookup. Outside Nimble: a serializer API to decode multiple row ranges from one batch, torchwave allocation groups plus three crash and corruption fixes, HUGEINT value filter merging, nested OPAQUE deserialization, a Spark-aligned high-precision DECIMAL to REAL/DOUBLE cast, and field-id matching for Iceberg equality delete columns.

Also advances the Velox compare link in `README.md`, which `scripts/check-velox-readme.sh` requires to match the submodule SHA.

No Axiom code changes.

Differential Revision: D117447449
