### PR TITLE
fix(optimizer): Enforce an equality before dropping the key that proves it (#1801)

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -799,15 +799,10 @@ void collectImpliedSameTableEqualities(
   };
 
   for (auto* table : tables) {
-    const ColumnVector* columns = nullptr;
-    if (table->is(PlanType::kTableNode)) {
-      columns = &table->as<BaseTable>()->columns;
-    } else if (table->is(PlanType::kDerivedTableNode)) {
-      columns = &table->as<DerivedTable>()->columns;
-    } else {
+    if (!table->isTable()) {
       continue;
     }
-    for (auto* column : *columns) {
+    for (auto* column : table->as<TableObject>()->columns) {
       if (auto* equivalence = column->equivalence()) {
         processEquivalence(equivalence);
       }

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -77,32 +77,32 @@ ColumnCP Column::create(std::string_view prefix, const Value& value) {
   return make<Column>(queryCtx()->newName(prefix), /*relation=*/nullptr, value);
 }
 
-void Column::equals(ColumnCP other) const {
+bool Column::equals(ColumnCP other) const {
   if (!equivalence_ && !other->equivalence_) {
     auto* equiv = make<Equivalence>();
     equiv->columns.push_back(this);
     equiv->columns.push_back(other);
     equivalence_ = equiv;
     other->equivalence_ = equiv;
-    return;
+    return true;
   }
   if (!other->equivalence_) {
     other->equivalence_ = equivalence_;
     equivalence_->columns.push_back(other);
-    return;
+    return true;
   }
   if (!equivalence_) {
-    other->equals(this);
-    return;
+    return other->equals(this);
   }
   // Already in one class: merging would iterate and grow the same vector.
   if (equivalence_ == other->equivalence_) {
-    return;
+    return false;
   }
   for (auto& column : other->equivalence_->columns) {
     equivalence_->columns.push_back(column);
     column->equivalence_ = equivalence_;
   }
+  return true;
 }
 
 Name cname(PlanObjectCP relation) {

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -216,7 +216,15 @@ class Column : public Expr {
   /// side, so its key columns are not equal in its output. A join that emits
   /// one side only proves the equality but cannot supply both columns, so it
   /// registers its class per cover instead of here.
-  void equals(ColumnCP other) const;
+  ///
+  /// The relation is recorded on the columns themselves, so it carries no
+  /// notion of where it starts holding: below the join that proves it the
+  /// columns are unrelated. A consumer must therefore never use it to remove
+  /// the join key or filter that enforces it.
+  ///
+  /// Returns true when this call merged two classes that were separate, so a
+  /// caller can act on a newly proved equality exactly once.
+  bool equals(ColumnCP other) const;
 
   std::string toString() const override;
 

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -1875,8 +1875,6 @@ TEST_P(JoinTest, impliedFilterDedup) {
 }
 
 // Three or more columns from the same table in one equivalence class.
-// TODO: Assert the V2 plan after it applies implied same-input filters inferred
-// from join conditions.
 TEST_P(JoinTest, impliedSameTableEquality) {
   testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
   testConnector_->addTable("u", ROW({"x"}, BIGINT()));
@@ -1890,18 +1888,18 @@ TEST_P(JoinTest, impliedSameTableEquality) {
 
     auto matcher = matchScan("t")
                        .filter("a = b AND a = c")
-                       .hashJoin(matchScan("u"), core::JoinType::kInner)
+                       // Only the column the join still keys on reaches it.
+                       .projectIf(useV2_, {"a"})
+                       .hashJoinInner(matchScan("u"), {.keys = {{"a = x"}}})
                        .aggregation()
                        .build();
 
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
 
 // Equivalence class with same-table columns on both sides of the join.
-// TODO: Assert the V2 plan after it applies implied same-input filters to both
-// join inputs.
 TEST_P(JoinTest, impliedSameTableEqualityBothSides) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
       ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
@@ -1919,19 +1917,20 @@ TEST_P(JoinTest, impliedSameTableEqualityBothSides) {
     auto matcher =
         matchScan("t")
             .filter("a = b")
-            .hashJoin(matchScan("u").filter("x = y"), core::JoinType::kInner)
+            .projectIf(useV2_, {"a"})
+            .hashJoinInner(
+                matchScan("u").filter("x = y").projectIf(useV2_, {"x"}),
+                {.keys = {{"a = x"}}})
             .aggregation()
             .build();
 
     auto plan = toSingleNodePlan(query);
-    AXIOM_ASSERT_PLAN_V1(plan, matcher);
+    AXIOM_ASSERT_PLAN(plan, matcher);
   }
 }
 
 // With GROUP BY a, b, the synthesized a = b references only grouping keys
 // and is pushed below the aggregation onto t's scan.
-// TODO: Assert the V2 plan after it applies the implied same-input filter below
-// the aggregation.
 TEST_P(JoinTest, impliedSameTableEqualityBelowAggregation) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
   testConnector_->addTable("u", ROW({"x"}, BIGINT()));
@@ -1944,20 +1943,20 @@ TEST_P(JoinTest, impliedSameTableEqualityBelowAggregation) {
   auto matcher = matchScan("t")
                      .filter("a = b")
                      .singleAggregation({"a", "b"}, {})
-                     .project()
+                     // v1 narrows the aggregation to the surviving key with a
+                     // projection; v2 reads only that key without one.
+                     .projectIf(!useV2_, {"a"})
                      .hashJoin(matchScan("u"), core::JoinType::kInner)
                      .aggregation()
                      .build();
 
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN_V1(plan, matcher);
+  AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 // Synthesis into HAVING: when an equivalence class member is an aggregate
 // output, the implied equality can't push below the aggregation and stays
 // as a post-aggregation Filter (HAVING).
-// TODO: Assert the V2 plan after it applies the implied same-input filter above
-// the aggregation.
 TEST_P(JoinTest, impliedSameTableEqualityInHaving) {
   testConnector_->addTable("t", ROW({"k"}, BIGINT()))
       ->setStats(10'000, {{"k", {.numDistinct = 10'000}}});
@@ -1974,19 +1973,20 @@ TEST_P(JoinTest, impliedSameTableEqualityInHaving) {
                          matchScan("t")
                              .singleAggregation({"k"}, {"count(*) as c"})
                              .filter("k = c")
-                             .project(),
+                             // v1 narrows the aggregation to the surviving key
+                             // with a projection; v2 reads only that key
+                             // without one.
+                             .projectIf(!useV2_, {"k"}),
                          core::JoinType::kInner)
                      .aggregation()
                      .build();
 
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN_V1(plan, matcher);
+  AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 // With a LIMIT in the way, the synthesized equality lands as a Filter
 // above the Limit. The redundant join key is still dropped.
-// TODO: Assert the V2 plan after it applies the implied same-input filter above
-// the limit.
 TEST_P(JoinTest, impliedSameTableEqualityBlockedByLimit) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
   testConnector_->addTable("u", ROW({"x"}, BIGINT()));
@@ -1999,23 +1999,17 @@ TEST_P(JoinTest, impliedSameTableEqualityBlockedByLimit) {
   auto matcher = matchScan("t")
                      .limit()
                      .filter("a = b")
-                     .hashJoin(matchScan("u"), core::JoinType::kInner)
+                     .hashJoinInner(matchScan("u"), {.keys = {{"a = x"}}})
                      .aggregation()
                      .build();
 
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN_V1(plan, matcher);
+  AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 // Explicit WHERE and synthesized equality converge on the same LIMIT DT
 // target. The filter appears exactly once above the Limit.
-// TODO: Run with V2 after legal many-to-one join keys no longer fail with
-// duplicate substitution sources.
 TEST_P(JoinTest, impliedSameTableEqualityBlockedByLimitDedup) {
-  if (useV2_) {
-    GTEST_SKIP() << "Not supported by the V2 optimizer";
-  }
-
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
   testConnector_->addTable("u", ROW({"x"}, BIGINT()));
 
@@ -2025,12 +2019,19 @@ TEST_P(JoinTest, impliedSameTableEqualityBlockedByLimitDedup) {
       "WHERE lim.a = lim.b";
   SCOPED_TRACE(query);
 
-  auto matcher = matchScan("t")
-                     .limit()
-                     .filter("a = b")
-                     .hashJoin(matchScan("u"), core::JoinType::kInner)
-                     .aggregation()
-                     .build();
+  auto matcher =
+      matchScan("t")
+          .limit()
+          .filter("a = b")
+          // TODO: v2 keeps the second key. It drops one only where
+          // it derived the filter itself, and here the query
+          // already stated it.
+          .hashJoinInner(
+              matchScan("u"),
+              {.keys = useV2_ ? std::vector<std::string>{"a = x", "b = x"}
+                              : std::vector<std::string>{"a = x"}})
+          .aggregation()
+          .build();
 
   auto plan = toSingleNodePlan(query);
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -2041,8 +2042,6 @@ TEST_P(JoinTest, impliedSameTableEqualityBlockedByLimitDedup) {
 // columns with the same left-side column. For t LEFT JOIN u ON u.x = t.a
 // AND u.y = t.a, any u row in the output must satisfy both conditions, so
 // u.x = u.y holds.
-// TODO: Assert the V2 plan after it applies the implied same-input filter to
-// the null-supplying join input.
 TEST_P(JoinTest, impliedSameTableEqualityOuterJoin) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
       ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
@@ -2056,19 +2055,19 @@ TEST_P(JoinTest, impliedSameTableEqualityOuterJoin) {
 
   auto matcher =
       matchScan("t")
-          .hashJoin(matchScan("u").filter("x = y"), core::JoinType::kLeft)
+          .hashJoin(
+              matchScan("u").filter("x = y").projectIf(useV2_, {"x"}),
+              core::JoinType::kLeft)
           .aggregation()
           .build();
 
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN_V1(plan, matcher);
+  AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 // SEMI join (EXISTS) gets slot-pattern same-table eq synthesis on its
 // subquery side: surviving left rows require a matching right row, so the
 // same-table eq on the right side is sound.
-// TODO: Assert the V2 plan after it applies the implied same-input filter to
-// the existence input.
 TEST_P(JoinTest, impliedSameTableEqualitySemiJoin) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
       ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
@@ -2083,18 +2082,17 @@ TEST_P(JoinTest, impliedSameTableEqualitySemiJoin) {
   auto matcher =
       matchScan("t")
           .hashJoin(
-              matchScan("u").filter("x = y"), core::JoinType::kLeftSemiFilter)
+              matchScan("u").filter("x = y").projectIf(useV2_, {"x"}),
+              core::JoinType::kLeftSemiFilter)
           .aggregation()
           .build();
 
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN_V1(plan, matcher);
+  AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 // RIGHT JOIN is normalized to LEFT JOIN; same-table synthesis fires on
 // the (now-right) u side, producing u.x = u.y.
-// TODO: Assert the V2 plan after it applies the implied same-input filter
-// following right-to-left join normalization.
 TEST_P(JoinTest, impliedSameTableEqualityRightJoinNormalized) {
   testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()))
       ->setStats(10'000, {{"a", {.numDistinct = 10'000}}});
@@ -2107,12 +2105,17 @@ TEST_P(JoinTest, impliedSameTableEqualityRightJoinNormalized) {
 
   auto matcher =
       matchScan("t")
-          .hashJoin(matchScan("u").filter("x = y"), core::JoinType::kLeft)
+          // v2 also drops the key the filter makes redundant, so it reads only
+          // the surviving one.
+          .hashJoinLeft(
+              matchScan("u").filter("x = y").projectIf(useV2_, {"x"}),
+              {.keys = useV2_ ? std::vector<std::string>{"a = x"}
+                              : std::vector<std::string>{"a = x", "a = y"}})
           .aggregation()
           .build();
 
   auto plan = toSingleNodePlan(query);
-  AXIOM_ASSERT_PLAN_V1(plan, matcher);
+  AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
 // FULL OUTER slot synthesis is unsound on either side (unmatched rows on

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -297,3 +297,50 @@ FROM t
 JOIN t u ON u.a = t.a
 JOIN t v ON v.b = u.b AND v.b = t.b
 WHERE t.b > 100
+----
+-- Two columns of one relation equated to columns of two different relations.
+-- Neither equality implies the other, so both must be applied.
+SELECT count(*)
+FROM (VALUES (1), (2)) AS t(x)
+JOIN (VALUES (1), (1), (2)) AS u(z) ON t.x = u.z
+JOIN (VALUES (1, 1), (1, 2), (2, 2)) AS v(p, q) ON v.p = t.x AND v.q = u.z
+----
+-- The same, returning the equated columns rather than a count.
+SELECT t.x, u.z, v.p, v.q
+FROM (VALUES (1), (2)) AS t(x)
+JOIN (VALUES (1), (1), (2)) AS u(z) ON t.x = u.z
+JOIN (VALUES (1, 1), (1, 2), (2, 2)) AS v(p, q) ON v.p = t.x AND v.q = u.z
+----
+-- Two columns of one relation equated to the same column of another.
+SELECT count(*) FROM t JOIN t u ON t.a = u.a AND t.b = u.a
+----
+-- Set operations match NULL to NULL, so a leg holding NULLs in both of the
+-- columns another leg equates must still be matched.
+SELECT x, x FROM (VALUES (null), (1)) AS t(x)
+INTERSECT
+SELECT p, q FROM (VALUES (null, null), (1, 1), (2, 3)) AS u(p, q)
+----
+-- The same for EXCEPT.
+SELECT x, x FROM (VALUES (null), (1), (2)) AS t(x)
+EXCEPT
+SELECT p, q FROM (VALUES (null, null), (1, 1)) AS u(p, q)
+----
+-- Both of u's columns are equated to the same column of t, so a u row only
+-- joins when they agree. Rows of t that join nothing are still returned.
+SELECT t.a, u.x
+FROM (VALUES (1), (2), (3)) AS t(a)
+LEFT JOIN (VALUES (1, 1), (null, 1), (1, null), (2, 2)) AS u(x, y)
+  ON u.x = t.a AND u.y = t.a
+----
+-- The same condition under EXISTS.
+SELECT a FROM (VALUES (1), (2), (3)) AS t(a)
+WHERE EXISTS (
+  SELECT 1 FROM (VALUES (1, 1), (null, 1), (1, null), (2, 2)) AS u(x, y)
+  WHERE u.x = t.a AND u.y = t.a)
+----
+-- The same condition under NOT EXISTS, where a row of t is returned only
+-- when no row of u joins it.
+SELECT a FROM (VALUES (1), (2), (3)) AS t(a)
+WHERE NOT EXISTS (
+  SELECT 1 FROM (VALUES (1, 1), (null, 1), (1, null), (2, 2)) AS u(x, y)
+  WHERE u.x = t.a AND u.y = t.a)

--- a/axiom/optimizer/v2/Builder.cpp
+++ b/axiom/optimizer/v2/Builder.cpp
@@ -17,6 +17,7 @@
 #include "axiom/optimizer/v2/Builder.h"
 
 #include "axiom/optimizer/FunctionRegistry.h"
+#include "axiom/optimizer/v2/ExprFactory.h"
 
 namespace facebook::axiom::optimizer::v2 {
 
@@ -147,7 +148,10 @@ const optimizer::Aggregate* Builder::makeAggregate(
   return aggregate;
 }
 
-void Builder::dropRepeatedKeyPairs(Join::Key& key) {
+namespace {
+
+// Drops key pairs equal to an earlier pair. `a = b AND a = b` is one equality.
+void dropRepeatedKeyPairs(Join::Key& key) {
   const size_t numKeys = key.leftKeys.size();
 
   // Interned expressions compare by pointer. A pair repeating one that was
@@ -185,18 +189,203 @@ void Builder::dropRepeatedKeyPairs(Join::Key& key) {
   key.rightKeys = std::move(rightKeys);
 }
 
-void Builder::addEquivalences(const Join::Key& key) {
-  if (key.joinType != velox::core::JoinType::kInner) {
-    return;
-  }
-  for (size_t i = 0; i < key.leftKeys.size(); ++i) {
-    ExprCP leftKey = key.leftKeys[i];
-    ExprCP rightKey = key.rightKeys[i];
-    if (leftKey->isColumn() && rightKey->isColumn()) {
-      leftKey->as<Column>()->equals(rightKey->as<Column>());
+// Drops predicates equal to an earlier one. A predicate stated twice selects
+// the same rows as one stated once, unless evaluating it twice can give two
+// answers, so a non-deterministic one is kept.
+void dropRepeatedPredicates(Filter::Key& key) {
+  PlanObjectSet seen;
+  ExprVector predicates;
+  predicates.reserve(key.predicates.size());
+  for (ExprCP predicate : key.predicates) {
+    if (predicate->containsNonDeterministic()) {
+      predicates.push_back(predicate);
+      continue;
+    }
+    if (!seen.contains(predicate)) {
+      seen.add(predicate);
+      predicates.push_back(predicate);
     }
   }
+  if (predicates.size() < key.predicates.size()) {
+    key.predicates = std::move(predicates);
+  }
 }
+
+// Columns a filter has made equal, each mapped to the one they were equated
+// to. Two columns with the same anchor hold one value.
+using ColumnAnchors = folly::F14FastMap<ColumnCP, ColumnCP>;
+
+// Whether `anchors` records `left` and `right` as filter-enforced equal.
+bool isEnforcedEqual(const ColumnAnchors& anchors, ExprCP left, ExprCP right) {
+  if (left == right) {
+    return true;
+  }
+  if (!left->isColumn() || !right->isColumn()) {
+    return false;
+  }
+  const auto leftAnchor = anchors.find(left->as<Column>());
+  const auto rightAnchor = anchors.find(right->as<Column>());
+  return leftAnchor != anchors.end() && rightAnchor != anchors.end() &&
+      leftAnchor->second == rightAnchor->second;
+}
+
+// Drops key pairs that repeat an earlier pair modulo equalities the derived
+// filters enforce: two columns with the same anchor hold one value.
+void dropEnforcedKeyPairs(
+    Join::Key& key,
+    const ColumnAnchors& leftEnforced,
+    const ColumnAnchors& rightEnforced) {
+  if (leftEnforced.empty() && rightEnforced.empty()) {
+    // Only pairs equal to an earlier one could be redundant, and
+    // `dropRepeatedKeyPairs` has already removed those.
+    return;
+  }
+
+  ExprVector leftKeys;
+  ExprVector rightKeys;
+  for (size_t i = 0; i < key.leftKeys.size(); ++i) {
+    bool redundant = false;
+    for (size_t kept = 0; kept < leftKeys.size(); ++kept) {
+      if (isEnforcedEqual(leftEnforced, leftKeys[kept], key.leftKeys[i]) &&
+          isEnforcedEqual(rightEnforced, rightKeys[kept], key.rightKeys[i])) {
+        redundant = true;
+        break;
+      }
+    }
+    if (!redundant) {
+      leftKeys.push_back(key.leftKeys[i]);
+      rightKeys.push_back(key.rightKeys[i]);
+    }
+  }
+  key.leftKeys = std::move(leftKeys);
+  key.rightKeys = std::move(rightKeys);
+}
+
+// Returns `input` filtered by those of `conjuncts` that the chain of Filters
+// topping `input` does not already apply, or `input` itself when it applies
+// them all.
+NodeCP withNewConjuncts(Builder& builder, NodeCP input, ExprVector conjuncts) {
+  // Exprs are interned, so a conjunct this input already applies is the same
+  // pointer. Skipping it keeps a second join deriving the same equality from
+  // stacking a duplicate Filter.
+  PlanObjectSet applied;
+  for (NodeCP node = input; node->is(NodeType::kFilter);
+       node = node->as<Filter>()->input()) {
+    for (ExprCP predicate : node->as<Filter>()->predicates()) {
+      applied.add(predicate);
+    }
+  }
+
+  ExprVector fresh;
+  for (ExprCP conjunct : conjuncts) {
+    if (!applied.contains(conjunct)) {
+      fresh.push_back(conjunct);
+    }
+  }
+  if (fresh.empty()) {
+    return input;
+  }
+  return builder.make<Filter>({input, std::move(fresh)});
+}
+
+// Returns `input` filtered by an equality between the first of each group in
+// `groups` and every other member, recording each group's members against
+// that first one in `enforced`.
+template <typename Key>
+NodeCP withGroupEqualities(
+    Builder& builder,
+    NodeCP input,
+    const std::vector<std::pair<Key, ColumnVector>>& groups,
+    ColumnAnchors& enforced) {
+  ExprVector conjuncts;
+  ExprFactory factory{builder};
+  for (const auto& [key, columns] : groups) {
+    for (size_t i = 1; i < columns.size(); ++i) {
+      conjuncts.push_back(factory.makeEq(columns[0], columns[i]));
+      enforced[columns[0]] = columns[0];
+      enforced[columns[i]] = columns[0];
+    }
+  }
+  return withNewConjuncts(builder, input, std::move(conjuncts));
+}
+
+// Returns `input` with a filter enforcing the equalities it holds implicitly:
+// two of its columns in one class of `classes` are equal only where every join
+// of that class is applied. Making that explicit keeps it enforced when a
+// later step treats the two as interchangeable, and lets pushdown carry it to
+// the source. Records the columns it made equal in `enforced`.
+NodeCP withImpliedEqualities(
+    Builder& builder,
+    NodeCP input,
+    const folly::F14FastSet<EquivalenceP>& classes,
+    ColumnAnchors& enforced) {
+  // Insertion-ordered: the conjuncts below are part of the Filter's identity,
+  // so their order must not depend on pointer values.
+  std::vector<std::pair<EquivalenceP, ColumnVector>> byClass;
+  for (ColumnCP column : input->outputColumns()) {
+    const EquivalenceP equivalence = column->equivalence();
+    if (equivalence == nullptr || !classes.contains(equivalence)) {
+      continue;
+    }
+    auto it = std::ranges::find_if(
+        byClass, [&](const auto& entry) { return entry.first == equivalence; });
+    if (it == byClass.end()) {
+      byClass.emplace_back(equivalence, ColumnVector{});
+      it = byClass.end() - 1;
+    }
+    it->second.push_back(column);
+  }
+
+  return withGroupEqualities(builder, input, byClass, enforced);
+}
+
+// Returns `input` filtered by the equalities `keys` imply: two keys paired
+// with one and the same key on the other side are equal on every matched row.
+// `pairedKeys` aligns 1:1 with `keys`. Records the columns it made equal in
+// `enforced`.
+NodeCP withKeyImpliedEqualities(
+    Builder& builder,
+    NodeCP input,
+    const ExprVector& pairedKeys,
+    const ExprVector& keys,
+    ColumnAnchors& enforced) {
+  std::vector<std::pair<ColumnCP, ColumnVector>> byPairedKey;
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (!keys[i]->isColumn() || !pairedKeys[i]->isColumn()) {
+      continue;
+    }
+    ColumnCP paired = pairedKeys[i]->as<Column>();
+    auto it = std::ranges::find_if(
+        byPairedKey, [&](const auto& entry) { return entry.first == paired; });
+    if (it == byPairedKey.end()) {
+      byPairedKey.emplace_back(paired, ColumnVector{});
+      it = byPairedKey.end() - 1;
+    }
+    it->second.push_back(keys[i]->as<Column>());
+  }
+
+  return withGroupEqualities(builder, input, byPairedKey, enforced);
+}
+
+// These join types never emit a right row that found no match, so dropping a
+// right row that cannot match is unobservable.
+bool rightEmittedOnlyOnMatch(velox::core::JoinType joinType) {
+  using JoinType = velox::core::JoinType;
+  return joinType == JoinType::kInner || joinType == JoinType::kLeft ||
+      joinType == JoinType::kLeftSemiFilter ||
+      joinType == JoinType::kLeftSemiProject || joinType == JoinType::kAnti;
+}
+
+// The same for the left side. A mark-producing right semi join qualifies: a
+// left row that cannot match sets no mark.
+bool leftEmittedOnlyOnMatch(velox::core::JoinType joinType) {
+  using JoinType = velox::core::JoinType;
+  return joinType == JoinType::kInner || joinType == JoinType::kRight ||
+      joinType == JoinType::kRightSemiFilter ||
+      joinType == JoinType::kRightSemiProject;
+}
+
+} // namespace
 
 std::pair<NodeCP, ExprVector> Builder::materializeKeys(
     NodeCP input,
@@ -235,6 +424,62 @@ std::pair<NodeCP, ExprVector> Builder::materializeKeys(
   return {
       make<Project>({input, std::move(exprs), std::move(columns)}),
       std::move(newKeys)};
+}
+
+void Builder::normalizeKey(Filter::Key& key) {
+  dropRepeatedPredicates(key);
+}
+
+void Builder::normalizeKey(Join::Key& key) {
+  dropRepeatedKeyPairs(key);
+
+  // A derived equality is plain `=`, so it drops a row holding a NULL key.
+  // Where such a row matches, deriving one would change the result.
+  const bool nullKeysMatch = key.nullAsValue || key.nullAware;
+
+  if (key.joinType != velox::core::JoinType::kInner) {
+    // No class: these columns are not equal in the output. A side whose
+    // unmatched rows are not emitted can still be filtered, since a row
+    // failing an equality the keys imply never matches.
+    if (nullKeysMatch) {
+      return;
+    }
+    ColumnAnchors leftEnforced;
+    ColumnAnchors rightEnforced;
+    if (rightEmittedOnlyOnMatch(key.joinType)) {
+      key.right = withKeyImpliedEqualities(
+          *this, key.right, key.leftKeys, key.rightKeys, rightEnforced);
+    }
+    if (leftEmittedOnlyOnMatch(key.joinType)) {
+      key.left = withKeyImpliedEqualities(
+          *this, key.left, key.rightKeys, key.leftKeys, leftEnforced);
+    }
+    dropEnforcedKeyPairs(key, leftEnforced, rightEnforced);
+    return;
+  }
+
+  // Classes this join's keys newly merged. A chain of joins sharing one class
+  // must derive its equality once, at the join that proves it.
+  folly::F14FastSet<EquivalenceP> merged;
+  for (size_t i = 0; i < key.leftKeys.size(); ++i) {
+    ExprCP leftKey = key.leftKeys[i];
+    ExprCP rightKey = key.rightKeys[i];
+    if (leftKey->isColumn() && rightKey->isColumn()) {
+      ColumnCP leftColumn = leftKey->as<Column>();
+      if (leftColumn->equals(rightKey->as<Column>())) {
+        merged.insert(leftColumn->equivalence());
+      }
+    }
+  }
+  if (merged.empty() || nullKeysMatch) {
+    return;
+  }
+
+  ColumnAnchors leftEnforced;
+  ColumnAnchors rightEnforced;
+  key.left = withImpliedEqualities(*this, key.left, merged, leftEnforced);
+  key.right = withImpliedEqualities(*this, key.right, merged, rightEnforced);
+  dropEnforcedKeyPairs(key, leftEnforced, rightEnforced);
 }
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Builder.h
+++ b/axiom/optimizer/v2/Builder.h
@@ -54,23 +54,18 @@ class Builder {
   /// newly constructed node. `Expr` leaves use `makeLiteral` / `makeCall` /
   /// `makeAggregate`.
   ///
-  /// A `Join` key is normalized first: a repeated equi-key pair is dropped, so
-  /// the node's keys can be fewer than 'key' holds and joins differing only in
-  /// a repeated equality are one node.
+  /// A `Join` or `Filter` key is normalized first. A join drops repeated and
+  /// implied equi-key pairs and may gain a filter on an input, so the node's
+  /// keys can be fewer than 'key' holds and joins differing only in a repeated
+  /// equality are one node. A filter drops repeated predicates.
   template <typename T>
   const T* make(typename T::Key key) {
-    if constexpr (std::is_same_v<T, Join>) {
-      // Before the lookup: a join that repeats an equality is the same join
-      // as one that states it once.
-      dropRepeatedKeyPairs(key);
+    if constexpr (std::is_same_v<T, Join> || std::is_same_v<T, Filter>) {
+      normalizeKey(key);
     }
     auto& dedup = setFor<T>();
     if (auto it = dedup.find(key); it != dedup.end()) {
       return *it;
-    }
-    if constexpr (std::is_same_v<T, Join>) {
-      // Before construction: the Join ctor caches partitioning from these.
-      addEquivalences(key);
     }
     const T* node = optimizer::make<T>(std::move(key));
     // After construction, so `inputs()` is available and the set allocates in
@@ -190,16 +185,12 @@ class Builder {
   // expr on left when neither is a literal. No-op otherwise.
   void canonicalizeCall(Name& name, ExprVector& args) const;
 
-  // Adds an inner join's equi-key columns to one equivalence class (see
-  // `Column::equals`): equated columns hold the same value on every output row,
-  // so any surviving member partitions the output as the dropped key did.
-  // No-op for non-inner joins (an outer join's build key may be null-padded, so
-  // its columns are not equal on every row) and for non-column keys.
-  static void addEquivalences(const Join::Key& key);
-
-  // Drops key pairs equal to an earlier pair. `a = b AND a = b` is one
-  // equality.
-  static void dropRepeatedKeyPairs(Join::Key& key);
+  // Rewrites 'key' to the canonical form of the node it describes, so two keys
+  // that describe one node reach one entry in the dedup set. Runs before the
+  // lookup, and for a join before construction too, since the `Join` ctor
+  // reads the equivalence classes this records.
+  void normalizeKey(Join::Key& key);
+  void normalizeKey(Filter::Key& key);
 
   template <typename T>
   auto& setFor() {


### PR DESCRIPTION
Summary:

This query returns 5 rows. The right answer is 3:

    SELECT count(*)
    FROM (VALUES (1), (2)) AS t(x)
    JOIN (VALUES (1), (1), (2)) AS u(z) ON t.x = u.z
    JOIN (VALUES (1, 1), (1, 2), (2, 2)) AS v(p, q) ON v.p = t.x AND v.q = u.z

Only one of the last two conditions is applied. Asking for the columns instead of a count shows a row that breaks the one that was dropped. It reproduces under v1, v2 and syntactic join order.

The three equalities put `t.x`, `u.z`, `v.p` and `v.q` in one equivalence class. A join key whose two columns are in one class is then dropped as redundant. That is sound only when something else enforces the equality, and here nothing did: `v.p = v.q` holds only where the dropped key was applied.

Both optimizers now derive the equality and enforce it as a filter before dropping anything.

- v1 inferred those filters for base and derived tables only, so a class whose members all sat in other relation kinds was never seen. It now covers every table kind.
- v2 never inferred them at all. It now does, from the equivalence class for an inner join and from the keys themselves for a join that emits a row of one side only when it matches. `Column::equals` reports whether it merged two classes, so each equality is derived once, at the join that proves it.
- Dropping a key pair now requires that a filter actually equates it to a kept pair, rather than that the columns share a class.

Under `nullAsValue` or `nullAware` a NULL key can match, so no filter is derived there.

Reviewed By: amitkdutta

Differential Revision: D117804244


