### PR TITLE
feat(optimizer): Derive filters from a constant join input (#1817)

### DIFF
--- a/axiom/optimizer/tests/FixedPointTest.cpp
+++ b/axiom/optimizer/tests/FixedPointTest.cpp
@@ -129,13 +129,15 @@ TEST_F(FixedPointTest, multipleWorkersRejected) {
 
 TEST_F(FixedPointTest, outerJoinInAnchor) {
   // The anchor outer join remains outer when the step maps NULL to non-NULL.
+  testConnector_->addTable("u", ROW("n", INTEGER()));
+
   auto logicalPlan = parseSelect(
       "WITH RECURSIVE t(n) AS ("
       "  SELECT r.n FROM (VALUES 1) l(k) "
       "  LEFT JOIN (VALUES (2, 2)) r(k, n) ON l.k = r.k "
       "  UNION ALL "
       "  SELECT coalesce(n, 1) FROM t WHERE n IS NULL) "
-      "SELECT t.n FROM t JOIN (VALUES 1) e(n) ON t.n = e.n",
+      "SELECT t.n FROM t JOIN u ON t.n = u.n",
       kTestConnectorId);
 
   auto matcher =
@@ -147,7 +149,7 @@ TEST_F(FixedPointTest, outerJoinInAnchor) {
                           .plan(matchDelta("t", {"n"})
                                     .filter("n IS NULL")
                                     .project({"coalesce(n, 1)"})))
-          .hashJoinInner(matchValues())
+          .hashJoinInner(matchScan("u"))
           .project()
           .build();
   AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
@@ -276,10 +278,14 @@ TEST_F(FixedPointTest, twoRecursionsInJoinRejected) {
 }
 
 TEST_F(FixedPointTest, outerJoinAndFilter) {
+  // A predicate above the fixed point stays there, and still reaches the other
+  // side of the join through the equality.
+  testConnector_->addTable("u", ROW("n", INTEGER()));
+
   auto logicalPlan = parseSelect(
       "WITH RECURSIVE r(n) AS ("
       "VALUES 1 UNION ALL SELECT n + 1 FROM r WHERE n < 10) "
-      "SELECT r.n + 1 FROM r JOIN (VALUES 2) v(n) ON r.n = v.n "
+      "SELECT r.n + 1 FROM r JOIN u ON r.n = u.n "
       "WHERE r.n > 0",
       kTestConnectorId);
 
@@ -292,7 +298,7 @@ TEST_F(FixedPointTest, outerJoinAndFilter) {
                                     .project({"n + 1"})))
           .aliases({"n"})
           .filter("n > 0")
-          .hashJoinInner(matchValues().aliases({"n"}).filter("n > 0"))
+          .hashJoinInner(matchScan("u").aliases({"n"}).filter("n > 0"))
           .project()
           .build();
 

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -2643,6 +2643,84 @@ TEST_P(JoinTest, dphypGreedySnowflake) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
+// An inner join against constant rows restricts the other side to the values
+// those rows hold, so each join key gets a filter on the other input. A
+// one-row input restricts to a single value, leaving the join nothing to do.
+TEST_P(JoinTest, constantInput) {
+  testConnector_->addTable("t", ROW({"a", "b"}, INTEGER()));
+
+  // Several rows restrict the key to their values; the join stays to reject
+  // what the filter admits but no row matches.
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT t.a FROM t JOIN (VALUES 1, 3) AS v(k) ON t.a = v.k");
+    AXIOM_ASSERT_PLAN_V2(
+        plan,
+        matchScan("t")
+            .filter("a in (1, 3)")
+            .hashJoinInner(matchValues())
+            .build());
+  }
+
+  // Each key is restricted on its own.
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT t.a FROM t JOIN (VALUES (1, 5), (3, 5)) AS v(k, m) "
+        "ON t.a = v.k AND t.b = v.m");
+    AXIOM_ASSERT_PLAN_V2(
+        plan,
+        matchScan("t")
+            .filter("a in (1, 3) AND b = 5")
+            .hashJoinInner(matchValues())
+            .build());
+  }
+
+  // Nothing equals null, so a key that holds only nulls empties the join.
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT t.a FROM t JOIN (VALUES CAST(NULL AS INTEGER), "
+        "CAST(NULL AS INTEGER)) AS v(k) ON t.a = v.k");
+    AXIOM_ASSERT_PLAN_V2(plan, matchValues().build());
+  }
+
+  // One row leaves an equality and no join.
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT t.a FROM t JOIN (VALUES 1) AS v(k) ON t.a = v.k");
+    AXIOM_ASSERT_PLAN_V2(plan, matchScan("t").filter("a = 1").build());
+  }
+
+  // The equality reaches the pass above the join rather than as a join key.
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT t.a FROM t, (VALUES 1) AS v(k) WHERE t.a = v.k");
+    AXIOM_ASSERT_PLAN_V2(plan, matchScan("t").filter("a = 1").build());
+  }
+
+  // A value the query selects survives as a projected constant.
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT t.a, v.k FROM t JOIN (VALUES 1) AS v(k) ON t.a = v.k");
+    AXIOM_ASSERT_PLAN_V2(
+        plan, matchScan("t").filter("a = 1").project({"a", "1 as k"}).build());
+  }
+
+  // A left join keeps the rows that match nothing.
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT t.a, v.k FROM t LEFT JOIN (VALUES 1) AS v(k) ON t.a = v.k");
+    AXIOM_ASSERT_PLAN_V2(
+        plan, matchScan("t").hashJoinLeft(matchValues()).project().build());
+  }
+
+  // An inequality against the one row restricts the other input too.
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT t.a FROM t JOIN (VALUES 1) AS v(k) ON t.a > v.k");
+    AXIOM_ASSERT_PLAN_V2(plan, matchScan("t").filter("a > 1").build());
+  }
+}
+
 AXIOM_INSTANTIATE_V1_V2(JoinTest);
 
 } // namespace

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -677,6 +677,14 @@ class PlanMatcherBuilder {
   PlanMatcherBuilder& broadcast(
       std::optional<axiom::optimizer::FragmentType> producer = std::nullopt);
 
+  /// Matches a broadcast shuffle boundary (see broadcast()) only when
+  /// 'condition' is true; otherwise a no-op.
+  PlanMatcherBuilder& broadcastIf(
+      bool condition,
+      std::optional<axiom::optimizer::FragmentType> producer = std::nullopt) {
+    return condition ? broadcast(producer) : *this;
+  }
+
   /// Matches an arbitrary (round-robin) shuffle boundary in a distributed plan.
   /// Verifies that PartitionedOutputNode::isArbitrary() is true. When
   /// 'producer' is set, also asserts the type of the producer fragment this

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -955,6 +955,7 @@ TEST_P(UnnestTest, joinWithConstantUnnest) {
           .project({"array[1, 2] as arr"}, options)
           .unnest({}, {"arr"}, std::nullopt)
           .aliases({"e"})
+          .filterIf(useV2_, "e in (1, 2)")
           .hashJoinInner(matchValues().aliases({"k"}), {.keys = {{"e = k"}}})
           .project({"k as a"})
           .build());
@@ -992,10 +993,13 @@ TEST_P(UnnestTest, joinOfConstantUnnests) {
 TEST_P(UnnestTest, joinEdgeCrossingWithUnnest) {
   const parse::ParseOptions options = {.parseIntegerAsBigint = false};
 
+  testConnector_->addTable("u", ROW({"k", "m"}, INTEGER()))
+      ->setStats(1, {{"k", {.numDistinct = 1}}, {"m", {.numDistinct = 1}}});
+
   auto query =
       "SELECT t.a, e, u.k FROM (VALUES (1, ARRAY[10, 20])) AS t(a, arr) "
       "CROSS JOIN UNNEST(arr) AS w(e) "
-      "JOIN (VALUES (1, 10)) AS u(k, m) ON u.k = t.a AND u.m = e";
+      "JOIN u ON u.k = t.a AND u.m = e";
   SCOPED_TRACE(query);
 
   auto logicalPlan = parseSelect(query, kTestConnectorId);
@@ -1004,7 +1008,7 @@ TEST_P(UnnestTest, joinEdgeCrossingWithUnnest) {
       ? matchValues()
             .aliases({"a", "arr"})
             .hashJoinInner(
-                matchValues().aliases({"k", "m"}), {.keys = {{"a = k"}}})
+                matchScan("u").aliases({"k", "m"}), {.keys = {{"a = k"}}})
             .unnest({"a", "m"}, {"arr"})
             .aliases({"a", "m", "e"})
             .filter("eq(e, m)")
@@ -1015,7 +1019,7 @@ TEST_P(UnnestTest, joinEdgeCrossingWithUnnest) {
             .unnest({"a"}, {"arr"})
             .aliases({"a", "e"})
             .hashJoinInner(
-                matchValues().aliases({"k", "m"}),
+                matchScan("u").aliases({"k", "m"}),
                 {.keys = {{"a = k", "e = m"}}})
             .project()
             .build();
@@ -1054,11 +1058,14 @@ TEST_P(UnnestTest, inSubqueryOverUnnest) {
 // An expansion goes above a join that does not read what it produces, so the
 // join runs on the rows before they multiply.
 TEST_P(UnnestTest, unnestPlacedAboveJoin) {
+  testConnector_->addTable("s", ROW("a", INTEGER()))
+      ->setStats(1, {{"a", {.numDistinct = 1}}});
+
   auto query =
       "SELECT s.a, e "
       "FROM (VALUES (1, ARRAY[10, 20])) AS m(k, data) "
       "CROSS JOIN UNNEST(m.data) AS t(e) "
-      "JOIN (VALUES (1)) AS s(a) ON s.a = m.k";
+      "JOIN s ON s.a = m.k";
   SCOPED_TRACE(query);
 
   auto logicalPlan = parseSelect(query, kTestConnectorId);
@@ -1070,31 +1077,34 @@ TEST_P(UnnestTest, unnestPlacedAboveJoin) {
     return;
   }
 
-  auto matcher =
-      matchValues()
-          .aliases({"k", "data"})
-          .hashJoinInner(matchValues().aliases({"a"}), {.keys = {{"k = a"}}})
-          .unnest({"a"}, {"data"})
-          .project()
-          .build();
+  auto makeMatcher = [](bool distributed) {
+    return matchValues()
+        .aliases({"k", "data"})
+        .hashJoinInner(
+            matchScan("s").aliases({"a"}).broadcastIf(distributed),
+            {.keys = {{"k = a"}}})
+        .unnest({"a"}, {"data"})
+        .project()
+        .build();
+  };
 
   {
     SCOPED_TRACE("cost-based enumeration");
-    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), makeMatcher(false));
 
     auto distributed =
         planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributed.plan, matcher);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributed.plan, makeMatcher(true));
   }
 
   {
     SCOPED_TRACE("greedy fallback");
     optimizerOptions_.dphypEnumerationBudget = 1;
-    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), makeMatcher(false));
 
     auto distributed =
         planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributed.plan, matcher);
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(distributed.plan, makeMatcher(true));
   }
 }
 

--- a/axiom/optimizer/v2/ExprFactory.cpp
+++ b/axiom/optimizer/v2/ExprFactory.cpp
@@ -92,6 +92,16 @@ ExprCP ExprFactory::makeEq(ExprCP lhs, ExprCP rhs) {
       builder_.functionNames().equality, {lhs, rhs}, /*specialForm=*/false);
 }
 
+ExprCP ExprFactory::makeIn(ExprCP value, ExprVector list) {
+  VELOX_CHECK(!list.empty());
+  ExprVector arguments;
+  arguments.reserve(list.size() + 1);
+  arguments.push_back(value);
+  arguments.insert(arguments.end(), list.begin(), list.end());
+  return makeBooleanCall(
+      SpecialFormCallNames::kIn, std::move(arguments), /*specialForm=*/true);
+}
+
 ExprCP ExprFactory::makeLessThanOrEqual(ExprCP lhs, ExprCP rhs) {
   const Name name = builder_.functionNames().lte;
   VELOX_USER_CHECK_NOT_NULL(

--- a/axiom/optimizer/v2/ExprFactory.h
+++ b/axiom/optimizer/v2/ExprFactory.h
@@ -71,6 +71,9 @@ class ExprFactory {
   /// Builds `lhs = rhs`.
   ExprCP makeEq(ExprCP lhs, ExprCP rhs);
 
+  /// Builds `value IN (list...)`. 'list' must not be empty.
+  ExprCP makeIn(ExprCP value, ExprVector list);
+
   /// Builds `lhs <= rhs`.
   ExprCP makeLessThanOrEqual(ExprCP lhs, ExprCP rhs);
 

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -1140,6 +1140,11 @@ Values::Values(Key key)
   }
 }
 
+const velox::Variant& Values::valueAt(size_t row, size_t column) const {
+  VELOX_CHECK_NOT_NULL(rows_);
+  return rows_->array()[row].row()[channels_[column]];
+}
+
 size_t Values::cardinality() const {
   if (rows_ != nullptr) {
     return rows_->array().size();

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -972,6 +972,10 @@ class Values : public Node {
   /// `Variant`s or by the logical node.
   size_t cardinality() const;
 
+  /// Value of `outputColumns()[column]` in row 'row'. Only for folded rows,
+  /// i.e. when `rows()` is set.
+  const velox::Variant& valueAt(size_t row, size_t column) const;
+
   std::span<const NodeCP> inputs() const override {
     return {};
   }

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -254,13 +254,17 @@ bool canPushLeft(velox::core::JoinType joinType, bool leftOnly) {
 
 // Returns the cross-side `Column == Column` equi-pairs reachable on
 // `node` — either explicitly via `leftKeys`/`rightKeys` or as
-// `eq(Column, Column)` conjuncts in the join's filter. Pairs are distinct;
+// `eq(Column, Column)` conjuncts in the join's filter or in
+// `extraConjuncts`, which a caller uses to include the pending conjuncts: a
+// `WHERE` equality reaches this pass as a pending conjunct and only becomes
+// the join's condition once the pass routes it there. Pairs are distinct;
 // the same equality may be written more than once. The returned pair has
 // equal-length `first` (left columns) and `second` (right columns) vectors.
 std::pair<ColumnVector, ColumnVector> collectEquiColumnPairs(
     JoinCP node,
     const PlanObjectSet& leftColumns,
-    const PlanObjectSet& rightColumns) {
+    const PlanObjectSet& rightColumns,
+    const ExprVector& extraConjuncts = {}) {
   ColumnVector leftKeys;
   ColumnVector rightKeys;
 
@@ -282,24 +286,21 @@ std::pair<ColumnVector, ColumnVector> collectEquiColumnPairs(
       addPair(leftKey->as<Column>(), rightKey->as<Column>());
     }
   }
-  if (node->filter().empty()) {
-    return {std::move(leftKeys), std::move(rightKeys)};
-  }
 
   const Name equalityName = toName(FunctionRegistry::instance()->equality());
-  for (ExprCP conjunct : node->filter()) {
+  const auto addEqualityPair = [&](ExprCP conjunct) {
     if (!conjunct->is(PlanType::kCallExpr)) {
-      continue;
+      return;
     }
     const Call* call = conjunct->as<Call>();
     if (call->name() != equalityName) {
-      continue;
+      return;
     }
     ExprCP first = call->args()[0];
     ExprCP second = call->args()[1];
     if (!first->is(PlanType::kColumnExpr) ||
         !second->is(PlanType::kColumnExpr)) {
-      continue;
+      return;
     }
     ColumnCP firstColumn = first->as<Column>();
     ColumnCP secondColumn = second->as<Column>();
@@ -311,6 +312,13 @@ std::pair<ColumnVector, ColumnVector> collectEquiColumnPairs(
         rightColumns.contains(firstColumn)) {
       addPair(secondColumn, firstColumn);
     }
+  };
+
+  for (ExprCP conjunct : node->filter()) {
+    addEqualityPair(conjunct);
+  }
+  for (ExprCP conjunct : extraConjuncts) {
+    addEqualityPair(conjunct);
   }
   return {std::move(leftKeys), std::move(rightKeys)};
 }
@@ -901,19 +909,29 @@ class Pushdown : public NodeRewriter<PushdownContext> {
           rightColumns);
     }
 
-    // Inner-join equi-key pairs let pending conjuncts cross to the
-    // other side. If derivation produces a literal-false conjunct, the
-    // join can't yield any rows.
+    ExprVector leftPending;
+    ExprVector rightPending;
+    ExprVector inFilter;
+    ExprVector above;
+
     if (newKind == velox::core::JoinType::kInner) {
+      if (NodeCP replacement = rewriteConstantInputJoin(
+              node,
+              leftColumns,
+              rightColumns,
+              context,
+              leftPending,
+              rightPending)) {
+        return replacement;
+      }
+      // Inner-join equi-key pairs let pending conjuncts cross to the
+      // other side. If derivation produces a literal-false conjunct, the
+      // join can't yield any rows.
       if (deriveTransitive(node, leftColumns, rightColumns, context.pending)) {
         return makeEmptyValues(node);
       }
     }
 
-    ExprVector leftPending;
-    ExprVector rightPending;
-    ExprVector inFilter;
-    ExprVector above;
     for (ExprCP conjunct : context.pending) {
       const auto& columns = conjunct->columns();
       // Pushable to a side only if every referenced column lives on
@@ -1950,6 +1968,192 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     const auto* call = expr->as<Call>();
     return call->name() == builder().functionNames().equality &&
         call->args().size() == 2 && call->args()[0] == call->args()[1];
+  }
+
+  struct ConstantJoinInput {
+    // Null unless exactly one input is a constant `Values`.
+    const Values* values{nullptr};
+    bool onLeft{false};
+  };
+
+  // An inner join against a constant `Values` restricts its other input to the
+  // values that `Values` holds. Three cases:
+  //   - no rows: nothing joins, so the result is empty.
+  //   - one row: every condition is pinned to a constant, so the join becomes
+  //     a Project of those constants over a Filter on the other input.
+  //   - several rows: the join stays, and each key gains `key IN (values)` on
+  //     the other input.
+  // Returns the replacement for the first two cases. Returns nullptr for the
+  // third, having left its filters in the pending of the input that is not
+  // constant, and when 'node' has no constant input.
+  NodeCP rewriteConstantInputJoin(
+      JoinCP node,
+      const PlanObjectSet& leftColumns,
+      const PlanObjectSet& rightColumns,
+      PushdownContext& context,
+      ExprVector& leftPending,
+      ExprVector& rightPending) {
+    const ConstantJoinInput side = constantSide(node);
+    if (side.values == nullptr) {
+      return nullptr;
+    }
+    if (side.values->cardinality() == 0) {
+      return makeEmptyValues(node);
+    }
+
+    if (side.values->cardinality() > 1) {
+      return restrictOtherInput(
+                 node,
+                 side,
+                 leftColumns,
+                 rightColumns,
+                 context,
+                 side.onLeft ? rightPending : leftPending)
+          ? makeEmptyValues(node)
+          : nullptr;
+    }
+
+    ExprFactory::ExprSubstitution constants;
+    for (size_t i = 0; i < side.values->outputColumns().size(); ++i) {
+      ColumnCP column = side.values->outputColumns()[i];
+      constants.emplace(
+          column,
+          builder().makeLiteral(
+              velox::Variant(side.values->valueAt(0, i)),
+              column->value().type));
+    }
+
+    // The join's own conditions vanish with it, so each becomes a filter on
+    // the other input. Conjuncts above the join need no such care: the Project
+    // below still produces the `Values` columns, now constant, and pushdown
+    // substitutes them on the way down.
+    ExprVector filters;
+    filters.reserve(node->leftKeys().size() + node->filter().size());
+
+    // True if 'conjunct' is always false, leaving the join empty.
+    const auto restate = [&](ExprCP conjunct) {
+      return simplifier_.simplifyFilter(
+          exprs_.replace(conjunct, constants), filters);
+    };
+
+    for (size_t i = 0; i < node->leftKeys().size(); ++i) {
+      if (restate(exprs_.makeEq(node->leftKeys()[i], node->rightKeys()[i]))) {
+        return makeEmptyValues(node);
+      }
+    }
+    for (ExprCP conjunct : node->filter()) {
+      if (restate(conjunct)) {
+        return makeEmptyValues(node);
+      }
+    }
+
+    NodeCP input = side.onLeft ? node->right() : node->left();
+    if (!filters.empty()) {
+      input = builder().make<Filter>({input, std::move(filters)});
+    }
+
+    // The `Values` columns the join output carries become constants; without
+    // any, the other input already produces what the join did.
+    ExprVector exprs;
+    ColumnVector outputColumns;
+    exprs.reserve(node->outputColumns().size());
+    outputColumns.reserve(node->outputColumns().size());
+    bool readsConstant = false;
+    for (ColumnCP column : node->outputColumns()) {
+      const auto constant = constants.find(column);
+      readsConstant |= constant != constants.end();
+      exprs.push_back(constant == constants.end() ? column : constant->second);
+      outputColumns.push_back(column);
+    }
+    if (!readsConstant) {
+      return rewrite(input, context);
+    }
+    return rewrite(
+        builder().make<Project>(
+            {input, std::move(exprs), std::move(outputColumns)}),
+        context);
+  }
+
+  // Adds `key IN (values)` to 'otherInputPending' for each equi-key of 'node'
+  // whose key column comes from the constant input. Derived per key, so with
+  // several keys the filters admit combinations no row of the constant input
+  // has. That is sound, because the join still rejects them. Returns true if a
+  // derived filter can never hold, so no row joins.
+  //
+  // The filters go straight to the other input rather than through
+  // 'context.pending', which crosses to both sides: read off the constant
+  // input, they always hold on it.
+  bool restrictOtherInput(
+      JoinCP node,
+      const ConstantJoinInput& side,
+      const PlanObjectSet& leftColumns,
+      const PlanObjectSet& rightColumns,
+      PushdownContext& context,
+      ExprVector& otherInputPending) {
+    auto [leftKeys, rightKeys] = collectEquiColumnPairs(
+        node, leftColumns, rightColumns, context.pending);
+
+    ExprVector derived;
+    for (size_t i = 0; i < leftKeys.size(); ++i) {
+      ColumnCP valuesKey = side.onLeft ? leftKeys[i] : rightKeys[i];
+      ColumnCP probeKey = side.onLeft ? rightKeys[i] : leftKeys[i];
+      if (simplifier_.simplifyFilter(
+              makeKeyFilter(*side.values, valuesKey, probeKey), derived)) {
+        return true;
+      }
+    }
+    appendAll(otherInputPending, derived);
+    return false;
+  }
+
+  // The join's constant `Values` input, when exactly one input is constant.
+  static ConstantJoinInput constantSide(JoinCP node) {
+    const Values* left = constantInput(node->left());
+    const Values* right = constantInput(node->right());
+    if ((left == nullptr) == (right == nullptr)) {
+      return {};
+    }
+    return left != nullptr ? ConstantJoinInput{left, true}
+                           : ConstantJoinInput{right, false};
+  }
+
+  // Returns 'node' as a `Values` holding folded rows, or nullptr.
+  static const Values* constantInput(NodeCP node) {
+    if (!node->is(NodeType::kValues)) {
+      return nullptr;
+    }
+    const auto* values = node->as<Values>();
+    return values->rows() != nullptr ? values : nullptr;
+  }
+
+  // Returns `probeKey = v` over the single value 'values' holds for
+  // 'valuesKey', or `probeKey IN (v...)` over its distinct values.
+  ExprCP
+  makeKeyFilter(const Values& values, ColumnCP valuesKey, ColumnCP probeKey) {
+    const ColumnVector& outputColumns = values.outputColumns();
+    const auto it =
+        std::find(outputColumns.begin(), outputColumns.end(), valuesKey);
+    VELOX_CHECK(
+        it != outputColumns.end(),
+        "Join key is not a column of the input it reads: {}",
+        valuesKey->toString());
+    const size_t column = it - outputColumns.begin();
+
+    const TypeCP type = valuesKey->value().type;
+    ExprVector distinct;
+    folly::F14FastSet<ExprCP> seen;
+    for (size_t row = 0; row < values.cardinality(); ++row) {
+      ExprCP literal = builder().makeLiteral(
+          velox::Variant(values.valueAt(row, column)), type);
+      if (seen.insert(literal).second) {
+        distinct.push_back(literal);
+      }
+    }
+
+    if (distinct.size() == 1) {
+      return exprs_.makeEq(probeKey, distinct[0]);
+    }
+    return exprs_.makeIn(probeKey, std::move(distinct));
   }
 
   // Derives new pending conjuncts via each cross-side


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/307


An inner join against constant rows tells you something about its other input: only rows whose key appears among those values can join. v2 now says so as a filter, which reaches the other input's scan.

    SELECT * FROM t JOIN (VALUES 1) AS v(k) ON t.a = v.k

plans to a scan of `t` filtered on `a = 1`, with no join at all. Before, the scan read every row and the join discarded almost all of them.

The constant input's row count decides what happens:

- No rows: nothing joins, so the result is empty.
- One row: every key and filter conjunct is pinned to a constant, so the join becomes a `Project` of those constants over a `Filter` on the other input, and the join itself is gone.
- Several rows: the join stays, and each key gains `key IN (values)` on the other input. That admits key combinations no single row has, which is sound because the join still rejects them.

Predicates written above the join need no special handling. The `Project` still produces the constant input's columns, so pushdown substitutes them on the way down as it does for any projection.

The constant input has to be a `Values` node. A constant subtree that is not one — a `Project` over a `Values`, which is how a literal of a different type than the column reaches the join, or a join of two `Values` — is not recognized, and nothing folds such a subtree into a `Values` today.

Reviewed By: xiaoxmeng

Differential Revision: D118393162


