### PR TITLE
fix(parser): Allow GROUP BY and ORDER BY negative constants

### DIFF
--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -823,8 +823,8 @@ std::vector<size_t> GroupByPlanner::resolveSortOrdinals(
   std::vector<size_t> preResolved(sortingKeyExprs_.size(), 0);
   for (size_t i = 0; i < sortingKeyExprs_.size(); ++i) {
     const auto& sortKey = orderBy->sortItems().at(i)->sortKey();
-    if (sortKey->is(NodeType::kLongLiteral)) {
-      preResolved.at(i) = sortKey->as<LongLiteral>()->value();
+    if (const auto position = LongLiteral::asSelectPosition(*sortKey)) {
+      preResolved.at(i) = position.value();
     }
   }
 
@@ -854,8 +854,8 @@ bool GroupByPlanner::isIdentityProjection() const {
 lp::ExprApi GroupByPlanner::resolveGroupingExpression(
     const ExpressionPtr& expr,
     const std::vector<lp::ExprApi>& selectExprs) {
-  if (expr->is(NodeType::kLongLiteral)) {
-    const auto n = expr->as<LongLiteral>()->value();
+  if (const auto position = LongLiteral::asSelectPosition(*expr)) {
+    const auto n = position.value();
     AXIOM_PRESTO_SEMANTIC_CHECK_GE(
         n,
         static_cast<int64_t>(1),

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1310,8 +1310,8 @@ class RelationPlanner : public AstVisitor {
     SortKeyExpansion result;
     for (const auto& item : orderBy->sortItems()) {
       const auto& sortExpr = item->sortKey();
-      if (sortExpr->is(NodeType::kLongLiteral)) {
-        const auto n = sortExpr->as<LongLiteral>()->value();
+      if (const auto position = LongLiteral::asSelectPosition(*sortExpr)) {
+        const auto n = position.value();
         AXIOM_PRESTO_SEMANTIC_CHECK_GE(
             n,
             static_cast<int64_t>(1),
@@ -1459,8 +1459,8 @@ class RelationPlanner : public AstVisitor {
   }
 
   lp::ExprApi toSortingKey(const ExpressionPtr& expr, ExprOptions options) {
-    if (expr->is(NodeType::kLongLiteral)) {
-      const auto n = expr->as<LongLiteral>()->value();
+    if (const auto position = LongLiteral::asSelectPosition(*expr)) {
+      const auto n = position.value();
       AXIOM_PRESTO_SEMANTIC_CHECK_GE(
           n,
           static_cast<int64_t>(1),

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -283,6 +283,17 @@ int64_t parseIntegerLiteral(
   return result.value();
 }
 
+// Out-of-range magnitudes are not errors: they saturate to infinity or to a
+// subnormal, as in Presto.
+double parseDoubleLiteral(std::string_view text, const NodeLocation& location) {
+  auto result = folly::tryTo<double>(text);
+  if (result.hasError()) {
+    AXIOM_PRESTO_SEMANTIC_FAIL(
+        location, std::string(text), "Cannot parse double literal: {}", text);
+  }
+  return result.value();
+}
+
 } // namespace
 
 void AstBuilder::trace(std::string_view name) const {
@@ -3105,8 +3116,9 @@ std::any AstBuilder::visitDecimalLiteral(
 
   auto text = stripDigitSeparators(ctx->getText(), options_.friendlySql);
   if (options_.parseDecimalLiteralAsDouble) {
-    return std::static_pointer_cast<Expression>(
-        std::make_shared<DoubleLiteral>(getLocation(ctx), std::stod(text)));
+    const auto location = getLocation(ctx);
+    return std::static_pointer_cast<Expression>(std::make_shared<DoubleLiteral>(
+        location, parseDoubleLiteral(text, location)));
   }
   return std::static_pointer_cast<Expression>(
       std::make_shared<DecimalLiteral>(getLocation(ctx), text));
@@ -3116,8 +3128,9 @@ std::any AstBuilder::visitDoubleLiteral(
     PrestoSqlParser::DoubleLiteralContext* ctx) {
   trace("visitDoubleLiteral");
   auto text = stripDigitSeparators(ctx->getText(), options_.friendlySql);
-  return std::static_pointer_cast<Expression>(
-      std::make_shared<DoubleLiteral>(getLocation(ctx), std::stod(text)));
+  const auto location = getLocation(ctx);
+  return std::static_pointer_cast<Expression>(std::make_shared<DoubleLiteral>(
+      location, parseDoubleLiteral(text, location)));
 }
 
 std::any AstBuilder::visitIntegerLiteral(

--- a/axiom/sql/presto/ast/AstLiterals.h
+++ b/axiom/sql/presto/ast/AstLiterals.h
@@ -138,6 +138,14 @@ class LongLiteral : public Literal {
     return value_;
   }
 
+  /// Returns the value of 'expr' if it can name a select-list position, as in
+  /// GROUP BY 1 or ORDER BY 2. Zero and values past the select list are
+  /// positions too, and are reported as out of range by the caller. A negative
+  /// value is not a position: the lexer emits no negative integer token, so a
+  /// negative literal is the folded form of unary minus, which is an ordinary
+  /// constant expression.
+  static std::optional<int64_t> asSelectPosition(const Expression& expr);
+
   void accept(AstVisitor* visitor) override;
 
   size_t hash() const override {

--- a/axiom/sql/presto/ast/AstNodesAll.cpp
+++ b/axiom/sql/presto/ast/AstNodesAll.cpp
@@ -302,6 +302,17 @@ void LongLiteral::accept(AstVisitor* visitor) {
   visitor->visitLongLiteral(this);
 }
 
+std::optional<int64_t> LongLiteral::asSelectPosition(const Expression& expr) {
+  if (!expr.is(NodeType::kLongLiteral)) {
+    return std::nullopt;
+  }
+  const auto value = expr.as<LongLiteral>()->value();
+  if (value < 0) {
+    return std::nullopt;
+  }
+  return value;
+}
+
 void DoubleLiteral::accept(AstVisitor* visitor) {
   visitor->visitDoubleLiteral(this);
 }

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -255,6 +255,16 @@ TEST_F(AggregationParserTest, simpleGroupBy) {
           .output());
 }
 
+// A negative value is a constant expression to group by, not a position.
+TEST_F(AggregationParserTest, groupByNegativeConstant) {
+  testSelect(
+      "SELECT n_nationkey, COUNT(*) FROM nation GROUP BY n_nationkey, -1",
+      matchScan()
+          .aggregate({"n_nationkey", "-1"}, {"count(*) AS count"})
+          .project()
+          .output());
+}
+
 // GROUP BY ordinals with SELECT * and other expanding items.
 TEST_F(AggregationParserTest, groupByOrdinalWithSelectStar) {
   testSelect(

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -359,6 +359,13 @@ TEST_F(ExpressionParserTest, doubleLiteral) {
   test("1.23E-5", 1.23e-5);
   test(".5E2", 0.5e2);
   test("1E+5", 1e5);
+
+  // Magnitudes below DBL_MIN parse to their exact subnormal value.
+  test("1.02537302548306E-309", 1.02537302548306e-309);
+  test("5E-324", 5e-324);
+
+  // Without an exponent the literal is a decimal, parsed as DOUBLE by default.
+  test("0." + std::string(308, '0') + "1", 1e-309);
 }
 
 TEST_F(ExpressionParserTest, decimalLiteralAsDecimal) {

--- a/axiom/sql/presto/tests/SortParserTest.cpp
+++ b/axiom/sql/presto/tests/SortParserTest.cpp
@@ -380,6 +380,12 @@ TEST_F(SortParserTest, distinct) {
           "ORDER BY 2 DESC"),
       "ORDER BY position is not in the select list: 2");
 
+  // A negative value is a constant expression to sort by, not a position.
+  parseSql(
+      "SELECT a, b "
+      "FROM (VALUES (1, 2), (3, 4)) AS t(a, b) "
+      "ORDER BY -1");
+
   VELOX_ASSERT_THROW(
       parseSql(
           "SELECT a + b "


### PR DESCRIPTION
Summary:
A query grouping by a negative constant failed to plan:

    SELECT a, count(*) FROM t GROUP BY a, -1

reported `GROUP BY position is not in select list: -1`. Presto plans this query, grouping by the constant. `ORDER BY -1` failed the same way.

The parser folds unary minus on an integer literal into one negative literal, so the clauses that read a literal as a select-list position could not tell `-1` from a position the user wrote. A position is now taken only from a non-negative literal — the lexer emits no negative integer token, so a negative literal always came from unary minus. `GROUP BY 0` remains an error, as in Presto.

Differential Revision: D117549800
