### PR TITLE
fix(v2): Flatten a nested UNION into its parent UNION

### DIFF
--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -309,19 +309,18 @@ TEST_P(SetTest, intersect) {
           .filter(filter);
     };
     auto matcher =
-        matchLeg("nationkey > 12")
+        matchLeg("nationkey > 11")
             .hashJoin(
-                matchLeg("nationkey > 11")
+                matchLeg("nationkey > 12")
                     .hashJoin(
                         matchLeg("nationkey < 21 and (regionkey + 1) % 3 = 1"),
                         core::JoinType::kRightSemiFilter),
                 core::JoinType::kRightSemiFilter)
             .singleAggregation()
-            .project()
-            .project()
+            .project({"n_regionkey + 1 as rk"})
             .build();
 
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN_V2(plan, matcher);
   }
 }
 
@@ -674,9 +673,6 @@ TEST_P(SetTest, nondeterministicFilterAboveUnion) {
             .filter("k::double > rand()")
             .build());
 
-    // Asserted for v1 only: v2 gathers the union legs into one driver instead
-    // of spreading them round-robin, leaving the partial aggregation above it
-    // single-threaded.
     AXIOM_ASSERT_DISTRIBUTED_PLAN_V1(
         planVelox(logicalPlan).plan,
         matchScan("nation")
@@ -783,18 +779,18 @@ TEST_P(SetTest, filterColumnPruningInUnionAll) {
   // 'x' is filtered but not in the output, so it is pruned from each leg. The
   // alias binds the (disambiguated on the second leg) filter column.
   auto matchLeg = [](const std::string& filter) {
-    return matchScan("t").aliases({std::nullopt, "x"}).filter(filter).project();
+    return matchScan("t").aliases({"x", std::nullopt}).filter(filter).project();
   };
 
   {
     auto matcher = matchLeg("x > 0").localPartition(matchLeg("x > 0")).build();
-    AXIOM_ASSERT_PLAN_V1(toSingleNodePlan(logicalPlan), matcher);
+    AXIOM_ASSERT_PLAN_V2(toSingleNodePlan(logicalPlan), matcher);
   }
 
   {
     auto matcher =
         matchLeg("x > 0").localPartition(matchLeg("x > 0")).gather().build();
-    AXIOM_ASSERT_DISTRIBUTED_PLAN_V1(planVelox(logicalPlan).plan, matcher);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN_V2(planVelox(logicalPlan).plan, matcher);
   }
 }
 

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -236,7 +236,7 @@ TEST_P(SetTest, unionFlatten) {
                          .aggregation()
                          .build();
 
-      AXIOM_ASSERT_PLAN_V1(plan, matcher);
+      AXIOM_ASSERT_PLAN(plan, matcher);
     } else if (
         leftType == lp::SetOperation::kUnionAll &&
         rightType == lp::SetOperation::kUnionAll) {

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -600,10 +600,13 @@ class Translator {
       const std::vector<lp::ExprPtr>& projectExprs,
       const std::vector<std::string>& projectNames,
       Scope& windowScope);
+  // `dedupAbove` says the caller dedups the result, which subsumes a nested
+  // UNION's own dedup and so allows flattening such a leg.
   Translated buildUnionAll(
       const std::vector<lp::LogicalPlanNodePtr>& inputs,
       const velox::RowTypePtr& outputType,
-      const LpNameSet& required);
+      const LpNameSet& required,
+      bool dedupAbove);
 
   // Translates `predicateExpr` against `scope` (lifting any subqueries
   // above `input` via Apply) and lowers it onto `input`. Returns an
@@ -2207,23 +2210,24 @@ ColumnCP columnInScope(const Scope& scope, const std::string& name) {
 Translated Translator::buildUnionAll(
     const std::vector<lp::LogicalPlanNodePtr>& inputs,
     const velox::RowTypePtr& outputType,
-    const LpNameSet& required) {
-  // Flatten nested UNION ALL into one N-way union: a leg that is itself a UNION
-  // ALL contributes its own legs directly. Legs align positionally with the
-  // union's outputType at every level, so a flattened leg maps to the same kept
-  // positions as a direct one.
+    const LpNameSet& required,
+    bool dedupAbove) {
+  // Legs align positionally with the union's outputType at every level, so a
+  // flattened leg maps to the same kept positions as a direct one.
   std::vector<lp::LogicalPlanNodePtr> flatInputs;
   std::function<void(const lp::LogicalPlanNodePtr&)> collect =
       [&](const lp::LogicalPlanNodePtr& node) {
-        if (node->kind() == lp::NodeKind::kSet &&
-            node->as<lp::SetNode>()->operation() ==
-                lp::SetOperation::kUnionAll) {
-          for (const auto& child : node->inputs()) {
-            collect(child);
+        if (node->kind() == lp::NodeKind::kSet) {
+          const auto operation = node->as<lp::SetNode>()->operation();
+          if (operation == lp::SetOperation::kUnionAll ||
+              (dedupAbove && operation == lp::SetOperation::kUnion)) {
+            for (const auto& child : node->inputs()) {
+              collect(child);
+            }
+            return;
           }
-        } else {
-          flatInputs.push_back(node);
         }
+        flatInputs.push_back(node);
       };
   for (const auto& in : inputs) {
     collect(in);
@@ -2301,10 +2305,14 @@ Translated Translator::translateSet(
     const LpNameSet& required) {
   switch (set.operation()) {
     case lp::SetOperation::kUnionAll:
-      return buildUnionAll(set.inputs(), set.outputType(), required);
+      return buildUnionAll(
+          set.inputs(), set.outputType(), required, /*dedupAbove=*/false);
     case lp::SetOperation::kUnion: {
       Translated all = buildUnionAll(
-          set.inputs(), set.outputType(), allNames(*set.outputType()));
+          set.inputs(),
+          set.outputType(),
+          allNames(*set.outputType()),
+          /*dedupAbove=*/true);
       const ColumnVector& cols = all.node->outputColumns();
       Scope newScope;
       populateScope(*set.outputType(), cols, newScope);


### PR DESCRIPTION
Summary:
v2 flattened a nested set-operation leg into its parent only when the leg was a `UNION ALL`, ignoring the parent. So

    SELECT a FROM t UNION SELECT b FROM t UNION SELECT c FROM u UNION SELECT d FROM u

kept the tree nested and deduped three times where once suffices. v1 flattens it to one `UnionAll` with a single dedup on top.

`buildUnionAll` now also takes whether the caller dedups the result. That dedup subsumes a nested `UNION`'s own, so such a leg can be absorbed; a `UNION ALL` parent still absorbs only `UNION ALL` legs, since it must not drop duplicates. That is the same matrix `ToGraph::translateUnion` uses for v1.

`SetTest.unionFlatten` covers all four root and child combinations and no longer needs its v1 pin.

bypass-github-export-checks

Differential Revision: D117684213
