### PR TITLE
feat(exec): Enforce NOT NULL constraints on table writes

### DIFF
--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -142,12 +142,10 @@ class LocalHiveConnectorMetadataTest
         /*explain=*/false);
 
     auto builder = exec::test::PlanBuilder().values({values});
-    auto insertHandle = std::make_shared<core::InsertTableHandle>(
-        velox::exec::test::kHiveConnectorId, handle->veloxHandle());
     auto plan = builder.startTableWriter()
                     .outputDirectoryPath(outputPath)
                     .targetColumns(table->type())
-                    .insertHandle(insertHandle)
+                    .insertHandle(handle->veloxHandle())
                     .fileFormat(format)
                     .endTableWriter()
                     .planNode();

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -2319,7 +2319,9 @@ velox::core::PlanNodePtr ToVelox::makeWrite(
   VELOX_CHECK(!finishWrite_, "Only single TableWrite per query supported");
   auto insertTableHandle =
       std::make_shared<const velox::core::InsertTableHandle>(
-          connectorId, handle->veloxHandle());
+          connectorId,
+          handle->veloxHandle(),
+          /*notNullColumns=*/folly::F14FastSet<std::string>{});
   finishWrite_ = {
       metadata,
       connectorId,

--- a/axiom/optimizer/tests/TestConnectorQueryTest.cpp
+++ b/axiom/optimizer/tests/TestConnectorQueryTest.cpp
@@ -47,7 +47,8 @@ class TestConnectorQueryTest : public QueryTestBase,
     auto handle = std::make_shared<core::InsertTableHandle>(
         kTestConnectorId,
         std::make_shared<connector::TestInsertTableHandle>(SchemaTableName{
-            std::string(connector::TestConnector::kDefaultSchema), tableName}));
+            std::string(connector::TestConnector::kDefaultSchema), tableName}),
+        /*notNullColumns=*/folly::F14FastSet<std::string>{});
     auto write = std::make_shared<core::TableWriteNode>(
         "writenodeid",
         source->outputType(),

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -2092,7 +2092,9 @@ velox::core::PlanNodePtr Emitter::emitTableWrite(const TableWrite& tableWrite) {
   VELOX_CHECK(!finishWrite_, "Only one TableWrite per query is supported");
   auto insertTableHandle =
       std::make_shared<const velox::core::InsertTableHandle>(
-          connectorId, handle->veloxHandle());
+          connectorId,
+          handle->veloxHandle(),
+          /*notNullColumns=*/folly::F14FastSet<std::string>{});
   finishWrite_ = FinishWrite{
       metadata,
       connectorId,


### PR DESCRIPTION
Summary:
## Why

The native (Prestissimo) worker currently accepts NULLs into NOT NULL columns
silently, while the Java engine rejects them in `TableWriterOperator` before any
file is written — a data-integrity and Java-parity gap
(https://github.com/prestodb/presto/issues/28156).

## What

Table writes can now enforce NOT NULL constraints on selected columns. Writing a
null into a column marked NOT NULL fails with, for example:
`NULL value not allowed for NOT NULL column: c1`.

`InsertTableHandle` carries the list of NOT NULL column names (empty means
unconstrained), so the constraint travels with the write-request descriptor and
round-trips through plan serialization. `TableWriteNode` validates at
construction that each name exists in the target schema. `TableWriter` maps each
constrained column to its input column and checks it with
`DecodedVector::hasNulls()`, which catches nulls behind dictionary or constant
encoding as well as flat vectors. The check is opt-in and only scans the listed
columns.

Part of https://github.com/prestodb/presto/issues/28156. E2E protocol changes:
https://github.com/prestodb/presto/pull/28040.

X-link: https://github.com/facebookincubator/velox/pull/18135

Reviewed By: shrinidhijoshi

Differential Revision: D116681749

Pulled By: Yuhta


