### PR TITLE
misc: Advance Velox (#1809)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Axiom integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/c5d718286feeb31f7e34bbbb572d14aa93a0adbc...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/3ea8fd7bc74e244e21585975a79e58ccf7233b32...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that


### PR DESCRIPTION
Summary:

Moves the Velox pin from `c5d718286` to `3ea8fd7bc`.

Axiom's OSS build is broken: the optimizer was updated internally to the new `UnnestNode` API, where `unnestNames` is a `std::vector<std::optional<std::string>>`, and the pinned Velox submodule predates that change.

Differential Revision: D118164946
