### PR TITLE
fix(v2): Fold calls to null when an argument is null

### DIFF
--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -328,7 +328,7 @@ TEST_P(PlanTest, nullPropagation) {
     auto matcher = matchScan("t").project({expected, "a", "b"}).build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
 

--- a/axiom/optimizer/v2/ExprSimplifier.cpp
+++ b/axiom/optimizer/v2/ExprSimplifier.cpp
@@ -160,11 +160,15 @@ ExprCP ExprSimplifier::tryFoldConstant(ExprCP expr) {
 
   // A call with default null behavior (result is null whenever any argument is
   // null) folds to null if any argument is the constant null -- even when its
-  // other arguments reference columns. Special forms (and/or/if/coalesce/try)
-  // carry kNonDefaultNullBehavior, so they are excluded.
+  // other arguments reference columns. Special forms are given
+  // kNonDefaultNullBehavior unconditionally, so they are excluded.
+  // `Call::functions()` aggregates the arguments' bits, so the call's own bits
+  // are recomputed here.
   if (expr->is(PlanType::kCallExpr)) {
     const auto* call = expr->as<Call>();
-    if (!call->functions().contains(FunctionSet::kNonDefaultNullBehavior)) {
+    const FunctionSet ownFunctions = functionBits(
+        call->name(), SpecialFormCallNames::isSpecialForm(call->name()));
+    if (!ownFunctions.contains(FunctionSet::kNonDefaultNullBehavior)) {
       for (ExprCP arg : call->args()) {
         if (arg->is(PlanType::kLiteralExpr) &&
             arg->as<Literal>()->literal().isNull()) {


### PR DESCRIPTION
Summary:
`SELECT coalesce(a, b) + null FROM t` planned in v2 with the `plus` intact; v1 folds it to `null`. A function with default null behavior returns null whenever an argument is null, and that holds however the argument is computed — a child that does not propagate nulls says nothing about the parent.

The fold read `Call::functions()`, which is the call's own bits OR-ed with every argument's bits, so `coalesce`'s `kNonDefaultNullBehavior` showed up on the enclosing `plus` and suppressed it. It now reads the call's own bits, recomputed from the name the way `ExprFactory::rebuildCall` already does.

bypass-github-export-checks

Differential Revision: D117713417
