### PR TITLE
fix(runner): Include stack directly

### DIFF
--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -22,6 +22,7 @@
 #include <folly/coro/BlockingWait.h>
 #include <folly/coro/Coroutine.h>
 #include <folly/coro/Task.h>
+#include <stack>
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "velox/common/base/SpillConfig.h"


### PR DESCRIPTION
Summary: `LocalRunner` uses `std::stack` but previously received its declaration through an unrelated Folly header. Include `<stack>` directly so removing that transitive include does not break the runner build.

Differential Revision: D118543056


