### PR TITLE
refactor(v2): Drop the redundant Key type at make sites

### DIFF
--- a/axiom/optimizer/v2/DecorrelatePass.cpp
+++ b/axiom/optimizer/v2/DecorrelatePass.cpp
@@ -275,7 +275,7 @@ class Decorrelator : public NodeRewriter<> {
     ColumnVector innerCorrelations =
         recomputeCorrelations(newBody, input->outputColumns());
 
-    NodeCP innerApply = builder().make<Apply>(Apply::Key{
+    NodeCP innerApply = builder().make<Apply>({
         input,
         newBody,
         std::move(innerCorrelations),
@@ -329,7 +329,7 @@ class Decorrelator : public NodeRewriter<> {
       liftedExprs.push_back(node->includeMarker());
     }
 
-    return builder().make<Project>(Project::Key{
+    return builder().make<Project>({
         decorrelatedInner,
         std::move(liftedExprs),
         node->outputColumns(),
@@ -372,7 +372,7 @@ class Decorrelator : public NodeRewriter<> {
     appendAll(innerOutputColumns, input->outputColumns());
     innerOutputColumns.push_back(node->markColumn());
 
-    NodeCP innerApply = builder().make<Apply>(Apply::Key{
+    NodeCP innerApply = builder().make<Apply>({
         input,
         newBody,
         std::move(innerCorrelations),
@@ -444,7 +444,7 @@ class Decorrelator : public NodeRewriter<> {
     innerOutputColumns.push_back(node->markColumn());
     ColumnVector innerCorrelations =
         recomputeCorrelations(newBody, input->outputColumns());
-    NodeCP innerApply = builder().make<Apply>(Apply::Key{
+    NodeCP innerApply = builder().make<Apply>({
         input,
         newBody,
         std::move(innerCorrelations),
@@ -476,8 +476,8 @@ class Decorrelator : public NodeRewriter<> {
       int64_t count,
       ExprVector accumulatedFilter) {
     ColumnCP rowNumberPartition = makeIdColumn();
-    NodeCP taggedInput = builder().make<AssignUniqueId>(
-        AssignUniqueId::Key{input, rowNumberPartition});
+    NodeCP taggedInput =
+        builder().make<AssignUniqueId>({input, rowNumberPartition});
 
     NodeCP newBody = limitBody->input();
     ExprVector windowOrderKeys;
@@ -501,7 +501,7 @@ class Decorrelator : public NodeRewriter<> {
     ColumnVector innerCorrelations =
         recomputeCorrelations(newBody, taggedInput->outputColumns());
 
-    NodeCP innerApply = builder().make<Apply>(Apply::Key{
+    NodeCP innerApply = builder().make<Apply>({
         taggedInput,
         newBody,
         std::move(innerCorrelations),
@@ -526,7 +526,7 @@ class Decorrelator : public NodeRewriter<> {
 
     const Literal* countLiteral =
         builder().makeLiteral(velox::Variant(count), toType(velox::BIGINT()));
-    NodeCP filtered = builder().make<Filter>(Filter::Key{
+    NodeCP filtered = builder().make<Filter>({
         windowed,
         ExprVector{
             exprFactory_.makeLessThanOrEqual(rowNumberColumn, countLiteral)},
@@ -549,7 +549,7 @@ class Decorrelator : public NodeRewriter<> {
         finalExprs.push_back(outputColumn);
       }
     }
-    return builder().make<Project>(Project::Key{
+    return builder().make<Project>({
         enforced,
         std::move(finalExprs),
         node->outputColumns(),
@@ -610,7 +610,7 @@ class Decorrelator : public NodeRewriter<> {
     appendAll(outputs, input->outputColumns());
     outputs.push_back(rowNumberColumn);
 
-    return builder().make<Window>(Window::Key{
+    return builder().make<Window>({
         input,
         std::move(functions),
         ExprVector{partition},
@@ -756,7 +756,7 @@ class Decorrelator : public NodeRewriter<> {
         finalExprs.push_back(outputColumn);
       }
     }
-    return builder().make<Project>(Project::Key{
+    return builder().make<Project>({
         decorrelatedChain,
         std::move(finalExprs),
         node->outputColumns(),
@@ -843,7 +843,7 @@ class Decorrelator : public NodeRewriter<> {
             outputColumn == node->includeMarker() ? applyAIncludeMarker
                                                   : outputColumn);
       }
-      return builder().make<Project>(Project::Key{
+      return builder().make<Project>({
           chain,
           std::move(finalExprs),
           node->outputColumns(),
@@ -920,8 +920,7 @@ class Decorrelator : public NodeRewriter<> {
         exprFactory_.makeAnd(
             exprFactory_.makeNot(perOuter.anyMatch),
             isFirstRowOfOuter(perOuter.padOrdinal)));
-    NodeCP filtered =
-        builder().make<Filter>(Filter::Key{perOuter.node, ExprVector{keep}});
+    NodeCP filtered = builder().make<Filter>({perOuter.node, ExprVector{keep}});
 
     NodeCP enforced = node->enforceSingleRow()
         ? enforceScalarSingleRow(filtered, rowId)
@@ -948,7 +947,7 @@ class Decorrelator : public NodeRewriter<> {
             builder().makeNull(outputColumn->value().type)));
       }
     }
-    return builder().make<Project>(Project::Key{
+    return builder().make<Project>({
         enforced,
         std::move(finalExprs),
         node->outputColumns(),
@@ -958,7 +957,7 @@ class Decorrelator : public NodeRewriter<> {
   // Tags each 'input' row with a fresh id, so a later window can group a
   // chain's rows by the outer they came from.
   NodeCP tagOuterRows(NodeCP input, ColumnCP rowId) {
-    return builder().make<AssignUniqueId>(AssignUniqueId::Key{input, rowId});
+    return builder().make<AssignUniqueId>({input, rowId});
   }
 
   // A fresh BOOLEAN column for a kLeftSemiProject leg's mark. Each leg of a
@@ -982,7 +981,7 @@ class Decorrelator : public NodeRewriter<> {
     appendUnique(outputs, body->outputColumns());
     outputs.push_back(marker);
 
-    return builder().make<Apply>(Apply::Key{
+    return builder().make<Apply>({
         input,
         body,
         recomputeCorrelations(body, input->outputColumns()),
@@ -1012,7 +1011,7 @@ class Decorrelator : public NodeRewriter<> {
     appendAll(outputs, input->outputColumns());
     outputs.push_back(mark);
 
-    return builder().make<Apply>(Apply::Key{
+    return builder().make<Apply>({
         input,
         body,
         recomputeCorrelations(body, input->outputColumns()),
@@ -1082,7 +1081,7 @@ class Decorrelator : public NodeRewriter<> {
     appendAll(exprs, newExprs);
     appendAll(outputs, columns);
     return builder().make<Project>(
-        Project::Key{input, std::move(exprs), std::move(outputs)});
+        {input, std::move(exprs), std::move(outputs)});
   }
 
   NodeCP appendColumn(NodeCP input, ColumnCP column, ExprCP expr) {
@@ -1108,7 +1107,7 @@ class Decorrelator : public NodeRewriter<> {
     outputs.push_back(anyMatch);
     outputs.push_back(padOrdinal);
 
-    return builder().make<Window>(Window::Key{
+    return builder().make<Window>({
         input,
         std::move(functions),
         ExprVector{partition},
@@ -1185,7 +1184,7 @@ class Decorrelator : public NodeRewriter<> {
         finalExprs.push_back(outputColumn);
       }
     }
-    return builder().make<Project>(Project::Key{
+    return builder().make<Project>({
         decorrelatedChain,
         std::move(finalExprs),
         node->outputColumns(),
@@ -1239,8 +1238,8 @@ class Decorrelator : public NodeRewriter<> {
 
     // Any row of an outer serves: `anyMatch` reads the whole partition, and
     // the rest of the output is outer columns, which the partition shares.
-    NodeCP filtered = builder().make<Filter>(Filter::Key{
-        perOuter.node, ExprVector{isFirstRowOfOuter(perOuter.padOrdinal)}});
+    NodeCP filtered = builder().make<Filter>(
+        {perOuter.node, ExprVector{isFirstRowOfOuter(perOuter.padOrdinal)}});
 
     PlanObjectSet outerColumns =
         PlanObjectSet::fromObjects(input->outputColumns());
@@ -1256,7 +1255,7 @@ class Decorrelator : public NodeRewriter<> {
           "kLeftSemiProject Apply must output only outer columns and its mark");
       finalExprs.push_back(outputColumn);
     }
-    return builder().make<Project>(Project::Key{
+    return builder().make<Project>({
         filtered,
         std::move(finalExprs),
         node->outputColumns(),
@@ -1280,7 +1279,7 @@ class Decorrelator : public NodeRewriter<> {
       outputs.push_back(marker);
     }
 
-    return builder().make<Unnest>(Unnest::Key{
+    return builder().make<Unnest>({
         input,
         unnestBody->unnestExpressions(),
         std::move(replicated),
@@ -1341,7 +1340,7 @@ class Decorrelator : public NodeRewriter<> {
     appendAll(innerOutputColumns, input->outputColumns());
     appendUnique(innerOutputColumns, newBody->outputColumns());
 
-    NodeCP innerApply = builder().make<Apply>(Apply::Key{
+    NodeCP innerApply = builder().make<Apply>({
         input,
         newBody,
         recomputeCorrelations(newBody, input->outputColumns()),
@@ -1362,8 +1361,7 @@ class Decorrelator : public NodeRewriter<> {
     const ColumnVector unnestOutputs = lifted->outputColumns();
 
     if (!liftedFilter.empty()) {
-      lifted =
-          builder().make<Filter>(Filter::Key{lifted, std::move(liftedFilter)});
+      lifted = builder().make<Filter>({lifted, std::move(liftedFilter)});
     }
 
     // The lift carries every column the inner Apply produced, in its own
@@ -1373,7 +1371,7 @@ class Decorrelator : public NodeRewriter<> {
     }
     ExprVector finalExprs;
     appendAll(finalExprs, node->outputColumns());
-    return builder().make<Project>(Project::Key{
+    return builder().make<Project>({
         lifted,
         std::move(finalExprs),
         node->outputColumns(),
@@ -1457,7 +1455,7 @@ class Decorrelator : public NodeRewriter<> {
     windowOutputs.push_back(anyUnknown);
     windowOutputs.push_back(padOrdinal);
 
-    NodeCP windowed = builder().make<Window>(Window::Key{
+    NodeCP windowed = builder().make<Window>({
         compared,
         std::move(functions),
         ExprVector{rowId},
@@ -1481,7 +1479,7 @@ class Decorrelator : public NodeRewriter<> {
       ColumnCP padOrdinal,
       ExprCP mark) {
     NodeCP oneRowPerOuter = builder().make<Filter>(
-        Filter::Key{input, ExprVector{isFirstRowOfOuter(padOrdinal)}});
+        {input, ExprVector{isFirstRowOfOuter(padOrdinal)}});
 
     ExprVector finalExprs;
     finalExprs.reserve(node->outputColumns().size());
@@ -1489,7 +1487,7 @@ class Decorrelator : public NodeRewriter<> {
       finalExprs.push_back(
           outputColumn == node->markColumn() ? mark : outputColumn);
     }
-    return builder().make<Project>(Project::Key{
+    return builder().make<Project>({
         oneRowPerOuter,
         std::move(finalExprs),
         node->outputColumns(),
@@ -1543,7 +1541,7 @@ class Decorrelator : public NodeRewriter<> {
     ColumnVector innerCorrelations =
         recomputeCorrelations(newBody, input->outputColumns());
 
-    NodeCP innerApply = builder().make<Apply>(Apply::Key{
+    NodeCP innerApply = builder().make<Apply>({
         input,
         newBody,
         std::move(innerCorrelations),
@@ -1558,8 +1556,8 @@ class Decorrelator : public NodeRewriter<> {
     });
     NodeCP decorrelatedInner = rewrite(innerApply);
 
-    NodeCP withId = builder().make<AssignUniqueId>(
-        AssignUniqueId::Key{decorrelatedInner, idColumn});
+    NodeCP withId =
+        builder().make<AssignUniqueId>({decorrelatedInner, idColumn});
 
     // Final Project reorders `withId`'s cols to match
     // `node->outputColumns()` and aliases the inner includeMarker to
@@ -1573,7 +1571,7 @@ class Decorrelator : public NodeRewriter<> {
         finalExprs.push_back(outputColumn);
       }
     }
-    return builder().make<Project>(Project::Key{
+    return builder().make<Project>({
         withId,
         std::move(finalExprs),
         node->outputColumns(),
@@ -1783,7 +1781,7 @@ class Decorrelator : public NodeRewriter<> {
 
     NodeCP cleanBody = localPredicates.empty()
         ? base
-        : builder().make<Filter>(Filter::Key{base, std::move(localPredicates)});
+        : builder().make<Filter>({base, std::move(localPredicates)});
     return EquiCorrelation{
         cleanBody, std::move(split.leftKeys), std::move(split.rightKeys)};
   }
@@ -1824,7 +1822,7 @@ class Decorrelator : public NodeRewriter<> {
     }
 
     AggregateCallVector aggregates = aggregate->aggregates();
-    NodeCP groupedBody = builder().make<Aggregate>(Aggregate::Key{
+    NodeCP groupedBody = builder().make<Aggregate>({
         correlation.cleanBody,
         std::move(correlation.rightKeys),
         std::move(aggregates),
@@ -1844,7 +1842,7 @@ class Decorrelator : public NodeRewriter<> {
     ExprVector rightKeyExprs;
     appendAll(rightKeyExprs, rightKeyColumns);
 
-    NodeCP join = builder().make<Join>(Join::Key{
+    NodeCP join = builder().make<Join>({
         input,
         groupedBody,
         velox::core::JoinType::kLeft,
@@ -1980,8 +1978,7 @@ class Decorrelator : public NodeRewriter<> {
       AggregateCP aggregate,
       ExprVector filterPre) {
     ColumnCP rowIdColumn = makeIdColumn();
-    NodeCP taggedInput =
-        builder().make<AssignUniqueId>(AssignUniqueId::Key{input, rowIdColumn});
+    NodeCP taggedInput = builder().make<AssignUniqueId>({input, rowIdColumn});
 
     NodeCP body = aggregate->input();
 
@@ -2005,7 +2002,7 @@ class Decorrelator : public NodeRewriter<> {
     ColumnVector innerCorrelations =
         recomputeCorrelations(body, taggedInput->outputColumns());
 
-    NodeCP applyNode = builder().make<Apply>(Apply::Key{
+    NodeCP applyNode = builder().make<Apply>({
         taggedInput,
         body,
         std::move(innerCorrelations),
@@ -2073,7 +2070,7 @@ class Decorrelator : public NodeRewriter<> {
     }
     appendAll(liftedOutputColumns, input->outputColumns());
 
-    return builder().make<Aggregate>(Aggregate::Key{
+    return builder().make<Aggregate>({
         decorrelatedInner,
         std::move(groupingKeys),
         std::move(liftedAggregates),
@@ -2147,7 +2144,7 @@ class Decorrelator : public NodeRewriter<> {
     // row per outer (grouped by the per-outer id, or one match per outer
     // from the join-back), so there are no pad rows to exclude.
     finalExpressions.push_back(builder().makeBoolean(true));
-    return builder().make<Project>(Project::Key{
+    return builder().make<Project>({
         child,
         std::move(finalExpressions),
         node->outputColumns(),
@@ -2193,7 +2190,7 @@ class Decorrelator : public NodeRewriter<> {
     outputColumns.push_back(includeMarker);
 
     return builder().make<Project>(
-        Project::Key{body, std::move(exprs), std::move(outputColumns)});
+        {body, std::move(exprs), std::move(outputColumns)});
   }
 
   NodeCP
@@ -2207,7 +2204,7 @@ class Decorrelator : public NodeRewriter<> {
           filter,
           PlanObjectSet::fromObjects(input->outputColumns()),
           PlanObjectSet::fromObjects(markedBody->outputColumns()));
-      return builder().make<Join>(Join::Key{
+      return builder().make<Join>({
           input,
           markedBody,
           velox::core::JoinType::kLeft,
@@ -2227,8 +2224,7 @@ class Decorrelator : public NodeRewriter<> {
 
     // Tag input rows with a fresh BIGINT id column.
     ColumnCP idColumn = makeIdColumn();
-    NodeCP taggedInput =
-        builder().make<AssignUniqueId>(AssignUniqueId::Key{input, idColumn});
+    NodeCP taggedInput = builder().make<AssignUniqueId>({input, idColumn});
 
     // Build LEFT JOIN; output carries taggedInput.cols ++ markedBody.cols
     // (i.e., input.cols + idColumn + body.cols + includeMarker).
@@ -2243,7 +2239,7 @@ class Decorrelator : public NodeRewriter<> {
         filter,
         PlanObjectSet::fromObjects(taggedInput->outputColumns()),
         PlanObjectSet::fromObjects(markedBody->outputColumns()));
-    NodeCP join = builder().make<Join>(Join::Key{
+    NodeCP join = builder().make<Join>({
         taggedInput,
         markedBody,
         velox::core::JoinType::kLeft,
@@ -2264,7 +2260,7 @@ class Decorrelator : public NodeRewriter<> {
     ExprVector finalExprs;
     finalExprs.reserve(apply->outputColumns().size());
     appendAll(finalExprs, apply->outputColumns());
-    return builder().make<Project>(Project::Key{
+    return builder().make<Project>({
         enforced,
         std::move(finalExprs),
         apply->outputColumns(),
@@ -2289,7 +2285,7 @@ class Decorrelator : public NodeRewriter<> {
         filter,
         PlanObjectSet::fromObjects(input->outputColumns()),
         PlanObjectSet::fromObjects(body->outputColumns()));
-    return builder().make<Join>(Join::Key{
+    return builder().make<Join>({
         input,
         body,
         velox::core::JoinType::kInner,
@@ -2358,7 +2354,7 @@ class Decorrelator : public NodeRewriter<> {
     appendAll(innerOutputColumns, input->outputColumns());
     innerOutputColumns.push_back(node->markColumn());
 
-    NodeCP newApply = builder().make<Apply>(Apply::Key{
+    NodeCP newApply = builder().make<Apply>({
         input,
         newBody,
         std::move(innerCorrelations),
@@ -2423,7 +2419,7 @@ class Decorrelator : public NodeRewriter<> {
       finalExprs.reserve(input->outputColumns().size() + 1);
       appendAll(finalExprs, input->outputColumns());
       finalExprs.push_back(builder().makeBoolean(true));
-      return builder().make<Project>(Project::Key{
+      return builder().make<Project>({
           input,
           std::move(finalExprs),
           node->outputColumns(),
@@ -2456,7 +2452,7 @@ class Decorrelator : public NodeRewriter<> {
       outputs.push_back(rawMark);
       appendAll(outputs, input->outputColumns());
 
-      NodeCP agg = builder().make<Aggregate>(Aggregate::Key{
+      NodeCP agg = builder().make<Aggregate>({
           decorrelatedInner,
           ExprVector{innerApply.rowIdColumn},
           std::move(aggregates),
@@ -2470,7 +2466,7 @@ class Decorrelator : public NodeRewriter<> {
       finalExprs.reserve(input->outputColumns().size() + 1);
       appendAll(finalExprs, input->outputColumns());
       finalExprs.push_back(markExpr);
-      return builder().make<Project>(Project::Key{
+      return builder().make<Project>({
           agg,
           std::move(finalExprs),
           node->outputColumns(),
@@ -2521,7 +2517,7 @@ class Decorrelator : public NodeRewriter<> {
       stage1OutputColumns.push_back(padPresentColumn);
     }
 
-    NodeCP stage1 = builder().make<Aggregate>(Aggregate::Key{
+    NodeCP stage1 = builder().make<Aggregate>({
         decorrelatedInner,
         std::move(stage1GroupingKeys),
         std::move(stage1Aggregates),
@@ -2575,7 +2571,7 @@ class Decorrelator : public NodeRewriter<> {
       stage15Expressions.push_back(combinedExpr);
       stage15Outputs.push_back(combinedColumn);
 
-      NodeCP stage15 = builder().make<Project>(Project::Key{
+      NodeCP stage15 = builder().make<Project>({
           stage1,
           std::move(stage15Expressions),
           std::move(stage15Outputs),
@@ -2601,7 +2597,7 @@ class Decorrelator : public NodeRewriter<> {
       stage2Outputs.push_back(hasTrueColumn);
       appendAll(stage2Outputs, input->outputColumns());
 
-      NodeCP stage2 = builder().make<Aggregate>(Aggregate::Key{
+      NodeCP stage2 = builder().make<Aggregate>({
           stage15,
           ExprVector{innerApply.rowIdColumn},
           std::move(stage2Aggregates),
@@ -2617,7 +2613,7 @@ class Decorrelator : public NodeRewriter<> {
     appendAll(finalExpressions, input->outputColumns());
     finalExpressions.push_back(markExpr);
 
-    return builder().make<Project>(Project::Key{
+    return builder().make<Project>({
         finalInput,
         std::move(finalExpressions),
         node->outputColumns(),
@@ -2723,7 +2719,7 @@ class Decorrelator : public NodeRewriter<> {
       stage1OutputColumns.push_back(padPresentColumn);
     }
 
-    NodeCP stage1 = builder().make<Aggregate>(Aggregate::Key{
+    NodeCP stage1 = builder().make<Aggregate>({
         decorrelatedInner,
         std::move(stage1GroupingKeys),
         std::move(stage1Aggregates),
@@ -2801,7 +2797,7 @@ class Decorrelator : public NodeRewriter<> {
       stage15Expressions.push_back(combinedExpr);
       stage15Outputs.push_back(combinedColumn);
 
-      NodeCP stage15 = builder().make<Project>(Project::Key{
+      NodeCP stage15 = builder().make<Project>({
           stage1,
           std::move(stage15Expressions),
           std::move(stage15Outputs),
@@ -2833,7 +2829,7 @@ class Decorrelator : public NodeRewriter<> {
       stage2Outputs.push_back(hasNullColumn);
       appendAll(stage2Outputs, input->outputColumns());
 
-      NodeCP stage2 = builder().make<Aggregate>(Aggregate::Key{
+      NodeCP stage2 = builder().make<Aggregate>({
           stage15,
           ExprVector{innerApply.rowIdColumn},
           std::move(stage2Aggregates),
@@ -2862,7 +2858,7 @@ class Decorrelator : public NodeRewriter<> {
     appendAll(finalExpressions, input->outputColumns());
     finalExpressions.push_back(markExpr);
 
-    return builder().make<Project>(Project::Key{
+    return builder().make<Project>({
         finalInput,
         std::move(finalExpressions),
         node->outputColumns(),
@@ -2921,7 +2917,7 @@ class Decorrelator : public NodeRewriter<> {
       appendAll(leftKeys, split.leftKeys);
       appendAll(rightKeys, split.rightKeys);
     }
-    return builder().make<Join>(Join::Key{
+    return builder().make<Join>({
         input,
         body,
         velox::core::JoinType::kLeftSemiProject,
@@ -2953,7 +2949,7 @@ class Decorrelator : public NodeRewriter<> {
   // per `perOuterId`, raising SQL's "scalar subquery returned multiple
   // rows" error otherwise.
   NodeCP enforceScalarSingleRow(NodeCP input, ColumnCP perOuterId) {
-    return builder().make<EnforceDistinct>(EnforceDistinct::Key{
+    return builder().make<EnforceDistinct>({
         input,
         ExprVector{perOuterId},
         toName("Scalar sub-query has returned multiple rows"),

--- a/axiom/optimizer/v2/ExpandAggregatePass.cpp
+++ b/axiom/optimizer/v2/ExpandAggregatePass.cpp
@@ -114,14 +114,14 @@ class AggregateExpander : public NodeRewriter<> {
     if (newInput == node->input() && aggregates == node->aggregates()) {
       return node;
     }
-    return builder().make<Aggregate>(Aggregate::Key{
-        .input = newInput,
-        .groupingKeys = node->groupingKeys(),
-        .aggregates = std::move(aggregates),
-        .outputColumns = node->outputColumns(),
-        .step = node->step(),
-        .groupId = node->groupId(),
-        .globalGroupingSets = node->globalGroupingSets()});
+    return builder().make<Aggregate>(
+        {.input = newInput,
+         .groupingKeys = node->groupingKeys(),
+         .aggregates = std::move(aggregates),
+         .outputColumns = node->outputColumns(),
+         .step = node->step(),
+         .groupId = node->groupId(),
+         .globalGroupingSets = node->globalGroupingSets()});
   }
 
  private:
@@ -197,7 +197,7 @@ class AggregateExpander : public NodeRewriter<> {
       appendAll(outputColumns, currentInput->outputColumns());
       appendAll(outputColumns, group.markers);
 
-      currentInput = builder().make<MarkDistinct>(MarkDistinct::Key{
+      currentInput = builder().make<MarkDistinct>({
           currentInput,
           group.markers,
           group.keys,

--- a/axiom/optimizer/v2/FoldMetadataAggregatePass.cpp
+++ b/axiom/optimizer/v2/FoldMetadataAggregatePass.cpp
@@ -222,14 +222,14 @@ class Folder : public NodeRewriter<NoContext> {
       aggregates.push_back(aggregate->fallback());
     }
 
-    return builder().make<Aggregate>(Aggregate::Key{
-        .input = newInput,
-        .groupingKeys = node->groupingKeys(),
-        .aggregates = std::move(aggregates),
-        .outputColumns = node->outputColumns(),
-        .step = node->step(),
-        .groupId = node->groupId(),
-        .globalGroupingSets = node->globalGroupingSets()});
+    return builder().make<Aggregate>(
+        {.input = newInput,
+         .groupingKeys = node->groupingKeys(),
+         .aggregates = std::move(aggregates),
+         .outputColumns = node->outputColumns(),
+         .step = node->step(),
+         .groupId = node->groupId(),
+         .globalGroupingSets = node->globalGroupingSets()});
   }
 
   const OptimizerSession& session_;

--- a/axiom/optimizer/v2/JoinTreeEmitter.cpp
+++ b/axiom/optimizer/v2/JoinTreeEmitter.cpp
@@ -207,7 +207,7 @@ NodeCP restoreTargets(
     exprs.push_back(it != reps.end() ? it->second : target);
   }
   return state.builder.make<Project>(
-      Project::Key{node, std::move(exprs), ColumnVector{targets}});
+      {node, std::move(exprs), ColumnVector{targets}});
 }
 
 // The equalities of `extraEdges` — the inner edges that crossed the same
@@ -250,11 +250,11 @@ NodeCP emitLeaf(const LeafOp* leaf, EmitState& state) {
   if (partitionType != nullptr && node->is(NodeType::kScan)) {
     const auto* scan = node->as<Scan>();
     if (scan->groupedPartitionType() != partitionType) {
-      return state.builder.make<Scan>(Scan::Key{
-          .baseTable = scan->baseTable(),
-          .outputColumns = scan->outputColumns(),
-          .scanHandle = scan->scanHandle(),
-          .groupedPartitionType = partitionType});
+      return state.builder.make<Scan>(
+          {.baseTable = scan->baseTable(),
+           .outputColumns = scan->outputColumns(),
+           .scanHandle = scan->scanHandle(),
+           .groupedPartitionType = partitionType});
     }
   }
   return node;
@@ -313,17 +313,17 @@ Emitted buildUnnest(const UnnestOp* unnest, Emitted input, EmitState& state) {
     outputColumns.push_back(origUnnest->markerColumn());
   }
 
-  NodeCP node = state.builder.make<Unnest>(Unnest::Key{
-      input.node,
-      std::move(unnestExpressions),
-      std::move(replicatedColumns),
-      origUnnest->unnestColumns(),
-      origUnnest->ordinalityColumn(),
-      origUnnest->markerColumn(),
-      std::move(outputColumns)});
+  NodeCP node = state.builder.make<Unnest>(
+      {input.node,
+       std::move(unnestExpressions),
+       std::move(replicatedColumns),
+       origUnnest->unnestColumns(),
+       origUnnest->ordinalityColumn(),
+       origUnnest->markerColumn(),
+       std::move(outputColumns)});
 
   if (!predicates.empty()) {
-    node = state.builder.make<Filter>(Filter::Key{node, std::move(predicates)});
+    node = state.builder.make<Filter>({node, std::move(predicates)});
   }
 
   retainVisible(input.materialized, node);
@@ -460,18 +460,18 @@ Emitted buildJoin(
     }
   }
 
-  NodeCP node = state.builder.make<Join>(Join::Key{
-      left.node,
-      right.node,
-      join->joinType,
-      std::move(leftKeys),
-      std::move(rightKeys),
-      std::move(filter),
-      edge.nullAware(),
-      edge.nullAsValue(),
-      std::move(outputColumns)});
+  NodeCP node = state.builder.make<Join>(
+      {left.node,
+       right.node,
+       join->joinType,
+       std::move(leftKeys),
+       std::move(rightKeys),
+       std::move(filter),
+       edge.nullAware(),
+       edge.nullAsValue(),
+       std::move(outputColumns)});
   if (!aboveJoin.empty()) {
-    node = state.builder.make<Filter>(Filter::Key{node, std::move(aboveJoin)});
+    node = state.builder.make<Filter>({node, std::move(aboveJoin)});
   }
   retainVisible(materialized, node);
   return {node, std::move(materialized)};
@@ -505,19 +505,19 @@ Emitted buildReversedAnti(
   auto materialized = merge(probe.materialized, build.materialized);
   const auto substitution =
       merge(collapsedColumns(mergedChildReps(join, state)), materialized);
-  NodeCP rightSemiProject = state.builder.make<Join>(Join::Key{
-      probe.node,
-      build.node,
-      velox::core::JoinType::kRightSemiProject,
-      rewrite(ExprVector{edge.rightKeys()}, substitution, state),
-      rewrite(ExprVector{edge.leftKeys()}, substitution, state),
-      rewrite(ExprVector{edge.filter()}, substitution, state),
-      edge.nullAware(),
-      edge.nullAsValue(),
-      std::move(joinOutput)});
+  NodeCP rightSemiProject = state.builder.make<Join>(
+      {probe.node,
+       build.node,
+       velox::core::JoinType::kRightSemiProject,
+       rewrite(ExprVector{edge.rightKeys()}, substitution, state),
+       rewrite(ExprVector{edge.leftKeys()}, substitution, state),
+       rewrite(ExprVector{edge.filter()}, substitution, state),
+       edge.nullAware(),
+       edge.nullAsValue(),
+       std::move(joinOutput)});
 
   NodeCP filtered = state.builder.make<Filter>(
-      Filter::Key{rightSemiProject, ExprVector{state.exprs.makeNot(mark)}});
+      {rightSemiProject, ExprVector{state.exprs.makeNot(mark)}});
 
   // Project away the mark, restoring the antijoin's output schema. Every
   // entry is a pass-through of the preserved-side column.
@@ -527,7 +527,7 @@ Emitted buildReversedAnti(
     projectExprs.push_back(column);
   }
   NodeCP node = state.builder.make<Project>(
-      Project::Key{filtered, std::move(projectExprs), antiOutput});
+      {filtered, std::move(projectExprs), antiOutput});
   retainVisible(materialized, node);
   return {node, std::move(materialized)};
 }
@@ -625,8 +625,7 @@ Emitted emitExchange(const ExchangeOp* exchange, EmitState& state) {
         partitioning.keys[i]->toString());
   }
   partitioning.keys = std::move(columnKeys);
-  NodeCP node = state.builder.make<Exchange>(
-      Exchange::Key{keyed, std::move(partitioning)});
+  NodeCP node = state.builder.make<Exchange>({keyed, std::move(partitioning)});
   return {node, std::move(input.materialized)};
 }
 
@@ -741,8 +740,7 @@ NodeCP JoinTreeEmitter::emitComponents(
     // partitioning and a single-task (Values / global-aggregate) or scan build
     // is isolated in its own fragment instead of co-locating with the probe.
     if (numWorkers > 1) {
-      build = builder.make<Exchange>(
-          Exchange::Key{build, Partitioning::globalBroadcast()});
+      build = builder.make<Exchange>({build, Partitioning::globalBroadcast()});
     }
     cover.unionSet(componentRoots[order[i]]->cover());
     const bool isLast = (i + 1 == order.size());
@@ -751,19 +749,19 @@ NodeCP JoinTreeEmitter::emitComponents(
         : coverNarrowedColumns(state.graph, cover, result, build);
     const auto substitution =
         merge(collapsedColumns(graph.coverColumnReps(cover)), materialized);
-    result = builder.make<Join>(Join::Key{
-        result,
-        build,
-        velox::core::JoinType::kInner,
-        /*leftKeys=*/ExprVector{},
-        /*rightKeys=*/ExprVector{},
-        rewrite(
-            takeReadyConjuncts(state.graph, cover, state.fired),
-            substitution,
-            state),
-        /*nullAware=*/false,
-        /*nullAsValue=*/false,
-        std::move(columns)});
+    result = builder.make<Join>(
+        {result,
+         build,
+         velox::core::JoinType::kInner,
+         /*leftKeys=*/ExprVector{},
+         /*rightKeys=*/ExprVector{},
+         rewrite(
+             takeReadyConjuncts(state.graph, cover, state.fired),
+             substitution,
+             state),
+         /*nullAware=*/false,
+         /*nullAsValue=*/false,
+         std::move(columns)});
   }
 
   if (collapsed) {

--- a/axiom/optimizer/v2/NodeRewriter.h
+++ b/axiom/optimizer/v2/NodeRewriter.h
@@ -175,14 +175,14 @@ class NodeRewriter {
     if (newInput == node->input()) {
       return node;
     }
-    return builder_.template make<Aggregate>(Aggregate::Key{
-        .input = newInput,
-        .groupingKeys = node->groupingKeys(),
-        .aggregates = node->aggregates(),
-        .outputColumns = node->outputColumns(),
-        .step = node->step(),
-        .groupId = node->groupId(),
-        .globalGroupingSets = node->globalGroupingSets()});
+    return builder_.template make<Aggregate>(
+        {.input = newInput,
+         .groupingKeys = node->groupingKeys(),
+         .aggregates = node->aggregates(),
+         .outputColumns = node->outputColumns(),
+         .step = node->step(),
+         .groupId = node->groupId(),
+         .globalGroupingSets = node->globalGroupingSets()});
   }
 
   virtual NodeCP rewriteGroupId(const GroupId* node, TContext& context) {
@@ -395,7 +395,7 @@ class NodeRewriter {
         newConvergence == node->convergence()) {
       return node;
     }
-    return builder_.template make<FixedPoint>(FixedPoint::Key{
+    return builder_.template make<FixedPoint>({
         .anchor = newAnchor,
         .step = newStep,
         .convergence = newConvergence,

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -247,12 +247,12 @@ class GroupedScanRewriter : public NodeRewriter<> {
     }
     // Coarsened to the worker count here so the plan carries the group count
     // it will run with, and two scans that scale alike stay one node.
-    NodeCP grouped = builder().make<Scan>(Scan::Key{
-        .baseTable = node->baseTable(),
-        .outputColumns = node->outputColumns(),
-        .scanHandle = node->scanHandle(),
-        .groupedPartitionType = queryCtx()->scaledPartitionType(
-            available.partitionType, numWorkers_)});
+    NodeCP grouped = builder().make<Scan>(
+        {.baseTable = node->baseTable(),
+         .outputColumns = node->outputColumns(),
+         .scanHandle = node->scanHandle(),
+         .groupedPartitionType = queryCtx()->scaledPartitionType(
+             available.partitionType, numWorkers_)});
     // A scan already read this way interns back to itself, and then this
     // rewrite changed nothing.
     if (grouped != node) {
@@ -312,7 +312,7 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
         node->recursiveNumDrivers() == kRecursiveNumDrivers) {
       return node;
     }
-    return builder().make<FixedPoint>(FixedPoint::Key{
+    return builder().make<FixedPoint>({
         .anchor = anchor,
         .step = step,
         .convergence = convergence,
@@ -366,16 +366,16 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
     if (newLeft == node->left() && newRight == node->right()) {
       return node;
     }
-    return builder().make<Join>(Join::Key{
-        .left = newLeft,
-        .right = newRight,
-        .joinType = node->joinType(),
-        .leftKeys = leftKeys,
-        .rightKeys = rightKeys,
-        .filter = node->filter(),
-        .nullAware = node->nullAware(),
-        .nullAsValue = node->nullAsValue(),
-        .outputColumns = node->outputColumns()});
+    return builder().make<Join>(
+        {.left = newLeft,
+         .right = newRight,
+         .joinType = node->joinType(),
+         .leftKeys = leftKeys,
+         .rightKeys = rightKeys,
+         .filter = node->filter(),
+         .nullAware = node->nullAware(),
+         .nullAsValue = node->nullAsValue(),
+         .outputColumns = node->outputColumns()});
   }
 
   NodeCP rewriteJoin(const Join* node, NoContext& context) override {
@@ -793,14 +793,14 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
     if (!materialized.empty()) {
       groupingKeys = exprFactory_.replace(groupingKeys, materialized);
     }
-    return builder().make<Aggregate>(Aggregate::Key{
-        .input = coLocatedInput,
-        .groupingKeys = groupingKeys,
-        .aggregates = node->aggregates(),
-        .outputColumns = node->outputColumns(),
-        .step = node->step(),
-        .groupId = node->groupId(),
-        .globalGroupingSets = node->globalGroupingSets()});
+    return builder().make<Aggregate>(
+        {.input = coLocatedInput,
+         .groupingKeys = groupingKeys,
+         .aggregates = node->aggregates(),
+         .outputColumns = node->outputColumns(),
+         .step = node->step(),
+         .groupId = node->groupId(),
+         .globalGroupingSets = node->globalGroupingSets()});
   }
 
   // True when 'node' can two-stage into partial + final, independent of whether
@@ -901,14 +901,14 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
                   finalColumn->value().cardinality}));
     }
 
-    NodeCP partial = builder().make<Aggregate>(Aggregate::Key{
-        .input = input,
-        .groupingKeys = node->groupingKeys(),
-        .aggregates = node->aggregates(),
-        .outputColumns = std::move(partialColumns),
-        .step = AggregateStep::kPartial,
-        .groupId = node->groupId(),
-        .globalGroupingSets = node->globalGroupingSets()});
+    NodeCP partial = builder().make<Aggregate>(
+        {.input = input,
+         .groupingKeys = node->groupingKeys(),
+         .aggregates = node->aggregates(),
+         .outputColumns = std::move(partialColumns),
+         .step = AggregateStep::kPartial,
+         .groupId = node->groupId(),
+         .globalGroupingSets = node->globalGroupingSets()});
 
     // The final groups the exchanged partials by their output grouping-key
     // columns (the partial already evaluated any compound grouping
@@ -927,14 +927,14 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
         : finalKeys.empty()             ? gather(partial)
                                         : partition(partial, finalKeys);
 
-    return builder().make<Aggregate>(Aggregate::Key{
-        .input = finalInput,
-        .groupingKeys = finalKeys,
-        .aggregates = node->aggregates(),
-        .outputColumns = finalColumns,
-        .step = AggregateStep::kFinal,
-        .groupId = node->groupId(),
-        .globalGroupingSets = node->globalGroupingSets()});
+    return builder().make<Aggregate>(
+        {.input = finalInput,
+         .groupingKeys = finalKeys,
+         .aggregates = node->aggregates(),
+         .outputColumns = finalColumns,
+         .step = AggregateStep::kFinal,
+         .groupId = node->groupId(),
+         .globalGroupingSets = node->globalGroupingSets()});
   }
 
   // Distributes a window: its input must be partitioned on the PARTITION BY

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
@@ -413,14 +413,14 @@ NodeCP Rewriter::rewriteAggregate(
     }
   }
 
-  return builder().make<Aggregate>(Aggregate::Key{
-      .input = std::move(precompute).node(),
-      .groupingKeys = std::move(newGroupingKeys),
-      .aggregates = std::move(newAggregates),
-      .outputColumns = aggregate->outputColumns(),
-      .step = aggregate->step(),
-      .groupId = aggregate->groupId(),
-      .globalGroupingSets = aggregate->globalGroupingSets()});
+  return builder().make<Aggregate>(
+      {.input = std::move(precompute).node(),
+       .groupingKeys = std::move(newGroupingKeys),
+       .aggregates = std::move(newAggregates),
+       .outputColumns = aggregate->outputColumns(),
+       .step = aggregate->step(),
+       .groupId = aggregate->groupId(),
+       .globalGroupingSets = aggregate->globalGroupingSets()});
 }
 
 NodeCP Rewriter::rewriteWindow(const Window* window, NoContext& context) {
@@ -713,7 +713,7 @@ NodeCP Rewriter::rewriteFixedPoint(
       convergence == fixedPoint->convergence()) {
     return fixedPoint;
   }
-  return builder().make<FixedPoint>(FixedPoint::Key{
+  return builder().make<FixedPoint>({
       .anchor = anchor,
       .step = step,
       .convergence = convergence,

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -773,14 +773,14 @@ class Pushdown : public NodeRewriter<PushdownContext> {
       NodeCP newInput = rewrite(node->input(), childContext);
       NodeCP newAggregate = (newInput == node->input())
           ? static_cast<NodeCP>(node)
-          : builder().make<Aggregate>(Aggregate::Key{
-                .input = newInput,
-                .groupingKeys = node->groupingKeys(),
-                .aggregates = node->aggregates(),
-                .outputColumns = node->outputColumns(),
-                .step = node->step(),
-                .groupId = node->groupId(),
-                .globalGroupingSets = node->globalGroupingSets()});
+          : builder().make<Aggregate>(
+                {.input = newInput,
+                 .groupingKeys = node->groupingKeys(),
+                 .aggregates = node->aggregates(),
+                 .outputColumns = node->outputColumns(),
+                 .step = node->step(),
+                 .groupId = node->groupId(),
+                 .globalGroupingSets = node->globalGroupingSets()});
       return maybeWrapFilter(newAggregate, std::move(context.pending));
     }
 
@@ -833,14 +833,14 @@ class Pushdown : public NodeRewriter<PushdownContext> {
         survivingAggregates.size() == node->aggregates().size();
     NodeCP newAggregate = unchanged
         ? static_cast<NodeCP>(node)
-        : builder().make<Aggregate>(Aggregate::Key{
-              .input = newInput,
-              .groupingKeys = node->groupingKeys(),
-              .aggregates = std::move(survivingAggregates),
-              .outputColumns = std::move(survivingOutputs),
-              .step = node->step(),
-              .groupId = node->groupId(),
-              .globalGroupingSets = node->globalGroupingSets()});
+        : builder().make<Aggregate>(
+              {.input = newInput,
+               .groupingKeys = node->groupingKeys(),
+               .aggregates = std::move(survivingAggregates),
+               .outputColumns = std::move(survivingOutputs),
+               .step = node->step(),
+               .groupId = node->groupId(),
+               .globalGroupingSets = node->globalGroupingSets()});
     return maybeWrapFilter(newAggregate, std::move(blocked));
   }
 
@@ -1815,7 +1815,7 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     NodeCP fixedPoint = node;
     if (newAnchor != node->anchor() || newStep != node->step() ||
         newConvergence != node->convergence()) {
-      fixedPoint = builder().make<FixedPoint>(FixedPoint::Key{
+      fixedPoint = builder().make<FixedPoint>({
           .anchor = newAnchor,
           .step = newStep,
           .convergence = newConvergence,

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -874,7 +874,7 @@ NodeCP Translator::makeWorkingTable() {
       activeFixedPoint_.has_value(),
       "WorkingTable requires an enclosing FixedPoint");
   const auto& enclosing = *activeFixedPoint_;
-  return builder_.make<WorkingTable>(WorkingTable::Key{
+  return builder_.make<WorkingTable>({
       .name = enclosing.stateName,
       .outputColumns = enclosing.stateColumns,
       .readMode = WorkingTableReadMode::kLatestDelta,
@@ -895,7 +895,7 @@ NodeCP Translator::makeEmptyDeltaConvergence() {
       {});
   ColumnCP countColumn =
       Column::create("__converged_count", Value(toType(velox::BIGINT())));
-  NodeCP aggregation = builder_.make<Aggregate>(Aggregate::Key{
+  NodeCP aggregation = builder_.make<Aggregate>({
       .input = workingTable,
       .groupingKeys = {},
       .aggregates = {count},
@@ -907,7 +907,7 @@ NodeCP Translator::makeEmptyDeltaConvergence() {
   ExprCP convergedExpr = exprFactory_.makeEq(countColumn, zero);
   ColumnCP convergedColumn =
       Column::create("converged", Value(toType(velox::BOOLEAN())));
-  return builder_.make<Project>(Project::Key{
+  return builder_.make<Project>({
       .input = aggregation,
       .exprs = {convergedExpr},
       .outputColumns = {convergedColumn},
@@ -970,7 +970,7 @@ Translated Translator::translateFixedPoint(
   NodeCP convergence = makeEmptyDeltaConvergence();
 
   return {
-      builder_.make<FixedPoint>(FixedPoint::Key{
+      builder_.make<FixedPoint>({
           .anchor = anchor.node,
           .step = step.node,
           .convergence = convergence,
@@ -1899,11 +1899,11 @@ Translated Translator::translateAggregate(
   }
 
   if (groupingSets.empty()) {
-    AggregateCP aggNode = builder_.make<Aggregate>(Aggregate::Key{
-        .input = currentInput,
-        .groupingKeys = std::move(groupingKeys),
-        .aggregates = std::move(aggregates),
-        .outputColumns = std::move(outputColumns)});
+    AggregateCP aggNode = builder_.make<Aggregate>(
+        {.input = currentInput,
+         .groupingKeys = std::move(groupingKeys),
+         .aggregates = std::move(aggregates),
+         .outputColumns = std::move(outputColumns)});
     return {
         appendConstantColumns(aggNode, foldedColumns, foldedExprs),
         std::move(newScope)};
@@ -2018,14 +2018,14 @@ NodeCP Translator::lowerGroupingSets(
     setsCopy.emplace_back(set.begin(), set.end());
   }
 
-  NodeCP groupIdNode = builder_.make<GroupId>(GroupId::Key{
-      groupIdInput,
-      groupIdInputKeys,
-      aggregationInputs,
-      setsCopy,
-      keyOutputColumns,
-      groupIdColumn,
-      groupIdOutputs});
+  NodeCP groupIdNode = builder_.make<GroupId>(
+      {groupIdInput,
+       groupIdInputKeys,
+       aggregationInputs,
+       setsCopy,
+       keyOutputColumns,
+       groupIdColumn,
+       groupIdOutputs});
 
   // Aggregate keys: the GroupId key output columns plus the group-id column.
   ExprVector aggGroupingKeys;
@@ -2050,14 +2050,14 @@ NodeCP Translator::lowerGroupingSets(
   aggOutputColumns.push_back(groupIdColumn);
   appendAll(aggOutputColumns, aggResultColumns);
 
-  AggregateCP aggNode = builder_.make<Aggregate>(Aggregate::Key{
-      .input = groupIdNode,
-      .groupingKeys = std::move(aggGroupingKeys),
-      .aggregates = std::move(aggregates),
-      .outputColumns = std::move(aggOutputColumns),
-      .step = AggregateStep::kSingle,
-      .groupId = aggGroupId,
-      .globalGroupingSets = std::move(globalGroupingSets)});
+  AggregateCP aggNode = builder_.make<Aggregate>(
+      {.input = groupIdNode,
+       .groupingKeys = std::move(aggGroupingKeys),
+       .aggregates = std::move(aggregates),
+       .outputColumns = std::move(aggOutputColumns),
+       .step = AggregateStep::kSingle,
+       .groupId = aggGroupId,
+       .globalGroupingSets = std::move(globalGroupingSets)});
   return aggNode;
 }
 
@@ -2751,7 +2751,7 @@ bool Translator::tryJoinIntoPendingLifts(NodeCP body, LiftTarget& target) {
   // kLeft because the pending lifts carry values other references read. An
   // inner join would drop their row when the body has no match, and the
   // EnforceSingleRow above would then null every column, not just the body's.
-  NodeCP join = builder_.make<Join>(Join::Key{
+  NodeCP join = builder_.make<Join>({
       target.pendingLifts,
       child,
       velox::core::JoinType::kLeft,
@@ -2762,8 +2762,7 @@ bool Translator::tryJoinIntoPendingLifts(NodeCP body, LiftTarget& target) {
       /*nullAsValue=*/false,
       std::move(joinOutput),
   });
-  target.pendingLifts =
-      builder_.make<EnforceSingleRow>(EnforceSingleRow::Key{join});
+  target.pendingLifts = builder_.make<EnforceSingleRow>({join});
   return true;
 }
 
@@ -2782,7 +2781,7 @@ ColumnCP Translator::aliasIfNameCollides(
     ColumnCP alias = Column::create(
         std::string(returnedColumn->name()) + "__lift",
         returnedColumn->value());
-    body = builder_.make<Project>(Project::Key{
+    body = builder_.make<Project>({
         body,
         ExprVector{returnedColumn},
         ColumnVector{alias},
@@ -2795,7 +2794,7 @@ ColumnCP Translator::aliasIfNameCollides(
 NodeCP Translator::crossJoin(NodeCP left, NodeCP right) {
   ColumnVector output = left->outputColumns();
   appendUnique(output, right->outputColumns());
-  return builder_.make<Join>(Join::Key{
+  return builder_.make<Join>({
       left,
       right,
       velox::core::JoinType::kInner,
@@ -3214,7 +3213,7 @@ ExprCP Translator::liftSubquery(
       // produces exactly one row, in which case the guard is a no-op.
       NodeCP wrapped = producesExactlyOneRow(body)
           ? body
-          : builder_.make<EnforceSingleRow>(EnforceSingleRow::Key{body});
+          : builder_.make<EnforceSingleRow>({body});
 
       liftTarget->pendingLifts = liftTarget->pendingLifts == nullptr
           ? wrapped
@@ -3365,17 +3364,16 @@ ExprCP Translator::tryFoldConstantScalar(NodeCP body) {
 
   NodeCP foldInput = valuesNode;
   if (filter != nullptr) {
-    foldInput =
-        builder_.make<Filter>(Filter::Key{valuesNode, filter->predicates()});
+    foldInput = builder_.make<Filter>({valuesNode, filter->predicates()});
   }
-  const Aggregate* foldAggregate = builder_.make<Aggregate>(Aggregate::Key{
-      .input = foldInput,
-      .groupingKeys = aggregate->groupingKeys(),
-      .aggregates = aggregate->aggregates(),
-      .outputColumns = aggregate->outputColumns(),
-      .step = aggregate->step(),
-      .groupId = aggregate->groupId(),
-      .globalGroupingSets = aggregate->globalGroupingSets()});
+  const Aggregate* foldAggregate = builder_.make<Aggregate>(
+      {.input = foldInput,
+       .groupingKeys = aggregate->groupingKeys(),
+       .aggregates = aggregate->aggregates(),
+       .outputColumns = aggregate->outputColumns(),
+       .step = aggregate->step(),
+       .groupId = aggregate->groupId(),
+       .globalGroupingSets = aggregate->globalGroupingSets()});
 
   // A scalar subquery produces exactly one column.
   const ColumnVector& outputColumns = foldAggregate->outputColumns();


### PR DESCRIPTION
Summary: `Builder::make<T>` takes a `typename T::Key`, so the parameter type is already fixed by the template argument and a braced initializer converts to it. Naming the struct again, as in `make<Project>(Project::Key{...})`, says the type twice; the shorter `make<Project>({...})` was already in use at some call sites and is now used at all of them.

Differential Revision: D117521505
