### PR TITLE
fix(hive): Honor the direction in sorted_by

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ For CSV files, create the table with schema first, then copy the files in.
 mkdir -p /tmp/my_data
 _build/debug/axiom/cli/axiom_sql --data_path /tmp/my_data --data_format text \
   --query "CREATE TABLE sales (id INTEGER, name VARCHAR, amount DOUBLE)
-           WITH (file_format = 'text', \"field.delim\" = ',')"
+           WITH (format = 'text', \"field.delim\" = ',')"
 ```
 
 **2. Copy CSV files into the table directory:**

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -16,8 +16,10 @@
 
 #include "axiom/connectors/hive/HiveConnectorMetadata.h"
 
+#include <boost/algorithm/string/predicate.hpp>
 #include <fmt/ranges.h>
 #include <folly/Conv.h>
+#include <folly/String.h>
 #include <algorithm>
 #include <utility>
 #include "velox/connectors/hive/HiveConnector.h"
@@ -619,6 +621,46 @@ ConnectorWriteHandlePtr HiveConnectorMetadata::beginWrite(
       velox::exec::TableWriteTraits::outputType(std::nullopt),
       table,
       kind);
+}
+
+std::vector<SortKey> SortKey::parse(const std::vector<std::string>& entries) {
+  std::vector<SortKey> keys;
+  keys.reserve(entries.size());
+  for (const auto& entry : entries) {
+    std::vector<std::string> parts;
+    folly::split(' ', entry, parts, /*ignoreEmpty=*/true);
+    VELOX_USER_CHECK(
+        parts.size() == 1 || parts.size() == 2,
+        "Invalid sorted_by entry: {}",
+        entry);
+
+    bool ascending = true;
+    if (parts.size() == 2) {
+      ascending = boost::iequals(parts[1], "ASC");
+      VELOX_USER_CHECK(
+          ascending || boost::iequals(parts[1], "DESC"),
+          "Invalid sort direction: {}",
+          parts[1]);
+    }
+
+    keys.push_back(
+        SortKey{
+            .column = parts[0],
+            .order = SortOrder{
+                .isAscending = ascending, .isNullsFirst = ascending}});
+  }
+  return keys;
+}
+
+std::vector<std::string> SortKey::toEntries(const std::vector<SortKey>& keys) {
+  std::vector<std::string> entries;
+  entries.reserve(keys.size());
+  for (const auto& key : keys) {
+    entries.push_back(
+        key.order.isAscending ? key.column
+                              : fmt::format("{} DESC", key.column));
+  }
+  return entries;
 }
 
 void HiveConnectorMetadata::validateOptions(

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -628,7 +628,7 @@ void HiveConnectorMetadata::validateOptions(
       HiveWriteOptions::kBucketCount,
       HiveWriteOptions::kPartitionedBy,
       HiveWriteOptions::kSortedBy,
-      HiveWriteOptions::kFileFormat,
+      HiveWriteOptions::kFormat,
       HiveWriteOptions::kCompressionKind,
       HiveWriteOptions::kFieldDelim,
       HiveWriteOptions::kSerializationNullFormat,

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -270,6 +270,22 @@ class HiveConnectorWriteHandle : public ConnectorWriteHandle {
   std::vector<std::string> statsGroupingKeys_;
 };
 
+/// A key the rows of a bucket are sorted by. A `sorted_by` entry names the
+/// key's column and, optionally, a direction, as in 'ds DESC'; ascending is
+/// the default. Nulls go where the direction puts them: first ascending and
+/// last descending, the only pairings Hive can state.
+struct SortKey {
+  std::string column;
+  SortOrder order;
+
+  /// Parses the entries of a `sorted_by` option. Fails on an entry that is not
+  /// a column name followed by an optional ASC or DESC.
+  static std::vector<SortKey> parse(const std::vector<std::string>& entries);
+
+  /// Renders 'keys' back as `sorted_by` entries.
+  static std::vector<std::string> toEntries(const std::vector<SortKey>& keys);
+};
+
 /// The full list of options accepted for createTable.
 /// Any specified options not listed below will trigger
 /// a validation error during table create.

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -296,7 +296,7 @@ class HiveWriteOptions {
 
   /// The table storage format. See velox::dwio::common::FileFormat.
   /// The default is DWRF format.
-  static constexpr auto kFileFormat = "file_format";
+  static constexpr auto kFormat = "format";
 
   /// The table compression kind. See velox::common::CompressionKind.
   /// The default is ZSTD compression.

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -882,7 +882,7 @@ struct CreateTableOptions {
 
   std::optional<int32_t> numBuckets;
   std::vector<std::string> bucketedByColumns;
-  std::vector<std::string> sortedByColumns;
+  std::vector<SortKey> sortKeys;
 
   // SerDe options. Primarily used for TEXT format files, but may evolve
   // to support other formats in the future.
@@ -974,10 +974,14 @@ CreateTableOptions parseCreateTableOptions(
 
     result.numBuckets = numBuckets;
 
-    it = options.find("sorted_by");
+    it = options.find(HiveWriteOptions::kSortedBy);
     if (it != options.end()) {
-      result.sortedByColumns = it->second.array<std::string>();
+      result.sortKeys = SortKey::parse(it->second.array<std::string>());
     }
+  } else {
+    VELOX_USER_CHECK(
+        options.find(HiveWriteOptions::kSortedBy) == options.end(),
+        "sorted_by requires bucketed_by");
   }
 
   // Parse SerDe options
@@ -1071,9 +1075,11 @@ CreateTableOptions parseCreateTableOptions(
       options.bucketedByColumns.push_back(bucketCol.asString());
     }
 
+    std::vector<std::string> sortedBy;
     for (const auto& sortCol : bucketObj["sortedBy"]) {
-      options.sortedByColumns.push_back(sortCol.asString());
+      sortedBy.push_back(sortCol.asString());
     }
+    options.sortKeys = SortKey::parse(sortedBy);
   }
 
   return options;
@@ -1116,7 +1122,7 @@ folly::dynamic toSchemaJson(
     buckets["bucketCount"] = fmt::format("{}", options.numBuckets.value());
 
     buckets["bucketedBy"] = toJsonArray(options.bucketedByColumns);
-    buckets["sortedBy"] = toJsonArray(options.sortedByColumns);
+    buckets["sortedBy"] = toJsonArray(SortKey::toEntries(options.sortKeys));
     schema["bucketProperty"] = buckets;
   }
 
@@ -1197,9 +1203,9 @@ std::shared_ptr<LocalTable> createLocalTable(
         velox::Variant(createTableOptions.numBuckets.value());
   }
 
-  if (!createTableOptions.sortedByColumns.empty()) {
+  if (!createTableOptions.sortKeys.empty()) {
     options[HiveWriteOptions::kSortedBy] =
-        toVariantArray(createTableOptions.sortedByColumns);
+        toVariantArray(SortKey::toEntries(createTableOptions.sortKeys));
   }
 
   const std::optional<int32_t> numBuckets = createTableOptions.numBuckets;
@@ -1232,12 +1238,12 @@ std::shared_ptr<LocalTable> createLocalTable(
       bucketedBy.push_back(column);
     }
 
-    for (const auto& columnName : createTableOptions.sortedByColumns) {
-      auto column = table->findColumn(columnName);
+    for (const auto& sortKey : createTableOptions.sortKeys) {
+      auto column = table->findColumn(sortKey.column);
       VELOX_CHECK_NOT_NULL(
-          column, "Sorted-by column not found: {}", columnName);
+          column, "Sorted-by column not found: {}", sortKey.column);
       sortedBy.push_back(column);
-      sortOrders.push_back(SortOrder{true, true}); // ASC NULLS FIRST.
+      sortOrders.push_back(sortKey.order);
     }
   }
 

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -934,7 +934,7 @@ CreateTableOptions parseCreateTableOptions(
         toLower(it->second.value<std::string>()));
   }
 
-  it = options.find(HiveWriteOptions::kFileFormat);
+  it = options.find(HiveWriteOptions::kFormat);
   if (it != options.end()) {
     result.fileFormat = velox::dwio::common::toFileFormat(
         toLower(it->second.value<std::string>()));
@@ -1160,7 +1160,7 @@ std::shared_ptr<LocalTable> createLocalTable(
   }
 
   if (createTableOptions.fileFormat.has_value()) {
-    options[HiveWriteOptions::kFileFormat] = std::string(
+    options[HiveWriteOptions::kFormat] = std::string(
         velox::dwio::common::FileFormatName::toName(
             createTableOptions.fileFormat.value()));
   }

--- a/axiom/connectors/hive/README.md
+++ b/axiom/connectors/hive/README.md
@@ -257,7 +257,7 @@ supported:
 | `bucketed_by` | Array of bucketing column names, e.g. `ARRAY['key']`. Requires `bucket_count`. |
 | `bucket_count` | Number of buckets (must be a power of 2). Requires `bucketed_by`. |
 | `sorted_by` | Array of sort column names (within each bucket), e.g. `ARRAY['key']`. Only supported for bucketed tables. |
-| `file_format` | Storage format: `PARQUET`, `DWRF`, `TEXT`. Defaults to `--data_format`. |
+| `format` | Storage format: `PARQUET`, `DWRF`, `TEXT`. Defaults to `--data_format`. |
 | `compression_kind` | Compression: `NONE`, `ZSTD` (default), `SNAPPY`, `GZIP`, `LZ4`, `ZLIB`, `LZO`. |
 
 ### CREATE TABLE
@@ -298,7 +298,7 @@ WITH (
     bucketed_by = ARRAY['orderkey'],
     bucket_count = 16,
     sorted_by = ARRAY['orderkey'],
-    file_format = 'DWRF',
+    format = 'DWRF',
     compression_kind = 'SNAPPY'
 );
 ```
@@ -311,7 +311,7 @@ CREATE TABLE t AS SELECT * FROM tpch.tiny.lineitem;
 
 -- With table properties.
 CREATE TABLE t
-WITH (partitioned_by = ARRAY['ds'], file_format = 'DWRF')
+WITH (partitioned_by = ARRAY['ds'], format = 'DWRF')
 AS SELECT orderkey, totalprice, ds FROM orders;
 ```
 

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -330,7 +330,8 @@ TEST_F(LocalHiveConnectorMetadataTest, createTable) {
   folly::F14FastMap<std::string, velox::Variant> options = {
       {HiveWriteOptions::kBucketedBy, velox::Variant::array({"key1"})},
       {HiveWriteOptions::kBucketCount, 4LL},
-      {HiveWriteOptions::kSortedBy, velox::Variant::array({"key1", "key2"})},
+      {HiveWriteOptions::kSortedBy,
+       velox::Variant::array({"key1", "key2 DESC"})},
       {HiveWriteOptions::kPartitionedBy, velox::Variant::array({"ds"})},
       {HiveWriteOptions::kFormat, "parquet"},
       {HiveWriteOptions::kCompressionKind, "zstd"}};
@@ -367,6 +368,11 @@ TEST_F(LocalHiveConnectorMetadataTest, createTable) {
   EXPECT_EQ(expected->orderColumns().size(), 2);
   EXPECT_EQ(expected->orderColumns()[0], expected->columns()[0]);
   EXPECT_EQ(expected->orderColumns()[1], expected->columns()[1]);
+  ASSERT_EQ(expected->sortOrder().size(), 2);
+  EXPECT_TRUE(expected->sortOrder()[0].isAscending);
+  EXPECT_TRUE(expected->sortOrder()[0].isNullsFirst);
+  EXPECT_FALSE(expected->sortOrder()[1].isAscending);
+  EXPECT_FALSE(expected->sortOrder()[1].isNullsFirst);
   EXPECT_EQ(expected->hivePartitionColumns().size(), 1);
   EXPECT_EQ(expected->hivePartitionColumns()[0], expected->columns()[3]);
   EXPECT_TRUE(expected->hivePartitionColumns()[0]->includeInExplainIo());
@@ -415,6 +421,33 @@ TEST_F(LocalHiveConnectorMetadataTest, createTable) {
   compareTableLayout(table, metadata_->findTable({kDefaultSchema, "test"}));
   compareTableData(
       "test", data, {{"ds", partition}}, dwio::common::FileFormat::PARQUET);
+}
+
+TEST_F(LocalHiveConnectorMetadataTest, invalidSortedBy) {
+  auto tableType = ROW({{"key1", BIGINT()}, {"data", BIGINT()}});
+
+  auto create =
+      [&](const folly::F14FastMap<std::string, velox::Variant>& options) {
+        metadata_->createTable(
+            makeSession(),
+            {kDefaultSchema, "test"},
+            tableType,
+            options,
+            /*ifNotExists=*/false,
+            /*explain=*/false);
+      };
+
+  VELOX_ASSERT_USER_THROW(
+      create({{HiveWriteOptions::kSortedBy, velox::Variant::array({"key1"})}}),
+      "sorted_by requires bucketed_by");
+
+  VELOX_ASSERT_USER_THROW(
+      create(
+          {{HiveWriteOptions::kBucketedBy, velox::Variant::array({"key1"})},
+           {HiveWriteOptions::kBucketCount, 4LL},
+           {HiveWriteOptions::kSortedBy,
+            velox::Variant::array({"key1 BACKWARDS"})}}),
+      "Invalid sort direction: BACKWARDS");
 }
 
 TEST_F(LocalHiveConnectorMetadataTest, addColumn) {

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -332,7 +332,7 @@ TEST_F(LocalHiveConnectorMetadataTest, createTable) {
       {HiveWriteOptions::kBucketCount, 4LL},
       {HiveWriteOptions::kSortedBy, velox::Variant::array({"key1", "key2"})},
       {HiveWriteOptions::kPartitionedBy, velox::Variant::array({"ds"})},
-      {HiveWriteOptions::kFileFormat, "parquet"},
+      {HiveWriteOptions::kFormat, "parquet"},
       {HiveWriteOptions::kCompressionKind, "zstd"}};
 
   auto session = makeSession();
@@ -423,7 +423,7 @@ TEST_F(LocalHiveConnectorMetadataTest, addColumn) {
 
   folly::F14FastMap<std::string, velox::Variant> options = {
       {HiveWriteOptions::kPartitionedBy, velox::Variant::array({"ds"})},
-      {HiveWriteOptions::kFileFormat, "parquet"}};
+      {HiveWriteOptions::kFormat, "parquet"}};
 
   auto session = makeSession();
   auto table = metadata_->createTable(
@@ -541,7 +541,7 @@ TEST_F(LocalHiveConnectorMetadataTest, addColumnExplain) {
   auto tableType = ROW({{"id", BIGINT()}, {"name", VARCHAR()}});
 
   folly::F14FastMap<std::string, velox::Variant> options = {
-      {HiveWriteOptions::kFileFormat, "parquet"}};
+      {HiveWriteOptions::kFormat, "parquet"}};
 
   auto session = makeSession();
   metadata_->createTable(

--- a/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
@@ -468,14 +468,17 @@ TEST_P(BucketedExecutionTest, select) {
             .tableScan("s_one")
             .aggregate({"customer_id"}, {"sum(amount)"})
             .build());
-    // One bucket caps the fragment at one task.
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+    // One bucket holds every row, so pairing rows by it co-locates nothing.
+    // The table is read plainly and the aggregation shuffles, spreading it
+    // over the workers rather than running it on one task.
+    AXIOM_ASSERT_DISTRIBUTED_PLAN_V2(
         plan.plan,
         matchScan("s_one")
             .partialAggregation()
+            .shuffle({"customer_id"})
             .localPartition({"customer_id"})
             .finalAggregation()
-            .fragment({.width = 1, .bucketedScans = 1})
+            .fragment({.width = 4})
             .gather()
             .build());
   }

--- a/axiom/optimizer/tests/CsvReadWriteTest.cpp
+++ b/axiom/optimizer/tests/CsvReadWriteTest.cpp
@@ -64,7 +64,7 @@ TEST_P(CsvReadWriteTest, createTextTable) {
 
   runCtas(
       "CREATE TABLE text_test(id, name) "
-      "WITH (file_format = 'TEXT', compression_kind = 'NONE') "
+      "WITH (format = 'TEXT', compression_kind = 'NONE') "
       "AS SELECT 1, 'Alice'");
 
   EXPECT_EQ(
@@ -75,7 +75,7 @@ TEST_P(CsvReadWriteTest, createTextTable) {
       ")\n"
       "WITH (\n"
       "   compression_kind = 'none',\n"
-      "   file_format = 'text'\n"
+      "   format = 'text'\n"
       ")");
 }
 
@@ -88,7 +88,7 @@ TEST_P(CsvReadWriteTest, createCsvTable) {
 
   runCtas(
       "CREATE TABLE csv_test(id, name) "
-      "WITH (file_format = 'TEXT', \"field.delim\" = ',', "
+      "WITH (format = 'TEXT', \"field.delim\" = ',', "
       "\"serialization.null.format\" = '\\N') "
       "AS SELECT 1, 'Alice'");
 
@@ -100,7 +100,7 @@ TEST_P(CsvReadWriteTest, createCsvTable) {
       ")\n"
       "WITH (\n"
       "   field.delim = ',',\n"
-      "   file_format = 'text',\n"
+      "   format = 'text',\n"
       "   serialization.null.format = '\\N'\n"
       ")");
 }
@@ -119,7 +119,7 @@ TEST_P(CsvReadWriteTest, validateSchemaFileProperties) {
   });
 
   folly::F14FastMap<std::string, velox::Variant> options = {
-      {"file_format", "text"},
+      {"format", "text"},
       {"field.delim", "|"},
       {"serialization.null.format", ""},
   };
@@ -136,8 +136,8 @@ TEST_P(CsvReadWriteTest, validateSchemaFileProperties) {
 
   const auto& tableOptions = table->options();
 
-  ASSERT_TRUE(tableOptions.count("file_format"));
-  EXPECT_EQ(tableOptions.at("file_format").value<std::string>(), "text");
+  ASSERT_TRUE(tableOptions.count("format"));
+  EXPECT_EQ(tableOptions.at("format").value<std::string>(), "text");
 
   ASSERT_TRUE(tableOptions.count("field.delim"));
   EXPECT_EQ(tableOptions.at("field.delim").value<std::string>(), "|");
@@ -162,7 +162,7 @@ TEST_P(CsvReadWriteTest, readCustomDelimiterWithVariousTypes) {
   });
 
   folly::F14FastMap<std::string, velox::Variant> options = {
-      {"file_format", "text"},
+      {"format", "text"},
       {"field.delim", "|"},
       {"serialization.null.format", ""},
   };
@@ -199,7 +199,7 @@ TEST_P(CsvReadWriteTest, writeWithInsertStatement) {
   });
 
   folly::F14FastMap<std::string, velox::Variant> options = {
-      {"file_format", "text"},
+      {"format", "text"},
       {"field.delim", "\1"},
       {"serialization.null.format", "\\N"},
   };

--- a/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
@@ -376,14 +376,18 @@ TEST_P(HiveBucketedExecutionTest, singleBucket) {
   auto logicalPlan =
       parseSelect("SELECT c_nationkey, count(*) FROM t GROUP BY 1");
   auto plan = planDistributed(logicalPlan);
-  AXIOM_ASSERT_DISTRIBUTED_PLAN(
+  // One bucket holds every row, so pairing rows by it co-locates nothing. The
+  // table is read plainly and the aggregation shuffles, spreading it over the
+  // workers rather than running it on one task.
+  AXIOM_ASSERT_DISTRIBUTED_PLAN_V2(
       plan.plan,
       matchHiveScan("t")
           .partialAggregation({"c_nationkey"}, {"count(*) as cnt"})
+          .notBucketed()
+          .shuffle({"c_nationkey"})
           .localPartition({"c_nationkey"})
           .finalAggregation({"c_nationkey"}, {"count(cnt) as cnt"})
-          .bucketed()
-          .fragmentWidth(1)
+          .fragmentWidth(4)
           .gather()
           .build());
 }

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -431,6 +431,16 @@ inline auto in(
     }                                             \
   }
 
+// AXIOM_ASSERT_DISTRIBUTED_PLAN under the same terms.
+#define AXIOM_ASSERT_DISTRIBUTED_PLAN_V2(plan, matcher) \
+  {                                                     \
+    auto _axiom_plan_ = (plan);                         \
+    if (useV2_) {                                       \
+      ASSERT_TRUE((matcher)->match(*_axiom_plan_))      \
+          << _axiom_plan_->toString(true);              \
+    }                                                   \
+  }
+
 // Instantiates a value-parameterized (`TEST_P`) suite for both optimizers,
 // producing `V1/<suite>.<case>/_` and `V2/<suite>.<case>/_`. The fixture must
 // derive from `WithParamInterface<bool>` and set `useV2_ = GetParam()` in

--- a/axiom/optimizer/tests/TpchDataGenerator.cpp
+++ b/axiom/optimizer/tests/TpchDataGenerator.cpp
@@ -53,7 +53,7 @@ void TpchDataGenerator::createTables(
     }
 
     auto sql = fmt::format(
-        "CREATE TABLE {} WITH (file_format = '{}') AS SELECT * FROM tpch.\"{}\".{}",
+        "CREATE TABLE {} WITH (format = '{}') AS SELECT * FROM tpch.\"{}\".{}",
         tableName,
         velox::dwio::common::FileFormatName::toName(format),
         fmt::format("sf{}", scaleFactor),

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -416,7 +416,7 @@ TEST_P(WriteTest, basic) {
   });
 
   folly::F14FastMap<std::string, velox::Variant> options = {
-      {"file_format", "parquet"},
+      {"format", "parquet"},
       {"compression_kind", "snappy"},
   };
 

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -529,6 +529,12 @@ Partitioning bucketPartition(
     return {};
   }
 
+  // A partitioning into one partition puts every row in the same partition, so
+  // it tells a consumer nothing about where a row is: no partitioning at all.
+  if (partitionType->numPartitions() == 1) {
+    return {};
+  }
+
   ExprVector keys;
   keys.reserve(partitionColumns.size());
   for (const auto* partitionColumn : partitionColumns) {

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -265,11 +265,13 @@ class Scan : public Node {
     return groupedPartitionType_;
   }
 
-  /// The bucketing this scan's table storage affords, expressed over the
-  /// columns this scan outputs. Empty when the table is not bucketed, or when
-  /// a bucketing column is not in the output and the partitioning therefore
-  /// cannot be stated over it. This is what is possible; `groupedPartitionType`
-  /// is what the plan chose.
+  /// The bucketing of this scan's table that a plan can exploit, expressed over
+  /// the columns this scan outputs. Returns an unspecified partitioning when
+  /// the table carries no bucketing, when a bucketing column is not among the
+  /// outputs and the partitioning therefore cannot be stated over them, or when
+  /// the table has a single bucket, which holds every row and so co-locates
+  /// nothing an ordinary read would not. Of what this offers,
+  /// `groupedPartitionType` is the one the plan chose.
   Partitioning storageBucketing() const;
 
   std::span<const NodeCP> inputs() const override {


### PR DESCRIPTION
Summary:
A create that asks for a descending sort:

    CREATE TABLE t WITH (bucket_count = 4, bucketed_by = ARRAY['id'], sorted_by = ARRAY['ds DESC']) AS SELECT ...

fails with `Sorted-by column not found: ds DESC` -- the whole entry was taken as a column name. A table whose entries named a column and nothing else was accepted, then written ascending with nulls first whatever the DDL said.

A `sorted_by` entry is now parsed into a column and a direction, and that direction reaches the writer through the table layout. Nulls follow the direction: first ascending and last descending, the only pairings Hive can state.

Adds a check that `sorted_by` comes with `bucketed_by`; a sort on an unbucketed table used to be dropped silently.

Differential Revision: D117513845
