### PR TITLE
test: Use matchScan and matchValues helpers

### DIFF
--- a/axiom/optimizer/tests/FilterPushdownTest.cpp
+++ b/axiom/optimizer/tests/FilterPushdownTest.cpp
@@ -53,8 +53,7 @@ TEST_F(FilterPushdownTest, throughAggregation) {
 
   {
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder()
-                       .hiveScan("orders", test::lt("o_custkey", (int64_t)100))
+    auto matcher = matchHiveScan("orders", test::lt("o_custkey", (int64_t)100))
                        .singleAggregation()
                        .filter("a0 > 200.0")
                        .build();
@@ -83,8 +82,7 @@ TEST_F(FilterPushdownTest, throughAggregation) {
                                .build();
 
     auto plan = toSingleNodePlan(separateFilters);
-    auto matcher = core::PlanMatcherBuilder()
-                       .hiveScan("nation", test::gt("n_name", std::string("a")))
+    auto matcher = matchHiveScan("nation", test::gt("n_name", std::string("a")))
                        .singleAggregation({"n_name"}, {"count(1) as cnt"})
                        .filter("cnt > 10 and cnt > length(n_name)")
                        .build();
@@ -100,16 +98,15 @@ TEST_F(FilterPushdownTest, redundantCast) {
                          .build();
 
   auto plan = toSingleNodePlan(logicalPlan);
-  auto matcher = core::PlanMatcherBuilder()
-                     .hiveScan("nation", test::lt("n_nationkey", (int64_t)10))
-                     .build();
+  auto matcher =
+      matchHiveScan("nation", test::lt("n_nationkey", (int64_t)10)).build();
 
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 TEST_F(FilterPushdownTest, throughJoin) {
   auto startMatcher = [](const auto& tableName) {
-    return core::PlanMatcherBuilder().tableScan(tableName);
+    return matchHiveScan(tableName);
   };
 
   // Filter uses columns from both sides of the join. Expected to stay after the
@@ -152,8 +149,7 @@ TEST_F(FilterPushdownTest, throughJoin) {
     auto plan = toSingleNodePlan(logicalPlan);
 
     auto matcher =
-        core::PlanMatcherBuilder()
-            .hiveScan("nation", test::lt("n_nationkey", (int64_t)10))
+        matchHiveScan("nation", test::lt("n_nationkey", (int64_t)10))
             .hashJoin(startMatcher("region"), velox::core::JoinType::kInner)
             .aggregation()
             .build();
@@ -172,13 +168,13 @@ TEST_F(FilterPushdownTest, throughJoin) {
 
     auto plan = toSingleNodePlan(logicalPlan);
 
-    auto matcher = startMatcher("nation")
-                       .hashJoin(
-                           core::PlanMatcherBuilder().hiveScan(
-                               "region", test::lt("r_regionkey", (int64_t)10)),
-                           velox::core::JoinType::kInner)
-                       .aggregation()
-                       .build();
+    auto matcher =
+        startMatcher("nation")
+            .hashJoin(
+                matchHiveScan("region", test::lt("r_regionkey", (int64_t)10)),
+                velox::core::JoinType::kInner)
+            .aggregation()
+            .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -195,14 +191,13 @@ TEST_F(FilterPushdownTest, throughJoin) {
 
     auto plan = toSingleNodePlan(logicalPlan);
 
-    auto matcher = core::PlanMatcherBuilder()
-                       .hiveScan("nation", test::eq("n_regionkey", (int64_t)1))
-                       .hashJoin(
-                           core::PlanMatcherBuilder().hiveScan(
-                               "region", test::eq("r_regionkey", (int64_t)1)),
-                           velox::core::JoinType::kInner)
-                       .aggregation()
-                       .build();
+    auto matcher =
+        matchHiveScan("nation", test::eq("n_regionkey", (int64_t)1))
+            .hashJoin(
+                matchHiveScan("region", test::eq("r_regionkey", (int64_t)1)),
+                velox::core::JoinType::kInner)
+            .aggregation()
+            .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -216,9 +211,7 @@ TEST_F(FilterPushdownTest, inListWithDuplicates) {
                          .build();
 
   auto plan = toSingleNodePlan(logicalPlan);
-  auto matcher = core::PlanMatcherBuilder()
-                     .hiveScan("nation", test::eq("n_nationkey", 5LL))
-                     .build();
+  auto matcher = matchHiveScan("nation", test::eq("n_nationkey", 5LL)).build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
@@ -234,9 +227,7 @@ TEST_F(FilterPushdownTest, orWithSubsumedDisjunct) {
                          .build();
 
   auto plan = toSingleNodePlan(logicalPlan);
-  auto matcher = core::PlanMatcherBuilder()
-                     .hiveScan("nation", test::eq("n_regionkey", 1LL))
-                     .build();
+  auto matcher = matchHiveScan("nation", test::eq("n_regionkey", 1LL)).build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
@@ -254,11 +245,9 @@ TEST_F(FilterPushdownTest, multiTableOrFilter) {
 
   auto plan = toSingleNodePlan(logicalPlan);
   auto matcher =
-      core::PlanMatcherBuilder()
-          .hiveScan("nation", test::in("n_name", {"FRANCE", "JAPAN"}))
+      matchHiveScan("nation", test::in("n_name", {"FRANCE", "JAPAN"}))
           .hashJoin(
-              core::PlanMatcherBuilder().hiveScan(
-                  "region", test::in("r_name", {"ASIA", "EUROPE"})),
+              matchHiveScan("region", test::in("r_name", {"ASIA", "EUROPE"})),
               velox::core::JoinType::kInner)
           .filter(
               "(n_name = 'FRANCE' AND r_name = 'EUROPE') OR "

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -411,12 +411,10 @@ TEST_F(PlanTest, filterToJoinEdge) {
 
   {
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher =
-        core::PlanMatcherBuilder()
-            .tableScan("nation")
-            .project()
-            .hashJoin(core::PlanMatcherBuilder().tableScan("region").project())
-            .build();
+    auto matcher = matchHiveScan("nation")
+                       .project()
+                       .hashJoin(matchHiveScan("region").project())
+                       .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -450,19 +448,15 @@ TEST_F(PlanTest, filterToJoinEdge) {
 
   {
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder()
-                       .tableScan("nation")
-                       // TODO Why is this filter not pushed down into scan?
-                       .filter("rand() < 2.0")
-                       .project()
-                       .hashJoin(
-                           core::PlanMatcherBuilder()
-                               .tableScan("region")
-                               .filter("rand() < 3.0")
-                               .project())
-                       .filter("rand() < 4.0")
-                       .project()
-                       .build();
+    auto matcher =
+        matchHiveScan("nation")
+            // TODO Why is this filter not pushed down into scan?
+            .filter("rand() < 2.0")
+            .project()
+            .hashJoin(matchHiveScan("region").filter("rand() < 3.0").project())
+            .filter("rand() < 4.0")
+            .project()
+            .build();
 
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
@@ -525,15 +519,13 @@ TEST_F(PlanTest, filterBreakup) {
 
     auto plan = toSingleNodePlan(logicalPlan);
     auto matcher =
-        core::PlanMatcherBuilder()
-            .hiveScan("lineitem", std::move(lineitemFilters))
-            .hashJoin(
-                core::PlanMatcherBuilder().hiveScan(
-                    "part",
-                    {},
-                    "\"or\"(\"and\"(p_size between 1 and 15, (p_brand = 'Brand#34' AND p_container LIKE 'LG%')), "
-                    "   \"or\"(\"and\"(p_size between 1 and 5, (p_brand = 'Brand#12' AND p_container LIKE 'SM%')), "
-                    "          \"and\"(p_size between 1 and 10, (p_brand = 'Brand#23' AND p_container LIKE 'MED%'))))"))
+        matchHiveScan("lineitem", std::move(lineitemFilters))
+            .hashJoin(matchHiveScan(
+                "part",
+                {},
+                "\"or\"(\"and\"(p_size between 1 and 15, (p_brand = 'Brand#34' AND p_container LIKE 'LG%')), "
+                "   \"or\"(\"and\"(p_size between 1 and 5, (p_brand = 'Brand#12' AND p_container LIKE 'SM%')), "
+                "          \"and\"(p_size between 1 and 10, (p_brand = 'Brand#23' AND p_container LIKE 'MED%'))))"))
             .filter()
             .project()
             .singleAggregation()

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -222,11 +222,9 @@ TEST_P(SetTest, unionFlatten) {
     // Each leg now carries a separate Filter node above its TableScan. The
     // first child of a LocalPartition has no rename Project; non-first children
     // do.
-    auto nonFirstChildMatcher =
-        core::PlanMatcherBuilder().tableScan().filter().project();
+    auto nonFirstChildMatcher = matchScan("nation").filter().project();
     if (rootType == lp::SetOperation::kUnion) {
-      auto matcher = core::PlanMatcherBuilder()
-                         .tableScan()
+      auto matcher = matchScan("nation")
                          .filter()
                          .localPartition({
                              nonFirstChildMatcher,
@@ -240,8 +238,7 @@ TEST_P(SetTest, unionFlatten) {
     } else if (
         leftType == lp::SetOperation::kUnionAll &&
         rightType == lp::SetOperation::kUnionAll) {
-      auto matcher = core::PlanMatcherBuilder()
-                         .tableScan()
+      auto matcher = matchScan("nation")
                          .filter()
                          .localPartition({
                              nonFirstChildMatcher,
@@ -254,19 +251,17 @@ TEST_P(SetTest, unionFlatten) {
       continue;
     } else {
       // We cannot flatten UNION inside UNION ALL.
-      auto matcher = core::PlanMatcherBuilder()
-                         .tableScan()
-                         .filter()
-                         .localPartition(nonFirstChildMatcher)
-                         .aggregation()
-                         .localPartition(
-                             core::PlanMatcherBuilder()
-                                 .tableScan()
-                                 .filter()
-                                 .localPartition(nonFirstChildMatcher)
-                                 .aggregation()
-                                 .project())
-                         .build();
+      auto matcher =
+          matchScan("nation")
+              .filter()
+              .localPartition(nonFirstChildMatcher)
+              .aggregation()
+              .localPartition(matchScan("nation")
+                                  .filter()
+                                  .localPartition(nonFirstChildMatcher)
+                                  .aggregation()
+                                  .project())
+              .build();
 
       AXIOM_ASSERT_PLAN(plan, matcher);
     }
@@ -976,7 +971,7 @@ TEST_P(SetTest, unionAllWithDistinctAndCountStar) {
         matchScan("t")
             .singleAggregation({"a"}, {})
             .project({})
-            .localPartition(core::PlanMatcherBuilder().values(ROW({})))
+            .localPartition(matchValues(ROW({})))
             .singleAggregation({}, {"count(*) as c"})
             .build());
   }
@@ -996,9 +991,7 @@ TEST_P(SetTest, unionAllWithDistinctAndCountStar) {
         matchScan("t")
             .singleAggregation({"a"}, {})
             .project({})
-            .localPartition(
-                {core::PlanMatcherBuilder().values(ROW({})),
-                 core::PlanMatcherBuilder().values(ROW({}))})
+            .localPartition({matchValues(ROW({})), matchValues(ROW({}))})
             .singleAggregation({}, {"count(*) as c"})
             .build());
   }
@@ -1018,7 +1011,7 @@ TEST_P(SetTest, unionAllWithDistinctAndCountStar) {
         matchScan("t")
             .singleAggregation({"a"}, {})
             .project({})
-            .localPartition(core::PlanMatcherBuilder().values(ROW({})))
+            .localPartition(matchValues(ROW({})))
             .singleAggregation({}, {"count(*) as cnt"})
             .filter("cnt > 0")
             .build());

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -294,12 +294,10 @@ class SubfieldTest : public HiveQueriesTestBase,
         plan, {{"float_features", {subfield("10010"), subfield("10020")}}});
 
     auto matcher =
-        core::PlanMatcherBuilder()
-            .hiveScan("features", {}, "float_features[10010] + 1 < 10000")
+        matchHiveScan("features", {}, "float_features[10010] + 1 < 10000")
             .localPartition(
-                core::PlanMatcherBuilder()
-                    .hiveScan(
-                        "features", {}, "float_features[10010] + 1 < 10000")
+                matchHiveScan(
+                    "features", {}, "float_features[10010] + 1 < 10000")
                     .project())
             .project()
             .build();
@@ -873,8 +871,7 @@ TEST_P(SubfieldTest, subquery) {
 
     auto plan = toSingleNodePlan(logicalPlan);
 
-    auto matcher = core::PlanMatcherBuilder()
-                       .tableScan("t_subquery")
+    auto matcher = matchHiveScan("t_subquery")
                        .project()
                        .hashJoin(matchValues().project())
                        .project()

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -57,8 +57,7 @@ TEST_P(SubqueryTest, uncorrelatedScalar) {
     auto plan = toSingleNodePlan(query);
     auto matcher = matchHiveScan("nation")
                        .hashJoin(
-                           core::PlanMatcherBuilder()
-                               .hiveScan("region", {}, "r_name like 'AF%'")
+                           matchHiveScan("region", {}, "r_name like 'AF%'")
                                .enforceSingleRow(),
                            velox::core::JoinType::kInner)
                        .build();
@@ -76,8 +75,7 @@ TEST_P(SubqueryTest, uncorrelatedScalar) {
     auto plan = toSingleNodePlan(query);
     auto matcher = matchHiveScan("nation")
                        .hashJoin(
-                           core::PlanMatcherBuilder().hiveScan(
-                               "region", test::gt("r_name", "ASIA")),
+                           matchHiveScan("region", test::gt("r_name", "ASIA")),
                            velox::core::JoinType::kLeftSemiFilter)
                        .build();
 
@@ -96,8 +94,7 @@ TEST_P(SubqueryTest, uncorrelatedScalar) {
     auto matcher =
         matchHiveScan("nation")
             .hashJoin(
-                core::PlanMatcherBuilder()
-                    .hiveScan("region", test::gt("r_name", "ASIA"))
+                matchHiveScan("region", test::gt("r_name", "ASIA"))
                     .project({"cast(cast(r_regionkey as tinyint) as bigint)"}),
                 velox::core::JoinType::kLeftSemiFilter)
             .build();
@@ -115,8 +112,7 @@ TEST_P(SubqueryTest, uncorrelatedScalar) {
     auto plan = toSingleNodePlan(query);
     auto matcher = matchHiveScan("nation")
                        .hashJoin(
-                           core::PlanMatcherBuilder().hiveScan(
-                               "region", test::gt("r_name", "ASIA")),
+                           matchHiveScan("region", test::gt("r_name", "ASIA")),
                            velox::core::JoinType::kAnti,
                            {.nullAware = true})
                        .build();
@@ -223,7 +219,7 @@ TEST_P(SubqueryTest, correlatedExists) {
 
     auto matcher = matchHiveScan("nation")
                        .hashJoin(
-                           core::PlanMatcherBuilder().hiveScan("region", {}),
+                           matchHiveScan("region", {}),
                            velox::core::JoinType::kLeftSemiFilter)
                        .build();
 
@@ -393,8 +389,7 @@ TEST_P(SubqueryTest, uncorrelatedProject) {
     // with a mark column. nullAware is true for IN semantics.
     auto matcher = matchHiveScan("nation")
                        .hashJoin(
-                           core::PlanMatcherBuilder().hiveScan(
-                               "region", test::gt("r_name", "ASIA")),
+                           matchHiveScan("region", test::gt("r_name", "ASIA")),
                            velox::core::JoinType::kLeftSemiProject,
                            {.nullAware = true})
                        .project()
@@ -416,8 +411,7 @@ TEST_P(SubqueryTest, uncorrelatedProject) {
     // join with a mark column and NOT applied to the result. nullAware is true.
     auto matcher = matchHiveScan("nation")
                        .hashJoin(
-                           core::PlanMatcherBuilder().hiveScan(
-                               "region", test::gt("r_name", "ASIA")),
+                           matchHiveScan("region", test::gt("r_name", "ASIA")),
                            velox::core::JoinType::kLeftSemiProject,
                            {.nullAware = true})
                        .project()
@@ -903,7 +897,7 @@ TEST_P(SubqueryTest, correlatedProject) {
     // join with a mark column. nullAware is false for EXISTS semantics.
     auto matcher = matchHiveScan("nation")
                        .hashJoin(
-                           core::PlanMatcherBuilder().hiveScan("region", {}),
+                           matchHiveScan("region", {}),
                            velox::core::JoinType::kLeftSemiProject,
                            {.nullAware = false})
                        .project()
@@ -925,7 +919,7 @@ TEST_P(SubqueryTest, correlatedProject) {
     // the key is not null-aware, as for the EXISTS above.
     auto matcher = matchHiveScan("nation")
                        .hashJoin(
-                           core::PlanMatcherBuilder().hiveScan("region", {}),
+                           matchHiveScan("region", {}),
                            velox::core::JoinType::kLeftSemiProject,
                            {.nullAware = false})
                        .project()
@@ -947,7 +941,7 @@ TEST_P(SubqueryTest, correlatedProject) {
     // PROJECT join with a mark column and NOT applied.
     auto matcher = matchHiveScan("nation")
                        .hashJoin(
-                           core::PlanMatcherBuilder().hiveScan("region", {}),
+                           matchHiveScan("region", {}),
                            velox::core::JoinType::kLeftSemiProject,
                            {.nullAware = false})
                        .project()
@@ -1018,7 +1012,7 @@ TEST_P(SubqueryTest, correlatedNotExists) {
 
     auto matcher = matchHiveScan("nation")
                        .hashJoin(
-                           core::PlanMatcherBuilder().hiveScan("region", {}),
+                           matchHiveScan("region", {}),
                            velox::core::JoinType::kAnti,
                            {.nullAware = false})
                        .build();
@@ -1060,7 +1054,7 @@ TEST_P(SubqueryTest, correlatedNotExists) {
     // join with a mark column and NOT applied.
     auto matcher = matchHiveScan("nation")
                        .hashJoin(
-                           core::PlanMatcherBuilder().hiveScan("region", {}),
+                           matchHiveScan("region", {}),
                            velox::core::JoinType::kLeftSemiProject,
                            {.nullAware = false})
                        .project()


### PR DESCRIPTION
Summary:
Plan matchers spelled their root node as `core::PlanMatcherBuilder().tableScan(...)`, `.hiveScan(...)` or `.values(...)`, though `QueryTestBase` and `HiveQueriesTestBase` already offer `matchScan`, `matchHiveScan` and `matchValues` for exactly that. Using the helpers drops 35 lines.

In `SetTest.unionFlatten` this also names the table the matcher was already relying on: the root was a bare `tableScan()` matching any scan, and is now `matchScan("nation")`.

What remains on the raw builder are roots the helpers do not cover: `tableScan()` with no table name, and the `fixedPoint` and `stateSource` roots in `FixedPointTest`.

bypass-github-export-checks

Differential Revision: D117685099


