### PR TITLE
misc: Advance Velox

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Axiom integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/3221d03fc546a290c01b6a511068f7d8bc148365...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/c5d718286feeb31f7e34bbbb572d14aa93a0adbc...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that


### PR DESCRIPTION
Summary:
Moves the Velox pin from `3221d03fc` to `c5d718286`, 17 commits.

Nimble dominates the range:

- Parallel stream encoding, and a string shared dictionary encoding whose alphabet bytes now count toward column stats.
- Faster boolean stream slicing, faster `BlockBitPacking` indexed view reads, and a preallocated index projector slice buffer.
- Integral constancy answered from min/max rather than unique counts.
- Fuzzer coverage: null generation in the table evolution fuzzer, per-chunk variation of the random encoding, and Huffman excluded from writer fuzzing.

Outside Nimble:

- An all-null fast path for nullable materialization, and a `toIntermediateFastPathCalls` runtime stat in `HashAggregation`.
- HDFS transient read failures retried with backoff and reopen.
- A Wave kernel cache made safe to share between processes, and the TorchWave whole-graph AOT load/run API.
- FBOS updated to `v2026.07.13.00`.

Also advances the Velox compare link in `README.md`, which `scripts/check-velox-readme.sh` requires to match the submodule SHA.

No Axiom code changes.

Differential Revision: D118075911
