### PR TITLE
fix(optimizer): Stop dropping correlated subquery filters

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -2405,6 +2405,25 @@ bool DerivedTable::addFilter(ExprCP conjunct) {
   return true;
 }
 
+namespace {
+
+// True if 'table' is the null-producing side of an outer join in 'dt'. Such a
+// table cannot take on further join edges: any edge added to it would have to
+// be applied after the outer join, which the join order search cannot express.
+bool isNullProducingSide(const DerivedTableP dt, PlanObjectCP table) {
+  for (const auto* join : dt->joins) {
+    if (join->rightOptional() && join->rightTable() == table) {
+      return true;
+    }
+    if (join->leftOptional() && join->leftTable() == table) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
+
 void DerivedTable::distributeConjuncts() {
   if (!having.empty()) {
     VELOX_CHECK_NOT_NULL(aggregation);
@@ -2500,6 +2519,14 @@ void DerivedTable::distributeConjuncts() {
         // One side references this dt's own output (e.g. the nullable column
         // of a contained outer join), so this cannot be a base-table join
         // equality. Leave it in place to evaluate above the join.
+        continue;
+      }
+
+      if (isNullProducingSide(this, tables[0]) ||
+          isNullProducingSide(this, tables[1])) {
+        // The conjunct constrains a table whose join order position is already
+        // pinned by an outer join. Leave it in place to evaluate above that
+        // join.
         continue;
       }
 

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -149,13 +149,13 @@ TEST_F(TpchPlanTest, q01) {
 TEST_F(TpchPlanTest, q02) {
   // (
   //   ((partsupp INNER part) INNER (supplier INNER (nation INNER region)))
-  //   INNER
+  //   LEFT
   //   agg((
   //     (partsupp LEFT SEMI (FILTER) part)
   //     INNER
   //     (supplier INNER (nation INNER region))
   //   ))
-  // )
+  // ) FILTER ps_supplycost = min
   auto matcher =
       matchScan("partsupp")
           .hashJoinInner(
@@ -164,7 +164,7 @@ TEST_F(TpchPlanTest, q02) {
               matchScan("supplier")
                   .hashJoinInner(matchScan("nation").hashJoinInner(
                       matchScan("region").filter("r_name = 'EUROPE'"))))
-          .hashJoinInner(
+          .hashJoinLeft(
               matchScan("partsupp")
                   .hashJoinLeftSemiFilter(matchScan("part").filter(
                       "p_size = 15 and p_type like '%BRASS'"))
@@ -176,6 +176,7 @@ TEST_F(TpchPlanTest, q02) {
                                   .filter("region_name = 'EUROPE'"))))
                   .aggregation()
                   .project())
+          .filter("ps_supplycost = min")
           .topN()
           .project()
           .build();

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -736,6 +736,20 @@ LEFT JOIN (VALUES (1, 'x')) AS u(k, b) ON t.a = u.k
 INNER JOIN (VALUES (1)) AS v(c)
   ON u.b IN (SELECT 'x' FROM (VALUES (1)) AS w(d) WHERE d = v.c)
 ----
+-- A correlated scalar aggregate attaches to p through a LEFT join during
+-- decorrelation. The comparison with sibling ps must remain a filter above
+-- that join instead of becoming a second join edge on the null-producing
+-- aggregate side.
+SELECT ps.k, ps.cost
+FROM (VALUES (1), (2)) AS p(k),
+     (VALUES (1, 100.0), (1, 200.0), (2, 50.0), (2, 30.0)) AS ps(k, cost)
+WHERE p.k = ps.k
+  AND ps.cost = (
+      SELECT min(ps2.cost)
+      FROM (VALUES (1, 100.0), (1, 200.0), (2, 50.0), (2, 30.0)) AS ps2(k, cost)
+      WHERE ps2.k = p.k)
+ORDER BY ps.k
+----
 -- Shared CTE with a nested-IN filter, referenced from both UNION legs,
 -- second leg wrapping it in GROUP BY.
 WITH s AS (


### PR DESCRIPTION

A correlated scalar subquery predicate could be silently dropped by the v1 optimizer.

For example, this query (simplified from tpch Q2) must keep only the cheapest `ps` row for each key:

```sql
SELECT ps.k, ps.cost
FROM (VALUES (1), (2)) AS p(k),
     (VALUES (1, 100.0), (1, 200.0), (2, 50.0), (2, 30.0)) AS ps(k, cost)
WHERE p.k = ps.k
  AND ps.cost = (
      SELECT min(ps2.cost)
      FROM (VALUES (1, 100.0), (1, 200.0), (2, 50.0), (2, 30.0)) AS ps2(k, cost)
      WHERE ps2.k = p.k)
ORDER BY ps.k
```

Before this change, v1 returned all 4 `ps` rows. The `ps.cost = (...)` predicate was lost, so only `p.k = ps.k` remained effective. But the correct result should be:

```text
k | cost
1 | 100
2 |  30
```


**Root cause**

Decorrelation rewrites the scalar subquery into an aggregate relation, conceptually:

```text
MINS(k, min_cost)
```

and attaches it to the correlated outer table with a LEFT join:

```text
p LEFT JOIN MINS ON p.k = MINS.k
```

After decorrelation, the original comparison is an ordinary filter evaluated after both inputs are available:

```text
Filter ps.cost = MINS.min_cost
└─ p ⋈ ps ON p.k = ps.k
   LEFT JOIN MINS ON p.k = MINS.k
```

`distributeConjuncts` incorrectly recognized this filter as a reorderable join equality simply because it references two tables. It promoted `ps.cost = MINS.min_cost` into a join edge between `ps` and `MINS`.

When join search places p and ps first, it later adds MINS through the required non-commutative LEFT join. Extra inner edges are merged only when the candidate being added is itself an inner join. In this join order, the candidate that adds MINS is the LEFT join, so the promoted ps.cost = MINS.min_cost edge is not incorporated. The original conjunct had already been removed, so no filter remains to evaluate it.

**Fix**

Do not promote a two-table equality into a join edge when either endpoint is the null-producing side of an outer join. The conjunct remains a filter above the outer join, where both `ps.cost` and `MINS.min_cost` are available and the comparison is correctly evaluated.

Only v1 is affected. v2 uses a separate decorrelation pipeline and returns the correct result before and after this change. The new SQL regression runs under both versions to guard against a future v2 regression.