### PR TITLE
fix(optimizer): Ignore a bucketing into a single bucket (#1773)

### DIFF
--- a/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
@@ -468,14 +468,17 @@ TEST_P(BucketedExecutionTest, select) {
             .tableScan("s_one")
             .aggregate({"customer_id"}, {"sum(amount)"})
             .build());
-    // One bucket caps the fragment at one task.
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+    // One bucket holds every row, so pairing rows by it co-locates nothing.
+    // The table is read plainly and the aggregation shuffles, spreading it
+    // over the workers rather than running it on one task.
+    AXIOM_ASSERT_DISTRIBUTED_PLAN_V2(
         plan.plan,
         matchScan("s_one")
             .partialAggregation()
+            .shuffle({"customer_id"})
             .localPartition({"customer_id"})
             .finalAggregation()
-            .fragment({.width = 1, .bucketedScans = 1})
+            .fragment({.width = 4})
             .gather()
             .build());
   }

--- a/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
@@ -376,14 +376,18 @@ TEST_P(HiveBucketedExecutionTest, singleBucket) {
   auto logicalPlan =
       parseSelect("SELECT c_nationkey, count(*) FROM t GROUP BY 1");
   auto plan = planDistributed(logicalPlan);
-  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+  // One bucket holds every row, so pairing rows by it co-locates nothing. The
+  // table is read plainly and the aggregation shuffles, spreading it over the
+  // workers rather than running it on one task.
+  AXIOM_ASSERT_DISTRIBUTED_PLAN_V2(
       plan.plan,
       matchHiveScan("t")
           .partialAggregation({"c_nationkey"}, {"count(*) as cnt"})
+          .notBucketed()
+          .shuffle({"c_nationkey"})
           .localPartition({"c_nationkey"})
           .finalAggregation({"c_nationkey"}, {"count(cnt) as cnt"})
-          .bucketed()
-          .fragmentWidth(1)
+          .fragmentWidth(4)
           .gather()
           .build());
 }

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -431,6 +431,16 @@ inline auto in(
     }                                             \
   }
 
+// AXIOM_ASSERT_DISTRIBUTED_PLAN under the same terms.
+#define AXIOM_ASSERT_DISTRIBUTED_PLAN_V2(plan, matcher) \
+  {                                                     \
+    auto _axiom_plan_ = (plan);                         \
+    if (useV2_) {                                       \
+      ASSERT_TRUE((matcher)->match(*_axiom_plan_))      \
+          << _axiom_plan_->toString(true);              \
+    }                                                   \
+  }
+
 // Instantiates a value-parameterized (`TEST_P`) suite for both optimizers,
 // producing `V1/<suite>.<case>/_` and `V2/<suite>.<case>/_`. The fixture must
 // derive from `WithParamInterface<bool>` and set `useV2_ = GetParam()` in

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -529,6 +529,12 @@ Partitioning bucketPartition(
     return {};
   }
 
+  // A partitioning into one partition puts every row in the same partition, so
+  // it tells a consumer nothing about where a row is: no partitioning at all.
+  if (partitionType->numPartitions() == 1) {
+    return {};
+  }
+
   ExprVector keys;
   keys.reserve(partitionColumns.size());
   for (const auto* partitionColumn : partitionColumns) {

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -265,11 +265,13 @@ class Scan : public Node {
     return groupedPartitionType_;
   }
 
-  /// The bucketing this scan's table storage affords, expressed over the
-  /// columns this scan outputs. Empty when the table is not bucketed, or when
-  /// a bucketing column is not in the output and the partitioning therefore
-  /// cannot be stated over it. This is what is possible; `groupedPartitionType`
-  /// is what the plan chose.
+  /// The bucketing of this scan's table that a plan can exploit, expressed over
+  /// the columns this scan outputs. Returns an unspecified partitioning when
+  /// the table carries no bucketing, when a bucketing column is not among the
+  /// outputs and the partitioning therefore cannot be stated over them, or when
+  /// the table has a single bucket, which holds every row and so co-locates
+  /// nothing an ordinary read would not. Of what this offers,
+  /// `groupedPartitionType` is the one the plan chose.
   Partitioning storageBucketing() const;
 
   std::span<const NodeCP> inputs() const override {


### PR DESCRIPTION
Summary:

Tables are declared with one bucket in order to declare a sort order: `sorted_by` is accepted only on a bucketed table, so `bucket_count = 1` is the least bucketing that carries it. A single bucket holds every row, so pairing rows by it co-locates nothing that reading the table plainly would not. v2 read such a table one bucket group at a time anyway, which fixes its fragment at one task: a query over one ran on a single worker where it could have used all of them.

Reports a partitioning of one partition as no partitioning, so the table is read plainly and the query keeps its parallelism. `Scan::storageBucketing()` says so in its contract: it answers what a plan can exploit, not what the storage declares. Nothing is given up by that today, because v2 does not use table sortedness at all. It would not be free once it does — a sort order is stated within each bucket, so a consumer exploiting one needs an accessor that reports the bucketing faithfully.

This also unblocks a query that failed to plan with

    Partition count mismatch between producer fragment8 and consumer fragment7 (4 vs. 1)

whose fragment held one leg read by a single bucket group and another fed by a shuffle at the worker count. The mismatch itself is not addressed: a fragment can still end up holding two widths when a table's bucket count is greater than one and does not match the worker count.

Differential Revision: D117487044


