### PR TITLE
misc: Advance Velox

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Axiom integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/eb846b0fd042c8fcb145c693a5bc21f8f22d17ad...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/3221d03fc546a290c01b6a511068f7d8bc148365...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that


### PR DESCRIPTION
Summary:
Moves the Velox pin from `eb846b0fd` to `3221d03fc`, 16 commits.

Nimble dominates the range: rejecting `enableChunkIndex` without `enableChunking`, restoring the Huffman 12-bit guard and fixing NaN statistics comparison, re-sizing the merged flat map key buffer when an entry count repeats, cutting index projector slice overhead, moving the reader factory out of `fb/`, new writer-fuzzer checks for schema roundtrip and stripe group consistency, and `SubIntSplit` and reordering microbenchmark drivers. Outside Nimble: a split-level column mapping mode for file scans, an RPC congestion window that recovers after an overload backs it off, a `CacheShard::shutdown` race and leak fix, faster Parquet `DeltaBpDecoder` skip and decode, and `Type.h` dropped from the simple-function header path so nvcc can parse those headers.

Also advances the Velox compare link in `README.md`, which `scripts/check-velox-readme.sh` requires to match the submodule SHA.

No Axiom code changes.

Differential Revision: D117741163
