### PR TITLE
fix(optimizer): Decorrelate EXISTS with a scalar subquery

### DIFF
--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -353,6 +353,21 @@ FROM t
 SELECT t.a, NOT EXISTS (SELECT 1 FROM (SELECT u.a FROM u WHERE u.a = t.a) q JOIN v ON q.a = v.a) AS e
 FROM t
 ----
+-- A correlated EXISTS whose body also reads a scalar subquery: true exactly
+-- for the outer rows whose `a` equals `min(v.a)`.
+SELECT t.a, EXISTS (SELECT 1 FROM u WHERE u.a = t.a AND u.a = (SELECT min(a) FROM v)) AS e
+FROM t
+----
+-- The same with a comparison instead: true exactly for the outer rows whose
+-- `a` exceeds `min(v.a)`, and no `u` row qualifies for the rest.
+SELECT t.a, EXISTS (SELECT 1 FROM u WHERE u.a = t.a AND u.a > (SELECT min(a) FROM v)) AS e
+FROM t
+----
+-- The negation: true exactly for the outer rows whose `a` differs from
+-- `min(v.a)`, and never NULL.
+SELECT t.a, NOT EXISTS (SELECT 1 FROM u WHERE u.a = t.a AND u.a = (SELECT min(a) FROM v)) AS e
+FROM t
+----
 -- An IN whose subquery reads an outer column.
 -- error_v1: Join filter references column from unplaced non-single-row table
 SELECT t.a, (SELECT count(*) FROM u WHERE u.a = t.a AND u.a IN (SELECT v.a + t.a FROM v)) AS n

--- a/axiom/optimizer/v2/DecorrelatePass.cpp
+++ b/axiom/optimizer/v2/DecorrelatePass.cpp
@@ -1118,8 +1118,9 @@ class Decorrelator : public NodeRewriter<> {
   }
 
   // Outer Apply is kLeftSemiProject. Currently supports EXISTS shape
-  // (inLhs == nullptr) over kInner cross-join body; mark = markA AND
-  // markB. IN shape and other Join kinds NYI loud.
+  // (inLhs == nullptr) over a kInner body. With nothing pairing the two sides
+  // the mark is markA AND markB; otherwise it is a property of the pair. IN
+  // shape and other Join kinds NYI loud.
   NodeCP joinPeelSemi(
       ApplyCP node,
       NodeCP input,
@@ -1138,9 +1139,13 @@ class Decorrelator : public NodeRewriter<> {
           joinBody->joinTypeName());
     }
 
-    if (!joinPredicate.empty()) {
-      // A predicate ties the two sides together, so existence is not the
-      // conjunction of each side's own.
+    // A predicate ties the two sides together, so existence is not the
+    // conjunction of each side's own. Anything accumulated above the body join
+    // counts: a single-side conjunct is pushed into its side before this pass,
+    // so what remains here reads both. The chain below could not test it
+    // anyway, its first leg being a semi join that forwards the outer's
+    // columns but not the body side's.
+    if (!joinPredicate.empty() || !accumulatedFilter.empty()) {
       return joinPeelSemiInnerWithPredicate(
           node,
           input,
@@ -1191,8 +1196,9 @@ class Decorrelator : public NodeRewriter<> {
     });
   }
 
-  // Outer kLeftSemiProject EXISTS over a body kInner Join carrying a
-  // predicate. The mark asks whether the outer has any (a, b) pair the
+  // Outer kLeftSemiProject EXISTS over a body kInner Join where some predicate
+  // pairs the two sides, whether it came from the join itself or from a filter
+  // above it. The mark asks whether the outer has any (a, b) pair the
   // predicate accepts, which a per-outer `bool_or` over the chain's rows
   // answers. The chain then collapses to the one row per outer the outer
   // Apply's contract calls for.


### PR DESCRIPTION
Summary:
A correlated EXISTS whose body also reads a scalar subquery failed to plan under the v2 optimizer. For example:

    SELECT t.a FROM t WHERE EXISTS (SELECT 1 FROM u WHERE u.a = t.a AND u.a = (SELECT min(a) FROM v))

fails with

    Join filter reads a column neither input produces

Decorrelation turns `Apply(outer, Join(A, B))` into a chain of two semi-join legs. That split is only valid when existence factors into one test per side, and the test for it looked only at the join's own predicate. A scalar subquery contributes no such predicate: the comparison against its single row sits in a filter above the join. So the chain was built for a body whose sides are in fact tied together. The filter then landed on the second leg. That leg cannot see A's columns, because the first leg is a semi join and forwards only the outer's.

A filter above the body join now also forces the pair-enumeration path. Any conjunct still sitting there reads both sides, since a single-side one is pushed into its side earlier.

Differential Revision: D118555992
