### PR TITLE
fix(v2): Block nondeterministic filter pushdown

### DIFF
--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -31,6 +31,12 @@ class JoinTest : public test::QueryTestBase,
     return lp::PlanBuilder::Context{kTestConnectorId, kDefaultSchema};
   }
 
+  using test::QueryTestBase::toSingleNodePlan;
+
+  velox::core::PlanNodePtr toSingleNodePlan(std::string_view sql) {
+    return QueryTestBase::toSingleNodePlan(parseSelect(sql, kTestConnectorId));
+  }
+
   void SetUp() override {
     test::QueryTestBase::SetUp();
     useV2_ = GetParam();
@@ -268,8 +274,7 @@ TEST_P(JoinTest, nestedOuterJoins) {
       "   RIGHT OUTER JOIN region r2 ON n.n_regionkey = r2.r_regionkey "
       "GROUP BY 1";
 
-  auto logicalPlan = parseSelect(sql, kTestConnectorId);
-  auto plan = toSingleNodePlan(logicalPlan);
+  auto plan = toSingleNodePlan(sql);
 
   auto matcher = matchScan("nation")
                      .hashJoin(matchScan("region"), core::JoinType::kFull)
@@ -485,10 +490,9 @@ TEST_P(JoinTest, unusedSingleRowAggregateCrossJoin) {
 
   auto logicalPlan = parseSelect(
       "SELECT a FROM t, (SELECT count(*) FROM u)", kTestConnectorId);
-  auto matcher = matchScan("t").build();
 
   auto plan = toSingleNodePlan(logicalPlan);
-  AXIOM_ASSERT_PLAN_V1(plan, matcher);
+  AXIOM_ASSERT_PLAN_V1(plan, matchScan("t").build());
 
   ASSERT_NO_THROW(planVelox(logicalPlan));
 }
@@ -624,7 +628,7 @@ TEST_P(JoinTest, crossThenLeft) {
             .aggregation()
             .build();
 
-  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
@@ -644,7 +648,7 @@ TEST_P(JoinTest, joinWithComputedAndProjectedKeys) {
           .projectIf(!useV2_, {"u0", "u1", "v0"})
           .build();
 
-  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
@@ -677,7 +681,7 @@ TEST_P(JoinTest, filterPushdownThroughCrossJoinUnnest) {
 
     auto matcher = matchScan("t").filter().unnest().build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -688,7 +692,7 @@ TEST_P(JoinTest, filterPushdownThroughCrossJoinUnnest) {
 
     auto matcher = matchValues().filter().project().unnest().project().build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
@@ -704,7 +708,7 @@ TEST_P(JoinTest, joinOnClause) {
     auto matcher =
         matchScan("t").project().hashJoin(matchScan("u").project()).build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -719,7 +723,7 @@ TEST_P(JoinTest, joinOnClause) {
                        .projectIf(!useV2_, {"t0", "1", "u0"})
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
@@ -771,7 +775,7 @@ TEST_P(JoinTest, leftThenFilter) {
                        .projectIf(!useV2_, {"a", "b", "c", "x", "z"})
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -793,7 +797,7 @@ TEST_P(JoinTest, leftThenFilter) {
                        .projectIf(!useV2_, {"a", "b", "c", "x", "y + 1 as z"})
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -815,7 +819,7 @@ TEST_P(JoinTest, leftThenFilter) {
                        .projectIf(!useV2_, {"a", "b", "c", "x", "y + 1 as z"})
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -845,7 +849,7 @@ TEST_P(JoinTest, leftThenFilter) {
                        .project({useV2_ ? "z * 2" : "(y + 1) * 2"})
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -868,7 +872,7 @@ TEST_P(JoinTest, leftThenFilter) {
                        .aggregation()
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -893,7 +897,7 @@ TEST_P(JoinTest, leftThenFilter) {
                        .projectIf(!useV2_, {"a", "b", "c", "x", "z"})
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -921,7 +925,7 @@ TEST_P(JoinTest, leftThenFilter) {
               .filter("a > y")
               .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -945,7 +949,7 @@ TEST_P(JoinTest, leftThenFilter) {
                        .filter("cardinality(coalesce(y, b)) > 0")
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -970,7 +974,7 @@ TEST_P(JoinTest, leftThenFilter) {
                        .project()
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
@@ -996,7 +1000,7 @@ TEST_P(JoinTest, fullThenFilter) {
                        .projectIf(!useV2_)
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -1020,7 +1024,7 @@ TEST_P(JoinTest, fullThenFilter) {
                        .projectIf(!useV2_)
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -1040,7 +1044,7 @@ TEST_P(JoinTest, fullThenFilter) {
                        .projectIf(!useV2_)
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -1065,7 +1069,7 @@ TEST_P(JoinTest, fullThenFilter) {
             .projectIf(!useV2_)
             .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -1092,7 +1096,7 @@ TEST_P(JoinTest, fullThenFilter) {
               .filter("a > y")
               .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
@@ -1113,7 +1117,7 @@ TEST_P(JoinTest, leftJoinOnClausePushdown) {
             .hashJoin(matchScan("u").filter("y > 0"), core::JoinType::kLeft)
             .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -1126,7 +1130,7 @@ TEST_P(JoinTest, leftJoinOnClausePushdown) {
     auto matcher =
         matchScan("t").hashJoin(matchScan("u"), core::JoinType::kLeft).build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -1138,7 +1142,7 @@ TEST_P(JoinTest, leftJoinOnClausePushdown) {
     auto matcher =
         matchScan("t").hashJoin(matchScan("u"), core::JoinType::kLeft).build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -1161,7 +1165,7 @@ TEST_P(JoinTest, leftJoinOnClausePushdown) {
                        .projectIf(!useV2_)
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -1180,7 +1184,7 @@ TEST_P(JoinTest, leftJoinOnClausePushdown) {
                            core::JoinType::kLeft)
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -1198,7 +1202,7 @@ TEST_P(JoinTest, leftJoinOnClausePushdown) {
                            core::JoinType::kLeft)
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -1219,7 +1223,7 @@ TEST_P(JoinTest, leftJoinOnClausePushdown) {
                            core::JoinType::kLeft)
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
@@ -1240,7 +1244,7 @@ TEST_P(JoinTest, constantFalseOuterJoinElimination) {
     auto matcher =
         matchScan("t").project({"a", "b", "c", "null", "null"}).build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
@@ -1254,7 +1258,7 @@ TEST_P(JoinTest, constantFalseOuterJoinElimination) {
     auto matcher =
         matchScan("u").project({"null", "null", "null", "x", "y"}).build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
@@ -1293,7 +1297,7 @@ TEST_P(JoinTest, impliedJoins) {
               .aggregation()
               .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -1315,7 +1319,7 @@ TEST_P(JoinTest, impliedJoins) {
             .aggregation()
             .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -1329,7 +1333,7 @@ TEST_P(JoinTest, impliedJoins) {
                        .aggregation()
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -1344,7 +1348,7 @@ TEST_P(JoinTest, impliedJoins) {
                        .aggregation()
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -1372,7 +1376,7 @@ TEST_P(JoinTest, impliedJoins) {
               .hashJoin(matchScan("v"), core::JoinType::kLeftSemiFilter)
               .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
@@ -1409,7 +1413,7 @@ TEST_P(JoinTest, impliedSameInputJoinFilters) {
             .aggregation()
             .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -1424,7 +1428,7 @@ TEST_P(JoinTest, impliedSameInputJoinFilters) {
             .aggregation()
             .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
@@ -1446,7 +1450,7 @@ TEST_P(JoinTest, impliedSameInputJoinFilters) {
             .aggregation()
             .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
@@ -1478,7 +1482,7 @@ TEST_P(JoinTest, impliedSemiJoinPropagation) {
                      .hashJoin(matchScan("u"), core::JoinType::kInner)
                      .build();
 
-  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
@@ -1551,7 +1555,7 @@ TEST_P(JoinTest, impliedFilters) {
             .hashJoin(matchScan("t").filter("a = 5"), core::JoinType::kInner)
             .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
@@ -1566,7 +1570,7 @@ TEST_P(JoinTest, impliedFilters) {
             .hashJoin(matchScan("u").filter("x > 100"), core::JoinType::kInner)
             .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
@@ -1582,7 +1586,7 @@ TEST_P(JoinTest, impliedFilters) {
                 matchScan("t").filter("a IN (1, 2, 3)"), core::JoinType::kInner)
             .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
@@ -1601,7 +1605,7 @@ TEST_P(JoinTest, impliedFilters) {
                 matchScan("u").filter("x IS NULL"), core::JoinType::kInner)
             .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
@@ -1617,7 +1621,7 @@ TEST_P(JoinTest, impliedFilters) {
                 matchScan("u").filter("x IS NOT NULL"), core::JoinType::kInner)
             .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 
@@ -1636,13 +1640,11 @@ TEST_P(JoinTest, impliedFilters) {
             .hashJoin(matchScan("v").filter("k = 5"), core::JoinType::kInner)
             .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
 
-// TODO: Assert the V2 plan after it keeps non-deterministic predicates above
-// joins.
 // Pushing `random()` below a join that can duplicate rows changes how often it
 // is evaluated and can change query results.
 TEST_P(JoinTest, impliedFilterNonPropagation) {
@@ -1652,18 +1654,72 @@ TEST_P(JoinTest, impliedFilterNonPropagation) {
       ->setStats(1'000, {{"x", {.numDistinct = 100}}});
 
   // Non-deterministic predicates do not propagate.
-  auto query =
-      "SELECT * FROM t, u "
-      "WHERE t.a = u.x AND t.a = cast(random() * 100 as bigint)";
-  SCOPED_TRACE(query);
+  {
+    auto query =
+        "SELECT * FROM t, u "
+        "WHERE t.a = u.x AND t.a = cast(random() * 100 as bigint)";
+    SCOPED_TRACE(query);
 
-  auto matcher = matchScan("t")
-                     .hashJoin(matchScan("u"), core::JoinType::kInner)
-                     .filter("a = cast(random() * 100.0 as bigint)")
-                     .build();
+    // TODO: Place the key-reconstruction Project after the filter, so it runs
+    // on the surviving rows only.
+    auto matcher = matchScan("t")
+                       .hashJoinInner(matchScan("u"))
+                       .projectIf(useV2_, {"a", "b", "a as x", "y"})
+                       .filter("a = cast(random() * 100.0 as bigint)")
+                       .build();
 
-  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
-  AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    auto plan = toSingleNodePlan(query);
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // The predicate is not propagated even when neither join key is in the
+  // output.
+  {
+    auto query =
+        "SELECT count(*) FROM t JOIN u ON t.a = u.x "
+        "WHERE t.a > 10000 * random()";
+    SCOPED_TRACE(query);
+
+    auto matcher = matchScan("t")
+                       .hashJoin(matchScan("u"), core::JoinType::kInner)
+                       .filter("a::double > 10000.0 * random()")
+                       .singleAggregation({}, {"count(*)"})
+                       .build();
+
+    AXIOM_ASSERT_PLAN_V2(toSingleNodePlan(query), matcher);
+  }
+
+  // A predicate written in the ON clause is not pushed into an input either.
+  {
+    auto query = "SELECT count(*) FROM t JOIN u ON t.a = u.x AND t.a > rand()";
+    SCOPED_TRACE(query);
+
+    auto matcher =
+        matchScan("t")
+            .hashJoinInner(matchScan("u"), {.filter = "a::double > rand()"})
+            .singleAggregation({}, {"count(*)"})
+            .build();
+
+    AXIOM_ASSERT_PLAN_V2(toSingleNodePlan(query), matcher);
+  }
+
+  // A non-deterministic equality is a join condition, not a join key: a key
+  // would be evaluated once per row of its input rather than once per pair.
+  {
+    auto query = "SELECT count(*) FROM t JOIN u ON t.a + rand() = u.x";
+    SCOPED_TRACE(query);
+
+    auto matcher = matchScan("t")
+                       .project({"a::double as ta"})
+                       .nestedLoopJoin(
+                           matchScan("u").project({"x::double as ux"}),
+                           core::JoinType::kInner,
+                           "ta + rand() = ux")
+                       .singleAggregation({}, {"count(*)"})
+                       .build();
+
+    AXIOM_ASSERT_PLAN_V2(toSingleNodePlan(query), matcher);
+  }
 }
 
 TEST_P(JoinTest, impliedFilterDedup) {
@@ -1687,7 +1743,7 @@ TEST_P(JoinTest, impliedFilterDedup) {
             .hashJoin(matchScan("t").filter("a = 5"), core::JoinType::kInner)
             .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
@@ -1712,7 +1768,7 @@ TEST_P(JoinTest, impliedSameTableEquality) {
                        .aggregation()
                        .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
@@ -1741,7 +1797,7 @@ TEST_P(JoinTest, impliedSameTableEqualityBothSides) {
             .aggregation()
             .build();
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
     AXIOM_ASSERT_PLAN_V1(plan, matcher);
   }
 }
@@ -1767,7 +1823,7 @@ TEST_P(JoinTest, impliedSameTableEqualityBelowAggregation) {
                      .aggregation()
                      .build();
 
-  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
@@ -1797,7 +1853,7 @@ TEST_P(JoinTest, impliedSameTableEqualityInHaving) {
                      .aggregation()
                      .build();
 
-  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
@@ -1821,7 +1877,7 @@ TEST_P(JoinTest, impliedSameTableEqualityBlockedByLimit) {
                      .aggregation()
                      .build();
 
-  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
@@ -1850,7 +1906,7 @@ TEST_P(JoinTest, impliedSameTableEqualityBlockedByLimitDedup) {
                      .aggregation()
                      .build();
 
-  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
@@ -1878,7 +1934,7 @@ TEST_P(JoinTest, impliedSameTableEqualityOuterJoin) {
           .aggregation()
           .build();
 
-  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
@@ -1905,7 +1961,7 @@ TEST_P(JoinTest, impliedSameTableEqualitySemiJoin) {
           .aggregation()
           .build();
 
-  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
@@ -1929,7 +1985,7 @@ TEST_P(JoinTest, impliedSameTableEqualityRightJoinNormalized) {
           .aggregation()
           .build();
 
-  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
@@ -1952,7 +2008,7 @@ TEST_P(JoinTest, impliedSameTableEqualityFullOuterJoinSkipped) {
                      .aggregation()
                      .build();
 
-  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
@@ -1975,7 +2031,7 @@ TEST_P(JoinTest, impliedSameTableEqualityMismatchedLeftKeys) {
                      .aggregation()
                      .build();
 
-  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
@@ -1997,7 +2053,7 @@ TEST_P(JoinTest, impliedSameTableEqualityPreservedSide) {
                      .aggregation()
                      .build();
 
-  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
@@ -2038,7 +2094,7 @@ TEST_P(JoinTest, leftJoinNoEqualitiesMultipleTables) {
                          "n_nationkey < s_nationkey")
                      .build();
 
-  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN_V1(plan, matcher);
 }
 
@@ -2062,7 +2118,7 @@ TEST_P(JoinTest, leftToInnerWithAggregation) {
       "WHERE b.x > 0";
   SCOPED_TRACE(query);
 
-  auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+  auto plan = toSingleNodePlan(query);
 
   // V2 is better: it derives `a > 0` on t, materializes the cast once before
   // DISTINCT, and eliminates the V1 output-reconstruction Projects.
@@ -2101,7 +2157,7 @@ TEST_P(JoinTest, duplicateJoinOutputColumns) {
         ") AS s ON t.k = s.k";
     SCOPED_TRACE(query);
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
 
     auto matcher = matchScan("t")
                        .hashJoin(matchScan("u"), core::JoinType::kLeft)
@@ -2121,7 +2177,7 @@ TEST_P(JoinTest, duplicateJoinOutputColumns) {
         ") AS s ON t.k = s.k";
     SCOPED_TRACE(query);
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
 
     auto matcher = matchScan("t")
                        .hashJoin(matchScan("u"), core::JoinType::kLeft)
@@ -2143,7 +2199,7 @@ TEST_P(JoinTest, duplicateJoinOutputColumns) {
         "WHERE s.a = 1";
     SCOPED_TRACE(query);
 
-    auto plan = toSingleNodePlan(parseSelect(query, kTestConnectorId));
+    auto plan = toSingleNodePlan(query);
 
     // V2 is better: it drops the filter-only `a` column before the join.
     auto matcher = matchScan("t")

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -637,13 +637,8 @@ TEST_P(SetTest, unionDistinctOverGatherInputs) {
 // must stay above UNION DISTINCT's dedup — pushing it into the legs would
 // let each duplicate row evaluate the predicate independently before dedup,
 // changing query semantics.
-//
-// The filter references a column (`k > rand()` rather than
-// `rand() < 0.5`) so that distributeConjuncts considers it for pushdown
-// (the pushdown path requires the conjunct to reference a single table).
 TEST_P(SetTest, nondeterministicFilterAboveUnion) {
-  // UNION ALL: filter pushes into both scan legs (no dedup → safe). The
-  // pushed predicate becomes a Filter node above each scan leg.
+  // UNION ALL: filter pushes into both scan legs (no dedup → safe).
   {
     auto logicalPlan = parseSelect(
         "SELECT k FROM (SELECT n_nationkey AS k FROM nation "
@@ -651,15 +646,15 @@ TEST_P(SetTest, nondeterministicFilterAboveUnion) {
 
     auto buildMatcher = [&] {
       return matchScan("nation")
-          .filter("rand() < cast(n_nationkey as double)")
-          .project()
+          .filter("n_nationkey::double > rand()")
+          .project({"n_nationkey as k"})
           .localPartition(matchScan("region")
-                              .filter("rand() < cast(r_regionkey as double)")
-                              .project());
+                              .filter("r_regionkey::double > rand()")
+                              .project({"r_regionkey as k"}));
     };
 
-    AXIOM_ASSERT_PLAN_V1(toSingleNodePlan(logicalPlan), buildMatcher().build());
-    AXIOM_ASSERT_DISTRIBUTED_PLAN_V1(
+    AXIOM_ASSERT_PLAN_V2(toSingleNodePlan(logicalPlan), buildMatcher().build());
+    AXIOM_ASSERT_DISTRIBUTED_PLAN_V2(
         planVelox(logicalPlan).plan, buildMatcher().gather().build());
   }
 
@@ -670,22 +665,25 @@ TEST_P(SetTest, nondeterministicFilterAboveUnion) {
         "SELECT k FROM (SELECT n_nationkey AS k FROM nation "
         "UNION SELECT r_regionkey AS k FROM region) WHERE k > rand()");
 
-    AXIOM_ASSERT_PLAN_V1(
+    AXIOM_ASSERT_PLAN(
         toSingleNodePlan(logicalPlan),
         matchScan("nation")
-            .project()
-            .localPartition(matchScan("region").project())
+            .project({"n_nationkey as k"})
+            .localPartition(matchScan("region").project({"r_regionkey as k"}))
             .singleAggregation({"k"}, {})
-            .filter("cast(k as double) > rand()")
+            .filter("k::double > rand()")
             .build());
 
+    // Asserted for v1 only: v2 gathers the union legs into one driver instead
+    // of spreading them round-robin, leaving the partial aggregation above it
+    // single-threaded.
     AXIOM_ASSERT_DISTRIBUTED_PLAN_V1(
         planVelox(logicalPlan).plan,
         matchScan("nation")
-            .project()
-            .localPartition(matchScan("region").project())
+            .project({"n_nationkey as k"})
+            .localPartition(matchScan("region").project({"r_regionkey as k"}))
             .distributedSingleAggregation({"k"}, {})
-            .filter("cast(k as double) > rand()")
+            .filter("k::double > rand()")
             .gather()
             .build());
   }

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -1246,6 +1246,24 @@ TEST_P(UnnestTest, leftJoinLateralUnnestNotSupported) {
              : "Unsupported PlanNode LATERAL_JOIN");
 }
 
+// An unnest turns one input row into many, so a nondeterministic filter on a
+// replicated column must stay above it. Pushed below, one evaluation would
+// decide every row unnested from that input row.
+TEST_P(UnnestTest, nondeterministicFilterAboveUnnest) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {ARRAY(BIGINT()), BIGINT()}));
+
+  auto query = "SELECT n FROM t, UNNEST(a) AS _(n) WHERE b > rand()";
+  auto logicalPlan = parseSelect(query, kTestConnectorId);
+
+  auto matcher = matchScan("t")
+                     .unnest({"b"}, {"a"})
+                     .filter("b::double > rand()")
+                     .project({"n"})
+                     .build();
+
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+}
+
 AXIOM_INSTANTIATE_V1_V2(UnnestTest);
 
 } // namespace

--- a/axiom/optimizer/tests/WindowTest.cpp
+++ b/axiom/optimizer/tests/WindowTest.cpp
@@ -727,6 +727,27 @@ TEST_P(WindowTest, leftJoinWithWindowOrderingByRightSideColumn) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
+// A deterministic predicate on a partition key keeps or drops a partition
+// whole, so it may push below the window. A nondeterministic one instead thins
+// the partition, changing what the window function reads, so it stays above.
+// Asserted for v2 only: v1 still pushes the predicate below the window and
+// computes the aggregate over the thinned partition.
+TEST_P(WindowTest, nondeterministicFilterOnPartitionKey) {
+  auto plan = toSingleNodePlan(
+      "SELECT n_regionkey, s FROM ("
+      "  SELECT n_regionkey, sum(n_nationkey) OVER (PARTITION BY n_regionkey) "
+      "  AS s FROM nation"
+      ") WHERE n_regionkey > rand()");
+
+  auto matcher =
+      matchScan("nation")
+          .window({"sum(n_nationkey) OVER (PARTITION BY n_regionkey) as s"})
+          .filter("n_regionkey::double > rand()")
+          .project({"n_regionkey", "s"})
+          .build();
+  AXIOM_ASSERT_PLAN_V2(plan, matcher);
+}
+
 AXIOM_INSTANTIATE_V1_V2(WindowTest);
 
 } // namespace

--- a/axiom/optimizer/tests/sql/nondeterministic.sql
+++ b/axiom/optimizer/tests/sql/nondeterministic.sql
@@ -103,3 +103,8 @@ FROM (SELECT s[1] AS x FROM (SELECT shuffle(sequence(1, 5)) AS s FROM t))
 -- A deterministic complex value reused via subfield.
 -- duckdb: SELECT 1, 1 FROM t
 SELECT s[1] AS x, s[1] AS y FROM (SELECT sequence(1, 5) AS s FROM t)
+----
+-- A non-deterministic predicate on a join key. `a` is at least 1 and
+-- `-1 * random()` is at most 0, so every row passes and the answer is the plain
+-- self-join count, which makes the query comparable despite `random()`.
+SELECT count(*) FROM t t1 JOIN t t2 ON t1.a = t2.a WHERE t1.a > -1 * random()

--- a/axiom/optimizer/v2/JoinCondition.cpp
+++ b/axiom/optimizer/v2/JoinCondition.cpp
@@ -36,6 +36,13 @@ JoinCondition::Split JoinCondition::splitEquiKeys(
       result.residual.push_back(conjunct);
       continue;
     }
+    // A key is evaluated once per row of its own input and reused for every
+    // pair that row takes part in, so a nondeterministic equality stays a
+    // condition, which is evaluated per pair.
+    if (conjunct->containsNonDeterministic()) {
+      result.residual.push_back(conjunct);
+      continue;
+    }
     ExprCP lhs = call->args()[0];
     ExprCP rhs = call->args()[1];
     const auto& lhsCols = lhs->columns();

--- a/axiom/optimizer/v2/JoinCondition.h
+++ b/axiom/optimizer/v2/JoinCondition.h
@@ -21,13 +21,13 @@
 namespace facebook::axiom::optimizer::v2 {
 
 /// Normalizes raw join-condition conjuncts into the Join IR's split
-/// form. The invariant `Join` callers rely on: any `eq(leftExpr,
-/// rightExpr)` conjunct whose sides partition cleanly into one side
-/// each lives in `leftKeys` / `rightKeys`, never in `filter`.
+/// form. The invariant `Join` callers rely on: any deterministic
+/// `eq(leftExpr, rightExpr)` conjunct whose sides partition cleanly into one
+/// side each lives in `leftKeys` / `rightKeys`, never in `filter`.
 class JoinCondition {
  public:
   /// Output of `splitEquiKeys`: paired equi-keys plus the residual
-  /// non-equi conjuncts.
+  /// conjuncts that cannot be keys.
   struct Split {
     ExprVector leftKeys;
     ExprVector rightKeys;
@@ -38,8 +38,9 @@ class JoinCondition {
   /// condition). For each `eq(lhs, rhs)` whose `lhs` references only
   /// `leftColumns` and `rhs` only `rightColumns` (or vice versa, with
   /// the pair swapped to canonical left/right order), records it as a
-  /// `(leftKey, rightKey)` pair. Anything not matching that pattern
-  /// stays in `residual`.
+  /// `(leftKey, rightKey)` pair. Anything not matching that pattern stays in
+  /// `residual`, as does a nondeterministic equality: a key is evaluated once
+  /// per row of its own input, a condition once per candidate pair.
   static Split splitEquiKeys(
       const ExprVector& conjuncts,
       const PlanObjectSet& leftColumns,

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -391,6 +391,20 @@ std::pair<ExprVector, ExprVector> partition(
   return {std::move(noOverlap), std::move(overlap)};
 }
 
+// A nondeterministic conjunct may not cross a node whose output row count
+// differs from its input's: one evaluation on either side of the node stands
+// in for a different number of evaluations on the other, which admits a
+// different set of rows.
+void blockNondeterministic(ExprVector& pushable, ExprVector& blocked) {
+  std::erase_if(pushable, [&](ExprCP conjunct) {
+    if (!conjunct->containsNonDeterministic()) {
+      return false;
+    }
+    blocked.push_back(conjunct);
+    return true;
+  });
+}
+
 // Mirror of canPushLeft for the right input (from-above conjuncts).
 bool canPushRight(velox::core::JoinType joinType, bool rightOnly) {
   if (!rightOnly) {
@@ -746,7 +760,8 @@ class Pushdown : public NodeRewriter<PushdownContext> {
 
   // Aggregate: conjuncts referencing only grouping-key outputs push below
   // (substituted to the grouping-key expressions); conjuncts referencing
-  // any aggregate output stay above as a HAVING-equivalent Filter.
+  // any aggregate output stay above as a HAVING-equivalent Filter, as do
+  // nondeterministic conjuncts, since a group collapses rows.
   //
   // An aggregate that emits a row on empty input — a global aggregate (no
   // grouping keys), or one with a global (empty) grouping set — blocks
@@ -794,6 +809,8 @@ class Pushdown : public NodeRewriter<PushdownContext> {
 
     auto [substitutable, blocked] =
         partition(context.pending, aggregateOutputs);
+    blockNondeterministic(substitutable, blocked);
+
     ExprVector pushable;
     pushable.reserve(substitutable.size());
     for (ExprCP conjunct : substitutable) {
@@ -846,7 +863,9 @@ class Pushdown : public NodeRewriter<PushdownContext> {
 
   // Join: demote outer to inner when possible, then route each pending
   // conjunct to one of: left input, right input, join filter, or
-  // stay-above.
+  // stay-above. The join's own filter conjuncts are redistributed by the same
+  // rules. Neither moves a nondeterministic conjunct into an input, which
+  // would evaluate it once for rows the join then multiplies.
   NodeCP rewriteJoin(const Join* node, PushdownContext& context) override {
     PlanObjectSet leftColumns =
         PlanObjectSet::fromObjects(node->left()->outputColumns());
@@ -904,7 +923,11 @@ class Pushdown : public NodeRewriter<PushdownContext> {
       const bool leftOnly = !columns.empty() && columns.isSubset(leftColumns);
       const bool rightOnly = !columns.empty() && columns.isSubset(rightColumns);
 
-      if (canPushLeft(newKind, leftOnly)) {
+      // A nondeterministic conjunct must not move into an input: one evaluation
+      // per input row would then decide every output row that row produces.
+      if (conjunct->containsNonDeterministic() && (leftOnly || rightOnly)) {
+        above.push_back(conjunct);
+      } else if (canPushLeft(newKind, leftOnly)) {
         leftPending.push_back(conjunct);
       } else if (canPushRight(newKind, rightOnly)) {
         rightPending.push_back(conjunct);
@@ -922,6 +945,12 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     ExprVector keptFilter;
     keptFilter.reserve(node->filter().size());
     for (ExprCP conjunct : node->filter()) {
+      // Staying on the join is where a filter conjunct already is, so unlike
+      // the loop above this needs no test for which inputs it references.
+      if (conjunct->containsNonDeterministic()) {
+        keptFilter.push_back(conjunct);
+        continue;
+      }
       const auto& columns = conjunct->columns();
       const bool leftOnly = !columns.empty() && columns.isSubset(leftColumns);
       const bool rightOnly = !columns.empty() && columns.isSubset(rightColumns);
@@ -1385,7 +1414,8 @@ class Pushdown : public NodeRewriter<PushdownContext> {
 
   // Unnest: conjuncts referencing only replicated (pre-unnest) columns
   // push below. Conjuncts that touch any unnest-produced column or the
-  // ordinality column stay above — those don't exist on the input.
+  // ordinality column stay above — those don't exist on the input. So do
+  // nondeterministic conjuncts, since one input row yields many output rows.
   NodeCP rewriteUnnest(const Unnest* node, PushdownContext& context) override {
     PlanObjectSet outputOnlyColumns;
     for (const ColumnVector& perExpression : node->unnestColumns()) {
@@ -1398,6 +1428,7 @@ class Pushdown : public NodeRewriter<PushdownContext> {
       outputOnlyColumns.add(node->markerColumn());
     }
     auto [pushable, blocked] = partition(context.pending, outputOnlyColumns);
+    blockNondeterministic(pushable, blocked);
 
     // Columns this Unnest must still produce: those the consumer requires plus
     // the columns read by conjuncts that stay above. The marker keeps the rows
@@ -1517,8 +1548,10 @@ class Pushdown : public NodeRewriter<PushdownContext> {
 
   // Window: conjuncts whose columns are all direct partition-key
   // columns push below — within a partition those values are
-  // constant, so pre/post-filter are equivalent. All others stay
-  // above. A single ranking function then specializes into the cheapest node
+  // constant, so a deterministic conjunct keeps or drops the partition whole.
+  // All others stay above, as do nondeterministic conjuncts, which would
+  // instead thin a partition and change what the window functions read.
+  // A single ranking function then specializes into the cheapest node
   // that computes it; anything else stays a Window with unread functions
   // pruned.
   NodeCP rewriteWindow(const Window* node, PushdownContext& context) override {
@@ -1556,6 +1589,7 @@ class Pushdown : public NodeRewriter<PushdownContext> {
         blocked.push_back(conjunct);
       }
     }
+    blockNondeterministic(pushable, blocked);
 
     PlanObjectSet outputsKept = context.required;
     outputsKept.unionColumns(blocked);
@@ -1959,6 +1993,11 @@ class Pushdown : public NodeRewriter<PushdownContext> {
 
     ExprVector derived;
     for (ExprCP conjunct : pending) {
+      // A derived twin is a second, independent restriction, so deriving one
+      // from a nondeterministic conjunct rejects rows the query keeps.
+      if (conjunct->containsNonDeterministic()) {
+        continue;
+      }
       for (const auto& mapping : toLeft) {
         ExprCP substituted = exprs_.replace(conjunct, mapping);
         if (substituted != conjunct && !isSelfEquality(substituted) &&


### PR DESCRIPTION
Summary:
The v2 optimizer pushed nondeterministic predicates past nodes that change the number of rows, so the plan computed a different query than the one written. For example:

    SELECT a, s FROM (SELECT a, sum(b) OVER (PARTITION BY a) AS s FROM t) WHERE a > rand()

pushed `a > rand()` into the scan, leaving `sum(b)` to run over a randomly thinned partition. `UNION DISTINCT` had the same shape: the predicate reached both union legs, so a value present in each drew twice and survived if either draw passed.

A conjunct containing a nondeterministic call now stays above any node whose output row count differs from its input's:
- aggregation, including the dedup that lowers `UNION DISTINCT`
- unnest and window
- a join input, though the conjunct may still be the join's own condition, which is evaluated once per candidate pair either way

Two related paths change with it. Transitive derivation no longer copies a nondeterministic conjunct across an equi-pair, because the copy is a second independent restriction. Equi-key extraction no longer turns a nondeterministic equality into a join key, which would evaluate it once per build row instead of once per pair; such a join stays a nested loop, as it does under v1.

Pushdown across a row-preserving boundary is unaffected: a predicate still reaches a scan or the legs of a plain `UNION ALL`. v1 has the same bug for `Window` and still pushes the predicate below it.

Differential Revision: D117622587


