### PR TITLE
feat(optimizer): Fail a query that builds too many plan objects (#1807)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -177,9 +177,12 @@ std::string getLocalTimezone() {
 // thread-local queryCtx(), clearing it on destruction.
 class OptimizerContext {
  public:
-  explicit OptimizerContext(velox::memory::MemoryPool* pool)
+  OptimizerContext(velox::memory::MemoryPool* pool, int32_t maxPlanObjects)
       : allocator_(std::make_unique<velox::HashStringAllocator>(pool)),
-        context_(std::make_unique<optimizer::QueryGraphContext>(*allocator_)) {
+        context_(
+            std::make_unique<optimizer::QueryGraphContext>(
+                *allocator_,
+                maxPlanObjects)) {
     optimizer::queryCtx() = context_.get();
   }
 
@@ -1400,13 +1403,14 @@ std::string SqlQueryRunner::runExplainIo(
 
   if (useOptimizerV2_) {
     auto resolver = orDefaultSchemaResolver(schemaResolver);
-    OptimizerContext optimizerContext(optimizerPool_.get());
-    velox::exec::SimpleExpressionEvaluator evaluator(
-        queryCtx.get(), optimizerPool_.get());
     auto session = makeOptimizerSession(
         queryCtx->queryId(),
         collectConnectorProperties(*sessionConfig_),
         /*explain=*/true);
+    OptimizerContext optimizerContext(
+        optimizerPool_.get(), session->options().maxPlanObjects);
+    velox::exec::SimpleExpressionEvaluator evaluator(
+        queryCtx.get(), optimizerPool_.get());
     optimizer::v2::Optimizer optimizer(
         *logicalPlan, *resolver, *session, evaluator, queryCtx);
     return optimizer.explainIo(std::move(outputTable));
@@ -1855,17 +1859,18 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
   optimizer::MultiFragmentPlan::Options opts;
   opts.numWorkers = options.numWorkers;
   opts.numDrivers = options.numDrivers;
-  OptimizerContext optimizerContext(optimizerPool_.get());
+  auto connectorProperties = collectConnectorProperties(*sessionConfig_);
+  auto optimizerSession =
+      makeOptimizerSession(queryCtx->queryId(), connectorProperties, explain);
+
+  OptimizerContext optimizerContext(
+      optimizerPool_.get(), optimizerSession->options().maxPlanObjects);
 
   velox::exec::SimpleExpressionEvaluator evaluator(
       queryCtx.get(), optimizerPool_.get());
 
   auto history = std::make_unique<optimizer::VeloxHistory>();
   schemaResolver = orDefaultSchemaResolver(std::move(schemaResolver));
-
-  auto connectorProperties = collectConnectorProperties(*sessionConfig_);
-  auto optimizerSession =
-      makeOptimizerSession(queryCtx->queryId(), connectorProperties, explain);
   auto runnerSession = std::make_shared<runner::RunnerSession>(
       queryCtx->queryId(),
       user_,
@@ -2086,14 +2091,15 @@ std::vector<velox::RowVectorPtr> SqlQueryRunner::runShowStatsForQuery(
 
   if (useOptimizerV2_) {
     auto queryCtx = newQuery(options);
-    OptimizerContext optimizerContext(optimizerPool_.get());
-    velox::exec::SimpleExpressionEvaluator evaluator(
-        queryCtx.get(), optimizerPool_.get());
-    auto resolver = orDefaultSchemaResolver(nullptr);
     auto session = makeOptimizerSession(
         queryCtx->queryId(),
         collectConnectorProperties(*sessionConfig_),
         /*explain=*/false);
+    OptimizerContext optimizerContext(
+        optimizerPool_.get(), session->options().maxPlanObjects);
+    velox::exec::SimpleExpressionEvaluator evaluator(
+        queryCtx.get(), optimizerPool_.get());
+    auto resolver = orDefaultSchemaResolver(nullptr);
 
     const auto stats =
         optimizer::v2::Optimizer(

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -24,6 +24,7 @@
 #include "axiom/optimizer/ConnectorPushdownPass.h"
 #include "axiom/optimizer/Filters.h"
 #include "axiom/optimizer/FunctionRegistry.h"
+#include "axiom/optimizer/OptimizerOptions.h"
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/PlanUtils.h"
 #include "axiom/optimizer/PrecomputeProjection.h"
@@ -497,7 +498,8 @@ PlanAndStats Optimization::toVeloxPlan(
     velox::memory::MemoryPool& pool,
     MultiFragmentPlan::Options runnerOptions) {
   auto allocator = std::make_unique<velox::HashStringAllocator>(&pool);
-  auto context = std::make_unique<QueryGraphContext>(*allocator);
+  auto context = std::make_unique<QueryGraphContext>(
+      *allocator, optimizerSession->options().maxPlanObjects);
   queryCtx() = context.get();
   SCOPE_EXIT {
     queryCtx() = nullptr;
@@ -3897,6 +3899,8 @@ ExprCP Optimization::tryFoldConstant(ExprCP expr) {
     return nullptr;
   }
 
+  velox::Variant variant;
+  velox::TypePtr type;
   try {
     auto typedExpr = toTypedExpr(expr);
     auto exprSet = evaluator()->compile(typedExpr);
@@ -3906,17 +3910,19 @@ ExprCP Optimization::tryFoldConstant(ExprCP expr) {
     }
     const auto& constantExpr =
         static_cast<const velox::exec::ConstantExpr&>(first);
-    auto variant = constantExpr.value()->variantAt(0);
-    Value value(toType(constantExpr.type()), 1);
-    auto* registered = registerVariant(std::move(variant));
-    if (constantExpr.type()->isPrimitiveType()) {
-      value.min = registered;
-      value.max = registered;
-    }
-    return make<Literal>(value, registered);
+    variant = constantExpr.value()->variantAt(0);
+    type = constantExpr.type();
   } catch (const std::exception&) {
     return nullptr;
   }
+
+  Value value(toType(type), 1);
+  auto* registered = registerVariant(std::move(variant));
+  if (type->isPrimitiveType()) {
+    value.min = registered;
+    value.max = registered;
+  }
+  return make<Literal>(value, registered);
 }
 
 velox::Variant Optimization::evaluate(ExprCP expr) {

--- a/axiom/optimizer/OptimizerOptions.cpp
+++ b/axiom/optimizer/OptimizerOptions.cpp
@@ -41,6 +41,19 @@ int32_t parseRecursionLimit(std::string_view value) {
   return iterations;
 }
 
+int32_t parseMaxPlanObjects(std::string_view value) {
+  int32_t maxPlanObjects;
+  try {
+    maxPlanObjects = folly::to<int32_t>(value);
+  } catch (const folly::ConversionError&) {
+    VELOX_USER_FAIL(
+        "max_plan_objects must be a valid 32-bit integer: {}", value);
+  }
+  VELOX_USER_CHECK_GE(
+      maxPlanObjects, 1, "max_plan_objects must be >= 1: {}", value);
+  return maxPlanObjects;
+}
+
 std::vector<ConfigProperty> buildProperties(
     const std::unordered_map<std::string, std::string>& configOverrides) {
   std::vector<ConfigProperty> props = {
@@ -145,6 +158,15 @@ std::vector<ConfigProperty> buildProperties(
           "Maximum iterations for a recursion that has no bound of its own. Must be >= 1.",
       },
       {
+          std::string(OptimizerOptions::kMaxPlanObjects),
+          ConfigPropertyType::kInteger,
+          std::to_string(OptimizerOptions::kMaxPlanObjectsDefault),
+          "Fails a query that creates more than this many plan objects. "
+          "Bounds planning memory, which grows with the square of this count. "
+          "A query that exceeds it is expanding rather than merely large, "
+          "typically a CTE re-planned at each reference. Must be >= 1.",
+      },
+      {
           std::string(OptimizerOptions::kTraceFlags),
           ConfigPropertyType::kInteger,
           std::to_string(OptimizerOptions::kTraceFlagsDefault),
@@ -206,6 +228,8 @@ std::string OptimizerOptions::normalize(
         std::string(value), velox::config::CapacityUnit::BYTE);
   } else if (name == kRecursionLimit) {
     parseRecursionLimit(value);
+  } else if (name == kMaxPlanObjects) {
+    parseMaxPlanObjects(value);
   }
   return std::string(value);
 }
@@ -253,6 +277,7 @@ OptimizerOptions OptimizerOptions::from(
   setLong(kSmallQueryMaxScanRows, options.smallQueryMaxScanRows);
   setInt(kSmallQueryNumWorkers, options.smallQueryNumWorkers);
   setInt(kParallelProjectWidth, options.parallelProjectWidth);
+  setInt(kMaxPlanObjects, options.maxPlanObjects);
   setInt(kGreedyJoinThreshold, options.greedyJoinThreshold);
   setCapacity(kBroadcastSizeLimit, options.broadcastSizeLimit);
   setInt(kDphypEnumerationBudget, options.dphypEnumerationBudget);

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -58,6 +58,7 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   static constexpr std::string_view kSmallQueryNumWorkers =
       "small_query_num_workers";
   static constexpr std::string_view kRecursionLimit = "recursion_limit";
+  static constexpr std::string_view kMaxPlanObjects = "max_plan_objects";
   static constexpr std::string_view kTraceFlags = "trace_flags";
 
   // Default values — single source of truth for field initializers
@@ -72,6 +73,10 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   static constexpr int64_t kBroadcastSizeLimitDefaultBytes = 100LL << 20;
   static constexpr int32_t kDphypEnumerationBudgetDefault = 100'000;
   static constexpr int32_t kRecursionLimitDefault = 1'000;
+  // Bounds planning memory, which grows with the square of this count, so a
+  // higher limit costs quadratically more. Set well above the plan size of an
+  // ordinary query: a plan that reaches it is expanding, not merely large.
+  static constexpr int32_t kMaxPlanObjectsDefault = 100'000;
   static constexpr bool kPushdownSubfieldsDefault = false;
   static constexpr bool kAllMapsAsStructDefault = false;
   static constexpr bool kSampleJoinsDefault = false;
@@ -90,6 +95,11 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   /// cascade: code default -> config file -> session override.
   explicit OptimizerOptions(
       std::unordered_map<std::string, std::string> configOverrides);
+
+  /// Fails a query that creates more than this many plan objects. Planning
+  /// memory grows with the square of this count, so raising it is expensive:
+  /// 5x the limit is ~25x the memory.
+  int32_t maxPlanObjects{kMaxPlanObjectsDefault};
 
   /// Parallelizes independent projections over this many threads. 1 means no
   /// parallel projection.

--- a/axiom/optimizer/QueryGraphContext.cpp
+++ b/axiom/optimizer/QueryGraphContext.cpp
@@ -36,8 +36,14 @@ const auto& stepKindNames() {
 
 AXIOM_DEFINE_ENUM_NAME(StepKind, stepKindNames);
 
-QueryGraphContext::QueryGraphContext(velox::HashStringAllocator& allocator)
-    : allocator_(allocator), cache_(allocator_) {
+QueryGraphContext::QueryGraphContext(
+    velox::HashStringAllocator& allocator,
+    int32_t maxPlanObjects)
+    : allocator_(allocator),
+      cache_(allocator_),
+      maxPlanObjects_(maxPlanObjects) {
+  VELOX_USER_CHECK_GE(maxPlanObjects, 1, "max_plan_objects must be >= 1");
+
   auto addName = [&](const char* name) {
     names_.emplace(std::string_view(name, strlen(name)));
   };

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -362,12 +362,23 @@ class QueryGraphContext {
  public:
   static constexpr int32_t kArenaAlignment = 8;
 
-  explicit QueryGraphContext(velox::HashStringAllocator& allocator);
+  /// 'maxPlanObjects' caps how many plan objects this query may create; a
+  /// query that exceeds it fails rather than planning. The sets kept per
+  /// object are indexed by object id, so planning memory grows with the
+  /// square of this count, and an unbounded plan exhausts memory instead of
+  /// erroring. See OptimizerOptions::kMaxPlanObjectsDefault.
+  QueryGraphContext(
+      velox::HashStringAllocator& allocator,
+      int32_t maxPlanObjects);
 
   /// Returns a new unique id to use for 'object' and associates 'object' to
   /// this id. Tagging objects with integers ids is useful for efficiently
   /// representing sets of objects as bitmaps.
   int32_t newId(PlanObject* object) {
+    VELOX_USER_CHECK_LT(
+        objects_.size(),
+        maxPlanObjects_,
+        "Query is too complex to plan: it exceeds the plan object limit");
     objects_.push_back(object);
     return static_cast<int32_t>(objects_.size() - 1);
   }
@@ -512,6 +523,10 @@ class QueryGraphContext {
 
   // PlanObjects are stored at the index given by their id.
   std::vector<PlanObjectP> objects_;
+
+  // See the constructor. Always >= 1, so the comparison in newId() is
+  // meaningful; size_t to compare against objects_.size() without a cast.
+  const size_t maxPlanObjects_;
 
   // Set of interned copies of identifiers. insert() into this returns the
   // canonical interned copy of any string. Lifetime is limited to 'allocator_'.

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -31,6 +31,7 @@
 #include "axiom/optimizer/ConstantExprEvaluator.h"
 #include "axiom/optimizer/DerivedTablePrinter.h"
 #include "axiom/optimizer/Optimization.h"
+#include "axiom/optimizer/OptimizerOptions.h"
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/runner/LocalRunner.h"
@@ -585,7 +586,8 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
     opts.numDrivers = FLAGS_num_drivers;
     auto allocator =
         std::make_unique<HashStringAllocator>(optimizerPool_.get());
-    auto context = std::make_unique<optimizer::QueryGraphContext>(*allocator);
+    auto context = std::make_unique<optimizer::QueryGraphContext>(
+        *allocator, optimizer::OptimizerOptions::kMaxPlanObjectsDefault);
 
     optimizer::queryCtx() = context.get();
     SCOPE_EXIT {

--- a/axiom/optimizer/tests/BitSetTest.cpp
+++ b/axiom/optimizer/tests/BitSetTest.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/optimizer/BitSet.h"
 #include <gtest/gtest.h>
+#include "axiom/optimizer/OptimizerOptions.h"
 #include "velox/common/memory/Memory.h"
 
 namespace facebook::axiom::optimizer {
@@ -30,7 +31,8 @@ class BitSetTest : public ::testing::Test {
   void SetUp() override {
     pool_ = velox::memory::memoryManager()->addLeafPool();
     allocator_ = std::make_unique<velox::HashStringAllocator>(pool_.get());
-    ctx_ = std::make_unique<QueryGraphContext>(*allocator_);
+    ctx_ = std::make_unique<QueryGraphContext>(
+        *allocator_, OptimizerOptions::kMaxPlanObjectsDefault);
     queryCtx() = ctx_.get();
   }
 

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -21,6 +21,7 @@
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/Optimization.h"
+#include "axiom/optimizer/OptimizerOptions.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/sql/presto/PrestoParser.h"
 #include "velox/expression/Expr.h"
@@ -85,7 +86,8 @@ class DerivedTablePrinterTest : public ::testing::Test {
   std::vector<std::string> toLines(const lp::LogicalPlanNode& plan) {
     auto allocator =
         std::make_unique<velox::HashStringAllocator>(optimizerPool_.get());
-    auto context = std::make_unique<QueryGraphContext>(*allocator);
+    auto context = std::make_unique<QueryGraphContext>(
+        *allocator, OptimizerOptions::kMaxPlanObjectsDefault);
     queryCtx() = context.get();
     SCOPE_EXIT {
       queryCtx() = nullptr;

--- a/axiom/optimizer/tests/FiltersTest.cpp
+++ b/axiom/optimizer/tests/FiltersTest.cpp
@@ -21,6 +21,7 @@
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/optimizer/Optimization.h"
+#include "axiom/optimizer/OptimizerOptions.h"
 #include "axiom/optimizer/QueryGraph.h"
 #include "axiom/optimizer/StatsFilterSelectivityEstimator.h"
 #include "axiom/optimizer/tests/HiveQueriesTestBase.h"
@@ -96,7 +97,8 @@ class FiltersTest : public test::HiveQueriesTestBase {
   // Runs the callback with a QueryGraphContext set up.
   void withContext(const std::function<void()>& callback) {
     HashStringAllocator allocator(&optimizerPool());
-    auto context = std::make_unique<optimizer::QueryGraphContext>(allocator);
+    auto context = std::make_unique<optimizer::QueryGraphContext>(
+        allocator, OptimizerOptions::kMaxPlanObjectsDefault);
     optimizer::queryCtx() = context.get();
 
     SCOPE_EXIT {

--- a/axiom/optimizer/tests/PrecomputeProjectionTest.cpp
+++ b/axiom/optimizer/tests/PrecomputeProjectionTest.cpp
@@ -19,6 +19,7 @@
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/Optimization.h"
+#include "axiom/optimizer/OptimizerOptions.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
@@ -50,7 +51,8 @@ class PrecomputeProjectionTest : public ::testing::Test {
       const std::function<void(DerivedTableCP dt)>& testRoutine) {
     auto allocator =
         std::make_unique<velox::HashStringAllocator>(optimizerPool_.get());
-    auto context = std::make_unique<QueryGraphContext>(*allocator);
+    auto context = std::make_unique<QueryGraphContext>(
+        *allocator, OptimizerOptions::kMaxPlanObjectsDefault);
     queryCtx() = context.get();
     SCOPE_EXIT {
       queryCtx() = nullptr;

--- a/axiom/optimizer/tests/QueryGraphContextTest.cpp
+++ b/axiom/optimizer/tests/QueryGraphContextTest.cpp
@@ -18,6 +18,9 @@
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
 #include <algorithm>
+#include "axiom/optimizer/OptimizerOptions.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/type/Type.h"
 
@@ -35,7 +38,8 @@ class QueryGraphContextTest : public ::testing::Test {
   void SetUp() override {
     pool_ = velox::memory::memoryManager()->addLeafPool();
     allocator_ = std::make_unique<velox::HashStringAllocator>(pool_.get());
-    ctx_ = std::make_unique<QueryGraphContext>(*allocator_);
+    ctx_ = std::make_unique<QueryGraphContext>(
+        *allocator_, OptimizerOptions::kMaxPlanObjectsDefault);
     queryCtx() = ctx_.get();
   }
 
@@ -288,6 +292,30 @@ TEST_F(QueryGraphContextTest, pathOrdering) {
     EXPECT_FALSE(pathValues[i] < pathValues[i - 1])
         << "Sort result not ordered at index " << i;
   }
+}
+
+TEST_F(QueryGraphContextTest, planObjectLimit) {
+  // Creating more plan objects than the limit fails the query. Uses its own
+  // context so the limit is reached in a few objects.
+  constexpr int32_t kLimit = 8;
+  velox::HashStringAllocator allocator(pool_.get());
+  auto context = std::make_unique<QueryGraphContext>(allocator, kLimit);
+  queryCtx() = context.get();
+  SCOPE_EXIT {
+    queryCtx() = ctx_.get();
+  };
+
+  const Value value(toType(velox::BIGINT()), 1);
+  const auto* literal =
+      queryCtx()->registerVariant(std::make_unique<velox::Variant>(1LL));
+
+  for (auto i = 0; i < kLimit; ++i) {
+    make<Literal>(value, literal);
+  }
+
+  VELOX_ASSERT_THROW(
+      make<Literal>(value, literal),
+      "Query is too complex to plan: it exceeds the plan object limit");
 }
 
 } // namespace

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/optimizer/tests/QueryTestBase.h"
+#include "axiom/optimizer/OptimizerOptions.h"
 
 #include <ctime>
 
@@ -205,7 +206,8 @@ PlanCost QueryTestBase::optimizationCost(
     const std::optional<OptimizerOptions>& optimizerOptions) {
   auto& queryCtx = getQueryCtx();
   auto allocator = std::make_unique<HashStringAllocator>(optimizerPool_.get());
-  auto context = std::make_unique<optimizer::QueryGraphContext>(*allocator);
+  auto context = std::make_unique<optimizer::QueryGraphContext>(
+      *allocator, OptimizerOptions::kMaxPlanObjectsDefault);
   optimizer::queryCtx() = context.get();
   SCOPE_EXIT {
     optimizer::queryCtx() = nullptr;
@@ -236,7 +238,8 @@ void QueryTestBase::verifyOptimization(
   auto& veloxQueryCtx = getQueryCtx();
 
   HashStringAllocator allocator(optimizerPool_.get());
-  auto context = std::make_unique<optimizer::QueryGraphContext>(allocator);
+  auto context = std::make_unique<optimizer::QueryGraphContext>(
+      allocator, OptimizerOptions::kMaxPlanObjectsDefault);
   optimizer::queryCtx() = context.get();
   SCOPE_EXIT {
     optimizer::queryCtx() = nullptr;
@@ -296,7 +299,8 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
   auto& queryCtx = getQueryCtx();
 
   auto allocator = std::make_unique<HashStringAllocator>(optimizerPool_.get());
-  auto context = std::make_unique<optimizer::QueryGraphContext>(*allocator);
+  auto context = std::make_unique<optimizer::QueryGraphContext>(
+      *allocator, OptimizerOptions::kMaxPlanObjectsDefault);
   optimizer::queryCtx() = context.get();
   SCOPE_EXIT {
     optimizer::queryCtx() = nullptr;

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -20,6 +20,7 @@
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/Optimization.h"
+#include "axiom/optimizer/OptimizerOptions.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/sql/presto/PrestoParser.h"
 #include "velox/expression/Expr.h"
@@ -137,7 +138,8 @@ class RelationOpPrinterTest : public ::testing::Test {
       int32_t numDrivers = 1) {
     auto allocator =
         std::make_unique<velox::HashStringAllocator>(optimizerPool_.get());
-    auto context = std::make_unique<QueryGraphContext>(*allocator);
+    auto context = std::make_unique<QueryGraphContext>(
+        *allocator, OptimizerOptions::kMaxPlanObjectsDefault);
     queryCtx() = context.get();
     SCOPE_EXIT {
       queryCtx() = nullptr;

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -20,6 +20,7 @@
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/Optimization.h"
+#include "axiom/optimizer/OptimizerOptions.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/optimizer/v2/Optimize.h"
 #include "axiom/runner/LocalRunner.h"
@@ -108,8 +109,8 @@ std::shared_ptr<runner::LocalRunner> makeLocalRunnerImpl(
       queryId);
 
   auto allocator = std::make_unique<HashStringAllocator>(optimizerPool.get());
-  auto graphContext =
-      std::make_unique<optimizer::QueryGraphContext>(*allocator);
+  auto graphContext = std::make_unique<optimizer::QueryGraphContext>(
+      *allocator, OptimizerOptions::kMaxPlanObjectsDefault);
   optimizer::queryCtx() = graphContext.get();
   SCOPE_EXIT {
     optimizer::queryCtx() = nullptr;

--- a/axiom/optimizer/v2/ExprSimplifier.cpp
+++ b/axiom/optimizer/v2/ExprSimplifier.cpp
@@ -182,6 +182,8 @@ ExprCP ExprSimplifier::tryFoldConstant(ExprCP expr) {
     return expr;
   }
 
+  velox::Variant variant;
+  velox::TypePtr type;
   try {
     auto typedExpr = ExprEmitter{evaluator_.pool()}.toTypedExpr(expr);
     auto exprSet = evaluator_.compile(typedExpr);
@@ -191,17 +193,16 @@ ExprCP ExprSimplifier::tryFoldConstant(ExprCP expr) {
     }
     const auto& constantExpr =
         static_cast<const velox::exec::ConstantExpr&>(first);
-    auto variant = constantExpr.value()->variantAt(0);
-    Value value(toType(constantExpr.type()), 1);
-    auto* registered = queryCtx()->registerVariant(
-        std::make_unique<velox::Variant>(std::move(variant)));
-    return builder_.makeLiteral(value, registered);
+    variant = constantExpr.value()->variantAt(0);
+    type = constantExpr.type();
   } catch (const velox::VeloxException&) {
     // Data-dependent evaluation failure on constant args (e.g.
     // division-by-zero, invalid cast). Leave the call unchanged so the
     // error surfaces at execution.
     return expr;
   }
+
+  return builder_.makeLiteral(std::move(variant), toType(type));
 }
 
 velox::Variant ExprSimplifier::evaluate(ExprCP expr) {

--- a/axiom/optimizer/v2/tests/UnitTestBase.h
+++ b/axiom/optimizer/v2/tests/UnitTestBase.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string_view>
 
+#include "axiom/optimizer/OptimizerOptions.h"
 #include "axiom/optimizer/PlanObject.h"
 #include "axiom/optimizer/QueryGraphContext.h"
 #include "axiom/optimizer/v2/Builder.h"
@@ -45,7 +46,8 @@ class UnitTestBase : public ::testing::Test {
     pool_ = velox::memory::memoryManager()->addLeafPool(
         ::testing::UnitTest::GetInstance()->current_test_info()->name());
     allocator_ = std::make_unique<velox::HashStringAllocator>(pool_.get());
-    context_ = std::make_unique<optimizer::QueryGraphContext>(*allocator_);
+    context_ = std::make_unique<optimizer::QueryGraphContext>(
+        *allocator_, OptimizerOptions::kMaxPlanObjectsDefault);
     optimizer::queryCtx() = context_.get();
     builder_ = std::make_unique<Builder>();
   }

--- a/axiom/pyspark/Optimizer.cpp
+++ b/axiom/pyspark/Optimizer.cpp
@@ -15,7 +15,9 @@
  */
 
 #include "axiom/pyspark/Optimizer.h"
+#include "axiom/optimizer/OptimizerOptions.h"
 
+#include <folly/ScopeGuard.h>
 #include <glog/logging.h>
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
@@ -101,12 +103,18 @@ facebook::axiom::optimizer::PlanAndStats optimize(
     const facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,
     const std::string& connectorId,
     velox::memory::MemoryPool* pool) {
+  facebook::axiom::optimizer::OptimizerOptions optimizerOptions;
+  optimizerOptions.sampleJoins = false;
+
   // Set up thread local structures.
   auto allocator = std::make_unique<velox::HashStringAllocator>(pool);
   auto context =
       std::make_unique<facebook::axiom::optimizer::QueryGraphContext>(
-          *allocator);
+          *allocator, optimizerOptions.maxPlanObjects);
   facebook::axiom::optimizer::queryCtx() = context.get();
+  SCOPE_EXIT {
+    facebook::axiom::optimizer::queryCtx() = nullptr;
+  };
 
   // Fetch connector and set up schema resolver.
   auto connector = velox::connector::getConnector(connectorId);
@@ -122,8 +130,6 @@ facebook::axiom::optimizer::PlanAndStats optimize(
   }
 
   auto history = std::make_unique<facebook::axiom::optimizer::VeloxHistory>();
-  facebook::axiom::optimizer::OptimizerOptions optimizerOptions;
-  optimizerOptions.sampleJoins = false;
 
   facebook::axiom::optimizer::MultiFragmentPlan::Options runnerOpts{
       .numWorkers = 1,


### PR DESCRIPTION
Summary:

A query whose plan expands without bound exhausts memory while planning, reporting a generic resource error after taking the machine with it. It now fails with `Query is too complex to plan: it exceeds the plan object limit`.

Planning memory grows with the square of the plan object count, for three reasons that multiply.

A `PlanObjectSet` is a bitmap with one bit per object id, so its size follows the largest id it contains rather than how many members it has: a set naming one object with id 900k allocates 112KB to hold two members. Ids come from a single counter, so a set built late in planning spans nearly every object created so far. And there are two such sets on every call — the columns it reads and the subexpressions under it.

Two sets per object, each averaging half the id range, is `numObjects^2 / 8` bytes. At a million objects that is a hundred GB. The practical consequence is that the limit is unforgiving: doubling it quadruples the memory it permits.

`QueryGraphContext::newId` is the single point every plan object passes through, so the ceiling goes there. The default is 100k, which bounds planning to a few hundred MB and leaves a wide margin over the largest plan seen in practice. `optimizer.max_plan_objects` sets it per session.

This is a guardrail, not a fix. Three causes remain: the dense set representation, which is what makes the cost quadratic; `subexpressions_`, maintained on every call for parallel projection, which is off by default; and a CTE being re-planned at each reference, which is what makes a plan expand in the first place.

Differential Revision: D117958343
