### PR TITLE
feat(optimizer): Add query resource estimates (#1820)

### DIFF
--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -17,7 +17,9 @@
 #include "axiom/optimizer/v2/Optimize.h"
 
 #include "axiom/optimizer/ConstantFold.h"
+#include "axiom/optimizer/EstimateMath.h"
 #include "axiom/optimizer/ExplainIo.h"
+#include "axiom/optimizer/PlanUtils.h"
 #include "axiom/optimizer/v2/Builder.h"
 #include "axiom/optimizer/v2/DecorrelatePass.h"
 #include "axiom/optimizer/v2/EmitPass.h"
@@ -108,6 +110,61 @@ std::optional<uint64_t> totalRawInputRows(NodeCP node) {
     total += *rows;
   }
 
+  return total;
+}
+
+// Returns the expected rows read by 'scan', including SYSTEM sampling. Row
+// filters do not reduce this count because the connector must read a row before
+// evaluating them.
+std::optional<float> scanInputRows(const Scan& scan) {
+  const auto* baseTable = scan.baseTable();
+  VELOX_CHECK_NOT_NULL(baseTable);
+  const auto numRows = baseTable->numRawInputRows;
+  if (!numRows.has_value()) {
+    return std::nullopt;
+  }
+
+  std::optional<float> result{static_cast<float>(*numRows)};
+  if (const auto sample = baseTable->sampledPercentage) {
+    result = mul(result, *sample / 100.0f);
+  }
+  return result;
+}
+
+// Sums the expected rows read by scans under 'node'. One unknown scan row
+// count makes the total unknown.
+std::optional<float> totalInputRows(NodeCP node) {
+  VELOX_CHECK_NOT_NULL(node);
+  if (node->is(NodeType::kScan)) {
+    const auto* scan = node->as<Scan>();
+    VELOX_CHECK_NOT_NULL(scan);
+    return scanInputRows(*scan);
+  }
+
+  std::optional<float> total{0};
+  for (NodeCP input : node->inputs()) {
+    total = add(total, totalInputRows(input));
+  }
+  return total;
+}
+
+// Sums the estimated logical bytes read by scans under 'node'. One unknown
+// scan row count makes the total unknown.
+std::optional<float> totalInputBytes(NodeCP node) {
+  VELOX_CHECK_NOT_NULL(node);
+  if (node->is(NodeType::kScan)) {
+    const auto* scan = node->as<Scan>();
+    VELOX_CHECK_NOT_NULL(scan);
+    const auto* scanHandle = scan->scanHandle();
+    VELOX_CHECK_NOT_NULL(
+        scanHandle, "Input byte estimation requires a connector read handle");
+    return mul(scanInputRows(*scan), scanHandle->inputRowBytes);
+  }
+
+  std::optional<float> total{0};
+  for (NodeCP input : node->inputs()) {
+    total = add(total, totalInputBytes(input));
+  }
   return total;
 }
 
@@ -249,6 +306,9 @@ QueryStats Optimizer::estimateQueryStats() {
 
   QueryStats result;
   result.cardinality = estimate.cardinality;
+  result.numInputRows = totalInputRows(frontend.pushed);
+  result.inputBytes = totalInputBytes(frontend.pushed);
+  result.outputBytes = mul(estimate.cardinality, byteSize(columns));
   result.columns.reserve(columns.size());
   for (size_t i = 0; i < columns.size(); ++i) {
     // `value` returns the estimator's post-filter refined constraint, falling

--- a/axiom/optimizer/v2/Optimize.h
+++ b/axiom/optimizer/v2/Optimize.h
@@ -48,12 +48,26 @@ struct QueryColumnStats {
   const velox::Variant* max;
 };
 
-/// Estimated result statistics of a query under the v2 optimizer.
-/// `cardinality` is the estimated output row count (nullopt when unknown);
-/// `columns` is aligned 1:1 with the query's output columns.
+/// Estimated output and resource statistics of a query under optimizer v2.
 struct QueryStats {
+  /// Estimated number of output rows, or nullopt when unknown.
   std::optional<float> cardinality;
+
+  /// Statistics aligned 1:1 with the query's output columns.
   std::vector<QueryColumnStats> columns;
+
+  /// Estimated rows read across all scans, or nullopt when any scan is
+  /// unknown. TABLESAMPLE SYSTEM scales this count by its sampling rate.
+  std::optional<float> numInputRows;
+
+  /// Estimated logical payload bytes read across all scans using
+  /// `Value::byteSize()` for column widths, or nullopt when any scan's row
+  /// count is unknown. This does not estimate compressed storage I/O.
+  std::optional<float> inputBytes;
+
+  /// Estimated logical payload bytes in the query result, or nullopt when
+  /// output cardinality is unknown.
+  std::optional<float> outputBytes;
 };
 
 /// Runs the v2 optimizer over a single logical plan. Construct with the plan
@@ -108,13 +122,10 @@ class Optimizer {
   std::string explainIo(
       std::optional<CatalogSchemaTableName> outputTable = std::nullopt);
 
-  /// Estimates the result statistics of the plan (the estimate behind
-  /// SHOW STATS FOR (<query>)). Runs the shared front end (translate +
-  /// pushdown) and, when the `useFilteredTableStats` option is set,
-  /// EstimateLeafStatsPass, then reads the root estimate via EstimateProvider —
-  /// the v2 analogue of v1 reading the root DerivedTable after logical
-  /// optimization. The returned pointers are valid only for the enclosing
-  /// QueryGraphContext's lifetime.
+  /// Estimates output and resource statistics for the plan. Runs the shared
+  /// front end (translate + pushdown) and, when the `useFilteredTableStats`
+  /// option is set, EstimateLeafStatsPass. The returned pointers are valid
+  /// only for the enclosing QueryGraphContext's lifetime.
   QueryStats estimateQueryStats();
 
  private:

--- a/axiom/optimizer/v2/ScanHandle.cpp
+++ b/axiom/optimizer/v2/ScanHandle.cpp
@@ -51,10 +51,12 @@ ScanHandle ScanHandle::build(
   const size_t numColumns = outputColumns.size() + filterOnlyColumns.size();
   std::vector<velox::connector::ColumnHandlePtr> readSchema;
   readSchema.reserve(numColumns);
+  float inputRowBytes{0};
   const auto addHandle = [&](ColumnCP column) {
     auto handle = layout->createColumnHandle(
         connectorSession, column->name(), /*subfields=*/{});
     readSchema.push_back(handle);
+    inputRowBytes += column->value().byteSize();
     return handle;
   };
 
@@ -115,6 +117,7 @@ ScanHandle ScanHandle::build(
 
   return ScanHandle{
       .tableHandle = std::move(tableHandle),
+      .inputRowBytes = inputRowBytes,
       .columnHandles = std::move(columnHandles),
   };
 }

--- a/axiom/optimizer/v2/ScanHandle.h
+++ b/axiom/optimizer/v2/ScanHandle.h
@@ -44,9 +44,13 @@ struct ScanHandle {
   /// Table handle with the accepted filters pushed into the connector.
   velox::connector::ConnectorTableHandlePtr tableHandle;
 
-  /// Column handle per column of the connector read schema: every column the
-  /// `Scan` outputs, plus the ones only the connector's own filters read,
-  /// which it reads without projecting.
+  /// Estimated logical width of the connector read schema, including columns
+  /// used only by pushed filters.
+  float inputRowBytes{0};
+
+  /// Column handle per column emitted by the `Scan`, including columns needed
+  /// by filters the connector rejected. Columns used only by accepted filters
+  /// contribute to `inputRowBytes` but are not emitted.
   folly::F14FastMap<ColumnCP, velox::connector::ColumnHandlePtr> columnHandles;
 };
 

--- a/axiom/optimizer/v2/tests/CMakeLists.txt
+++ b/axiom/optimizer/v2/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
   AlgebraicPropertiesTest.cpp
   JoinHypergraphTest.cpp
   NodePrinterTest.cpp
+  QueryStatsTest.cpp
   RelationSetTest.cpp
   TpchPlanTest.cpp
 )

--- a/axiom/optimizer/v2/tests/QueryStatsTest.cpp
+++ b/axiom/optimizer/v2/tests/QueryStatsTest.cpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fmt/format.h>
+#include <folly/ScopeGuard.h>
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/SchemaResolver.h"
+#include "axiom/optimizer/QueryGraphContext.h"
+#include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+#include "axiom/optimizer/v2/Optimize.h"
+#include "velox/expression/Expr.h"
+#include "velox/type/Type.h"
+
+namespace facebook::axiom::optimizer::v2::test {
+namespace {
+
+constexpr float kNationTableRows = 25;
+constexpr float kRegionTableRows = 5;
+constexpr int32_t kSystemSamplePercentage = 10;
+
+float estimatedValueBytes(const velox::TypePtr& type) {
+  return Value(type.get()).byteSize();
+}
+
+struct ResourceStats {
+  std::optional<float> inputRows;
+  std::optional<float> inputBytes;
+  std::optional<float> outputRows;
+  std::optional<float> outputBytes;
+};
+
+class QueryStatsTest : public optimizer::test::HiveQueriesTestBase {
+ protected:
+  static void SetUpTestCase() {
+    optimizer::test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables(
+        {velox::tpch::Table::TBL_NATION, velox::tpch::Table::TBL_REGION});
+  }
+
+  ResourceStats resourceStats(
+      std::string_view sql,
+      const std::optional<OptimizerOptions>& options = std::nullopt) {
+    auto& veloxQueryContext = getQueryCtx();
+    velox::HashStringAllocator allocator(&optimizerPool());
+    auto graphContext = std::make_unique<QueryGraphContext>(
+        allocator, OptimizerOptions::kMaxPlanObjectsDefault);
+    optimizer::queryCtx() = graphContext.get();
+    SCOPE_EXIT {
+      optimizer::queryCtx() = nullptr;
+    };
+
+    velox::exec::SimpleExpressionEvaluator evaluator(
+        veloxQueryContext.get(), &optimizerPool());
+    connector::SchemaResolver schemaResolver{
+        connector::ConnectorMetadataRegistry::global()};
+    const OptimizerSession session{
+        veloxQueryContext->queryId(),
+        "test",
+        options.value_or(optimizerOptions_),
+        connectorSessionProperties_};
+
+    const auto logicalPlan = parseSelect(sql);
+    const auto stats =
+        Optimizer(
+            *logicalPlan, schemaResolver, session, evaluator, veloxQueryContext)
+            .estimateQueryStats();
+    return {
+        .inputRows = stats.numInputRows,
+        .inputBytes = stats.inputBytes,
+        .outputRows = stats.cardinality,
+        .outputBytes = stats.outputBytes,
+    };
+  }
+};
+
+TEST_F(QueryStatsTest, singleScan) {
+  const auto stats = resourceStats("SELECT n_nationkey FROM nation");
+  const auto rowBytes = estimatedValueBytes(velox::BIGINT());
+
+  EXPECT_EQ(stats.inputRows, kNationTableRows);
+  EXPECT_EQ(stats.inputBytes, kNationTableRows * rowBytes);
+  EXPECT_EQ(stats.outputRows, kNationTableRows);
+  EXPECT_EQ(stats.outputBytes, kNationTableRows * rowBytes);
+}
+
+TEST_F(QueryStatsTest, noScans) {
+  const auto stats = resourceStats("SELECT 1");
+  const auto outputRowBytes = estimatedValueBytes(velox::INTEGER());
+
+  EXPECT_EQ(stats.inputRows, 0);
+  EXPECT_EQ(stats.inputBytes, 0);
+  EXPECT_EQ(stats.outputRows, 1);
+  EXPECT_EQ(stats.outputBytes, outputRowBytes);
+}
+
+TEST_F(QueryStatsTest, filterColumnContributesToInputWidth) {
+  const auto stats =
+      resourceStats("SELECT n_name FROM nation WHERE n_regionkey = 1");
+  const auto inputRowBytes = estimatedValueBytes(velox::VARCHAR()) +
+      estimatedValueBytes(velox::BIGINT());
+  const auto outputRowBytes = estimatedValueBytes(velox::VARCHAR());
+  const auto expectedOutputRows = kNationTableRows / kRegionTableRows;
+
+  EXPECT_EQ(stats.inputRows, kNationTableRows);
+  EXPECT_EQ(stats.inputBytes, kNationTableRows * inputRowBytes);
+  EXPECT_EQ(stats.outputRows, expectedOutputRows);
+  EXPECT_EQ(stats.outputBytes, expectedOutputRows * outputRowBytes);
+}
+
+TEST_F(QueryStatsTest, joinsSumAllScans) {
+  const auto stats = resourceStats(
+      "SELECT n_name, r_name FROM nation, region "
+      "WHERE n_regionkey = r_regionkey");
+  const auto inputRowBytes = estimatedValueBytes(velox::VARCHAR()) +
+      estimatedValueBytes(velox::BIGINT());
+  const auto outputRowBytes = 2 * estimatedValueBytes(velox::VARCHAR());
+
+  EXPECT_EQ(stats.inputRows, kNationTableRows + kRegionTableRows);
+  EXPECT_EQ(
+      stats.inputBytes, (kNationTableRows + kRegionTableRows) * inputRowBytes);
+  EXPECT_EQ(stats.outputRows, kNationTableRows);
+  EXPECT_EQ(stats.outputBytes, kNationTableRows * outputRowBytes);
+}
+
+TEST_F(QueryStatsTest, systemSampleReducesInput) {
+  const auto stats = resourceStats(
+      fmt::format(
+          "SELECT n_nationkey FROM nation TABLESAMPLE SYSTEM ({})",
+          kSystemSamplePercentage));
+  const auto expectedRows = kNationTableRows * kSystemSamplePercentage / 100.0f;
+  const auto rowBytes = estimatedValueBytes(velox::BIGINT());
+
+  EXPECT_EQ(stats.inputRows, expectedRows);
+  EXPECT_EQ(stats.inputBytes, expectedRows * rowBytes);
+  EXPECT_EQ(stats.outputRows, expectedRows);
+  EXPECT_EQ(stats.outputBytes, expectedRows * rowBytes);
+}
+
+TEST_F(QueryStatsTest, bernoulliSampleReadsAllInput) {
+  const auto stats = resourceStats(
+      "SELECT n_nationkey FROM nation TABLESAMPLE BERNOULLI (20)");
+  const auto rowBytes = estimatedValueBytes(velox::BIGINT());
+
+  // Bernoulli sampling reads every input row. Its nondeterministic predicate
+  // is not estimated, so the output estimate also stays conservatively at the
+  // unsampled cardinality.
+  EXPECT_EQ(stats.inputRows, kNationTableRows);
+  EXPECT_EQ(stats.inputBytes, kNationTableRows * rowBytes);
+  EXPECT_EQ(stats.outputRows, kNationTableRows);
+  EXPECT_EQ(stats.outputBytes, kNationTableRows * rowBytes);
+}
+
+TEST_F(QueryStatsTest, repeatedOutputColumn) {
+  const auto stats = resourceStats("SELECT n_name, n_name FROM nation");
+  const auto valueBytes = estimatedValueBytes(velox::VARCHAR());
+  const auto outputRowBytes = 2 * valueBytes;
+
+  EXPECT_EQ(stats.inputRows, kNationTableRows);
+  EXPECT_EQ(stats.inputBytes, kNationTableRows * valueBytes);
+  EXPECT_EQ(stats.outputRows, kNationTableRows);
+  EXPECT_EQ(stats.outputBytes, kNationTableRows * outputRowBytes);
+}
+
+TEST_F(QueryStatsTest, missingInputStatistics) {
+  OptimizerOptions options;
+  options.useFilteredTableStats = false;
+
+  const auto stats = resourceStats("SELECT n_nationkey FROM nation", options);
+  const auto outputRowBytes = estimatedValueBytes(velox::BIGINT());
+
+  EXPECT_EQ(stats.inputRows, std::nullopt);
+  EXPECT_EQ(stats.inputBytes, std::nullopt);
+  EXPECT_EQ(stats.outputRows, kNationTableRows);
+  EXPECT_EQ(stats.outputBytes, kNationTableRows * outputRowBytes);
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer::v2::test
+
+// TPC-H data generation instantiates a folly Singleton (DBGenBackend), which
+// requires folly::Init to have run registrationComplete().
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:

Extend optimizer-v2 `estimateQueryStats()` with aggregate input-row, input-logical-byte, and output-logical-byte estimates while preserving the existing output-row and column statistics. Input estimates sum scan work after pushdown, include filter-only read columns, scale `TABLESAMPLE SYSTEM`, and become unknown when any scan row count is unknown. `SHOW STATS FOR` continues to consume only the pre-existing fields.

Differential Revision: D118522999


