### PR TITLE
feat(optimizer): Fold aggregates over partition columns (#1811)

### DIFF
--- a/axiom/optimizer/ConstantFold.cpp
+++ b/axiom/optimizer/ConstantFold.cpp
@@ -89,7 +89,20 @@ int64_t nextConstantFoldId() {
 
 } // namespace
 
-velox::Variant ConstantPlanRunner::run(
+std::optional<velox::Variant> ConstantPlanRunner::runScalar(
+    const velox::core::PlanFragment& fragment) const {
+  VELOX_CHECK_EQ(
+      fragment.planNode->outputType()->size(),
+      1,
+      "runScalar needs a fragment of one column");
+  auto row = run(fragment);
+  if (!row.has_value()) {
+    return std::nullopt;
+  }
+  return std::move((*row)[0]);
+}
+
+std::optional<std::vector<velox::Variant>> ConstantPlanRunner::run(
     const velox::core::PlanFragment& fragment) const {
   // Serial mode runs in the caller's thread, so the query's own QueryCtx works
   // directly -- no executor, cache, or config of its own is needed.
@@ -100,9 +113,9 @@ velox::Variant ConstantPlanRunner::run(
       queryCtx_,
       velox::exec::Task::ExecutionMode::kSerial);
 
-  // Serial mode runs the whole pipeline in this thread. The plan has a Values
-  // source (no splits) and computes a single value, so next() yields exactly
-  // one non-empty single-row batch.
+  // Serial mode runs the whole pipeline in this thread. 'fragment' has no
+  // split-driven source and at most one row, so next() yields at most one
+  // non-empty single-row batch.
   velox::RowVectorPtr result;
   while (auto batch = task->next()) {
     if (batch->size() == 0) {
@@ -114,12 +127,10 @@ velox::Variant ConstantPlanRunner::run(
     result = batch;
   }
 
-  // At most one row: no row means a scalar over empty input, i.e. SQL NULL.
   if (result == nullptr) {
-    return velox::Variant::null(
-        fragment.planNode->outputType()->childAt(0)->kind());
+    return std::nullopt;
   }
-  return result->childAt(0)->variantAt(0);
+  return result->variantAt(0).row();
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ConstantFold.h
+++ b/axiom/optimizer/ConstantFold.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "axiom/connectors/ConnectorMetadata.h"
@@ -58,10 +59,16 @@ class ConstantPlanRunner {
       : queryCtx_{std::move(queryCtx)} {}
 
   /// Runs 'fragment' serially in the caller's thread (velox Task in kSerial
-  /// mode) and returns the single value of its result. 'fragment' must have no
-  /// split-driven sources and must produce a single column and at most one row;
-  /// no row yields a null of the column's type (a scalar over empty input).
-  velox::Variant run(const velox::core::PlanFragment& fragment) const;
+  /// mode) and returns its single result row, one Variant per output column,
+  /// or nullopt when it produced no row. 'fragment' must have no split-driven
+  /// sources and must produce at most one row.
+  std::optional<std::vector<velox::Variant>> run(
+      const velox::core::PlanFragment& fragment) const;
+
+  /// run() for a 'fragment' of one column, returning that column's value, or
+  /// nullopt when it produced no row. Fails if 'fragment' has another shape.
+  std::optional<velox::Variant> runScalar(
+      const velox::core::PlanFragment& fragment) const;
 
  private:
   const std::shared_ptr<velox::core::QueryCtx> queryCtx_;

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -487,10 +487,14 @@ Literal* tryFoldConstantDt(DerivedTableP dt) {
   VELOX_CHECK_EQ(1, veloxPlan.plan->fragments().size());
   const auto& fragment = veloxPlan.plan->fragments().front().fragment;
   ConstantPlanRunner constantPlanRunner{optimization->veloxQueryCtx()};
-  auto value = constantPlanRunner.run(fragment);
+  const auto& type = fragment.planNode->outputType()->childAt(0);
+  auto value = constantPlanRunner.runScalar(fragment);
   return make<Literal>(
-      toConstantValue(fragment.planNode->outputType()->childAt(0)),
-      registerVariant(std::move(value)));
+      toConstantValue(type),
+      registerVariant(
+          // A scalar subquery over no rows is NULL.
+          value.has_value() ? std::move(*value)
+                            : velox::Variant::null(type->kind())));
 }
 
 } // namespace

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -525,6 +525,7 @@ int main(int argc, char** argv) {
   registerQueryFile<"metadataAggregate">(/*v2Only=*/true);
   registerQueryFile<"nondeterministic">();
   registerQueryFile<"nullif">();
+  registerQueryFile<"partitionFold">();
   registerQueryFile<"set">();
   registerQueryFile<"sort">();
   registerQueryFile<"subfield">();

--- a/axiom/optimizer/tests/SubqueryFoldTest.cpp
+++ b/axiom/optimizer/tests/SubqueryFoldTest.cpp
@@ -27,9 +27,10 @@ namespace {
 using namespace velox;
 namespace lp = facebook::axiom::logical_plan;
 
-// Runs the scalar-subquery constant-fold cases under both the v1 and v2
-// optimizers. The fold lists a table's discrete-predicate (e.g. partition)
-// values and aggregates them instead of executing the subquery.
+// Runs the constant-fold cases under both the v1 and v2 optimizers. The fold
+// lists a table's discrete-predicate (e.g. partition) values and aggregates
+// them instead of reading the table, whether the aggregation is the body of a
+// scalar subquery or stands on its own.
 class SubqueryFoldTest : public test::HiveQueriesTestBase,
                          public testing::WithParamInterface<bool> {
  protected:
@@ -134,6 +135,23 @@ TEST_P(SubqueryFoldTest, foldable) {
     AXIOM_ASSERT_PLAN(plan, matchFilter("ds in ('2025-11-03', '2025-10-29')"));
   }
 
+  // A subquery over a one-row VALUES is that row's value.
+  {
+    auto logicalPlan = parseSql(
+        "SELECT * FROM t WHERE a = (SELECT y FROM (VALUES 1) AS v(y))");
+    auto plan = toSingleNodePlan(logicalPlan);
+    AXIOM_ASSERT_PLAN_V2(plan, matchFilter("a = 1"));
+  }
+
+  // A subquery over a multi-row VALUES cannot be a scalar and is rejected.
+  if (useV2_) {
+    auto logicalPlan = parseSql(
+        "SELECT * FROM t WHERE a = (SELECT y FROM (VALUES 1, 2, 3) AS v(y))");
+    VELOX_ASSERT_THROW(
+        toSingleNodePlan(logicalPlan),
+        "Scalar subquery produced more than one row");
+  }
+
   // A filter on the non-discrete column 'a' prevents the fold: the subquery is
   // evaluated normally rather than by listing discrete values.
   {
@@ -226,6 +244,72 @@ TEST_P(SubqueryFoldTest, foldableHivePartitions) {
     auto plan = toSingleNodePlan(
         "SELECT x FROM pt WHERE ds = (SELECT max(ds) FROM pt WHERE ds < '2')");
     AXIOM_ASSERT_PLAN(plan, matchHiveScan("pt", test::eq("ds", "1")).build());
+  }
+}
+
+// A global aggregation reading only partition columns is answered from the
+// partition listing, with no scan. Aggregates that are sensitive to duplicate
+// inputs, and columns that are not partition keys, are not.
+TEST_P(SubqueryFoldTest, foldableAggregationOverPartitions) {
+  // Partition keys 'ds' and 'k', data column 'x'. Three partitions:
+  // (ds='0',k=0), (ds='1',k=1), (ds='2',k=0).
+  runCtas(
+      "CREATE TABLE pt WITH (partitioned_by = ARRAY['ds', 'k']) AS "
+      "SELECT "
+      "     n_nationkey AS x, "
+      "     CAST(n_nationkey % 3 AS VARCHAR) AS ds, "
+      "     CAST(IF(n_nationkey % 3 = 1, 1, 0) AS INTEGER) AS k "
+      "FROM nation");
+  SCOPE_EXIT {
+    hiveMetadata().dropTableIfExists("pt");
+  };
+
+  {
+    auto plan = toSingleNodePlan("SELECT max(ds) FROM pt");
+    AXIOM_ASSERT_PLAN_V2(
+        plan,
+        matchValues(makeRowVector({makeFlatVector<std::string>({"2"})}))
+            .build());
+  }
+
+  // Every aggregate is answered from the one listing.
+  {
+    auto plan = toSingleNodePlan("SELECT max(ds), min(ds) FROM pt");
+    AXIOM_ASSERT_PLAN_V2(
+        plan,
+        matchValues(makeRowVector(
+                        {makeFlatVector<std::string>({"2"}),
+                         makeFlatVector<std::string>({"0"})}))
+            .build());
+  }
+
+  // Each UNION ALL branch folds on its own.
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT max(ds) AS m FROM pt UNION ALL SELECT max(ds) AS m FROM pt");
+
+    auto foldedValue = makeRowVector({makeFlatVector<std::string>({"2"})});
+    AXIOM_ASSERT_PLAN_V2(
+        plan,
+        matchValues(foldedValue)
+            .localPartition({matchValues(foldedValue).project()})
+            .build());
+  }
+
+  // count() counts rows, not partitions, so the listing cannot answer it.
+  {
+    auto plan = toSingleNodePlan("SELECT count(*) FROM pt");
+    AXIOM_ASSERT_PLAN_V2(
+        plan,
+        matchHiveScan("pt").singleAggregation({}, {"count(*) as c"}).build());
+  }
+
+  // 'x' is not a partition key, so the listing does not hold its values.
+  {
+    auto plan = toSingleNodePlan("SELECT max(x) FROM pt");
+    AXIOM_ASSERT_PLAN_V2(
+        plan,
+        matchHiveScan("pt").singleAggregation({}, {"max(x) as m"}).build());
   }
 }
 

--- a/axiom/optimizer/tests/sql/partitionFold.sql
+++ b/axiom/optimizer/tests/sql/partitionFold.sql
@@ -1,0 +1,38 @@
+-- connector: hive
+-- setup
+CREATE TABLE t (v BIGINT, ds VARCHAR) WITH (partitioned_by = ARRAY['ds'])
+----
+INSERT INTO t VALUES
+  (1, '2025-01-01'),
+  (2, '2025-01-02'),
+  (3, '2025-01-02')
+----
+CREATE TABLE u (d VARCHAR)
+----
+INSERT INTO u VALUES ('2025-01-01'), ('2025-01-02'), ('2025-01-03')
+-- end_setup
+
+-- An aggregate reading only a partition column is answered from the listing.
+SELECT max(ds) FROM t
+----
+SELECT max(ds), min(ds) FROM t
+----
+-- Each UNION ALL branch is answered on its own.
+SELECT max(ds) AS m FROM t UNION ALL SELECT min(ds) AS m FROM t
+----
+-- count() counts rows, not partitions.
+SELECT count(*) FROM t
+----
+-- The folded value restricts the outer scan.
+SELECT v FROM t WHERE ds = (SELECT max(ds) FROM t)
+----
+-- A filter on a non-partition column is not answerable from the listing.
+SELECT v FROM t WHERE ds = (SELECT max(ds) FROM t WHERE v > 1)
+----
+-- HAVING can reject the aggregate's row, leaving the subquery null, so
+-- nothing matches.
+-- count 0
+SELECT v FROM t WHERE ds = (SELECT max(ds) FROM t HAVING max(ds) > '2030-01-01')
+----
+-- A correlated predicate reads a column the listing does not have.
+SELECT d, (SELECT max(ds) FROM t WHERE t.ds > u.d) AS m FROM u

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -341,6 +341,11 @@ class SubqueryContext {
   // read it.
   bool correlateLifted(ColumnCP column);
 
+  // True if the body in flight has referenced an enclosing scope. A
+  // correlation recorded at an outer level is recorded at every level below
+  // it, so the innermost entry is the whole set the body can see.
+  bool hasCorrelations() const;
+
   // Enters/leaves the body of a subquery. 'liftTarget' is the node the
   // body will be lifted onto, i.e. the plan of the scope enclosing it.
   // `pop()` returns the correlated columns collected during that body,
@@ -368,6 +373,10 @@ void SubqueryContext::recordCorrelation(ColumnCP column, size_t level) {
   for (size_t i = level; i < correlationsStack_.size(); ++i) {
     correlationsStack_[i].push_back(column);
   }
+}
+
+bool SubqueryContext::hasCorrelations() const {
+  return !correlationsStack_.empty() && !correlationsStack_.back().empty();
 }
 
 ColumnCP SubqueryContext::correlateOuter(std::string_view name) {
@@ -737,12 +746,19 @@ class Translator {
       const Scope& outerScope,
       LiftTarget* liftTarget);
 
-  // Attempts to constant-fold an uncorrelated scalar subquery whose body is a
-  // global aggregation over a table's discrete-predicate (e.g. partition)
-  // columns. Lists the matching partition values via the connector, aggregates
-  // them by running a small Velox plan, and returns a `Literal`. Returns
-  // nullptr when the body does not have that shape or the connector declines.
-  ExprCP tryFoldConstantScalar(NodeCP body);
+  // Returns the value a scalar subquery over 'body' produces, when 'body' is a
+  // constant `Values`: its single row's value, or NULL if it has no rows.
+  // Returns nullptr when 'body' is anything else. Fails if 'body' has more than
+  // one row, which no scalar subquery may.
+  ExprCP tryScalarFromValues(NodeCP body);
+
+  // Evaluates 'aggregate' from the listed discrete-predicate (e.g. partition)
+  // values, returning one Variant per output column, or nullopt when it is not
+  // foldable: it must be a global aggregation whose aggregates all ignore
+  // duplicate inputs, over an optional Filter over a Scan of only
+  // discrete-predicate columns, on a connector that can list them.
+  std::optional<std::vector<velox::Variant>> tryEvaluateOverDiscreteValues(
+      const Aggregate* aggregate);
 
   // Translates each lp expression in 'expressions' against 'scope'.
   ExprVector translateAll(
@@ -1907,8 +1923,19 @@ Translated Translator::translateAggregate(
          .groupingKeys = std::move(groupingKeys),
          .aggregates = std::move(aggregates),
          .outputColumns = std::move(outputColumns)});
+    NodeCP node = aggNode;
+    if (auto row = tryEvaluateOverDiscreteValues(aggNode)) {
+      std::vector<velox::Variant> rows;
+      rows.push_back(velox::Variant::row(std::move(*row)));
+      node = builder_.makeValues(
+          /*source=*/nullptr,
+          queryCtx()->registerVariant(
+              std::make_unique<velox::Variant>(
+                  velox::Variant::array(std::move(rows)))),
+          aggNode->outputColumns());
+    }
     return {
-        appendConstantColumns(aggNode, foldedColumns, foldedExprs),
+        appendConstantColumns(node, foldedColumns, foldedExprs),
         std::move(newScope)};
   }
 
@@ -3207,12 +3234,12 @@ ExprCP Translator::liftSubquery(
         bodyOut.size(), 1, "Scalar subquery must produce exactly one column");
     returnedColumn = bodyOut[0];
 
-    // Fold an uncorrelated scalar subquery over partition columns to a constant
-    // (e.g. `max(ds)` from partition metadata) rather than executing it. The
-    // constant then flows into the outer predicate, where pushdown can prune
-    // the outer scan.
+    // A scalar subquery over a constant body is that constant; translating the
+    // body already reduced a foldable aggregation (e.g. `max(ds)` over
+    // partition metadata) to a one-row Values. The constant then flows into the
+    // outer predicate, where pushdown can prune the outer scan.
     if (correlationColumns.empty()) {
-      if (ExprCP folded = tryFoldConstantScalar(body)) {
+      if (ExprCP folded = tryScalarFromValues(body)) {
         return folded;
       }
     }
@@ -3301,14 +3328,44 @@ ExprCP Translator::liftSubquery(
   return returnedColumn;
 }
 
-ExprCP Translator::tryFoldConstantScalar(NodeCP body) {
-  if (!body->is(NodeType::kAggregate)) {
+ExprCP Translator::tryScalarFromValues(NodeCP body) {
+  if (!body->is(NodeType::kValues)) {
     return nullptr;
   }
 
-  const auto* aggregate = body->as<Aggregate>();
-  if (!aggregate->groupingKeys().empty()) {
+  VELOX_CHECK_EQ(body->outputColumns().size(), 1);
+
+  const auto* values = body->as<Values>();
+  const TypeCP type = body->outputColumns()[0]->value().type;
+
+  const size_t numRows = values->cardinality();
+  if (numRows == 0) {
+    // A scalar subquery over no rows is SQL NULL.
+    return builder_.makeNull(type);
+  }
+
+  VELOX_USER_CHECK_EQ(numRows, 1, "Scalar subquery produced more than one row");
+
+  // TODO: Read the value from a pass-through `lp::ValuesNode` too; only
+  // translate-time folded rows are handled here.
+  if (values->rows() == nullptr) {
     return nullptr;
+  }
+
+  const auto& row = values->rows()->array()[0].row();
+  return builder_.makeLiteral(velox::Variant(row[values->channels()[0]]), type);
+}
+
+std::optional<std::vector<velox::Variant>>
+Translator::tryEvaluateOverDiscreteValues(const Aggregate* aggregate) {
+  // A correlated body reads columns of an enclosing scope, which the listing
+  // does not produce.
+  if (subqueries_.hasCorrelations()) {
+    return std::nullopt;
+  }
+
+  if (!aggregate->groupingKeys().empty()) {
+    return std::nullopt;
   }
 
   // The fold aggregates a per-partition value list, so each aggregate must
@@ -3316,7 +3373,7 @@ ExprCP Translator::tryFoldConstantScalar(NodeCP body) {
   for (const optimizer::Aggregate* call : aggregate->aggregates()) {
     if (!call->functions().contains(FunctionSet::kIgnoreDuplicatesAggregate) &&
         !call->isDistinct()) {
-      return nullptr;
+      return std::nullopt;
     }
   }
 
@@ -3327,7 +3384,7 @@ ExprCP Translator::tryFoldConstantScalar(NodeCP body) {
     input = filter->input();
   }
   if (!input->is(NodeType::kScan)) {
-    return nullptr;
+    return std::nullopt;
   }
   const auto* scan = input->as<Scan>();
 
@@ -3337,12 +3394,12 @@ ExprCP Translator::tryFoldConstantScalar(NodeCP body) {
   auto discreteLayout =
       findDiscreteLayout(scan->outputColumns(), *scan->baseTable());
   if (discreteLayout.layout == nullptr) {
-    return nullptr;
+    return std::nullopt;
   }
 
-  // Offer the subquery's filters to the connector so it narrows the listing.
-  // Which of them it takes does not matter: the Filter below re-applies all of
-  // them, so 'rejected' is not read.
+  // Offer the filters to the connector so it narrows the listing. Which of
+  // them it takes does not matter: the Filter over the listed values re-applies
+  // all of them, so 'rejected' is not read.
   const ExprVector& filters =
       filter != nullptr ? filter->predicates() : ExprVector{};
   ExprVector rejected;
@@ -3359,7 +3416,7 @@ ExprCP Translator::tryFoldConstantScalar(NodeCP body) {
   auto discretePredicates = discreteLayout.layout->discretePredicates(
       connectorSession, discreteLayout.connectorColumns, handle.tableHandle);
   if (discretePredicates == nullptr) {
-    return nullptr;
+    return std::nullopt;
   }
 
   // Build a small plan that aggregates the listed partition values:
@@ -3387,9 +3444,12 @@ ExprCP Translator::tryFoldConstantScalar(NodeCP body) {
        .groupId = aggregate->groupId(),
        .globalGroupingSets = aggregate->globalGroupingSets()});
 
-  // A scalar subquery produces exactly one column.
   const ColumnVector& outputColumns = foldAggregate->outputColumns();
-  std::vector<std::string> outputNames{std::string(outputColumns[0]->name())};
+  std::vector<std::string> outputNames;
+  outputNames.reserve(outputColumns.size());
+  for (ColumnCP column : outputColumns) {
+    outputNames.emplace_back(column->name());
+  }
 
   // Lower the mini-plan through the shared physical-planning and emit passes,
   // then run it. It has a Values source and no Scan, so single-node options
@@ -3405,9 +3465,11 @@ ExprCP Translator::tryFoldConstantScalar(NodeCP body) {
   VELOX_CHECK_EQ(
       emitted.fragments.size(), 1, "Constant fold must produce one fragment");
 
-  return builder_.makeLiteral(
-      constantPlanRunner_.run(emitted.fragments.front().fragment),
-      outputColumns[0]->value().type);
+  auto row = constantPlanRunner_.run(emitted.fragments.front().fragment);
+  // The plan aggregates a Values with no grouping keys, so it emits one row
+  // even when the filter below leaves nothing.
+  VELOX_CHECK(row.has_value(), "Constant-fold plan produced no row");
+  return row;
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

A global aggregate that reads only a table's partition columns is now answered from the partition listing rather than by scanning. `SELECT max(ds) FROM t`, where `ds` is a partition key, plans to a single-row `Values` and reads no data.

The optimizer could already do this, but only for the body of an uncorrelated scalar subquery — `WHERE ds = (SELECT max(ds) FROM t)`. The same aggregate written on its own, or in a `UNION ALL` branch, or as a CTE, kept its scan. The check now runs wherever the aggregation is built, so position in the query no longer decides it. An aggregate qualifies when it has no grouping keys, every aggregate ignores duplicate inputs, and the scan reads only discrete-predicate columns. `count(*)` is excluded because it counts rows rather than partitions.

Folding an aggregation makes a scalar subquery's body a one-row `Values`, so the scalar path now reads that value rather than recomputing it. This also gives it constant `VALUES` bodies it did not handle before: `WHERE a = (SELECT y FROM (VALUES 1) AS v(y))` folds and prunes the scan, while a multi-row body now fails during planning instead of at run time, with `Scalar subquery produced more than one row`.

A folded value that reaches its consumer through a join does not prune that consumer. In

    WITH m AS (SELECT max(ds) AS d FROM t) SELECT * FROM t CROSS JOIN m WHERE t.ds = m.d

the aggregate folds, but the constant sits on the build side of the join rather than in the outer scan's filters, so the outer scan reads every partition. Rewriting a join against a single-row `Values` into a constant filter belongs in `PushdownAndPrunePass` and is left to a separate change.

Reviewed By: xiaoxmeng

Differential Revision: D118229952


