### PR TITLE
fix(parser): Accept subnormal double literals

### DIFF
--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -283,6 +283,17 @@ int64_t parseIntegerLiteral(
   return result.value();
 }
 
+// Out-of-range magnitudes are not errors: they saturate to infinity or to a
+// subnormal, as in Presto.
+double parseDoubleLiteral(std::string_view text, const NodeLocation& location) {
+  auto result = folly::tryTo<double>(text);
+  if (result.hasError()) {
+    AXIOM_PRESTO_SEMANTIC_FAIL(
+        location, std::string(text), "Cannot parse double literal: {}", text);
+  }
+  return result.value();
+}
+
 } // namespace
 
 void AstBuilder::trace(std::string_view name) const {
@@ -3105,8 +3116,9 @@ std::any AstBuilder::visitDecimalLiteral(
 
   auto text = stripDigitSeparators(ctx->getText(), options_.friendlySql);
   if (options_.parseDecimalLiteralAsDouble) {
-    return std::static_pointer_cast<Expression>(
-        std::make_shared<DoubleLiteral>(getLocation(ctx), std::stod(text)));
+    const auto location = getLocation(ctx);
+    return std::static_pointer_cast<Expression>(std::make_shared<DoubleLiteral>(
+        location, parseDoubleLiteral(text, location)));
   }
   return std::static_pointer_cast<Expression>(
       std::make_shared<DecimalLiteral>(getLocation(ctx), text));
@@ -3116,8 +3128,9 @@ std::any AstBuilder::visitDoubleLiteral(
     PrestoSqlParser::DoubleLiteralContext* ctx) {
   trace("visitDoubleLiteral");
   auto text = stripDigitSeparators(ctx->getText(), options_.friendlySql);
-  return std::static_pointer_cast<Expression>(
-      std::make_shared<DoubleLiteral>(getLocation(ctx), std::stod(text)));
+  const auto location = getLocation(ctx);
+  return std::static_pointer_cast<Expression>(std::make_shared<DoubleLiteral>(
+      location, parseDoubleLiteral(text, location)));
 }
 
 std::any AstBuilder::visitIntegerLiteral(

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -359,6 +359,13 @@ TEST_F(ExpressionParserTest, doubleLiteral) {
   test("1.23E-5", 1.23e-5);
   test(".5E2", 0.5e2);
   test("1E+5", 1e5);
+
+  // Magnitudes below DBL_MIN parse to their exact subnormal value.
+  test("1.02537302548306E-309", 1.02537302548306e-309);
+  test("5E-324", 5e-324);
+
+  // Without an exponent the literal is a decimal, parsed as DOUBLE by default.
+  test("0." + std::string(308, '0') + "1", 1e-309);
 }
 
 TEST_F(ExpressionParserTest, decimalLiteralAsDecimal) {


### PR DESCRIPTION
Summary:
A query containing a double literal below `DBL_MIN` failed to parse with:

    Query failed: stod

For example, `SELECT 1.02537302548306e-309`. glibc's `strtod` sets `ERANGE` for a subnormal result even though it returns the correct value, and `std::stod` turns that into an `out_of_range` exception that escapes the parser as a bare std error.

Both double-literal paths now parse with `folly::tryTo<double>`, which returns the subnormal and agrees with Presto. This mirrors `parseIntegerLiteral`, so an unparseable literal surfaces as a located semantic error rather than `stod`.

Differential Revision: D117547055


