### PR TITLE
fix(v2): Partition the probe of a counting join across drivers (#1799)

### DIFF
--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -207,10 +207,15 @@ class Column : public Expr {
     return alias_ != nullptr ? alias_ : toString();
   }
 
-  /// Asserts that 'this' and 'other' are joined on equality under inner-join
-  /// semantics (NULLs do not match). The relation is transitive, so if a and
-  /// b are previously asserted equal and c is asserted equal to b, a and c
-  /// are also equal.
+  /// Asserts that 'this' and 'other' hold the same value on every row the
+  /// plan produces, so either may stand for the other. The relation is
+  /// transitive, so if a and b are previously asserted equal and c is asserted
+  /// equal to b, a and c are also equal.
+  ///
+  /// Only inner joins assert this. An outer join null-pads its non-preserved
+  /// side, so its key columns are not equal in its output. A join that emits
+  /// one side only proves the equality but cannot supply both columns, so it
+  /// registers its class per cover instead of here.
   void equals(ColumnCP other) const;
 
   std::string toString() const override;

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -476,7 +476,7 @@ TEST_P(SetTest, intersectAll) {
             .hashJoin(matchBuild("t2"), core::JoinType::kCountingLeftSemiFilter)
             .hashJoin(matchBuild("t3"), core::JoinType::kCountingLeftSemiFilter)
             .build();
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 
   auto matchPartitionedBuild = [](const std::string& table) {

--- a/axiom/optimizer/tests/SetTest.cpp
+++ b/axiom/optimizer/tests/SetTest.cpp
@@ -535,15 +535,16 @@ TEST_P(SetTest, intersectAllSideSwap) {
   {
     auto logicalPlan =
         parseSelect("SELECT x FROM small INTERSECT ALL SELECT a FROM big");
-    AXIOM_ASSERT_PLAN_V1(
-        toSingleNodePlan(logicalPlan), startMatcher().project().build());
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(logicalPlan),
+        startMatcher().project({"a as x"}).build());
 
     // Output rename project: join outputs 'a' (probe) but query expects
     // 'x' (the original left side column name).
     auto distributedPlan = planVelox(logicalPlan);
     AXIOM_ASSERT_DISTRIBUTED_PLAN_V1(
         distributedPlan.plan,
-        startDistributedMatcher().project().gather().build());
+        startDistributedMatcher().project({"a as x"}).gather().build());
   }
 }
 

--- a/axiom/optimizer/tests/sql/set.sql
+++ b/axiom/optimizer/tests/sql/set.sql
@@ -206,3 +206,17 @@ SELECT a, b FROM t WHERE a = 1 AND b = 40
 SELECT a AS x, a AS y FROM t WHERE a = 1 AND b = 10
 INTERSECT
 SELECT a, a FROM t WHERE a = 1 AND b = 40
+----
+-- Multi-column INTERSECT ALL with NULLs on both sides.
+SELECT p, q FROM (VALUES (1, null), (1, null), (1, 10)) AS v(p, q)
+INTERSECT ALL
+SELECT r, s FROM (VALUES (1, null), (1, 10), (1, 10), (2, 2), (3, 3), (4, 4))
+  AS w(r, s)
+----
+-- Multi-column INTERSECT ALL as an input to a join, projecting both
+-- intersected columns and one from the joined table.
+SELECT i.a, i.b, t.c FROM (
+  SELECT a, b FROM t WHERE a < 3
+  INTERSECT ALL
+  SELECT a, b FROM t WHERE b <= 50
+) i JOIN t ON t.b = i.b WHERE i.a = 1

--- a/axiom/optimizer/v2/AlgebraicProperties.cpp
+++ b/axiom/optimizer/v2/AlgebraicProperties.cpp
@@ -24,12 +24,12 @@ namespace {
 
 using JoinType = velox::core::JoinType;
 
-constexpr int kKindCount = 5;
+constexpr int kKindCount = 6;
 
 // Compact ordinal for indexing the algebraic-properties table.
 // kInner = 0, kLeft = 1, kFull = 2, semijoin (⋉) = 3, antijoin (▷)
-// = 4. The paper's LOP is left-oriented; callers normalize kRight
-// and kRightSemi* by swapping operands and looking up the left
+// = 4, counting semijoin (⋉c) = 5. The paper's LOP is left-oriented; callers
+// normalize kRight and kRightSemi* by swapping operands and looking up the left
 // form. kLeftSemiFilter and kLeftSemiProject share the ⋉ row
 // (identical reorderability); kAnti maps to ▷.
 int kindIndex(JoinType type) {
@@ -45,6 +45,8 @@ int kindIndex(JoinType type) {
       return 3;
     case JoinType::kAnti:
       return 4;
+    case JoinType::kCountingLeftSemiFilter:
+      return 5;
     default:
       VELOX_NYI(
           "Algebraic properties not defined for join type: {}; "
@@ -69,6 +71,8 @@ constexpr AlgebraicProperties kTable[kKindCount][kKindCount] = {
         {.associative = true, .leftAsscom = true, .rightAsscom = false},
         // parent = ▷
         {.associative = true, .leftAsscom = true, .rightAsscom = false},
+        // parent = ⋉c
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
     },
     // child = kLeft
     {
@@ -82,6 +86,8 @@ constexpr AlgebraicProperties kTable[kKindCount][kKindCount] = {
         {.associative = false, .leftAsscom = true, .rightAsscom = false},
         // parent = ▷
         {.associative = false, .leftAsscom = true, .rightAsscom = false},
+        // parent = ⋉c
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
     },
     // child = kFull
     {
@@ -94,6 +100,8 @@ constexpr AlgebraicProperties kTable[kKindCount][kKindCount] = {
         // parent = ⋉
         {.associative = false, .leftAsscom = false, .rightAsscom = false},
         // parent = ▷
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
+        // parent = ⋉c
         {.associative = false, .leftAsscom = false, .rightAsscom = false},
     },
     // child = ⋉
@@ -108,6 +116,8 @@ constexpr AlgebraicProperties kTable[kKindCount][kKindCount] = {
         {.associative = false, .leftAsscom = true, .rightAsscom = false},
         // parent = ▷
         {.associative = false, .leftAsscom = true, .rightAsscom = false},
+        // parent = ⋉c
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
     },
     // child = ▷
     {
@@ -121,9 +131,25 @@ constexpr AlgebraicProperties kTable[kKindCount][kKindCount] = {
         {.associative = false, .leftAsscom = true, .rightAsscom = false},
         // parent = ▷
         {.associative = false, .leftAsscom = true, .rightAsscom = false},
+        // parent = ⋉c
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
+    },
+    // child = ⋉c
+    {
+        // parent = kInner
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
+        // parent = kLeft
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
+        // parent = kFull
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
+        // parent = ⋉
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
+        // parent = ▷
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
+        // parent = ⋉c
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
     },
 };
-
 } // namespace
 
 AlgebraicProperties AlgebraicProperties::derive(

--- a/axiom/optimizer/v2/AlgebraicProperties.h
+++ b/axiom/optimizer/v2/AlgebraicProperties.h
@@ -43,9 +43,11 @@ struct AlgebraicProperties {
   /// `kLeftSemiFilter`/`kLeftSemiProject` (semijoin ⋉, identical
   /// reorderability), and `kAnti` (antijoin ▷, sharing ⋉'s rows).
   /// Callers normalize `kRight`/`kRightSemi*` to their left forms
-  /// (operand swap) before lookup. Throws for other types via
-  /// `VELOX_NYI`, including the counting variants
-  /// (`kCountingLeftSemiFilter`/`kCountingAnti`), which stay opaque.
+  /// (operand swap) before lookup. `kCountingLeftSemiFilter` has a row and
+  /// column of all-false entries: multiset intersection is associative, but the
+  /// enumerator claims only operand exchange for it, and a false entry widens
+  /// the TES, which is what holds a chain in place. Throws for other types via
+  /// `VELOX_NYI`, including `kCountingAnti`, which stays opaque.
   ///
   /// Conditional entries (those the paper marks "+ if predicate
   /// rejects nulls") are collapsed to false. The precondition that

--- a/axiom/optimizer/v2/DPhyp.cpp
+++ b/axiom/optimizer/v2/DPhyp.cpp
@@ -87,6 +87,8 @@ velox::core::JoinType flipJoinType(velox::core::JoinType kind) {
   switch (kind) {
     case velox::core::JoinType::kInner:
     case velox::core::JoinType::kFull:
+    // Multiset intersection: exchanging the operands yields the same operation.
+    case velox::core::JoinType::kCountingLeftSemiFilter:
       return kind;
     case velox::core::JoinType::kLeft:
       return velox::core::JoinType::kRight;

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -318,9 +318,46 @@ class Emitter {
         .numRawInputRows = numRawInputRows};
   }
 
-  // Local exchange inserted below a final/single aggregation at numDrivers > 1
-  // so every row of a group is processed by one driver: a repartition on the
-  // grouping keys, or a gather to one driver when there are none.
+  // Whether every key of `inner` is also a key of `outer`.
+  bool keysContainAll(
+      const std::vector<velox::core::FieldAccessTypedExprPtr>& outer,
+      const std::vector<velox::core::FieldAccessTypedExprPtr>& inner) {
+    folly::F14FastSet<std::string_view> names;
+    for (const auto& key : outer) {
+      names.insert(key->name());
+    }
+    for (const auto& key : inner) {
+      if (!names.contains(key->name())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // A counting join needs each key on one driver: its per-key build counters
+  // are per-driver. Returns `probe` wrapped in a local partition on `keys`,
+  // unless each key already reaches one driver: with a single driver, or with
+  // a probe that is itself a counting join partitioned on a subset of these
+  // keys, since rows agreeing on these keys agree on those.
+  velox::core::PlanNodePtr addLocalPartitionForCountingJoin(
+      velox::core::PlanNodePtr probe,
+      const std::vector<velox::core::FieldAccessTypedExprPtr>& keys) {
+    if (options_.numDrivers <= 1) {
+      return probe;
+    }
+
+    const auto* probeJoin = probe->as<velox::core::HashJoinNode>();
+    if (probeJoin != nullptr &&
+        velox::core::isCountingJoin(probeJoin->joinType()) &&
+        keysContainAll(keys, probeJoin->leftKeys())) {
+      return probe;
+    }
+    return addLocalPartition(std::move(probe), keys);
+  }
+
+  // Returns `input` wrapped in a local exchange that brings all rows agreeing
+  // on `keys` to one driver: a hash repartition on `keys`, or a gather to a
+  // single driver when there are none.
   velox::core::PlanNodePtr addLocalPartition(
       velox::core::PlanNodePtr input,
       const std::vector<velox::core::FieldAccessTypedExprPtr>& keys) {
@@ -1142,6 +1179,10 @@ velox::core::PlanNodePtr Emitter::emitJoin(const Join& join) {
   if (!join.leftKeys().empty()) {
     auto leftKeys = toFieldAccessList(join.leftKeys(), "Join leftKey");
     auto rightKeys = toFieldAccessList(join.rightKeys(), "Join rightKey");
+
+    if (velox::core::isCountingJoin(join.joinType())) {
+      left = addLocalPartitionForCountingJoin(std::move(left), leftKeys);
+    }
 
     return std::make_shared<velox::core::HashJoinNode>(
         nextId(),

--- a/axiom/optimizer/v2/JoinEdge.h
+++ b/axiom/optimizer/v2/JoinEdge.h
@@ -34,6 +34,10 @@ namespace facebook::axiom::optimizer::v2 {
 /// every task. The right side is preserved by RIGHT / FULL outer joins and by
 /// right semi joins; for those the build cannot be broadcast, and the mirror
 /// orientation broadcasts the other side instead.
+///
+/// A counting join is excluded because its result depends on a per-key count
+/// over the whole build input: a broadcast copy would give every task the full
+/// count, so a key could be emitted once per task.
 inline bool canBroadcastBuild(velox::core::JoinType joinType) {
   using velox::core::JoinType;
   return joinType == JoinType::kInner || joinType == JoinType::kLeft ||

--- a/axiom/optimizer/v2/JoinFanout.cpp
+++ b/axiom/optimizer/v2/JoinFanout.cpp
@@ -88,6 +88,12 @@ std::optional<float> shapeByJoinType(
     case velox::core::JoinType::kAnti:
       return maxOf(
           0.0f, subtract(leftCardinality, minOf(leftCardinality, matched)));
+    case velox::core::JoinType::kCountingLeftSemiFilter:
+      // Multiset intersection emits min(count) per key, so the result cannot
+      // exceed either input, nor the match count. This is a bound rather
+      // than an estimate: with disjoint inputs it still reports the smaller
+      // input's size.
+      return minOf(minOf(leftCardinality, rightCardinality), matched);
     default:
       return matched;
   }

--- a/axiom/optimizer/v2/JoinHypergraph.cpp
+++ b/axiom/optimizer/v2/JoinHypergraph.cpp
@@ -118,6 +118,22 @@ void JoinHypergraph::addFilterConjunct(FilterConjunct conjunct) {
   invalidateCoverCaches();
 }
 
+namespace {
+
+// Whether a join of `joinType` proves its equi-key columns hold equal values
+// on every row it emits, so downstream may substitute either for the other.
+//
+// Only a join that emits matched rows alone proves it, since an unmatched or
+// null-padded row has unequal keys. Emitting one side is enough: the equal
+// column it does not emit is recovered by renaming above it.
+bool provesKeyEquality(velox::core::JoinType joinType) {
+  using velox::core::JoinType;
+  return joinType == JoinType::kInner ||
+      joinType == JoinType::kCountingLeftSemiFilter;
+}
+
+} // namespace
+
 PlanObjectSet JoinHypergraph::coverColumns(const RelationSet& cover) const {
   PlanObjectSet columns;
   cover.forEach([&](int32_t id) { columns.unionSet(relation(id).columns()); });
@@ -163,10 +179,10 @@ folly::F14FastMap<ColumnCP, ColumnCP> JoinHypergraph::coverColumnReps(
   };
 
   for (const auto& edge : edges_) {
-    // Only an inner join makes its key columns equal in the output: across an
-    // outer join the null-padded side's key is NULL, not equal to the
-    // preserved side, so those columns must not be collapsed.
-    if (edge.joinType() != velox::core::JoinType::kInner) {
+    // Only a join that proves its keys equal on every emitted row lets the two
+    // columns collapse. Where the join emits one side only, the representative
+    // may be the column it does not produce; the emitter projects it back.
+    if (!provesKeyEquality(edge.joinType())) {
       continue;
     }
     RelationSet endpoints{edge.left()};

--- a/axiom/optimizer/v2/JoinHypergraph.h
+++ b/axiom/optimizer/v2/JoinHypergraph.h
@@ -124,9 +124,11 @@ class JoinHypergraph {
   /// make the choice non-reproducible across runs and query forms. The order is
   /// total, so `best(A∪B) = best(best A, best B)`: a join's representative is
   /// always one of its children's representatives, hence present in a child's
-  /// output, independent of join order. Used to collapse provably-equal columns
-  /// to one, consistently for costing (row width) and emission (output columns
-  /// and key/filter references).
+  /// output, independent of join order. Where a child emits one side only, the
+  /// representative is made present by the projection the emitter places above
+  /// it.
+  /// Used to collapse provably-equal columns to one, consistently for costing
+  /// (row width) and emission (output columns and key/filter references).
   folly::F14FastMap<ColumnCP, ColumnCP> coverColumnReps(
       const RelationSet& cover) const;
 

--- a/axiom/optimizer/v2/JoinTreeEmitter.cpp
+++ b/axiom/optimizer/v2/JoinTreeEmitter.cpp
@@ -344,6 +344,9 @@ std::optional<ColumnVector> narrowSemiAntiOutput(
   switch (joinType) {
     case JoinType::kLeftSemiFilter:
     case JoinType::kAnti:
+    // A counting semi join is its own mirror, so the semi'd side is the probe
+    // in either orientation.
+    case JoinType::kCountingLeftSemiFilter:
       // Semi'd side is the probe (left) input.
       return ColumnVector{leftNode->outputColumns()};
     case JoinType::kRightSemiFilter:
@@ -368,6 +371,52 @@ std::optional<ColumnVector> narrowSemiAntiOutput(
   }
 }
 
+// Produces the demanded columns above a node that emitted the other member of
+// an equated pair, binding each absent column to the equal one that is
+// present. The keys are oriented: `leftKeys` is the emitted (probe) side.
+NodeCP projectDemanded(
+    NodeCP node,
+    const ColumnVector& demanded,
+    const ExprVector& leftKeys,
+    const ExprVector& rightKeys,
+    EmitState& state) {
+  const auto emitted = PlanObjectSet::fromObjects(node->outputColumns());
+  if (emitted.containsAll(demanded)) {
+    return node;
+  }
+  VELOX_CHECK_EQ(leftKeys.size(), rightKeys.size());
+
+  ExprVector exprs;
+  exprs.reserve(demanded.size());
+  for (ColumnCP column : demanded) {
+    ExprCP replacement = column;
+    if (!emitted.contains(column)) {
+      for (size_t i = 0; i < rightKeys.size(); ++i) {
+        if (rightKeys[i] == column) {
+          replacement = leftKeys[i];
+          break;
+        }
+      }
+      VELOX_CHECK(
+          replacement != column,
+          "Demanded column is absent from the join output and is not equated "
+          "to one that is present: {}",
+          column->toString());
+      VELOX_CHECK(
+          replacement->isColumn(),
+          "Replacement for a demanded column is not a column: {}",
+          column->toString());
+      VELOX_CHECK(
+          emitted.contains(replacement->as<Column>()),
+          "Replacement for a demanded column is not emitted by the join: {}",
+          column->toString());
+    }
+    exprs.push_back(replacement);
+  }
+  return state.builder.make<Project>(
+      {node, std::move(exprs), ColumnVector{demanded}});
+}
+
 Emitted buildJoin(
     const JoinOp* join,
     const Emitted& left,
@@ -377,6 +426,14 @@ Emitted buildJoin(
   const auto& edge = state.graph.edges()[join->edgeIndex];
   const bool isInner = edge.joinType() == velox::core::JoinType::kInner;
 
+  // True when the cover may have collapsed a demanded column onto the build
+  // side, leaving the probe-only output short of it.
+  const bool mayNeedProject =
+      join->joinType == velox::core::JoinType::kCountingLeftSemiFilter;
+  ColumnVector demanded;
+  if (mayNeedProject) {
+    demanded = outputColumns;
+  }
   if (auto narrowed = narrowSemiAntiOutput(
           join->joinType, left.node, right.node, edge.markColumn())) {
     outputColumns = std::move(*narrowed);
@@ -464,14 +521,21 @@ Emitted buildJoin(
       {left.node,
        right.node,
        join->joinType,
-       std::move(leftKeys),
-       std::move(rightKeys),
+       // The projection below reads these, so they outlive the Join.
+       leftKeys,
+       rightKeys,
        std::move(filter),
        edge.nullAware(),
        edge.nullAsValue(),
        std::move(outputColumns)});
   if (!aboveJoin.empty()) {
     node = state.builder.make<Filter>({node, std::move(aboveJoin)});
+  }
+  // A probe-only join emits its probe side, so a demanded column that the
+  // equated class placed on the other side is absent. Both hold the same value
+  // on every emitted row, so bind it to its partner through the keys.
+  if (mayNeedProject) {
+    node = projectDemanded(node, demanded, leftKeys, rightKeys, state);
   }
   retainVisible(materialized, node);
   return {node, std::move(materialized)};

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -388,8 +388,9 @@ ExprCP survivingEquiKey(ExprCP key, const PlanObjectSet& outputColumns) {
 
 // Output global partitioning of a join. A join keeps the probe's (left's)
 // partitioning when every output row is a probe row carrying its probe column
-// values unchanged, which holds for inner, left, and the left semi and anti
-// joins. Right and full joins emit build rows, so they drop it.
+// values unchanged, which holds for inner, left, the left semi and anti
+// joins, and the counting semijoin. Right and full joins emit build rows, so
+// they drop it.
 //
 // If every probe key is still an output column, the output is partitioned
 // exactly as the probe was. Otherwise only an inner join recovers a dropped
@@ -413,6 +414,7 @@ Partitioning joinGlobalPartition(
     case velox::core::JoinType::kLeftSemiFilter:
     case velox::core::JoinType::kLeftSemiProject:
     case velox::core::JoinType::kAnti:
+    case velox::core::JoinType::kCountingLeftSemiFilter:
       break;
     default:
       return {};

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -37,15 +37,37 @@ namespace facebook::axiom::optimizer::v2 {
 
 namespace {
 
+// A counting semi join is its own mirror, so a cluster may put either operand
+// on the build side. That rests on the shape INTERSECT ALL lowering gives it:
+// the keys cover both inputs' columns, so the exchanged orientation emits the
+// same values.
+void checkCountingSemiJoinExchangeable(const Join* join) {
+  VELOX_CHECK(
+      PlanObjectSet::fromObjects(join->leftKeys())
+          .containsAll(join->left()->outputColumns()),
+      "A counting semi join's keys must cover its probe columns: {}",
+      join->left()->toString());
+  VELOX_CHECK(
+      PlanObjectSet::fromObjects(join->rightKeys())
+          .containsAll(join->right()->outputColumns()),
+      "A counting semi join's keys must cover its build columns: {}",
+      join->right()->toString());
+}
+
 // Reorder limit: inner / LEFT / RIGHT / FULL equi-joins,
-// plus filtering semijoin (kLeftSemiFilter), antijoin (kAnti), and
-// mark-preserving semijoin (kLeftSemiProject).
+// plus filtering semijoin (kLeftSemiFilter), antijoin (kAnti),
+// mark-preserving semijoin (kLeftSemiProject), and counting semijoin
+// (kCountingLeftSemiFilter).
 bool isClusterable(const Join* join) {
   using velox::core::JoinType;
   if (join->leftKeys().empty()) {
     return false;
   }
   const auto kind = join->joinType();
+  if (kind == JoinType::kCountingLeftSemiFilter) {
+    checkCountingSemiJoinExchangeable(join);
+    return true;
+  }
   return kind == JoinType::kInner || kind == JoinType::kLeft ||
       kind == JoinType::kRight || kind == JoinType::kFull ||
       kind == JoinType::kLeftSemiFilter || kind == JoinType::kAnti ||

--- a/axiom/optimizer/v2/tests/AlgebraicPropertiesTest.cpp
+++ b/axiom/optimizer/v2/tests/AlgebraicPropertiesTest.cpp
@@ -94,6 +94,18 @@ TEST(AlgebraicPropertiesTest, table) {
 
   // kLeftSemiProject reorders like kLeftSemiFilter.
   expect(JoinType::kLeftSemiProject, JoinType::kInner, false, true, false);
+
+  // A counting semijoin does not reorder in either role.
+  expect(
+      JoinType::kCountingLeftSemiFilter, JoinType::kInner, false, false, false);
+  expect(
+      JoinType::kInner, JoinType::kCountingLeftSemiFilter, false, false, false);
+  expect(
+      JoinType::kCountingLeftSemiFilter,
+      JoinType::kCountingLeftSemiFilter,
+      false,
+      false,
+      false);
 }
 
 // For a commutative child, associativity implies left-asscom (and
@@ -140,7 +152,7 @@ TEST(AlgebraicPropertiesTest, unsupportedJoinTypeThrows) {
   VELOX_ASSERT_THROW(
       AlgebraicProperties::derive(JoinType::kRightSemiFilter, JoinType::kInner),
       "callers must normalize");
-  // Counting variants stay opaque leaves and are not reorderable.
+  // kCountingAnti has no defined properties; it stays an opaque leaf.
   VELOX_ASSERT_THROW(
       AlgebraicProperties::derive(JoinType::kCountingAnti, JoinType::kInner),
       "Algebraic properties not defined for join type");


### PR DESCRIPTION
Summary:

`INTERSECT ALL` lowers to a counting join, which keeps a per-key counter on its build side. Every driver builds its own counters. So a key that reaches several drivers is emitted once per driver, and

    SELECT a FROM t1 INTERSECT ALL SELECT a FROM t2

can return too many rows once the query runs with more than one driver. v2 emitted no local exchange to prevent this. v1 already did.

v2 now partitions the probe on the join keys, giving each driver a disjoint set of keys and its own counters. The exchange is skipped when the probe is itself a counting join partitioned on a subset of those keys, since rows that agree on these keys agree on those.

Reviewed By: kKPulla

Differential Revision: D117750194


