### PR TITLE
fix(optimizer): Keep probe partitioning in semi/anti joins (#1772)

### DIFF
--- a/axiom/optimizer/tests/sql/unionAll.sql
+++ b/axiom/optimizer/tests/sql/unionAll.sql
@@ -112,3 +112,16 @@ FROM (VALUES (1)) u(a)
 JOIN (VALUES (1)) v(b) ON u.a = v.b
 UNION ALL
 SELECT w.x FROM (VALUES (ARRAY[1])) v(arr) CROSS JOIN UNNEST(arr) AS w(x)
+----
+-- UNION ALL of a grouped leg and a single-task leg whose EXISTS subquery
+-- reads the table. The subquery matches, so the leg emits its row alongside
+-- the grouped rows.
+SELECT a FROM t GROUP BY a
+UNION ALL
+SELECT 42 WHERE EXISTS (SELECT 1 FROM t)
+----
+-- The same with NOT EXISTS. Its subquery matches nothing, so that leg also
+-- emits its row.
+SELECT a FROM t GROUP BY a
+UNION ALL
+SELECT 42 WHERE NOT EXISTS (SELECT 1 FROM t WHERE a > 100)

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -386,26 +386,36 @@ ExprCP survivingEquiKey(ExprCP key, const PlanObjectSet& outputColumns) {
   return nullptr;
 }
 
-// Output global partitioning of a join. Only an inner or left join keeps the
-// probe (left) rows in their partitions, so only those preserve a probe
-// partition; other join types drop it. If every probe key is still an output
-// column, the output is partitioned exactly as the probe was. Otherwise an
-// inner join recovers each remaining key: it keeps a key whose columns all
-// survive (a join projects columns unchanged, so a surviving column is
-// identity-projected, and an expression over surviving columns still partitions
-// the output), else substitutes an equal output column from the key's
-// inner-join equivalence class. A left join can't recover a key from its
-// null-padded build, so a dropped key makes its partition unspecified. A
-// non-hash distribution (gather / broadcast / arbitrary) carries no keys and is
-// inherited by kind, minus any merge order (see `Partitioning::dropOrder`).
+// Output global partitioning of a join. A join keeps the probe's (left's)
+// partitioning when every output row is a probe row carrying its probe column
+// values unchanged, which holds for inner, left, and the left semi and anti
+// joins. Right and full joins emit build rows, so they drop it.
+//
+// If every probe key is still an output column, the output is partitioned
+// exactly as the probe was. Otherwise only an inner join recovers a dropped
+// key: it keeps a key whose columns all survive (a join projects columns
+// unchanged, so a surviving column is identity-projected, and an expression
+// over surviving columns still partitions the output), else substitutes an
+// equal output column from the key's equivalence class. Only inner joins
+// register those equivalences, so recovery is inner-only and every other type
+// reports an unspecified partitioning once a key is dropped.
+//
+// A non-hash distribution (gather / broadcast / arbitrary) carries no keys and
+// is inherited by kind, minus any merge order (see `Partitioning::dropOrder`).
 Partitioning joinGlobalPartition(
     velox::core::JoinType joinType,
     NodeCP left,
     NodeCP right,
     const ColumnVector& outputColumns) {
-  if (joinType != velox::core::JoinType::kInner &&
-      joinType != velox::core::JoinType::kLeft) {
-    return {};
+  switch (joinType) {
+    case velox::core::JoinType::kInner:
+    case velox::core::JoinType::kLeft:
+    case velox::core::JoinType::kLeftSemiFilter:
+    case velox::core::JoinType::kLeftSemiProject:
+    case velox::core::JoinType::kAnti:
+      break;
+    default:
+      return {};
   }
 
   Partitioning probe = left->physicalProperties().globalPartition;


### PR DESCRIPTION
Summary:

A UNION ALL with a constant-row leg guarded by EXISTS failed to plan on more than one worker:

    SELECT a FROM t GROUP BY a
    UNION ALL
    SELECT 42 WHERE EXISTS (SELECT 1 FROM t)

failed with

    Incompatible fragment-type contributions in one fragment: FIXED + SINGLE

Physical planning isolates a union leg behind an exchange when the leg runs as one task, and reads that off the leg's output partitioning. A bare `Values` leg reports a gather and is isolated. Guard it with EXISTS and the leg becomes a semi join, and `joinGlobalPartition` reported no partitioning for anything but an inner or left join — so the leg looked parallel, stayed in the grouped leg's fragment, and pinned it to one task.

A semi or anti join emits probe rows carrying their probe column values unchanged, exactly as inner and left joins do, so the probe's partitioning survives. Reports it for those types too.

A dropped partitioning key is still recovered only for inner joins, since only they register the column equivalences the recovery substitutes from.

Differential Revision: D117452897


