### PR TITLE
fix(exec): Finish grouped tasks without split groups

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -337,6 +337,14 @@ class PartitionType {
   /// Number of partitions.
   virtual int32_t numPartitions() const = 0;
 
+  /// Number of split groups (buckets) rows are distributed into. Defaults to
+  /// numPartitions(); connectors that fold native buckets into fewer partitions
+  /// return the native bucket count so grouped execution can process one bucket
+  /// at a time.
+  virtual int32_t numGroups() const {
+    return numPartitions();
+  }
+
   virtual std::string toString() const = 0;
 
   template <typename T>

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -677,6 +677,9 @@ class TableLayout {
   /// @param session Connector session for the current query.
   /// @param tableHandle Table handle for the table; the connector reads its
   /// accepted filters from it in whatever representation it stored them.
+  /// @param partitionSelection Exact partitions selected for this scan. Null is
+  /// reserved for callers that do not perform partition selection during
+  /// planning.
   /// @param columns Names of table columns the optimizer is interested in.
   /// Column names correspond to actual table columns (not synthetic subfield
   /// projections). If the connector provides per-column statistics, it must
@@ -692,6 +695,7 @@ class TableLayout {
   virtual folly::coro::Task<std::optional<FilteredTableStats>> co_estimateStats(
       ConnectorSessionPtr /*session*/,
       velox::connector::ConnectorTableHandlePtr /*tableHandle*/,
+      PartitionSelectionPtr /*partitionSelection*/,
       std::vector<std::string> /*columns*/,
       const FilterSelectivityEstimator& /*estimator*/) const {
     co_return std::nullopt;
@@ -714,6 +718,9 @@ class TableLayout {
   /// @param session Connector session for the current query.
   /// @param tableHandle Table handle carrying the filters pushed via
   /// createTableHandle.
+  /// @param partitionSelection Exact partitions selected for this scan. Null is
+  /// reserved for callers that do not perform partition selection during
+  /// planning.
   /// @param groupingColumns Names of columns to group the counts by, in
   /// output-key order. Empty requests a single global count. The connector
   /// returns std::nullopt if it cannot group by these columns from metadata
@@ -728,6 +735,7 @@ class TableLayout {
   co_metadataCounts(
       ConnectorSessionPtr /*session*/,
       velox::connector::ConnectorTableHandlePtr /*tableHandle*/,
+      PartitionSelectionPtr /*partitionSelection*/,
       std::vector<std::string> /*groupingColumns*/,
       std::vector<std::string> /*columns*/) const {
     co_return std::nullopt;

--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <folly/container/F14Set.h>
 #include <folly/coro/Task.h>
 #include <velox/connectors/Connector.h>
 #include <optional>
@@ -26,20 +27,24 @@ namespace facebook::axiom::connector {
 
 class PartitionType;
 
-/// Wraps a Velox ConnectorSplit with optional placement metadata. groupId is a
-/// hard within-query routing constraint for grouped execution: splits with the
-/// same groupId are routed to the same task. affinityId is a soft cross-query
+/// Wraps a Velox ConnectorSplit with optional placement metadata. For grouped
+/// execution, groupId identifies the split's bucket (split group) and
+/// partitionId the task it must run on; the connector derives partitionId from
+/// groupId via the partitioning function. affinityId is a soft cross-query
 /// affinity hint: schedulers prefer to route splits with the same affinityId
-/// to the same task, but may choose another task for load balancing. When both
-/// are present, grouped-execution routing through groupId takes precedence
-/// over affinityId.
+/// to the same task, but may choose another task for load balancing.
 struct Split {
   /// The underlying Velox connector split.
   std::shared_ptr<velox::connector::ConnectorSplit> connectorSplit;
 
-  /// Group ID for bucketed routing; splits sharing a groupId are routed to
-  /// the same task. Absent means any task may handle this split.
+  /// Split group (bucket) this split belongs to, in [0, numGroups). Splits
+  /// sharing a groupId form one group processed together on the worker. Absent
+  /// for non-grouped scans.
   std::optional<int32_t> groupId{std::nullopt};
+
+  /// Task (partition) this split must be routed to, in [0, width). Present for
+  /// grouped execution. Absent means the runtime chooses the task.
+  std::optional<int32_t> partitionId{std::nullopt};
 
   /// Stable connector-generated affinity ID for split affinity. Connectors
   /// that support split affinity must generate the same ID for repeated reads
@@ -55,6 +60,11 @@ struct SplitBatch {
 
   /// True when there are no more splits to return.
   bool noMoreSplits{false};
+
+  /// Groups (buckets) for which no further splits will be returned. Lets the
+  /// runtime finalize a group as soon as its splits are exhausted rather than
+  /// waiting for the whole source to drain.
+  folly::F14FastSet<int32_t> noMoreSplitsForGroupId;
 };
 
 /// Enumerates splits. The table and partitions to cover are given to
@@ -147,8 +157,9 @@ class ConnectorSplitManager {
   /// enumeration metrics (e.g., file listing, Metastore RPCs).
   ///
   /// When 'partitionType' is non-null, the connector tags each emitted Split
-  /// with a groupId in [0, partitionType->numPartitions()). Pass 'nullptr'
-  /// for the non-bucketed case.
+  /// with a groupId (bucket) in [0, partitionType->numGroups()) and a
+  /// partitionId (target task) in [0, partitionType->numPartitions()). Pass
+  /// 'nullptr' for the non-bucketed case.
   ///
   /// When 'samplePercentage' is set (TABLESAMPLE SYSTEM), the source emits each
   /// split with that probability, in the open interval (0, 100); the caller

--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -18,6 +18,7 @@
 #include <folly/coro/Task.h>
 #include <velox/connectors/Connector.h>
 #include <optional>
+#include <utility>
 #include "axiom/common/QueryRuntimeStats.h"
 #include "axiom/connectors/ConnectorSession.h"
 
@@ -106,9 +107,32 @@ class PartitionHandle {
 
 using PartitionHandlePtr = std::shared_ptr<const PartitionHandle>;
 
+/// The exact partitions selected for one scan and the storage partitioning the
+/// connector guarantees across those partitions. A null storagePartitionType
+/// means the scan must be planned as unbucketed.
+struct PartitionSelection {
+  std::vector<PartitionHandlePtr> partitions;
+  std::shared_ptr<const PartitionType> storagePartitionType;
+};
+
+using PartitionSelectionPtr = std::shared_ptr<const PartitionSelection>;
+
 class ConnectorSplitManager {
  public:
   virtual ~ConnectorSplitManager() = default;
+
+  /// Selects the partitions read by 'tableHandle' and validates the declared
+  /// storage partitioning for exactly that set. The default preserves the
+  /// connector's declared partitioning.
+  virtual folly::coro::Task<PartitionSelection> co_selectPartitions(
+      const ConnectorSessionPtr& session,
+      const velox::connector::ConnectorTableHandlePtr& tableHandle,
+      std::shared_ptr<const PartitionType> declaredStoragePartitionType) {
+    auto partitions = co_await co_listPartitions(session, tableHandle);
+    co_return PartitionSelection{
+        .partitions = std::move(partitions),
+        .storagePartitionType = std::move(declaredStoragePartitionType)};
+  }
 
   /// Returns a list of all partitions that match the filters in
   /// 'tableHandle'. A non-partitioned table returns one partition.

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -87,6 +87,10 @@ class HivePartitionType : public connector::PartitionType {
     return numBuckets_;
   }
 
+  int32_t numGroups() const override {
+    return numBuckets_;
+  }
+
   /// Maps a native bucket index to a partition index.
   int32_t mapBucketToPartition(int32_t bucket) const {
     return (bucket % numBuckets_) % numPartitions_;

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -357,17 +357,26 @@ folly::coro::Task<SplitBatch> LocalHiveSplitSource::co_getSplits(
         builder.serdeParameters(serdeParameters_);
       }
       std::optional<int32_t> groupId;
+      std::optional<int32_t> partitionId;
       if (partitionType_ != nullptr) {
         VELOX_CHECK(
             info->bucketNumber.has_value(),
             "Bucketed scan requires bucketNumber on every file");
         const auto* hivePartitionType = partitionType_->as<HivePartitionType>();
         VELOX_CHECK_NOT_NULL(hivePartitionType, "Expected HivePartitionType");
-        groupId =
-            hivePartitionType->mapBucketToPartition(info->bucketNumber.value());
+        const int32_t bucket = info->bucketNumber.value();
+        // groupId is the Velox split group (bucket); partitionId is the task it
+        // routes to. numGroups() normalizes the native bucket into the common
+        // co-partitioned group space so both sides of a join co-locate.
+        groupId = bucket % hivePartitionType->numGroups();
+        partitionId = hivePartitionType->mapBucketToPartition(bucket);
+        splitGroupIds_.insert(*groupId);
       }
       batch.splits.push_back(
-          Split{.connectorSplit = builder.build(), .groupId = groupId});
+          Split{
+              .connectorSplit = builder.build(),
+              .groupId = groupId,
+              .partitionId = partitionId});
       ++splitWithinFile_;
     }
     if (splitWithinFile_ >= splitsPerFile) {
@@ -376,6 +385,9 @@ folly::coro::Task<SplitBatch> LocalHiveSplitSource::co_getSplits(
     }
   }
   batch.noMoreSplits = (fileIdx_ >= files_.size());
+  if (batch.noMoreSplits) {
+    batch.noMoreSplitsForGroupId = splitGroupIds_;
+  }
   co_return batch;
 }
 

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -576,6 +576,7 @@ folly::coro::Task<std::optional<FilteredTableStats>>
 LocalHiveTableLayout::co_estimateStats(
     ConnectorSessionPtr /*session*/,
     velox::connector::ConnectorTableHandlePtr tableHandle,
+    PartitionSelectionPtr /*partitionSelection*/,
     std::vector<std::string> columns,
     const FilterSelectivityEstimator& estimator) const {
   auto hiveHandle =
@@ -632,6 +633,7 @@ folly::coro::Task<std::optional<std::vector<MetadataCountGroup>>>
 LocalHiveTableLayout::co_metadataCounts(
     ConnectorSessionPtr /*session*/,
     velox::connector::ConnectorTableHandlePtr tableHandle,
+    PartitionSelectionPtr /*partitionSelection*/,
     std::vector<std::string> groupingColumns,
     std::vector<std::string> columns) const {
   auto hiveHandle =

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -168,6 +168,7 @@ class LocalHiveTableLayout : public HiveTableLayout {
   folly::coro::Task<std::optional<FilteredTableStats>> co_estimateStats(
       ConnectorSessionPtr session,
       velox::connector::ConnectorTableHandlePtr tableHandle,
+      PartitionSelectionPtr partitionSelection,
       std::vector<std::string> columns,
       const FilterSelectivityEstimator& estimator) const override;
 
@@ -181,6 +182,7 @@ class LocalHiveTableLayout : public HiveTableLayout {
   co_metadataCounts(
       ConnectorSessionPtr session,
       velox::connector::ConnectorTableHandlePtr tableHandle,
+      PartitionSelectionPtr partitionSelection,
       std::vector<std::string> groupingColumns,
       std::vector<std::string> columns) const override;
 

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/container/F14Set.h>
 #include <utility>
 
 #include "axiom/connectors/hive/HiveConnectorMetadata.h"
@@ -58,6 +59,7 @@ class LocalHiveSplitSource : public SplitSource {
   // When non-null, used to assign a groupId to each split for bucketed
   // execution.
   const std::shared_ptr<PartitionType> partitionType_;
+  folly::F14FastSet<int32_t> splitGroupIds_;
   size_t fileIdx_{0};
   int64_t splitWithinFile_{0};
 };

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -52,7 +52,10 @@ std::shared_ptr<PartitionType> TestPartitionType::copartition(
     return nullptr;
   }
   return std::make_shared<TestPartitionType>(
-      fewerPartitions, partitionKeyTypes_, inputType_);
+      fewerPartitions,
+      std::min(numGroups_, otherTest->numGroups_),
+      partitionKeyTypes_,
+      inputType_);
 }
 
 std::shared_ptr<PartitionType> TestPartitionType::scaleDown(
@@ -63,7 +66,7 @@ std::shared_ptr<PartitionType> TestPartitionType::scaleDown(
     --scaledPartitions;
   }
   return std::make_shared<TestPartitionType>(
-      scaledPartitions, partitionKeyTypes_, inputType_);
+      scaledPartitions, numGroups_, partitionKeyTypes_, inputType_);
 }
 
 velox::core::PartitionFunctionSpecPtr TestPartitionType::makeSpec(
@@ -421,15 +424,26 @@ folly::coro::Task<SplitBatch> TestSplitSource::co_getSplits(
     auto split =
         std::make_shared<TestConnectorSplit>(connectorId_, dataIndices_[i]);
     std::optional<int32_t> groupId;
+    std::optional<int32_t> partitionId;
     if (partitionType_ != nullptr) {
       VELOX_CHECK_LT(i, dataBucketIds_.size());
-      groupId = dataBucketIds_[i] % partitionType_->numPartitions();
+      groupId = dataBucketIds_[i] % partitionType_->numGroups();
+      partitionId = dataBucketIds_[i] % partitionType_->numPartitions();
     }
     batch.splits.push_back(
-        Split{.connectorSplit = std::move(split), .groupId = groupId});
+        Split{
+            .connectorSplit = std::move(split),
+            .groupId = groupId,
+            .partitionId = partitionId});
   }
   nextOffset_ = end;
   batch.noMoreSplits = (nextOffset_ >= dataIndices_.size());
+  if (batch.noMoreSplits && partitionType_ != nullptr) {
+    for (const auto bucketId : dataBucketIds_) {
+      batch.noMoreSplitsForGroupId.insert(
+          bucketId % partitionType_->numGroups());
+    }
+  }
   co_return batch;
 }
 

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -448,6 +448,23 @@ const TestTable& findTestTableForHandle(
 
 } // namespace
 
+folly::coro::Task<PartitionSelection> TestSplitManager::co_selectPartitions(
+    const ConnectorSessionPtr& session,
+    const velox::connector::ConnectorTableHandlePtr& tableHandle,
+    std::shared_ptr<const PartitionType> declaredStoragePartitionType) {
+  const auto& table = findTestTableForHandle(tableHandle);
+  VELOX_CHECK(
+      !table.layouts().empty(), "Test table must have at least one layout");
+  const auto* layout = table.layouts().front()->as<TestTableLayout>();
+  VELOX_CHECK_NOT_NULL(layout);
+  auto partitions = co_await co_listPartitions(session, tableHandle);
+  co_return PartitionSelection{
+      .partitions = std::move(partitions),
+      .storagePartitionType = layout->partitionsConsistent()
+          ? std::move(declaredStoragePartitionType)
+          : nullptr};
+}
+
 folly::coro::Task<std::vector<PartitionHandlePtr>>
 TestSplitManager::co_listPartitions(
     const ConnectorSessionPtr& session,
@@ -1009,6 +1026,15 @@ void TestConnectorMetadata::setStats(
   it->second->setStats(numRows, columnStats);
 }
 
+void TestConnectorMetadata::setPartitionsConsistent(
+    const SchemaTableName& tableName,
+    bool consistent) {
+  auto it = tables_.find(tableName);
+  VELOX_CHECK(
+      it != tables_.end(), "Table doesn't exist: {}", tableName.toString());
+  it->second->mutableLayout()->setPartitionsConsistent(consistent);
+}
+
 TestDataSource::TestDataSource(
     const velox::RowTypePtr& outputType,
     const velox::connector::ColumnHandleMap& handles,
@@ -1332,6 +1358,12 @@ void TestConnector::setStats(
     uint64_t numRows,
     const std::unordered_map<std::string, ColumnStatistics>& columnStats) {
   metadata_->setStats(tableName, numRows, columnStats);
+}
+
+void TestConnector::setPartitionsConsistent(
+    const SchemaTableName& tableName,
+    bool consistent) {
+  metadata_->setPartitionsConsistent(tableName, consistent);
 }
 
 std::shared_ptr<velox::connector::Connector> TestConnectorFactory::newConnector(

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -127,6 +127,14 @@ class TestTableLayout : public TableLayout {
     return partitionType_;
   }
 
+  void setPartitionsConsistent(bool consistent) {
+    partitionsConsistent_ = consistent;
+  }
+
+  bool partitionsConsistent() const {
+    return partitionsConsistent_;
+  }
+
   /// Records discrete values to use in 'discretePredicateColumns' and
   /// 'discretePredicates' APIs. If called repeatedly, overwrites previous
   /// values.
@@ -161,6 +169,7 @@ class TestTableLayout : public TableLayout {
   std::vector<const Column*> discreteValueColumns_;
   std::vector<velox::Variant> discreteValues_;
   std::shared_ptr<const PartitionType> partitionType_;
+  bool partitionsConsistent_{true};
 };
 
 /// RowVectors are appended using the addData() interface and the vector
@@ -295,6 +304,12 @@ class TestConnectorMetadata;
 /// only for the requested buckets' entries.
 class TestSplitManager : public ConnectorSplitManager {
  public:
+  folly::coro::Task<PartitionSelection> co_selectPartitions(
+      const ConnectorSessionPtr& session,
+      const velox::connector::ConnectorTableHandlePtr& tableHandle,
+      std::shared_ptr<const PartitionType> declaredStoragePartitionType)
+      override;
+
   folly::coro::Task<std::vector<PartitionHandlePtr>> co_listPartitions(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle) override;
@@ -581,6 +596,11 @@ class TestConnectorMetadata : public ConnectorMetadata {
       const SchemaTableName& tableName,
       uint64_t numRows,
       const std::unordered_map<std::string, ColumnStatistics>& columnStats);
+
+  /// Sets whether the table's partitions share its declared bucket layout.
+  void setPartitionsConsistent(
+      const SchemaTableName& tableName,
+      bool consistent);
 
   TablePtr createTable(
       const ConnectorSessionPtr& session,
@@ -911,6 +931,18 @@ class TestConnector : public velox::connector::Connector {
       uint64_t numRows,
       const std::unordered_map<std::string, ColumnStatistics>& columnStats) {
     setStats({std::string(kDefaultSchema), tableName}, numRows, columnStats);
+  }
+
+  /// Sets whether the table's selected partitions preserve its declared
+  /// bucketing.
+  void setPartitionsConsistent(
+      const SchemaTableName& tableName,
+      bool consistent);
+
+  /// Convenience overload that uses kDefaultSchema as the schema.
+  void setPartitionsConsistent(const std::string& tableName, bool consistent) {
+    setPartitionsConsistent(
+        {std::string(kDefaultSchema), tableName}, consistent);
   }
 
   bool dropTableIfExists(const SchemaTableName& name);

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -49,7 +49,19 @@ class TestPartitionType : public PartitionType {
       int32_t numPartitions,
       std::vector<velox::TypePtr> partitionKeyTypes,
       velox::RowTypePtr inputType)
+      : TestPartitionType(
+            numPartitions,
+            numPartitions,
+            std::move(partitionKeyTypes),
+            std::move(inputType)) {}
+
+  TestPartitionType(
+      int32_t numPartitions,
+      int32_t numGroups,
+      std::vector<velox::TypePtr> partitionKeyTypes,
+      velox::RowTypePtr inputType)
       : numPartitions_(numPartitions),
+        numGroups_(numGroups),
         partitionKeyTypes_(std::move(partitionKeyTypes)),
         inputType_(std::move(inputType)) {}
 
@@ -68,10 +80,15 @@ class TestPartitionType : public PartitionType {
     return numPartitions_;
   }
 
+  int32_t numGroups() const override {
+    return numGroups_;
+  }
+
   std::string toString() const override;
 
  private:
   const int32_t numPartitions_;
+  const int32_t numGroups_;
   const std::vector<velox::TypePtr> partitionKeyTypes_;
   const velox::RowTypePtr inputType_;
 };

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -632,11 +632,13 @@ CO_TEST_F(TestConnectorTest, bucketedTable) {
       co_await splitManager->co_listPartitions(session, tableHandle);
   EXPECT_EQ(partitions.size(), kNumBuckets);
 
-  // Pass a non-null partitionType with numPartitions < numBuckets so the
-  // connector folds buckets into groups and tags each Split with groupId.
-  constexpr int32_t kNumGroups = 2;
+  // Pass a non-null partitionType with numPartitions < numBuckets: the
+  // connector tags each Split with its bucket groupId and a partitionId that
+  // folds buckets into tasks.
+  constexpr int32_t kNumPartitions = 2;
+  constexpr int32_t kNumGroups = 4;
   auto partitionType = std::make_shared<TestPartitionType>(
-      kNumGroups, std::vector<TypePtr>{BIGINT()}, schema);
+      kNumPartitions, kNumGroups, std::vector<TypePtr>{BIGINT()}, schema);
   QueryRuntimeStats noopStats;
   auto source = splitManager->getSplitSource(
       session,
@@ -646,25 +648,36 @@ CO_TEST_F(TestConnectorTest, bucketedTable) {
       /*samplePercentage=*/std::nullopt,
       noopStats);
   std::vector<int32_t> observedGroupIds;
+  folly::F14FastSet<int32_t> completedGroupIds;
+  folly::F14FastSet<int32_t> expectedGroupIds;
   while (true) {
     auto batch = co_await source->co_getSplits(/*maxSplitCount=*/16);
     for (const auto& split : batch.splits) {
       CO_ASSERT_TRUE(split.groupId.has_value());
-      EXPECT_GE(*split.groupId, 0);
-      EXPECT_LT(*split.groupId, kNumGroups);
+      CO_ASSERT_TRUE(split.partitionId.has_value());
       auto testSplit = std::dynamic_pointer_cast<const TestConnectorSplit>(
           split.connectorSplit);
       CO_ASSERT_NE(testSplit, nullptr);
       const auto bucket = table->dataBucketIds()[testSplit->index()];
       EXPECT_EQ(*split.groupId, bucket % kNumGroups);
+      EXPECT_GE(*split.groupId, 0);
+      EXPECT_LT(*split.groupId, kNumGroups);
+      EXPECT_EQ(*split.partitionId, bucket % kNumPartitions);
+      EXPECT_GE(*split.partitionId, 0);
+      EXPECT_LT(*split.partitionId, kNumPartitions);
       observedGroupIds.push_back(*split.groupId);
+      expectedGroupIds.insert(bucket % kNumGroups);
     }
+    completedGroupIds.insert(
+        batch.noMoreSplitsForGroupId.begin(),
+        batch.noMoreSplitsForGroupId.end());
     if (batch.noMoreSplits) {
       break;
     }
   }
   co_await source->co_close();
   EXPECT_FALSE(observedGroupIds.empty());
+  EXPECT_EQ(completedGroupIds, expectedGroupIds);
 }
 
 TEST_F(TestConnectorTest, bucketedTableNonExistentBucketColumn) {

--- a/axiom/optimizer/MultiFragmentPlan.cpp
+++ b/axiom/optimizer/MultiFragmentPlan.cpp
@@ -686,6 +686,11 @@ void MultiFragmentPlan::checkConsistency(bool mayBeEmpty) const {
     return;
   }
 
+  VELOX_CHECK_GT(
+      options_.numConcurrentSplitGroups,
+      0,
+      "numConcurrentSplitGroups must be positive");
+
   checkFragmentTypes(fragments_, options_.numWorkers);
 
   checkProducerConsumerLinkage(fragments_);

--- a/axiom/optimizer/MultiFragmentPlan.h
+++ b/axiom/optimizer/MultiFragmentPlan.h
@@ -176,6 +176,11 @@ struct ExecutableFragment {
       std::shared_ptr<connector::PartitionType>>
       groupedNodes;
 
+  /// Number of split groups (buckets) for a grouped fragment. Distinct from
+  /// 'width' (task count): one task may process several groups in sequence.
+  /// std::nullopt when the fragment has no grouped scans.
+  std::optional<int32_t> numSplitGroups;
+
   /// Sample percentage per scan node for TABLESAMPLE SYSTEM. The split source
   /// for the scan emits each split with this probability, in the open interval
   /// (0, 100). Empty when no scan in this fragment is sampled.
@@ -203,6 +208,15 @@ class MultiFragmentPlan {
     /// Number of threads in a fragment in a worker. If 1, there are no local
     /// exchanges.
     int32_t numDrivers{4};
+
+    /// When true, the v2 optimizer emits fragments with useful certified
+    /// bucketed scans as Velox grouped execution so a task processes one split
+    /// group at a time. The v1 optimizer leaves bucketed fragments ungrouped.
+    bool groupedExecution{false};
+
+    /// In grouped execution, the maximum number of split groups a task
+    /// processes concurrently. Ignored for ungrouped fragments.
+    int32_t numConcurrentSplitGroups{2};
 
     /// Controls how query results are delivered from the final plan fragment.
     ///

--- a/axiom/optimizer/MultiFragmentPlan.h
+++ b/axiom/optimizer/MultiFragmentPlan.h
@@ -19,6 +19,7 @@
 #include <folly/container/F14Map.h>
 #include "axiom/common/Enums.h"
 #include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorSplitManager.h"
 #include "velox/core/PlanFragment.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/SimpleVector.h"
@@ -75,6 +76,10 @@ struct InputStage {
   /// Task prefix of producer stage.
   std::string producerTaskPrefix;
 };
+
+/// Selected partitions keyed by the emitted TableScanNode ID.
+using ScanPartitionSelectionMap = folly::
+    F14FastMap<velox::core::PlanNodeId, connector::PartitionSelectionPtr>;
 
 /// Callbacks to finalize writing to a connector after the query completes.
 /// On success, the runner calls 'commit'. On failure, 'abort'. Only one of the
@@ -222,8 +227,13 @@ class MultiFragmentPlan {
     }
   };
 
-  MultiFragmentPlan(std::vector<ExecutableFragment> fragments, Options options)
-      : fragments_{std::move(fragments)}, options_{std::move(options)} {}
+  MultiFragmentPlan(
+      std::vector<ExecutableFragment> fragments,
+      Options options,
+      ScanPartitionSelectionMap scanPartitionSelections = {})
+      : fragments_{std::move(fragments)},
+        options_{std::move(options)},
+        scanPartitionSelections_{std::move(scanPartitionSelections)} {}
 
   const std::vector<ExecutableFragment>& fragments() const {
     return fragments_;
@@ -231,6 +241,10 @@ class MultiFragmentPlan {
 
   const Options& options() const {
     return options_;
+  }
+
+  const ScanPartitionSelectionMap& scanPartitionSelections() const {
+    return scanPartitionSelections_;
   }
 
   /// @param detailed If true, includes details of each plan node. Otherwise,
@@ -259,6 +273,7 @@ class MultiFragmentPlan {
  private:
   const std::vector<ExecutableFragment> fragments_;
   const Options options_;
+  const ScanPartitionSelectionMap scanPartitionSelections_;
 };
 
 using MultiFragmentPlanPtr = std::shared_ptr<const MultiFragmentPlan>;

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -197,6 +197,7 @@ void Optimization::estimateAllBaseTableSelectivity(DerivedTable& dt) {
     tasks.push_back(layout->co_estimateStats(
         std::move(connectorSession),
         data->handle,
+        /*partitionSelection=*/nullptr,
         std::move(columnNames),
         estimator));
   }

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -514,12 +514,14 @@ void ToVelox::applyGroupedLeaves(
         std::const_pointer_cast<connector::PartitionType>(partitionType));
   }
   int32_t width = -1;
+  int32_t numGroups = -1;
   for (const auto& [_, pt] : fragment.groupedNodes) {
     if (pt == nullptr) {
       continue;
     }
     if (width < 0) {
       width = pt->numPartitions();
+      numGroups = pt->numGroups();
     } else {
       VELOX_CHECK_EQ(
           pt->numPartitions(),
@@ -530,6 +532,7 @@ void ToVelox::applyGroupedLeaves(
   if (width >= 0) {
     fragment.type = FragmentType::kFixed;
     fragment.width = width;
+    fragment.numSplitGroups = numGroups;
   }
 }
 

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -417,8 +417,10 @@ class ToVelox {
   // Translates 'groupedLeaves' (keyed by const RelationOp*) into entries in
   // 'fragment.groupedNodes' (keyed by Velox PlanNodeId) using
   // 'relationOpToNodeId_'. After translation, if any non-null PartitionType
-  // entry is present, sets fragment.type = kFixed and fragment.width =
-  // numPartitions().
+  // entry is present, sets fragment.type = kFixed, fragment.width =
+  // numPartitions() and fragment.numSplitGroups = numGroups(). Grouped
+  // execution itself is enabled only by the v2 emitter, whose scan-level
+  // partition certification makes the optimization safe.
   void applyGroupedLeaves(
       ExecutableFragment& fragment,
       const GroupedLeaves& groupedLeaves);

--- a/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
@@ -330,6 +330,32 @@ TEST_P(BucketedExecutionTest, groupedExecutionRunsEndToEnd) {
   }
 }
 
+TEST_P(BucketedExecutionTest, groupedExecutionClosesEmptyTasks) {
+  if (!useV2_) {
+    GTEST_SKIP() << "Grouped execution requires scan certification in v2";
+  }
+  const auto schema = ROW("customer_id", BIGINT());
+  testConnector_->addTable(
+      "ge_sparse",
+      schema,
+      velox::ROW({}),
+      connector::TestBucketSpec{{"customer_id"}, 8});
+  testConnector_->appendData(
+      "ge_sparse", makeRowVector({makeFlatVector<int64_t>({0, 1})}));
+
+  const auto logicalPlan = parseSelect(
+      "SELECT customer_id, count(*) FROM ge_sparse GROUP BY customer_id",
+      kTestConnectorId);
+  auto grouped = runVelox(
+      logicalPlan,
+      {.numWorkers = 2, .numDrivers = 2, .groupedExecution = true});
+  auto ungrouped = runVelox(
+      logicalPlan,
+      {.numWorkers = 2, .numDrivers = 2, .groupedExecution = false});
+
+  velox::exec::test::assertEqualResults(grouped.results, ungrouped.results);
+}
+
 TEST_P(BucketedExecutionTest, groupedJoinRunsEndToEnd) {
   if (!useV2_) {
     GTEST_SKIP() << "Grouped execution requires scan certification in v2";

--- a/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
@@ -20,6 +20,8 @@
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
+#include "velox/core/PlanFragment.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
 
 namespace facebook::axiom::optimizer {
 namespace {
@@ -105,6 +107,42 @@ class BucketedExecutionTest : public test::QueryTestBase,
         EXPECT_EQ(hashExchanges, expectedHashExchanges);
       }
       found = true;
+    }
+    EXPECT_TRUE(found) << "Expected at least one bucketed fragment";
+  }
+
+  // Asserts the bucketed fragment's Velox grouped-execution metadata.
+  static void expectGroupedExecution(
+      const MultiFragmentPlan& plan,
+      bool grouped) {
+    bool found = false;
+    for (const auto& fragment : plan.fragments()) {
+      if (fragment.groupedNodes.empty()) {
+        continue;
+      }
+      found = true;
+      ASSERT_TRUE(fragment.numSplitGroups.has_value());
+      EXPECT_GT(*fragment.numSplitGroups, 0);
+
+      const auto& veloxFragment = fragment.fragment;
+      if (!grouped) {
+        EXPECT_FALSE(veloxFragment.isGroupedExecution());
+        EXPECT_TRUE(veloxFragment.groupedExecutionLeafNodeIds.empty());
+        continue;
+      }
+
+      EXPECT_TRUE(veloxFragment.isGroupedExecution());
+      EXPECT_EQ(veloxFragment.numSplitGroups, *fragment.numSplitGroups);
+
+      size_t bucketedScans = 0;
+      for (const auto& [nodeId, partitionType] : fragment.groupedNodes) {
+        if (partitionType != nullptr) {
+          ++bucketedScans;
+          EXPECT_TRUE(veloxFragment.leafNodeRunsGroupedExecution(nodeId));
+        }
+      }
+      EXPECT_EQ(
+          veloxFragment.groupedExecutionLeafNodeIds.size(), bucketedScans);
     }
     EXPECT_TRUE(found) << "Expected at least one bucketed fragment";
   }
@@ -202,6 +240,255 @@ TEST_P(BucketedExecutionTest, join) {
           .fragment({.width = 4, .bucketedScans = 1, .bucketedExchanges = 1})
           .gather()
           .build());
+}
+
+TEST_P(BucketedExecutionTest, groupedExecutionFlag) {
+  addBucketedTable("ge_orders", {"customer_id"}, 128);
+  addBucketedTable(
+      "ge_customers", {"id"}, 128, ROW({"id", "name"}, {BIGINT(), VARCHAR()}));
+
+  const auto logicalPlan = parseSelect(
+      "SELECT * FROM ge_orders JOIN ge_customers "
+      "ON ge_orders.customer_id = ge_customers.id",
+      kTestConnectorId);
+
+  {
+    auto plan = planVelox(
+        logicalPlan,
+        {.numWorkers = 4, .numDrivers = 4, .groupedExecution = true},
+        optimizerOptions_);
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    expectGroupedExecution(*plan.plan, /*grouped=*/useV2_);
+  }
+
+  {
+    auto plan = planVelox(
+        logicalPlan,
+        {.numWorkers = 4, .numDrivers = 4, .groupedExecution = false},
+        optimizerOptions_);
+    expectBucketedFragmentWithWidth(*plan.plan, 4);
+    expectGroupedExecution(*plan.plan, /*grouped=*/false);
+  }
+}
+
+TEST_P(BucketedExecutionTest, groupedExecutionSkipsScanOnlyFragment) {
+  addBucketedTable("ge_scan_only", {"customer_id"}, 128);
+
+  auto plan = planVelox(
+      parseSelect("SELECT customer_id FROM ge_scan_only", kTestConnectorId),
+      {.numWorkers = 4, .numDrivers = 4, .groupedExecution = true},
+      optimizerOptions_);
+
+  for (const auto& fragment : plan.plan->fragments()) {
+    EXPECT_FALSE(fragment.fragment.isGroupedExecution());
+  }
+}
+
+TEST_P(BucketedExecutionTest, groupedExecutionRunsEndToEnd) {
+  if (!useV2_) {
+    GTEST_SKIP() << "Grouped execution requires scan certification in v2";
+  }
+  // 8 buckets over 2 workers, so each task processes multiple split groups.
+  const auto schema = ROW({"customer_id", "amount"}, {BIGINT(), DOUBLE()});
+  testConnector_->addTable(
+      "ge_run",
+      schema,
+      velox::ROW({}),
+      connector::TestBucketSpec{{"customer_id"}, 8});
+  testConnector_->appendData(
+      "ge_run",
+      makeRowVector(
+          {"customer_id", "amount"},
+          {makeFlatVector<int64_t>(
+               200, [](auto row) { return static_cast<int64_t>(row % 40); }),
+           makeFlatVector<double>(
+               200, [](auto row) { return static_cast<double>(row); })}));
+
+  const auto logicalPlan = parseSelect(
+      "SELECT customer_id, count(*), sum(amount) "
+      "FROM ge_run GROUP BY customer_id",
+      kTestConnectorId);
+
+  auto grouped = runVelox(
+      logicalPlan,
+      {.numWorkers = 2, .numDrivers = 2, .groupedExecution = true});
+  auto ungrouped = runVelox(
+      logicalPlan,
+      {.numWorkers = 2, .numDrivers = 2, .groupedExecution = false});
+
+  velox::exec::test::assertEqualResults(grouped.results, ungrouped.results);
+
+  size_t groupedSplitGroups = 0;
+  for (const auto& stageStats : grouped.stats) {
+    groupedSplitGroups += stageStats.completedSplitGroups.size();
+  }
+  EXPECT_GT(groupedSplitGroups, 0)
+      << "grouped run must complete at least one split group";
+
+  for (const auto& stageStats : ungrouped.stats) {
+    EXPECT_TRUE(stageStats.completedSplitGroups.empty());
+  }
+}
+
+TEST_P(BucketedExecutionTest, groupedJoinRunsEndToEnd) {
+  if (!useV2_) {
+    GTEST_SKIP() << "Grouped execution requires scan certification in v2";
+  }
+  // Two co-bucketed tables on the join key: build bucket N and probe bucket N
+  // run in the same split group, so the hash join executes co-located without a
+  // shuffle. Exercises a multi-source grouped pipeline (the case that a single
+  // grouped scan does not).
+  testConnector_->addTable(
+      "gj_orders",
+      ROW({"customer_id", "amount"}, {BIGINT(), DOUBLE()}),
+      velox::ROW({}),
+      connector::TestBucketSpec{{"customer_id"}, 8});
+  testConnector_->appendData(
+      "gj_orders",
+      makeRowVector(
+          {"customer_id", "amount"},
+          {makeFlatVector<int64_t>(
+               200, [](auto row) { return static_cast<int64_t>(row % 40); }),
+           makeFlatVector<double>(
+               200, [](auto row) { return static_cast<double>(row); })}));
+
+  testConnector_->addTable(
+      "gj_customers",
+      ROW({"id", "tag"}, {BIGINT(), BIGINT()}),
+      velox::ROW({}),
+      connector::TestBucketSpec{{"id"}, 8});
+  testConnector_->appendData(
+      "gj_customers",
+      makeRowVector(
+          {"id", "tag"},
+          {makeFlatVector<int64_t>(
+               40, [](auto row) { return static_cast<int64_t>(row); }),
+           makeFlatVector<int64_t>(
+               40, [](auto row) { return static_cast<int64_t>(row * 10); })}));
+
+  const auto logicalPlan = parseSelect(
+      "SELECT o.customer_id, o.amount, c.tag "
+      "FROM gj_orders o JOIN gj_customers c ON o.customer_id = c.id",
+      kTestConnectorId);
+
+  auto grouped = runVelox(
+      logicalPlan,
+      {.numWorkers = 2, .numDrivers = 2, .groupedExecution = true});
+  auto ungrouped = runVelox(
+      logicalPlan,
+      {.numWorkers = 2, .numDrivers = 2, .groupedExecution = false});
+
+  velox::exec::test::assertEqualResults(grouped.results, ungrouped.results);
+
+  size_t groupedSplitGroups = 0;
+  for (const auto& stageStats : grouped.stats) {
+    groupedSplitGroups += stageStats.completedSplitGroups.size();
+  }
+  EXPECT_GT(groupedSplitGroups, 0)
+      << "grouped join must complete at least one split group";
+}
+
+TEST_P(BucketedExecutionTest, groupedUnionRunsEndToEnd) {
+  if (!useV2_) {
+    GTEST_SKIP() << "Grouped execution requires scan certification in v2";
+  }
+  // UNION ALL of two co-bucketed tables feeding a bucketed aggregation. Both
+  // union legs are grouped, so the local exchange under the union runs grouped
+  // too (the case that errors when only some sources are grouped).
+  for (const auto& name : {"gu_a", "gu_b"}) {
+    testConnector_->addTable(
+        name,
+        ROW({"customer_id", "amount"}, {BIGINT(), DOUBLE()}),
+        velox::ROW({}),
+        connector::TestBucketSpec{{"customer_id"}, 8});
+    testConnector_->appendData(
+        name,
+        makeRowVector(
+            {"customer_id", "amount"},
+            {makeFlatVector<int64_t>(
+                 200, [](auto row) { return static_cast<int64_t>(row % 40); }),
+             makeFlatVector<double>(
+                 200, [](auto row) { return static_cast<double>(row); })}));
+  }
+
+  const auto logicalPlan = parseSelect(
+      "SELECT customer_id, count(*), sum(amount) FROM ("
+      "  SELECT customer_id, amount FROM gu_a"
+      "  UNION ALL"
+      "  SELECT customer_id, amount FROM gu_b"
+      ") GROUP BY customer_id",
+      kTestConnectorId);
+
+  auto grouped = runVelox(
+      logicalPlan,
+      {.numWorkers = 2, .numDrivers = 2, .groupedExecution = true});
+  auto ungrouped = runVelox(
+      logicalPlan,
+      {.numWorkers = 2, .numDrivers = 2, .groupedExecution = false});
+
+  velox::exec::test::assertEqualResults(grouped.results, ungrouped.results);
+
+  size_t groupedSplitGroups = 0;
+  for (const auto& stageStats : grouped.stats) {
+    groupedSplitGroups += stageStats.completedSplitGroups.size();
+  }
+  EXPECT_GT(groupedSplitGroups, 0)
+      << "grouped union must complete at least one split group";
+}
+
+TEST_P(BucketedExecutionTest, groupedMixedJoinRunsEndToEnd) {
+  if (!useV2_) {
+    GTEST_SKIP() << "Grouped execution requires scan certification in v2";
+  }
+  // Mixed grouped execution: a bucketed probe joined with an unbucketed build
+  // that is shuffled into the bucketed fragment. The probe pipeline runs
+  // grouped while the build (behind a remote exchange) runs ungrouped, sharing
+  // a single build hash table across all probe split groups.
+  testConnector_->addTable(
+      "gmj_orders",
+      ROW({"customer_id", "amount"}, {BIGINT(), DOUBLE()}),
+      velox::ROW({}),
+      connector::TestBucketSpec{{"customer_id"}, 8});
+  testConnector_->appendData(
+      "gmj_orders",
+      makeRowVector(
+          {"customer_id", "amount"},
+          {makeFlatVector<int64_t>(
+               200, [](auto row) { return static_cast<int64_t>(row % 40); }),
+           makeFlatVector<double>(
+               200, [](auto row) { return static_cast<double>(row); })}));
+
+  testConnector_->addTable(
+      "gmj_extras", ROW({"customer_id", "extra"}, {BIGINT(), BIGINT()}));
+  testConnector_->appendData(
+      "gmj_extras",
+      makeRowVector(
+          {"customer_id", "extra"},
+          {makeFlatVector<int64_t>(
+               40, [](auto row) { return static_cast<int64_t>(row); }),
+           makeFlatVector<int64_t>(
+               40, [](auto row) { return static_cast<int64_t>(row * 100); })}));
+
+  const auto logicalPlan = parseSelect(
+      "SELECT o.customer_id, o.amount, e.extra "
+      "FROM gmj_orders o JOIN gmj_extras e ON o.customer_id = e.customer_id",
+      kTestConnectorId);
+
+  auto grouped = runVelox(
+      logicalPlan,
+      {.numWorkers = 2, .numDrivers = 2, .groupedExecution = true});
+  auto ungrouped = runVelox(
+      logicalPlan,
+      {.numWorkers = 2, .numDrivers = 2, .groupedExecution = false});
+
+  velox::exec::test::assertEqualResults(grouped.results, ungrouped.results);
+
+  size_t groupedSplitGroups = 0;
+  for (const auto& stageStats : grouped.stats) {
+    groupedSplitGroups += stageStats.completedSplitGroups.size();
+  }
+  EXPECT_GT(groupedSplitGroups, 0)
+      << "grouped mixed join must complete at least one split group";
 }
 
 TEST_P(BucketedExecutionTest, semijoin) {

--- a/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
@@ -1217,6 +1217,48 @@ TEST_P(BucketedExecutionTest, bucketColumnRenamedByProjection) {
   }
 }
 
+TEST_P(BucketedExecutionTest, partitionSelectionControlsStorageBucketing) {
+  if (!useV2_) {
+    GTEST_SKIP();
+  }
+
+  addBucketedTable("selected_orders", {"customer_id"}, 16);
+  testConnector_->setPartitionsConsistent("selected_orders", false);
+
+  auto plan = planDistributed(parseSelect(
+      "SELECT customer_id, count(*) FROM selected_orders "
+      "GROUP BY customer_id",
+      kTestConnectorId));
+
+  ASSERT_EQ(plan.plan->scanPartitionSelections().size(), 1);
+  const auto& selection = plan.plan->scanPartitionSelections().begin()->second;
+  ASSERT_NE(selection, nullptr);
+  EXPECT_EQ(selection->partitions.size(), 16);
+  EXPECT_EQ(selection->storagePartitionType, nullptr);
+  for (const auto& fragment : plan.plan->fragments()) {
+    EXPECT_TRUE(fragment.groupedNodes.empty());
+  }
+}
+
+TEST_P(BucketedExecutionTest, partitionSelectionReachesPlanOutput) {
+  if (!useV2_) {
+    GTEST_SKIP();
+  }
+
+  addBucketedTable("selected_bucketed_orders", {"customer_id"}, 16);
+  auto plan = planDistributed(parseSelect(
+      "SELECT customer_id, count(*) FROM selected_bucketed_orders "
+      "GROUP BY customer_id",
+      kTestConnectorId));
+
+  ASSERT_EQ(plan.plan->scanPartitionSelections().size(), 1);
+  const auto& selection = plan.plan->scanPartitionSelections().begin()->second;
+  ASSERT_NE(selection, nullptr);
+  EXPECT_EQ(selection->partitions.size(), 16);
+  EXPECT_NE(selection->storagePartitionType, nullptr);
+  expectBucketedFragmentWithWidth(*plan.plan, 4);
+}
+
 AXIOM_INSTANTIATE_V1_V2(BucketedExecutionTest);
 
 } // namespace

--- a/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include "axiom/connectors/hive/HiveConnectorMetadata.h"
 #include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
 
 namespace facebook::axiom::optimizer {
 namespace {
@@ -89,6 +90,31 @@ class HiveBucketedExecutionTest : public test::HiveQueriesTestBase,
         logicalPlan,
         {.numWorkers = numWorkers, .numDrivers = 4},
         optimizerOptions_);
+  }
+
+  // Runs 'sql' distributed with grouped execution on and off, checks the
+  // results match, and returns the number of completed split groups reported
+  // for the grouped run (per-fragment, so groups a single task processed).
+  // Zero means grouped execution did not run; the ungrouped run must report no
+  // split groups at all.
+  size_t runGroupedVsUngrouped(const std::string& sql) {
+    const auto logicalPlan = parseSelect(sql);
+    auto grouped = runVelox(
+        logicalPlan,
+        {.numWorkers = 4, .numDrivers = 4, .groupedExecution = true});
+    auto ungrouped = runVelox(
+        logicalPlan,
+        {.numWorkers = 4, .numDrivers = 4, .groupedExecution = false});
+    velox::exec::test::assertEqualResults(grouped.results, ungrouped.results);
+
+    size_t splitGroups = 0;
+    for (const auto& stageStats : grouped.stats) {
+      splitGroups += stageStats.completedSplitGroups.size();
+    }
+    for (const auto& stageStats : ungrouped.stats) {
+      EXPECT_TRUE(stageStats.completedSplitGroups.empty());
+    }
+    return splitGroups;
   }
 
   std::vector<std::string> tablesToDrop_;
@@ -657,6 +683,62 @@ TEST_P(HiveBucketedExecutionTest, unionAllWithUnbucketedLeg) {
             .gather()
             .build());
   }
+}
+
+TEST_P(HiveBucketedExecutionTest, groupedAggregationRunsEndToEnd) {
+  if (!useV2_) {
+    GTEST_SKIP() << "Grouped execution requires scan certification in v2";
+  }
+  createBucketedTable("ge_agg", 16, {"c_nationkey"}, "SELECT * FROM customer");
+  const auto splitGroups = runGroupedVsUngrouped(
+      "SELECT c_nationkey, count(*) FROM ge_agg GROUP BY 1");
+  EXPECT_GT(splitGroups, 0)
+      << "grouped aggregation must complete at least one split group";
+}
+
+TEST_P(HiveBucketedExecutionTest, groupedJoinRunsEndToEnd) {
+  if (!useV2_) {
+    GTEST_SKIP() << "Grouped execution requires scan certification in v2";
+  }
+  createBucketedTable(
+      "ge_t",
+      16,
+      {"c_nationkey"},
+      "SELECT c_custkey, c_nationkey FROM customer");
+  createBucketedTable(
+      "ge_u",
+      16,
+      {"c_nationkey"},
+      "SELECT DISTINCT c_nationkey, cast(c_nationkey as varchar) as label FROM customer");
+  const auto splitGroups = runGroupedVsUngrouped(
+      "SELECT * FROM ge_t, ge_u WHERE ge_t.c_nationkey = ge_u.c_nationkey");
+  EXPECT_GT(splitGroups, 0)
+      << "co-located grouped join must complete at least one split group";
+}
+
+TEST_P(
+    HiveBucketedExecutionTest,
+    groupedJoinDifferentBucketCountsRunsEndToEnd) {
+  if (!useV2_) {
+    GTEST_SKIP() << "Grouped execution requires scan certification in v2";
+  }
+  // 8 divides 16, so the sides co-partition on a common 8-group space; a key in
+  // the 16-bucket table's bucket b co-locates with the 8-bucket table's bucket
+  // b % 8.
+  createBucketedTable(
+      "ge_t16",
+      16,
+      {"c_nationkey"},
+      "SELECT c_custkey, c_nationkey FROM customer");
+  createBucketedTable(
+      "ge_u8",
+      8,
+      {"c_nationkey"},
+      "SELECT DISTINCT c_nationkey, cast(c_nationkey as varchar) as label FROM customer");
+  const auto splitGroups = runGroupedVsUngrouped(
+      "SELECT * FROM ge_t16, ge_u8 WHERE ge_t16.c_nationkey = ge_u8.c_nationkey");
+  EXPECT_GT(splitGroups, 0)
+      << "grouped join across differing bucket counts must complete at least one split group";
 }
 
 AXIOM_INSTANTIATE_V1_V2(HiveBucketedExecutionTest);

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -1806,6 +1806,20 @@ void Emitter::finalizeGroupedLeaves(ExecutableFragment& fragment) {
   }
   fragment.type = FragmentType::kFixed;
   fragment.width = folded->numPartitions();
+
+  const int32_t numGroups = folded->numGroups();
+  fragment.numSplitGroups = numGroups;
+
+  if (options_.groupedExecution) {
+    fragment.fragment.executionStrategy =
+        velox::core::ExecutionStrategy::kGrouped;
+    fragment.fragment.numSplitGroups = numGroups;
+    for (const auto& [nodeId, partitionType] : fragment.groupedNodes) {
+      if (partitionType != nullptr) {
+        fragment.fragment.groupedExecutionLeafNodeIds.insert(nodeId);
+      }
+    }
+  }
 }
 
 velox::core::PlanNodePtr Emitter::emitChildFragment(

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -582,6 +582,9 @@ class Emitter {
   // takePrediction.
   NodePredictionMap prediction_;
 
+  // Selected partitions keyed by emitted TableScanNode ID.
+  ScanPartitionSelectionMap scanPartitionSelections_;
+
  public:
   // Lowers 'root' (plus the output rename to 'outputNames') into fragments,
   // returning them with the root fragment last.
@@ -599,6 +602,10 @@ class Emitter {
   // Transfers the per-node cardinality predictions collected during emit.
   NodePredictionMap takePrediction() {
     return std::move(prediction_);
+  }
+
+  ScanPartitionSelectionMap takeScanPartitionSelections() {
+    return std::move(scanPartitionSelections_);
   }
 };
 
@@ -656,6 +663,10 @@ velox::core::PlanNodePtr Emitter::emitScan(const Scan& scan) {
       velox::ROW(std::move(scanOutputNames), std::move(scanOutputTypes)),
       tableHandle,
       std::move(assignments));
+
+  if (handle.partitionSelection != nullptr) {
+    scanPartitionSelections_.emplace(scanNode->id(), handle.partitionSelection);
+  }
 
   // A grouped scan makes its fragment bucketed.
   if (const auto* partitionType = scan.groupedPartitionType()) {
@@ -2337,7 +2348,8 @@ EmitPass::Result EmitPass::run(
   return Result{
       std::move(fragments),
       emitter.takeFinishWrite(),
-      emitter.takePrediction()};
+      emitter.takePrediction(),
+      emitter.takeScanPartitionSelections()};
 }
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/EmitPass.h
+++ b/axiom/optimizer/v2/EmitPass.h
@@ -37,6 +37,8 @@ class EmitPass {
     /// Per-node estimates, keyed by emitted `PlanNodeId`, for EXPLAIN. Empty
     /// when estimates are unavailable.
     NodePredictionMap prediction;
+    /// Query-local partition selections keyed by emitted TableScanNode ID.
+    ScanPartitionSelectionMap scanPartitionSelections;
   };
 
   /// Lowers the tree-IR rooted at 'root' into fragments, projecting to the

--- a/axiom/optimizer/v2/EstimateLeafStatsPass.cpp
+++ b/axiom/optimizer/v2/EstimateLeafStatsPass.cpp
@@ -126,6 +126,7 @@ void EstimateLeafStatsPass::run(NodeCP root, const OptimizerSession& session) {
     requests.push_back(layout->co_estimateStats(
         std::move(connectorSession),
         handle->tableHandle,
+        handle->partitionSelection,
         std::move(columnNames),
         estimator));
   }

--- a/axiom/optimizer/v2/FoldMetadataAggregatePass.cpp
+++ b/axiom/optimizer/v2/FoldMetadataAggregatePass.cpp
@@ -136,6 +136,7 @@ class Folder : public NodeRewriter<NoContext> {
     auto result = folly::coro::blockingWait(layout->co_metadataCounts(
         std::move(connectorSession),
         handle.tableHandle,
+        handle.partitionSelection,
         std::move(groupingColumns),
         std::move(nullCountColumns)));
     if (!result.has_value()) {

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -16,6 +16,8 @@
 
 #include "axiom/optimizer/v2/Node.h"
 
+#include "axiom/optimizer/v2/ScanHandle.h"
+
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/optimizer/Schema.h"
 #include "axiom/optimizer/v2/KeyHash.h"
@@ -611,8 +613,14 @@ size_t Scan::KeyHash::operator()(const Scan* node) const {
 
 Partitioning Scan::storageBucketing() const {
   const connector::TableLayout* layout = baseTable_->layout();
-  return bucketPartition(
-      layout, outputColumns(), layout->partitionType().get());
+  // A missing selection means this connector did not opt into per-scan
+  // certification, so preserve its declared layout. A present selection with a
+  // null storagePartitionType is an explicit unbucketed result.
+  const auto* storagePartitionType =
+      scanHandle_ != nullptr && scanHandle_->partitionSelection != nullptr
+      ? scanHandle_->partitionSelection->storagePartitionType.get()
+      : layout->partitionType().get();
+  return bucketPartition(layout, outputColumns(), storagePartitionType);
 }
 
 size_t Scan::KeyHash::operator()(const Key& key) const {

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -175,7 +175,9 @@ PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
 
   PlanAndStats result;
   result.plan = std::make_shared<MultiFragmentPlan>(
-      std::move(emitted.fragments), planOptions);
+      std::move(emitted.fragments),
+      planOptions,
+      std::move(emitted.scanPartitionSelections));
   result.plan->checkConsistency(
       /*mayBeEmpty=*/plan_.is(logical_plan::NodeKind::kTableWrite));
   result.finishWrite = std::move(emitted.finishWrite);

--- a/axiom/optimizer/v2/ScanHandle.cpp
+++ b/axiom/optimizer/v2/ScanHandle.cpp
@@ -16,9 +16,11 @@
 
 #include "axiom/optimizer/v2/ScanHandle.h"
 
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/optimizer/QueryGraph.h"
 #include "axiom/optimizer/Schema.h"
 #include "axiom/optimizer/v2/ExprEmitter.h"
+#include "folly/coro/BlockingWait.h"
 
 namespace facebook::axiom::optimizer::v2 {
 
@@ -91,6 +93,19 @@ ScanHandle ScanHandle::build(
           std::move(typedFilters),
           rejectedFilterIndices);
 
+  connector::PartitionSelectionPtr partitionSelection;
+  // Some connectors provide table layouts without a registered
+  // ConnectorMetadata. Registered connectors resolve the exact selection
+  // through their split manager.
+  if (auto metadata =
+          connector::ConnectorMetadataRegistry::tryGet(layout->connectorId())) {
+    if (auto* splitManager = metadata->splitManager()) {
+      partitionSelection = std::make_shared<connector::PartitionSelection>(
+          folly::coro::blockingWait(splitManager->co_selectPartitions(
+              connectorSession, tableHandle, layout->partitionType())));
+    }
+  }
+
   // Each rejected index selects a conjunct the caller must apply above the
   // scan; the rest are the connector's responsibility, inside 'tableHandle'.
   for (int32_t index : rejectedFilterIndices) {
@@ -115,6 +130,7 @@ ScanHandle ScanHandle::build(
 
   return ScanHandle{
       .tableHandle = std::move(tableHandle),
+      .partitionSelection = std::move(partitionSelection),
       .columnHandles = std::move(columnHandles),
   };
 }

--- a/axiom/optimizer/v2/ScanHandle.h
+++ b/axiom/optimizer/v2/ScanHandle.h
@@ -18,6 +18,7 @@
 
 #include <folly/container/F14Map.h>
 
+#include "axiom/connectors/ConnectorSplitManager.h"
 #include "axiom/optimizer/OptimizerSession.h"
 #include "axiom/optimizer/QueryGraph.h"
 #include "velox/connectors/Connector.h"
@@ -43,6 +44,10 @@ struct ScanHandle {
 
   /// Table handle with the accepted filters pushed into the connector.
   velox::connector::ConnectorTableHandlePtr tableHandle;
+
+  /// Exact versioned partitions selected for this scan and the storage
+  /// partitioning certified across them.
+  connector::PartitionSelectionPtr partitionSelection;
 
   /// Column handle per column of the connector read schema: every column the
   /// `Scan` outputs, plus the ones only the connector's own filters read,

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -933,15 +933,52 @@ std::vector<velox::exec::TaskStats> LocalRunner::aggregatedStats() const {
   for (const auto& tasks : stages_) {
     VELOX_CHECK(!tasks.empty());
 
-    auto stats = tasks[0]->taskStats();
-    for (auto i = 1; i < tasks.size(); ++i) {
+    const auto hasOperatorStats = [](const velox::exec::TaskStats& stats) {
+      return std::any_of(
+          stats.pipelineStats.begin(),
+          stats.pipelineStats.end(),
+          [](const auto& pipeline) { return !pipeline.operatorStats.empty(); });
+    };
+    size_t baseTaskIndex{0};
+    while (baseTaskIndex < tasks.size() &&
+           !hasOperatorStats(tasks[baseTaskIndex]->taskStats())) {
+      ++baseTaskIndex;
+    }
+    if (baseTaskIndex == tasks.size()) {
+      baseTaskIndex = 0;
+    }
+
+    auto stats = tasks[baseTaskIndex]->taskStats();
+    for (size_t i = 0; i < tasks.size(); ++i) {
+      if (i == baseTaskIndex) {
+        continue;
+      }
       const auto moreStats = tasks[i]->taskStats();
-      for (auto pipeline = 0; pipeline < stats.pipelineStats.size();
+      stats.completedSplitGroups.insert(
+          moreStats.completedSplitGroups.begin(),
+          moreStats.completedSplitGroups.end());
+      if (moreStats.pipelineStats.empty()) {
+        continue;
+      }
+      VELOX_CHECK_EQ(
+          stats.pipelineStats.size(), moreStats.pipelineStats.size());
+      for (size_t pipeline = 0; pipeline < stats.pipelineStats.size();
            ++pipeline) {
         auto& pipelineStats = stats.pipelineStats[pipeline];
-        for (auto op = 0; op < pipelineStats.operatorStats.size(); ++op) {
+        const auto& morePipelineStats = moreStats.pipelineStats[pipeline];
+        if (morePipelineStats.operatorStats.empty()) {
+          continue;
+        }
+        if (pipelineStats.operatorStats.empty()) {
+          pipelineStats = morePipelineStats;
+          continue;
+        }
+        VELOX_CHECK_EQ(
+            pipelineStats.operatorStats.size(),
+            morePipelineStats.operatorStats.size());
+        for (size_t op = 0; op < pipelineStats.operatorStats.size(); ++op) {
           pipelineStats.operatorStats[op].add(
-              moreStats.pipelineStats[pipeline].operatorStats[op]);
+              morePipelineStats.operatorStats[op]);
         }
       }
     }

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -65,6 +65,7 @@ std::shared_ptr<connector::SplitSource>
 SimpleSplitSourceFactory::splitSourceForScan(
     const connector::ConnectorSessionPtr& /* session */,
     const velox::core::TableScanNode& scan,
+    connector::PartitionSelectionPtr /*partitionSelection*/,
     const std::shared_ptr<connector::PartitionType>& /*partitionType*/,
     std::optional<double> samplePercentage) {
   VELOX_USER_CHECK(
@@ -81,6 +82,7 @@ std::shared_ptr<connector::SplitSource>
 ConnectorSplitSourceFactory::splitSourceForScan(
     const connector::ConnectorSessionPtr& session,
     const velox::core::TableScanNode& scan,
+    connector::PartitionSelectionPtr partitionSelection,
     const std::shared_ptr<connector::PartitionType>& partitionType,
     std::optional<double> samplePercentage) {
   const auto& handle = scan.tableHandle();
@@ -88,26 +90,33 @@ ConnectorSplitSourceFactory::splitSourceForScan(
       connector::ConnectorMetadataRegistry::get(handle->connectorId());
   auto splitManager = metadata->splitManager();
 
-  auto listCpuStart = velox::process::threadCpuNanos();
-  auto listThreadId = std::this_thread::get_id();
-  auto listStart = std::chrono::steady_clock::now();
-  auto partitions = folly::coro::blockingWait(
-      splitManager->co_listPartitions(session, handle));
-  recordCpuIfSameThread(
-      runtimeStats_,
-      QueryRuntimeStats::kListPartitionsCpuNanos,
-      listCpuStart,
-      listThreadId);
-  runtimeStats_.addTiming(
-      QueryRuntimeStats::kListPartitionsWallNanos,
-      std::chrono::steady_clock::now() - listStart);
-  runtimeStats_.addCount(
-      QueryRuntimeStats::kListPartitionsCount, partitions.size());
+  std::vector<connector::PartitionHandlePtr> listedPartitions;
+  const std::vector<connector::PartitionHandlePtr>* partitions;
+  if (partitionSelection != nullptr) {
+    partitions = &partitionSelection->partitions;
+  } else {
+    auto listCpuStart = velox::process::threadCpuNanos();
+    auto listThreadId = std::this_thread::get_id();
+    auto listStart = std::chrono::steady_clock::now();
+    listedPartitions = folly::coro::blockingWait(
+        splitManager->co_listPartitions(session, handle));
+    recordCpuIfSameThread(
+        runtimeStats_,
+        QueryRuntimeStats::kListPartitionsCpuNanos,
+        listCpuStart,
+        listThreadId);
+    runtimeStats_.addTiming(
+        QueryRuntimeStats::kListPartitionsWallNanos,
+        std::chrono::steady_clock::now() - listStart);
+    runtimeStats_.addCount(
+        QueryRuntimeStats::kListPartitionsCount, listedPartitions.size());
+    partitions = &listedPartitions;
+  }
 
   return splitManager->getSplitSource(
       session,
       handle,
-      partitions,
+      *partitions,
       partitionType,
       samplePercentage,
       runtimeStats_);
@@ -528,8 +537,17 @@ std::shared_ptr<connector::SplitSource> LocalRunner::splitSourceForScan(
     const velox::core::TableScanNode& scan,
     const std::shared_ptr<connector::PartitionType>& partitionType,
     std::optional<double> samplePercentage) {
+  connector::PartitionSelectionPtr partitionSelection;
+  if (auto it = plan_->scanPartitionSelections().find(scan.id());
+      it != plan_->scanPartitionSelections().end()) {
+    partitionSelection = it->second;
+  }
   return splitSourceFactory_->splitSourceForScan(
-      session, scan, partitionType, samplePercentage);
+      session,
+      scan,
+      std::move(partitionSelection),
+      partitionType,
+      samplePercentage);
 }
 
 void LocalRunner::cancelTasks() {

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -152,7 +152,7 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
     std::shared_ptr<connector::SplitSource> source,
     velox::core::PlanNodeId scanId,
     std::vector<std::shared_ptr<velox::exec::Task>> tasks,
-    bool grouped,
+    std::optional<int32_t> numSplitGroups,
     std::function<void(std::exception_ptr)> onError,
     QueryRuntimeStats& runtimeStats) {
   std::exception_ptr ex;
@@ -162,12 +162,18 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
   const auto cancelToken = co_await folly::coro::co_current_cancellation_token;
   try {
     VELOX_CHECK(!tasks.empty(), "tasks must not be empty");
+    const bool grouped = numSplitGroups.has_value();
+    if (grouped) {
+      VELOX_CHECK_GT(*numSplitGroups, 0, "numSplitGroups must be positive");
+    }
 
     auto getSplitsCpuStart = velox::process::threadCpuNanos();
     auto getSplitsThreadId = std::this_thread::get_id();
     auto getSplitsStart = std::chrono::steady_clock::now();
     int64_t splitCount = 0;
     size_t taskIdx = 0;
+    // Task each seen group was routed to, for per-group noMoreSplitsForGroup.
+    folly::F14FastMap<int32_t, size_t> groupToTask;
     for (;;) {
       // Teardown requested: the tasks are being reaped, so remaining splits are
       // unnecessary. Bounds the reap's split-scope join to one co_getSplits().
@@ -177,14 +183,29 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
       auto batch = co_await source->co_getSplits(1);
       for (auto& split : batch.splits) {
         size_t targetTask;
+        int32_t groupId{-1};
         if (grouped) {
-          // Grouped execution routes each split to the task owning its group.
-          // The connector tags grouped splits with a groupId in
-          // [0, tasks.size()); same-group splits must share a task.
           VELOX_CHECK(
-              split.groupId.has_value(),
-              "Grouped scan produced a split without a groupId: {}",
+              split.groupId.has_value() && split.partitionId.has_value(),
+              "Grouped scan produced a split without groupId or partitionId: {}",
               scanId);
+          groupId = *split.groupId;
+          VELOX_CHECK_GE(groupId, 0);
+          VELOX_CHECK_LT(groupId, *numSplitGroups);
+          VELOX_CHECK_GE(*split.partitionId, 0);
+          targetTask = static_cast<size_t>(*split.partitionId);
+          VELOX_CHECK_LT(targetTask, tasks.size());
+          auto [it, inserted] = groupToTask.emplace(groupId, targetTask);
+          VELOX_CHECK(
+              inserted || it->second == targetTask,
+              "Split group maps to multiple tasks: {}",
+              groupId);
+        } else if (split.partitionId.has_value()) {
+          VELOX_CHECK_GE(*split.partitionId, 0);
+          targetTask = static_cast<size_t>(*split.partitionId);
+          VELOX_CHECK_LT(targetTask, tasks.size());
+        } else if (split.groupId.has_value()) {
+          // Legacy connectors use groupId as the fixed task index.
           VELOX_CHECK_LT(static_cast<size_t>(*split.groupId), tasks.size());
           targetTask = static_cast<size_t>(*split.groupId);
         } else {
@@ -196,8 +217,20 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
         }
         tasks.at(targetTask)
             ->addSplit(
-                scanId, velox::exec::Split(std::move(split.connectorSplit)));
+                scanId,
+                velox::exec::Split(std::move(split.connectorSplit), groupId));
         ++splitCount;
+      }
+      if (grouped) {
+        for (const auto groupId : batch.noMoreSplitsForGroupId) {
+          VELOX_CHECK_GE(groupId, 0);
+          VELOX_CHECK_LT(groupId, *numSplitGroups);
+          const auto it = groupToTask.find(groupId);
+          const size_t targetTask = it != groupToTask.end()
+              ? it->second
+              : static_cast<size_t>(groupId) % tasks.size();
+          tasks.at(targetTask)->noMoreSplitsForGroup(scanId, groupId);
+        }
       }
       if (batch.noMoreSplits) {
         break;
@@ -776,6 +809,10 @@ void LocalRunner::makeStages(
         fragment.type == optimizer::FragmentType::kSource
             ? plan_->options().numWorkers
             : 1);
+    const uint32_t concurrentSplitGroups =
+        fragment.fragment.isGroupedExecution()
+        ? static_cast<uint32_t>(plan_->options().numConcurrentSplitGroups)
+        : 1;
     for (auto i = 0; i < numTasks; ++i) {
       auto taskId = fmt::format(
           "local://{}/{}.{}",
@@ -801,7 +838,7 @@ void LocalRunner::makeStages(
         std::lock_guard<std::mutex> lock(mutex_);
         stages_.back().push_back(task);
       }
-      task->start(plan_->options().numDrivers);
+      task->start(plan_->options().numDrivers, concurrentSplitGroups);
     }
   }
 
@@ -835,6 +872,10 @@ void LocalRunner::makeStages(
             *scan,
             partitionType,
             samplePercentage);
+        const std::optional<int32_t> numSplitGroups =
+            fragment.fragment.leafNodeRunsGroupedExecution(scan->id())
+            ? fragment.numSplitGroups
+            : std::nullopt;
         splitScope_.add(
             folly::coro::co_withExecutor(
                 params_.queryCtx->executor(),
@@ -842,7 +883,7 @@ void LocalRunner::makeStages(
                     source,
                     scan->id(),
                     stage,
-                    /*grouped=*/partitionType != nullptr,
+                    numSplitGroups,
                     onError,
                     runtimeStats_)));
       }

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -46,6 +46,7 @@ class SplitSourceFactory {
   virtual std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan,
+      connector::PartitionSelectionPtr partitionSelection,
       const std::shared_ptr<connector::PartitionType>& partitionType,
       std::optional<double> samplePercentage) = 0;
 };
@@ -62,6 +63,7 @@ class SimpleSplitSourceFactory : public SplitSourceFactory {
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan,
+      connector::PartitionSelectionPtr partitionSelection,
       const std::shared_ptr<connector::PartitionType>& partitionType,
       std::optional<double> samplePercentage) override;
 
@@ -81,6 +83,7 @@ class ConnectorSplitSourceFactory : public SplitSourceFactory {
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan,
+      connector::PartitionSelectionPtr partitionSelection,
       const std::shared_ptr<connector::PartitionType>& partitionType,
       std::optional<double> samplePercentage) override;
 

--- a/axiom/runner/tests/ProgressReporterTest.cpp
+++ b/axiom/runner/tests/ProgressReporterTest.cpp
@@ -72,11 +72,16 @@ class GatedSplitSourceFactory : public SplitSourceFactory {
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan,
+      connector::PartitionSelectionPtr partitionSelection,
       const std::shared_ptr<connector::PartitionType>& partitionType,
       std::optional<double> samplePercentage) override {
     return std::make_shared<GatedSplitSource>(
         inner_.splitSourceForScan(
-            session, scan, partitionType, samplePercentage),
+            session,
+            scan,
+            std::move(partitionSelection),
+            partitionType,
+            samplePercentage),
         gate_);
   }
 


### PR DESCRIPTION
Summary:
Grouped execution could hang when a fixed task received no split groups. `Task::noMoreSplits()` reduced its partitioned-output driver count to zero while holding the task mutex, and the synchronous output-buffer completion callback tried to reacquire that mutex.

Move output-buffer driver-count updates outside the task lock. LocalRunner now aggregates statistics from tasks whose pipelines have no operators, which is the expected shape for an empty fixed task.

Differential Revision: D118221440
