### PR TITLE
feat(cli): Expose query result types (#1788)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -230,6 +230,35 @@ std::optional<CatalogSchemaTableName> explainIoOutputTable(
 
 namespace axiom::sql {
 
+SqlQueryRunner::SqlResultChunk::SqlResultChunk(std::string message)
+    : message{std::move(message)} {}
+
+SqlQueryRunner::SqlResultChunk::SqlResultChunk(velox::RowVectorPtr batch)
+    : batch{std::move(batch)} {
+  VELOX_CHECK_NOT_NULL(this->batch);
+  batchType = this->batch->rowType();
+}
+
+SqlQueryRunner::SqlResultChunk::SqlResultChunk(velox::RowTypePtr batchType)
+    : batchType{std::move(batchType)} {
+  VELOX_CHECK_NOT_NULL(this->batchType);
+}
+
+SqlQueryRunner::SqlResult::SqlResult(std::string message)
+    : message{std::move(message)} {}
+
+SqlQueryRunner::SqlResult::SqlResult(std::vector<velox::RowVectorPtr> results)
+    : results{std::move(results)} {
+  VELOX_CHECK_GT(this->results.size(), 0);
+  VELOX_CHECK_NOT_NULL(this->results.front());
+  resultType = this->results.front()->rowType();
+}
+
+SqlQueryRunner::SqlResult::SqlResult(velox::RowTypePtr resultType)
+    : resultType{std::move(resultType)} {
+  VELOX_CHECK_NOT_NULL(this->resultType);
+}
+
 void SqlQueryRunner::initialize(
     const std::function<std::pair<std::string, std::string>()>&
         initializeConnectors,
@@ -683,6 +712,31 @@ logical_plan::LogicalPlanNodePtr showSessionPlan(
   return builder.build();
 }
 
+folly::coro::Task<SqlQueryRunner::SqlResult> materializeResult(
+    folly::coro::AsyncGenerator<SqlQueryRunner::SqlResultChunk> generator) {
+  std::optional<std::string> message;
+  std::vector<velox::RowVectorPtr> results;
+  velox::RowTypePtr emptyResultType;
+
+  while (auto chunk = co_await generator.next()) {
+    if (chunk->message.has_value()) {
+      message = std::move(*chunk->message);
+    } else if (chunk->batch != nullptr) {
+      results.push_back(std::move(chunk->batch));
+    } else {
+      emptyResultType = std::move(chunk->batchType);
+    }
+  }
+
+  if (message.has_value()) {
+    co_return SqlQueryRunner::SqlResult{std::move(*message)};
+  }
+  if (!results.empty()) {
+    co_return SqlQueryRunner::SqlResult{std::move(results)};
+  }
+  co_return SqlQueryRunner::SqlResult{std::move(emptyResultType)};
+}
+
 } // namespace
 
 SqlQueryRunner::SqlResult SqlQueryRunner::run(
@@ -694,17 +748,8 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
       folly::coro::co_withCancellation(
           options.cancellationToken,
           folly::coro::co_invoke([&]() -> folly::coro::Task<SqlResult> {
-            SqlResult result;
-            auto generator = co_run(std::string(sql), options);
-            while (auto chunk = co_await generator.next()) {
-              if (chunk->message.has_value()) {
-                result.message = std::move(chunk->message);
-              }
-              if (chunk->batch != nullptr) {
-                result.results.push_back(std::move(chunk->batch));
-              }
-            }
-            co_return result;
+            co_return co_await materializeResult(
+                co_run(std::string(sql), options));
           })));
 }
 
@@ -899,18 +944,8 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
   std::string planString;
   return folly::coro::blockingWait(
       folly::coro::co_invoke([&]() -> folly::coro::Task<SqlResult> {
-        SqlResult result;
-        auto generator =
-            co_runUnchecked(sqlStatement, options, timing, planString);
-        while (auto chunk = co_await generator.next()) {
-          if (chunk->message.has_value()) {
-            result.message = std::move(chunk->message);
-          }
-          if (chunk->batch != nullptr) {
-            result.results.push_back(std::move(chunk->batch));
-          }
-        }
-        co_return result;
+        co_return co_await materializeResult(
+            co_runUnchecked(sqlStatement, options, timing, planString));
       }));
 }
 
@@ -1086,6 +1121,7 @@ SqlQueryRunner::co_runPlanStatement(
   // by const reference and pulls batches lazily.
   logical_plan::LogicalPlanNodePtr logicalPlan;
   std::shared_ptr<connector::SchemaResolver> schemaResolver;
+  velox::RowTypePtr emptyResultType;
 
   if (sqlStatement.isCreateTableAsSelect()) {
     const auto* ctas = sqlStatement.as<presto::CreateTableAsSelectStatement>();
@@ -1102,14 +1138,20 @@ SqlQueryRunner::co_runPlanStatement(
     logicalPlan = sqlStatement.as<presto::DeleteStatement>()->plan();
   } else if (sqlStatement.isSelect()) {
     logicalPlan = sqlStatement.as<presto::SelectStatement>()->plan();
+    emptyResultType = logicalPlan->outputType();
   } else {
     VELOX_UNREACHABLE("Unexpected plan statement: {}", sqlStatement.kindName());
   }
 
   auto generator = co_runLogicalPlan(
       logicalPlan, options, timing, planString, schemaResolver, runtimeStats);
+  bool yieldedBatch{false};
   while (auto batch = co_await generator.next()) {
+    yieldedBatch = true;
     co_yield SqlResultChunk{std::move(*batch)};
+  }
+  if (!yieldedBatch && emptyResultType != nullptr) {
+    co_yield SqlResultChunk{std::move(emptyResultType)};
   }
 }
 
@@ -1164,8 +1206,8 @@ SqlQueryRunner::co_runSessionStatement(
         options,
         timing,
         planString);
-    while (auto batch = co_await generator.next()) {
-      co_yield SqlResultChunk{std::move(*batch)};
+    while (auto chunk = co_await generator.next()) {
+      co_yield std::move(*chunk);
     }
     co_return;
   }
@@ -1908,7 +1950,8 @@ std::shared_ptr<runner::LocalRunner> SqlQueryRunner::makeLocalRunner(
       runtimeStats);
 }
 
-folly::coro::AsyncGenerator<velox::RowVectorPtr> SqlQueryRunner::co_showSession(
+folly::coro::AsyncGenerator<SqlQueryRunner::SqlResultChunk>
+SqlQueryRunner::co_showSession(
     const presto::ShowSessionStatement& statement,
     const RunOptions& options,
     QueryTiming& timing,
@@ -1917,9 +1960,15 @@ folly::coro::AsyncGenerator<velox::RowVectorPtr> SqlQueryRunner::co_showSession(
   // takes it by const reference, and a temporary would dangle once GCC
   // destroys co_await-operand temporaries at the suspension point.
   auto plan = showSessionPlan(*sessionConfig_, defaultConnectorId_, statement);
+  auto resultType = plan->outputType();
   auto generator = co_runLogicalPlan(plan, options, timing, planString);
+  bool yieldedBatch{false};
   while (auto batch = co_await generator.next()) {
-    co_yield std::move(*batch);
+    yieldedBatch = true;
+    co_yield SqlResultChunk{std::move(*batch)};
+  }
+  if (!yieldedBatch) {
+    co_yield SqlResultChunk{std::move(resultType)};
   }
 }
 

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -289,19 +289,24 @@ class SqlQueryRunner {
     folly::CancellationToken cancellationToken;
   };
 
-  /// One increment of a streamed query result, yielded by co_run(). Exactly one
-  /// field is set: `message` (yielded once) for statements that return a status
-  /// line (DDL/session/EXPLAIN); `batch` (yielded once per result batch) for a
-  /// row-producing statement (SELECT/INSERT/CTAS). Modeled like SqlResult so
-  /// the same explicit-move rule applies.
+  /// Represents one increment of a streamed query result from co_run().
+  /// Runner-produced chunks have one of these shapes:
+  /// - `message` only for statements that return a status line.
+  /// - `batch` and `batchType` when a result batch is produced.
+  /// - `batchType` only when a row-producing statement produces no batches.
+  ///
+  /// Modeled like SqlResult so the same explicit-move rule applies.
   struct SqlResultChunk {
-    SqlResultChunk() = default;
+    /// Creates a message-bearing chunk.
+    explicit SqlResultChunk(std::string message);
 
-    explicit SqlResultChunk(std::optional<std::string> message)
-        : message{std::move(message)} {}
+    /// Creates a batch-bearing chunk from a non-null batch and records its
+    /// type.
+    explicit SqlResultChunk(facebook::velox::RowVectorPtr batch);
 
-    explicit SqlResultChunk(facebook::velox::RowVectorPtr batch)
-        : batch{std::move(batch)} {}
+    /// Creates the metadata-only chunk for an empty result from a non-null
+    /// type.
+    explicit SqlResultChunk(facebook::velox::RowTypePtr batchType);
 
     SqlResultChunk(const SqlResultChunk&) = default;
     SqlResultChunk& operator=(const SqlResultChunk&) = default;
@@ -310,11 +315,14 @@ class SqlQueryRunner {
     // across a co_yield, leaving the chunk referring to storage in the
     // destroyed coroutine frame.
     SqlResultChunk(SqlResultChunk&& other) noexcept
-        : message{std::move(other.message)}, batch{std::move(other.batch)} {}
+        : message{std::move(other.message)},
+          batch{std::move(other.batch)},
+          batchType{std::move(other.batchType)} {}
 
     SqlResultChunk& operator=(SqlResultChunk&& other) noexcept {
       message = std::move(other.message);
       batch = std::move(other.batch);
+      batchType = std::move(other.batchType);
       return *this;
     }
 
@@ -322,21 +330,27 @@ class SqlQueryRunner {
 
     std::optional<std::string> message;
     facebook::velox::RowVectorPtr batch;
+
+    /// Carries the type of `batch`. For an empty row-producing result, the
+    /// first and only chunk carries the result type with a null `batch`.
+    facebook::velox::RowTypePtr batchType;
   };
 
-  /// Results of running a query. SELECT queries return a vector of results.
-  /// Other queries return a message. SELECT query that returns no rows returns
-  /// std::nullopt message and empty vector of results.
+  /// Represents a materialized query result from run() or runUnchecked().
+  /// Runner-produced values have one of these shapes:
+  /// - `message` only for statements that return a status line.
+  /// - `results` and `resultType` when one or more batches are produced.
+  /// - `resultType` only when a row-producing statement produces no batches.
   struct SqlResult {
-    SqlResult() = default;
+    /// Creates a message-bearing result.
+    explicit SqlResult(std::string message);
 
-    explicit SqlResult(
-        std::optional<std::string> message,
-        std::vector<facebook::velox::RowVectorPtr> results = {})
-        : message{std::move(message)}, results{std::move(results)} {}
+    /// Creates a result from a non-empty batch vector and derives `resultType`
+    /// from its non-null first batch.
+    explicit SqlResult(std::vector<facebook::velox::RowVectorPtr> results);
 
-    explicit SqlResult(std::vector<facebook::velox::RowVectorPtr> results)
-        : results{std::move(results)} {}
+    /// Creates a metadata-only empty result from a non-null type.
+    explicit SqlResult(facebook::velox::RowTypePtr resultType);
 
     SqlResult(const SqlResult&) = default;
     SqlResult& operator=(const SqlResult&) = default;
@@ -345,11 +359,13 @@ class SqlQueryRunner {
     // the result referring to storage in the destroyed child coroutine frame.
     SqlResult(SqlResult&& other) noexcept
         : message{std::move(other.message)},
-          results{std::move(other.results)} {}
+          results{std::move(other.results)},
+          resultType{std::move(other.resultType)} {}
 
     SqlResult& operator=(SqlResult&& other) noexcept {
       message = std::move(other.message);
       results = std::move(other.results);
+      resultType = std::move(other.resultType);
       return *this;
     }
 
@@ -357,13 +373,19 @@ class SqlQueryRunner {
 
     std::optional<std::string> message;
     std::vector<facebook::velox::RowVectorPtr> results;
+
+    /// Carries the type of `results`, including when a row-producing statement
+    /// produces no result batches.
+    facebook::velox::RowTypePtr resultType;
   };
 
   /// Runs a single SQL statement with full lifecycle: generates a query ID,
   /// fires onStart, parses, checks permissions, executes, fires onComplete.
   /// Yields the result incrementally as SqlResultChunks -- one message chunk
   /// for a statement that returns a status line, one chunk per result batch for
-  /// a row-producing statement -- so a caller can consume rows as they arrive.
+  /// a row-producing statement, or one metadata-only chunk when such a
+  /// statement produces no batches -- so a caller can consume rows as they
+  /// arrive.
   /// On failure, fires onComplete with error telemetry then re-throws from the
   /// consumer's next().
   ///
@@ -632,7 +654,9 @@ class SqlQueryRunner {
       QueryTiming& timing,
       std::string& planString);
 
-  folly::coro::AsyncGenerator<facebook::velox::RowVectorPtr> co_showSession(
+  // Executes SHOW SESSION and yields batches or a type-only chunk when no
+  // session properties match.
+  folly::coro::AsyncGenerator<SqlResultChunk> co_showSession(
       const presto::ShowSessionStatement& statement,
       const RunOptions& options,
       QueryTiming& timing,

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -46,6 +46,24 @@ namespace runner = facebook::axiom::runner;
 
 class SqlQueryRunnerTest : public SqlQueryRunnerTestBase {
  protected:
+  // Collects the complete stream for assertions across chunk shapes.
+  std::vector<SqlQueryRunner::SqlResultChunk> collectChunks(
+      std::string_view sql,
+      SqlQueryRunner::RunOptions options) {
+    return folly::coro::blockingWait(
+        folly::coro::co_invoke(
+            [&]() -> folly::coro::Task<
+                      std::vector<SqlQueryRunner::SqlResultChunk>> {
+              std::vector<SqlQueryRunner::SqlResultChunk> chunks;
+              auto generator =
+                  runner_->co_run(std::string(sql), std::move(options));
+              while (auto chunk = co_await generator.next()) {
+                chunks.push_back(std::move(*chunk));
+              }
+              co_return chunks;
+            }));
+  }
+
   // Asserts SHOW SCHEMAS returns exactly 'expected', in order.
   void assertSchemas(const std::vector<std::string>& expected) {
     auto result = run("SHOW SCHEMAS");
@@ -90,9 +108,25 @@ class SqlQueryRunnerTest : public SqlQueryRunnerTestBase {
 };
 
 TEST_F(SqlQueryRunnerTest, runSingleStatement) {
-  test::assertEqualVectors(
-      fetchSingleRow("SELECT 1"),
-      makeRowVector({makeFlatVector<int32_t>({1})}));
+  {
+    const auto result = run("SELECT 1");
+
+    EXPECT_FALSE(result.message.has_value());
+    ASSERT_EQ(result.results.size(), 1);
+    const auto& batch = result.results.front();
+    ASSERT_NE(batch, nullptr);
+    VELOX_EXPECT_EQ_TYPES(result.resultType, batch->rowType());
+    test::assertEqualVectors(
+        batch, makeRowVector({makeFlatVector<int32_t>({1})}));
+  }
+
+  {
+    const auto result = run("SELECT CAST(1 AS BIGINT) AS value WHERE false");
+
+    EXPECT_FALSE(result.message.has_value());
+    EXPECT_TRUE(result.results.empty());
+    VELOX_EXPECT_EQ_TYPES(result.resultType, ROW("value", BIGINT()));
+  }
 }
 
 TEST_F(SqlQueryRunnerTest, executionTimeout) {
@@ -181,33 +215,37 @@ TEST_F(SqlQueryRunnerTest, runHonorsCancellationToken) {
 }
 
 TEST_F(SqlQueryRunnerTest, coRunYieldsChunks) {
-  // co_run() is a generator: a SELECT yields batch chunks (no message); a
-  // statement that returns a status line yields a single message chunk.
-  auto collect = [&](std::string_view sql) {
-    return folly::coro::blockingWait(
-        folly::coro::co_invoke(
-            [&]() -> folly::coro::Task<
-                      std::vector<SqlQueryRunner::SqlResultChunk>> {
-              std::vector<SqlQueryRunner::SqlResultChunk> chunks;
-              auto generator = runner_->co_run(std::string(sql), {});
-              while (auto chunk = co_await generator.next()) {
-                chunks.push_back(std::move(*chunk));
-              }
-              co_return chunks;
-            }));
-  };
+  // co_run() distinguishes batch results, empty SELECT metadata, and status
+  // messages through separate chunk shapes.
+  {
+    const auto chunks = collectChunks("SELECT 1", {});
+    ASSERT_EQ(chunks.size(), 1);
+    const auto& chunk = chunks[0];
+    EXPECT_FALSE(chunk.message.has_value());
+    ASSERT_NE(chunk.batch, nullptr);
+    VELOX_EXPECT_EQ_TYPES(chunk.batchType, chunk.batch->rowType());
+    test::assertEqualVectors(
+        chunk.batch, makeRowVector({makeFlatVector<int32_t>({1})}));
+  }
 
-  auto selectChunks = collect("SELECT 1");
-  ASSERT_EQ(selectChunks.size(), 1);
-  EXPECT_FALSE(selectChunks[0].message.has_value());
-  ASSERT_NE(selectChunks[0].batch, nullptr);
-  test::assertEqualVectors(
-      selectChunks[0].batch, makeRowVector({makeFlatVector<int32_t>({1})}));
+  {
+    const auto chunks =
+        collectChunks("SELECT CAST(1 AS BIGINT) AS value WHERE false", {});
+    ASSERT_EQ(chunks.size(), 1);
+    const auto& chunk = chunks[0];
+    EXPECT_FALSE(chunk.message.has_value());
+    EXPECT_EQ(chunk.batch, nullptr);
+    VELOX_EXPECT_EQ_TYPES(chunk.batchType, ROW("value", BIGINT()));
+  }
 
-  auto explainChunks = collect("EXPLAIN (TYPE LOGICAL) SELECT 1");
-  ASSERT_EQ(explainChunks.size(), 1);
-  EXPECT_TRUE(explainChunks[0].message.has_value());
-  EXPECT_EQ(explainChunks[0].batch, nullptr);
+  {
+    const auto chunks = collectChunks("EXPLAIN (TYPE LOGICAL) SELECT 1", {});
+    ASSERT_EQ(chunks.size(), 1);
+    const auto& chunk = chunks[0];
+    EXPECT_EQ(chunk.batchType, nullptr);
+    EXPECT_TRUE(chunk.message.has_value());
+    EXPECT_EQ(chunk.batch, nullptr);
+  }
 }
 
 TEST_F(SqlQueryRunnerTest, coRunRowCountAcrossChunks) {
@@ -225,16 +263,14 @@ TEST_F(SqlQueryRunnerTest, coRunRowCountAcrossChunks) {
   };
 
   int64_t totalRows = 0;
-  folly::coro::blockingWait(
-      folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
-        auto generator = runner_->co_run("SELECT c FROM t", options);
-        while (auto chunk = co_await generator.next()) {
-          EXPECT_FALSE(chunk->message.has_value());
-          if (chunk->batch != nullptr) {
-            totalRows += chunk->batch->size();
-          }
-        }
-      }));
+  const auto chunks = collectChunks("SELECT c FROM t", options);
+  for (const auto& chunk : chunks) {
+    EXPECT_FALSE(chunk.message.has_value());
+    if (chunk.batch != nullptr) {
+      VELOX_EXPECT_EQ_TYPES(chunk.batchType, chunk.batch->rowType());
+      totalRows += chunk.batch->size();
+    }
+  }
 
   EXPECT_EQ(totalRows, kNumRows);
   ASSERT_TRUE(completion.has_value());
@@ -328,19 +364,30 @@ TEST_F(SqlQueryRunnerTest, runRejectsMultipleStatements) {
 
 TEST_F(SqlQueryRunnerTest, parseAndRunMixedStatementTypes) {
   auto statements = runner_->parseMultiple(
-      "SELECT 42; EXPLAIN (TYPE LOGICAL) SELECT 1; select 7", {});
-  ASSERT_EQ(3, statements.size());
+      "SELECT 42; SELECT CAST(1 AS BIGINT) AS value WHERE false; "
+      "EXPLAIN (TYPE LOGICAL) SELECT 1; select 7",
+      {});
+  ASSERT_EQ(4, statements.size());
 
   auto selectResult = runner_->runUnchecked(*statements[0], {});
   ASSERT_FALSE(selectResult.message.has_value());
+  ASSERT_EQ(selectResult.results.size(), 1);
+  const auto& selectBatch = selectResult.results.front();
+  ASSERT_NE(selectBatch, nullptr);
+  VELOX_EXPECT_EQ_TYPES(selectResult.resultType, selectBatch->rowType());
   test::assertEqualVectors(
-      selectResult.results[0], makeRowVector({makeFlatVector<int32_t>({42})}));
+      selectBatch, makeRowVector({makeFlatVector<int32_t>({42})}));
 
-  auto explainResult = runner_->runUnchecked(*statements[1], {});
+  auto emptyResult = runner_->runUnchecked(*statements[1], {});
+  ASSERT_FALSE(emptyResult.message.has_value());
+  EXPECT_TRUE(emptyResult.results.empty());
+  VELOX_EXPECT_EQ_TYPES(emptyResult.resultType, ROW("value", BIGINT()));
+
+  auto explainResult = runner_->runUnchecked(*statements[2], {});
   ASSERT_TRUE(explainResult.message.has_value());
   ASSERT_FALSE(explainResult.message.value().empty());
 
-  auto lastResult = runner_->runUnchecked(*statements[2], {});
+  auto lastResult = runner_->runUnchecked(*statements[3], {});
   ASSERT_FALSE(lastResult.message.has_value());
   test::assertEqualVectors(
       lastResult.results[0], makeRowVector({makeFlatVector<int32_t>({7})}));
@@ -1077,6 +1124,15 @@ TEST_F(SqlQueryRunnerTest, showSession) {
     auto names = fetchNames("SHOW SESSION LIKE 'test%'");
     EXPECT_THAT(names, ::testing::Each(::testing::StartsWith("test.")));
     EXPECT_THAT(names, ::testing::Contains("test.collect_column_statistics"));
+  }
+
+  {
+    const auto result = run("SHOW SESSION LIKE 'no_such_property%'");
+    EXPECT_FALSE(result.message.has_value());
+    EXPECT_TRUE(result.results.empty());
+    VELOX_EXPECT_EQ_TYPES(
+        result.resultType,
+        ROW({"Name", "Value", "Default", "Type", "Description"}, VARCHAR()));
   }
 }
 


### PR DESCRIPTION
Summary:

Query results did not expose their schema separately from data batches. Clients could inspect a populated batch, but an empty `SELECT` carried no type information.

Populate `batchType` on every streamed result batch. When a `SELECT` produces no batches, `co_run()` emits one metadata-only chunk with the logical type. `run()` and `runUnchecked()` return `resultType` in both cases, allowing clients to construct typed empty Arrow tables or data frames without rerunning the query.

Differential Revision: D117605898


