### PR TITLE
feat(cli): Expose query resource estimates (#1821)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -942,6 +942,72 @@ presto::SqlStatementPtr SqlQueryRunner::parseSingle(
   return statements.front();
 }
 
+QueryResourceEstimates SqlQueryRunner::estimateQueryStats(
+    std::string_view sql,
+    RunOptions options) {
+  options.queryId = options.queryId.value_or(queryIdGenerator_());
+  const auto statement = parseSingle(sql, options);
+
+  const auto& catalog =
+      options.defaultConnectorId.value_or(defaultConnectorId_);
+  const auto& schema = options.defaultSchema.value_or(defaultSchema_);
+  QueryCompletionInfo completionInfo{
+      .startInfo =
+          {*options.queryId,
+           std::string(sql),
+           std::chrono::system_clock::now(),
+           std::string(catalog),
+           std::string(schema),
+           statement->kind()},
+      .referencedTables = statement->referencedTables()};
+  options.tokenProvider = checkPermission(
+      options,
+      completionInfo,
+      statement->views(),
+      statement->referencedTables());
+
+  const auto* logicalPlan = statement->queryPlan();
+  VELOX_USER_CHECK_NOT_NULL(
+      logicalPlan,
+      "Query statistics require a statement with a logical plan, got: {}",
+      statement->kindName());
+  return estimateQueryStats(*logicalPlan, options);
+}
+
+QueryResourceEstimates SqlQueryRunner::estimateQueryStats(
+    const logical_plan::LogicalPlanNode& logicalPlan,
+    RunOptions options,
+    std::shared_ptr<connector::SchemaResolver> schemaResolver) {
+  options.queryId = options.queryId.value_or(queryIdGenerator_());
+  checkLogicalPlan(logicalPlan);
+  const auto& estimationPlan =
+      logicalPlan.is(logical_plan::NodeKind::kTableWrite)
+      ? *logicalPlan.onlyInput()
+      : logicalPlan;
+  auto queryCtx = newQuery(options);
+  auto session = makeOptimizerSession(
+      queryCtx->queryId(),
+      collectConnectorProperties(*sessionConfig_),
+      /*explain=*/false,
+      /*forceFilteredTableStats=*/true);
+  OptimizerContext optimizerContext(
+      optimizerPool_.get(), session->options().maxPlanObjects);
+  velox::exec::SimpleExpressionEvaluator evaluator(
+      queryCtx.get(), optimizerPool_.get());
+  auto resolver = orDefaultSchemaResolver(std::move(schemaResolver));
+  const auto stats =
+      optimizer::v2::Optimizer(
+          estimationPlan, *resolver, *session, evaluator, queryCtx)
+          .estimateQueryStats();
+
+  return {
+      .inputRows = stats.numInputRows,
+      .inputBytes = stats.inputBytes,
+      .outputRows = stats.cardinality,
+      .outputBytes = stats.outputBytes,
+  };
+}
+
 SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
     const presto::SqlStatement& sqlStatement,
     const RunOptions& options) {
@@ -1817,10 +1883,14 @@ std::shared_ptr<optimizer::OptimizerSession>
 SqlQueryRunner::makeOptimizerSession(
     std::string_view queryId,
     connector::ConnectorProperties connectorProperties,
-    bool explain) {
+    bool explain,
+    bool forceFilteredTableStats) {
   auto optimizerOptions = optimizer::OptimizerOptions::from(
       sessionConfig_->effectiveValues(kOptimizerPrefix));
   optimizerOptions.explain = explain;
+  if (forceFilteredTableStats) {
+    optimizerOptions.useFilteredTableStats = true;
+  }
   return std::make_shared<optimizer::OptimizerSession>(
       std::string(queryId),
       user_,

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -179,6 +179,24 @@ struct QueryCompletionInfo {
   std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats;
 };
 
+/// Owned query-level resource estimates produced by optimizer v2.
+struct QueryResourceEstimates {
+  /// Estimated rows read across all scans, or nullopt when unknown.
+  std::optional<float> inputRows;
+
+  /// Estimated logical payload bytes read across all scans, or nullopt when
+  /// unknown. This is not compressed storage I/O.
+  std::optional<float> inputBytes;
+
+  /// Estimated rows in the query result, or nullopt when unknown. For a
+  /// table-write plan, this describes the input to the write.
+  std::optional<float> outputRows;
+
+  /// Estimated logical payload bytes in the query result, or nullopt when
+  /// unknown. For a table-write plan, this describes the input to the write.
+  std::optional<float> outputBytes;
+};
+
 /// Invoked when a query starts, before parsing.
 using QueryStartCallback = std::function<void(const QueryStartInfo&)>;
 
@@ -465,6 +483,24 @@ class SqlQueryRunner {
       std::string_view sql,
       const RunOptions& options);
 
+  /// Returns optimizer-v2 resource estimates for a single SQL statement that
+  /// contains a logical plan, without physical planning or execution. Uses the
+  /// supplied query namespace and runs the configured permission and
+  /// logical-plan checks. Lifecycle callbacks in RunOptions are not invoked.
+  QueryResourceEstimates estimateQueryStats(
+      std::string_view sql,
+      RunOptions options);
+
+  /// Returns optimizer-v2 resource estimates for an arbitrary logical plan.
+  /// For a table-write root, estimates its input rather than the write-status
+  /// result. The logical-plan check runs, but parsing and permission checks
+  /// are the caller's responsibility.
+  QueryResourceEstimates estimateQueryStats(
+      const facebook::axiom::logical_plan::LogicalPlanNode& logicalPlan,
+      RunOptions options,
+      std::shared_ptr<facebook::axiom::connector::SchemaResolver>
+          schemaResolver = nullptr);
+
   /// Generates DOT representation of the query graph for a single SELECT
   /// statement. The output can be rendered using Graphviz:
   ///   dot -Tsvg output.dot -o output.svg
@@ -569,7 +605,8 @@ class SqlQueryRunner {
   makeOptimizerSession(
       std::string_view queryId,
       facebook::axiom::connector::ConnectorProperties connectorProperties,
-      bool explain);
+      bool explain,
+      bool forceFilteredTableStats = false);
 
   std::string runExplain(
       const facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,

--- a/axiom/cli/tests/CMakeLists.txt
+++ b/axiom/cli/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   LiveProgressDisplayTest.cpp
   QueryIdGeneratorTest.cpp
   QueryInterruptHandlerTest.cpp
+  QueryStatsTest.cpp
 )
 
 add_test(NAME axiom_cli_test COMMAND axiom_cli_test)

--- a/axiom/cli/tests/QueryStatsTest.cpp
+++ b/axiom/cli/tests/QueryStatsTest.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "axiom/cli/tests/SqlQueryRunnerTestBase.h"
+#include "axiom/optimizer/Schema.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/type/Type.h"
+
+namespace axiom::sql {
+namespace {
+
+constexpr float kTableRows = 100;
+
+float estimatedValueBytes(const facebook::velox::TypePtr& type) {
+  return facebook::axiom::optimizer::Value(type.get()).byteSize();
+}
+
+class QueryStatsTest : public SqlQueryRunnerTestBase {};
+
+TEST_F(QueryStatsTest, filteredOutputWithMissingScanStats) {
+  runner_->run(
+      "CREATE TABLE t AS "
+      "SELECT x FROM unnest(sequence(1, 100)) AS _(x)",
+      {});
+
+  const auto stats =
+      runner_->estimateQueryStats("SELECT x FROM t WHERE x > 50", {});
+  const auto rowBytes = estimatedValueBytes(facebook::velox::BIGINT());
+  const auto expectedOutputRows = kTableRows / 2;
+
+  EXPECT_EQ(stats.inputRows, std::nullopt);
+  EXPECT_EQ(stats.inputBytes, std::nullopt);
+  EXPECT_EQ(stats.outputRows, expectedOutputRows);
+  EXPECT_EQ(stats.outputBytes, expectedOutputRows * rowBytes);
+}
+
+TEST_F(QueryStatsTest, scanlessQuery) {
+  const auto stats = runner_->estimateQueryStats("SELECT 1", {});
+
+  EXPECT_EQ(stats.inputRows, 0);
+  EXPECT_EQ(stats.inputBytes, 0);
+  EXPECT_EQ(stats.outputRows, 1);
+  EXPECT_EQ(stats.outputBytes, estimatedValueBytes(facebook::velox::INTEGER()));
+}
+
+TEST_F(QueryStatsTest, insertQuery) {
+  runner_->run("CREATE TABLE t (x INTEGER)", {});
+
+  const auto stats =
+      runner_->estimateQueryStats("INSERT INTO t VALUES 1, 2, 3", {});
+  const auto outputRowBytes = estimatedValueBytes(facebook::velox::INTEGER());
+
+  EXPECT_EQ(stats.inputRows, 0);
+  EXPECT_EQ(stats.inputBytes, 0);
+  EXPECT_EQ(stats.outputRows, 3);
+  EXPECT_EQ(stats.outputBytes, 3 * outputRowBytes);
+}
+
+TEST_F(QueryStatsTest, createTableAsSelectQuery) {
+  const auto stats =
+      runner_->estimateQueryStats("CREATE TABLE t AS SELECT 1 AS x", {});
+
+  EXPECT_EQ(stats.inputRows, 0);
+  EXPECT_EQ(stats.inputBytes, 0);
+  EXPECT_EQ(stats.outputRows, 1);
+  EXPECT_EQ(stats.outputBytes, estimatedValueBytes(facebook::velox::INTEGER()));
+
+  const auto result = runner_->run("CREATE TABLE t AS SELECT 1 AS x", {});
+  ASSERT_EQ(result.results.size(), 1);
+  EXPECT_EQ(result.results.front()->size(), 1);
+}
+
+TEST_F(QueryStatsTest, logicalPlan) {
+  const auto statement = runner_->parseSingle("SELECT 1", {});
+  const auto& plan = statement->as<presto::SelectStatement>()->plan();
+
+  const auto stats = runner_->estimateQueryStats(*plan, {});
+
+  EXPECT_EQ(stats.inputRows, 0);
+  EXPECT_EQ(stats.inputBytes, 0);
+  EXPECT_EQ(stats.outputRows, 1);
+  EXPECT_EQ(stats.outputBytes, estimatedValueBytes(facebook::velox::INTEGER()));
+}
+
+TEST_F(QueryStatsTest, wrappedQueries) {
+  for (const auto sql : {"EXPLAIN SELECT 1", "SHOW STATS FOR (SELECT 1)"}) {
+    SCOPED_TRACE(sql);
+    const auto stats = runner_->estimateQueryStats(sql, {});
+
+    EXPECT_EQ(stats.inputRows, 0);
+    EXPECT_EQ(stats.inputBytes, 0);
+    EXPECT_EQ(stats.outputRows, 1);
+    EXPECT_EQ(
+        stats.outputBytes, estimatedValueBytes(facebook::velox::INTEGER()));
+  }
+}
+
+TEST_F(QueryStatsTest, rejectsStatementWithoutPlan) {
+  VELOX_ASSERT_USER_THROW(
+      runner_->estimateQueryStats("SHOW SESSION", {}),
+      "Query statistics require a statement with a logical plan, got: SHOW SESSION");
+}
+
+TEST_F(QueryStatsTest, checksPermission) {
+  bool permissionChecked{false};
+  runner_ = makeRunner(
+      "query_stats_permission",
+      /*queryIdGenerator=*/{},
+      [&](std::string_view queryId,
+          std::string_view sql,
+          std::string_view catalog,
+          std::optional<std::string_view> /*schema*/,
+          const auto& /*views*/,
+          const auto& /*referencedTables*/)
+          -> std::shared_ptr<facebook::velox::filesystems::TokenProvider> {
+        EXPECT_EQ(queryId, "stats_query");
+        EXPECT_EQ(sql, "SELECT 1");
+        EXPECT_EQ(catalog, "query_stats_permission");
+        permissionChecked = true;
+        return nullptr;
+      });
+  SqlQueryRunner::RunOptions options;
+  options.queryId = "stats_query";
+
+  runner_->estimateQueryStats("SELECT 1", options);
+
+  EXPECT_TRUE(permissionChecked);
+}
+
+} // namespace
+} // namespace axiom::sql

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -17,7 +17,9 @@
 #include "axiom/optimizer/v2/Optimize.h"
 
 #include "axiom/optimizer/ConstantFold.h"
+#include "axiom/optimizer/EstimateMath.h"
 #include "axiom/optimizer/ExplainIo.h"
+#include "axiom/optimizer/PlanUtils.h"
 #include "axiom/optimizer/v2/Builder.h"
 #include "axiom/optimizer/v2/DecorrelatePass.h"
 #include "axiom/optimizer/v2/EmitPass.h"
@@ -108,6 +110,61 @@ std::optional<uint64_t> totalRawInputRows(NodeCP node) {
     total += *rows;
   }
 
+  return total;
+}
+
+// Returns the expected rows read by 'scan', including SYSTEM sampling. Row
+// filters do not reduce this count because the connector must read a row before
+// evaluating them.
+std::optional<float> scanInputRows(const Scan& scan) {
+  const auto* baseTable = scan.baseTable();
+  VELOX_CHECK_NOT_NULL(baseTable);
+  const auto numRows = baseTable->numRawInputRows;
+  if (!numRows.has_value()) {
+    return std::nullopt;
+  }
+
+  std::optional<float> result{static_cast<float>(*numRows)};
+  if (const auto sample = baseTable->sampledPercentage) {
+    result = mul(result, *sample / 100.0f);
+  }
+  return result;
+}
+
+// Sums the expected rows read by scans under 'node'. One unknown scan row
+// count makes the total unknown.
+std::optional<float> totalInputRows(NodeCP node) {
+  VELOX_CHECK_NOT_NULL(node);
+  if (node->is(NodeType::kScan)) {
+    const auto* scan = node->as<Scan>();
+    VELOX_CHECK_NOT_NULL(scan);
+    return scanInputRows(*scan);
+  }
+
+  std::optional<float> total{0};
+  for (NodeCP input : node->inputs()) {
+    total = add(total, totalInputRows(input));
+  }
+  return total;
+}
+
+// Sums the estimated logical bytes read by scans under 'node'. One unknown
+// scan row count makes the total unknown.
+std::optional<float> totalInputBytes(NodeCP node) {
+  VELOX_CHECK_NOT_NULL(node);
+  if (node->is(NodeType::kScan)) {
+    const auto* scan = node->as<Scan>();
+    VELOX_CHECK_NOT_NULL(scan);
+    const auto* scanHandle = scan->scanHandle();
+    VELOX_CHECK_NOT_NULL(
+        scanHandle, "Input byte estimation requires a connector read handle");
+    return mul(scanInputRows(*scan), scanHandle->inputRowBytes);
+  }
+
+  std::optional<float> total{0};
+  for (NodeCP input : node->inputs()) {
+    total = add(total, totalInputBytes(input));
+  }
   return total;
 }
 
@@ -249,6 +306,9 @@ QueryStats Optimizer::estimateQueryStats() {
 
   QueryStats result;
   result.cardinality = estimate.cardinality;
+  result.numInputRows = totalInputRows(frontend.pushed);
+  result.inputBytes = totalInputBytes(frontend.pushed);
+  result.outputBytes = mul(estimate.cardinality, byteSize(columns));
   result.columns.reserve(columns.size());
   for (size_t i = 0; i < columns.size(); ++i) {
     // `value` returns the estimator's post-filter refined constraint, falling

--- a/axiom/optimizer/v2/Optimize.h
+++ b/axiom/optimizer/v2/Optimize.h
@@ -48,12 +48,26 @@ struct QueryColumnStats {
   const velox::Variant* max;
 };
 
-/// Estimated result statistics of a query under the v2 optimizer.
-/// `cardinality` is the estimated output row count (nullopt when unknown);
-/// `columns` is aligned 1:1 with the query's output columns.
+/// Estimated output and resource statistics of a query under optimizer v2.
 struct QueryStats {
+  /// Estimated number of output rows, or nullopt when unknown.
   std::optional<float> cardinality;
+
+  /// Statistics aligned 1:1 with the query's output columns.
   std::vector<QueryColumnStats> columns;
+
+  /// Estimated rows read across all scans, or nullopt when any scan is
+  /// unknown. TABLESAMPLE SYSTEM scales this count by its sampling rate.
+  std::optional<float> numInputRows;
+
+  /// Estimated logical payload bytes read across all scans using
+  /// `Value::byteSize()` for column widths, or nullopt when any scan's row
+  /// count is unknown. This does not estimate compressed storage I/O.
+  std::optional<float> inputBytes;
+
+  /// Estimated logical payload bytes in the query result, or nullopt when
+  /// output cardinality is unknown.
+  std::optional<float> outputBytes;
 };
 
 /// Runs the v2 optimizer over a single logical plan. Construct with the plan
@@ -108,13 +122,10 @@ class Optimizer {
   std::string explainIo(
       std::optional<CatalogSchemaTableName> outputTable = std::nullopt);
 
-  /// Estimates the result statistics of the plan (the estimate behind
-  /// SHOW STATS FOR (<query>)). Runs the shared front end (translate +
-  /// pushdown) and, when the `useFilteredTableStats` option is set,
-  /// EstimateLeafStatsPass, then reads the root estimate via EstimateProvider —
-  /// the v2 analogue of v1 reading the root DerivedTable after logical
-  /// optimization. The returned pointers are valid only for the enclosing
-  /// QueryGraphContext's lifetime.
+  /// Estimates output and resource statistics for the plan. Runs the shared
+  /// front end (translate + pushdown) and, when the `useFilteredTableStats`
+  /// option is set, EstimateLeafStatsPass. The returned pointers are valid
+  /// only for the enclosing QueryGraphContext's lifetime.
   QueryStats estimateQueryStats();
 
  private:

--- a/axiom/optimizer/v2/ScanHandle.cpp
+++ b/axiom/optimizer/v2/ScanHandle.cpp
@@ -51,10 +51,12 @@ ScanHandle ScanHandle::build(
   const size_t numColumns = outputColumns.size() + filterOnlyColumns.size();
   std::vector<velox::connector::ColumnHandlePtr> readSchema;
   readSchema.reserve(numColumns);
+  float inputRowBytes{0};
   const auto addHandle = [&](ColumnCP column) {
     auto handle = layout->createColumnHandle(
         connectorSession, column->name(), /*subfields=*/{});
     readSchema.push_back(handle);
+    inputRowBytes += column->value().byteSize();
     return handle;
   };
 
@@ -115,6 +117,7 @@ ScanHandle ScanHandle::build(
 
   return ScanHandle{
       .tableHandle = std::move(tableHandle),
+      .inputRowBytes = inputRowBytes,
       .columnHandles = std::move(columnHandles),
   };
 }

--- a/axiom/optimizer/v2/ScanHandle.h
+++ b/axiom/optimizer/v2/ScanHandle.h
@@ -44,9 +44,13 @@ struct ScanHandle {
   /// Table handle with the accepted filters pushed into the connector.
   velox::connector::ConnectorTableHandlePtr tableHandle;
 
-  /// Column handle per column of the connector read schema: every column the
-  /// `Scan` outputs, plus the ones only the connector's own filters read,
-  /// which it reads without projecting.
+  /// Estimated logical width of the connector read schema, including columns
+  /// used only by pushed filters.
+  float inputRowBytes{0};
+
+  /// Column handle per column emitted by the `Scan`, including columns needed
+  /// by filters the connector rejected. Columns used only by accepted filters
+  /// contribute to `inputRowBytes` but are not emitted.
   folly::F14FastMap<ColumnCP, velox::connector::ColumnHandlePtr> columnHandles;
 };
 

--- a/axiom/optimizer/v2/tests/CMakeLists.txt
+++ b/axiom/optimizer/v2/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
   AlgebraicPropertiesTest.cpp
   JoinHypergraphTest.cpp
   NodePrinterTest.cpp
+  QueryStatsTest.cpp
   RelationSetTest.cpp
   TpchPlanTest.cpp
 )

--- a/axiom/optimizer/v2/tests/QueryStatsTest.cpp
+++ b/axiom/optimizer/v2/tests/QueryStatsTest.cpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fmt/format.h>
+#include <folly/ScopeGuard.h>
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/SchemaResolver.h"
+#include "axiom/optimizer/QueryGraphContext.h"
+#include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+#include "axiom/optimizer/v2/Optimize.h"
+#include "velox/expression/Expr.h"
+#include "velox/type/Type.h"
+
+namespace facebook::axiom::optimizer::v2::test {
+namespace {
+
+constexpr float kNationTableRows = 25;
+constexpr float kRegionTableRows = 5;
+constexpr int32_t kSystemSamplePercentage = 10;
+
+float estimatedValueBytes(const velox::TypePtr& type) {
+  return Value(type.get()).byteSize();
+}
+
+struct ResourceStats {
+  std::optional<float> inputRows;
+  std::optional<float> inputBytes;
+  std::optional<float> outputRows;
+  std::optional<float> outputBytes;
+};
+
+class QueryStatsTest : public optimizer::test::HiveQueriesTestBase {
+ protected:
+  static void SetUpTestCase() {
+    optimizer::test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables(
+        {velox::tpch::Table::TBL_NATION, velox::tpch::Table::TBL_REGION});
+  }
+
+  ResourceStats resourceStats(
+      std::string_view sql,
+      const std::optional<OptimizerOptions>& options = std::nullopt) {
+    auto& veloxQueryContext = getQueryCtx();
+    velox::HashStringAllocator allocator(&optimizerPool());
+    auto graphContext = std::make_unique<QueryGraphContext>(
+        allocator, OptimizerOptions::kMaxPlanObjectsDefault);
+    optimizer::queryCtx() = graphContext.get();
+    SCOPE_EXIT {
+      optimizer::queryCtx() = nullptr;
+    };
+
+    velox::exec::SimpleExpressionEvaluator evaluator(
+        veloxQueryContext.get(), &optimizerPool());
+    connector::SchemaResolver schemaResolver{
+        connector::ConnectorMetadataRegistry::global()};
+    const OptimizerSession session{
+        veloxQueryContext->queryId(),
+        "test",
+        options.value_or(optimizerOptions_),
+        connectorSessionProperties_};
+
+    const auto logicalPlan = parseSelect(sql);
+    const auto stats =
+        Optimizer(
+            *logicalPlan, schemaResolver, session, evaluator, veloxQueryContext)
+            .estimateQueryStats();
+    return {
+        .inputRows = stats.numInputRows,
+        .inputBytes = stats.inputBytes,
+        .outputRows = stats.cardinality,
+        .outputBytes = stats.outputBytes,
+    };
+  }
+};
+
+TEST_F(QueryStatsTest, singleScan) {
+  const auto stats = resourceStats("SELECT n_nationkey FROM nation");
+  const auto rowBytes = estimatedValueBytes(velox::BIGINT());
+
+  EXPECT_EQ(stats.inputRows, kNationTableRows);
+  EXPECT_EQ(stats.inputBytes, kNationTableRows * rowBytes);
+  EXPECT_EQ(stats.outputRows, kNationTableRows);
+  EXPECT_EQ(stats.outputBytes, kNationTableRows * rowBytes);
+}
+
+TEST_F(QueryStatsTest, noScans) {
+  const auto stats = resourceStats("SELECT 1");
+  const auto outputRowBytes = estimatedValueBytes(velox::INTEGER());
+
+  EXPECT_EQ(stats.inputRows, 0);
+  EXPECT_EQ(stats.inputBytes, 0);
+  EXPECT_EQ(stats.outputRows, 1);
+  EXPECT_EQ(stats.outputBytes, outputRowBytes);
+}
+
+TEST_F(QueryStatsTest, filterColumnContributesToInputWidth) {
+  const auto stats =
+      resourceStats("SELECT n_name FROM nation WHERE n_regionkey = 1");
+  const auto inputRowBytes = estimatedValueBytes(velox::VARCHAR()) +
+      estimatedValueBytes(velox::BIGINT());
+  const auto outputRowBytes = estimatedValueBytes(velox::VARCHAR());
+  const auto expectedOutputRows = kNationTableRows / kRegionTableRows;
+
+  EXPECT_EQ(stats.inputRows, kNationTableRows);
+  EXPECT_EQ(stats.inputBytes, kNationTableRows * inputRowBytes);
+  EXPECT_EQ(stats.outputRows, expectedOutputRows);
+  EXPECT_EQ(stats.outputBytes, expectedOutputRows * outputRowBytes);
+}
+
+TEST_F(QueryStatsTest, joinsSumAllScans) {
+  const auto stats = resourceStats(
+      "SELECT n_name, r_name FROM nation, region "
+      "WHERE n_regionkey = r_regionkey");
+  const auto inputRowBytes = estimatedValueBytes(velox::VARCHAR()) +
+      estimatedValueBytes(velox::BIGINT());
+  const auto outputRowBytes = 2 * estimatedValueBytes(velox::VARCHAR());
+
+  EXPECT_EQ(stats.inputRows, kNationTableRows + kRegionTableRows);
+  EXPECT_EQ(
+      stats.inputBytes, (kNationTableRows + kRegionTableRows) * inputRowBytes);
+  EXPECT_EQ(stats.outputRows, kNationTableRows);
+  EXPECT_EQ(stats.outputBytes, kNationTableRows * outputRowBytes);
+}
+
+TEST_F(QueryStatsTest, systemSampleReducesInput) {
+  const auto stats = resourceStats(
+      fmt::format(
+          "SELECT n_nationkey FROM nation TABLESAMPLE SYSTEM ({})",
+          kSystemSamplePercentage));
+  const auto expectedRows = kNationTableRows * kSystemSamplePercentage / 100.0f;
+  const auto rowBytes = estimatedValueBytes(velox::BIGINT());
+
+  EXPECT_EQ(stats.inputRows, expectedRows);
+  EXPECT_EQ(stats.inputBytes, expectedRows * rowBytes);
+  EXPECT_EQ(stats.outputRows, expectedRows);
+  EXPECT_EQ(stats.outputBytes, expectedRows * rowBytes);
+}
+
+TEST_F(QueryStatsTest, bernoulliSampleReadsAllInput) {
+  const auto stats = resourceStats(
+      "SELECT n_nationkey FROM nation TABLESAMPLE BERNOULLI (20)");
+  const auto rowBytes = estimatedValueBytes(velox::BIGINT());
+
+  // Bernoulli sampling reads every input row. Its nondeterministic predicate
+  // is not estimated, so the output estimate also stays conservatively at the
+  // unsampled cardinality.
+  EXPECT_EQ(stats.inputRows, kNationTableRows);
+  EXPECT_EQ(stats.inputBytes, kNationTableRows * rowBytes);
+  EXPECT_EQ(stats.outputRows, kNationTableRows);
+  EXPECT_EQ(stats.outputBytes, kNationTableRows * rowBytes);
+}
+
+TEST_F(QueryStatsTest, repeatedOutputColumn) {
+  const auto stats = resourceStats("SELECT n_name, n_name FROM nation");
+  const auto valueBytes = estimatedValueBytes(velox::VARCHAR());
+  const auto outputRowBytes = 2 * valueBytes;
+
+  EXPECT_EQ(stats.inputRows, kNationTableRows);
+  EXPECT_EQ(stats.inputBytes, kNationTableRows * valueBytes);
+  EXPECT_EQ(stats.outputRows, kNationTableRows);
+  EXPECT_EQ(stats.outputBytes, kNationTableRows * outputRowBytes);
+}
+
+TEST_F(QueryStatsTest, missingInputStatistics) {
+  OptimizerOptions options;
+  options.useFilteredTableStats = false;
+
+  const auto stats = resourceStats("SELECT n_nationkey FROM nation", options);
+  const auto outputRowBytes = estimatedValueBytes(velox::BIGINT());
+
+  EXPECT_EQ(stats.inputRows, std::nullopt);
+  EXPECT_EQ(stats.inputBytes, std::nullopt);
+  EXPECT_EQ(stats.outputRows, kNationTableRows);
+  EXPECT_EQ(stats.outputBytes, kNationTableRows * outputRowBytes);
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer::v2::test
+
+// TPC-H data generation instantiates a folly Singleton (DBGenBackend), which
+// requires folly::Init to have run registrationComplete().
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}

--- a/axiom/sql/presto/SqlStatement.h
+++ b/axiom/sql/presto/SqlStatement.h
@@ -149,6 +149,13 @@ class SqlStatement {
     return referencedTables_;
   }
 
+  /// Returns the logical plan carried by this statement, or nullptr when the
+  /// statement has no query plan.
+  virtual const facebook::axiom::logical_plan::LogicalPlanNode* queryPlan()
+      const {
+    return nullptr;
+  }
+
  protected:
   explicit SqlStatement(SqlStatementKind kind)
       : kind_{kind}, views_{}, referencedTables_{} {}
@@ -186,6 +193,11 @@ class SelectStatement : public SqlStatement {
     return plan_;
   }
 
+  const facebook::axiom::logical_plan::LogicalPlanNode* queryPlan()
+      const override {
+    return plan_.get();
+  }
+
  private:
   const facebook::axiom::logical_plan::LogicalPlanNodePtr plan_;
 };
@@ -204,6 +216,11 @@ class InsertStatement : public SqlStatement {
 
   const facebook::axiom::logical_plan::LogicalPlanNodePtr& plan() const {
     return plan_;
+  }
+
+  const facebook::axiom::logical_plan::LogicalPlanNode* queryPlan()
+      const override {
+    return plan_.get();
   }
 
  private:
@@ -226,6 +243,11 @@ class DeleteStatement : public SqlStatement {
 
   const facebook::axiom::logical_plan::LogicalPlanNodePtr& plan() const {
     return plan_;
+  }
+
+  const facebook::axiom::logical_plan::LogicalPlanNode* queryPlan()
+      const override {
+    return plan_.get();
   }
 
  private:
@@ -342,6 +364,11 @@ class CreateTableAsSelectStatement : public SqlStatement {
 
   const facebook::axiom::logical_plan::LogicalPlanNodePtr& plan() const {
     return plan_;
+  }
+
+  const facebook::axiom::logical_plan::LogicalPlanNode* queryPlan()
+      const override {
+    return plan_.get();
   }
 
  private:
@@ -620,6 +647,11 @@ class ExplainStatement : public SqlStatement {
     return format_;
   }
 
+  const facebook::axiom::logical_plan::LogicalPlanNode* queryPlan()
+      const override {
+    return statement_->queryPlan();
+  }
+
  private:
   const SqlStatementPtr statement_;
   const bool analyze_;
@@ -640,6 +672,11 @@ class ShowStatsForQueryStatement : public SqlStatement {
 
   const SqlStatementPtr& statement() const {
     return statement_;
+  }
+
+  const facebook::axiom::logical_plan::LogicalPlanNode* queryPlan()
+      const override {
+    return statement_->queryPlan();
   }
 
  private:


### PR DESCRIPTION
Summary:

Callers can now estimate logical input and output rows and bytes from SQL or an existing logical plan without physical planning or execution. For example, analyzing `CREATE TABLE t AS SELECT 1` reports one row entering the table write without creating `t`.

Parsed statements expose the plan they carry, and wrappers delegate to the wrapped statement. The analysis uses the existing validation path and copies four optional totals from optimizer v2.

Filtered table statistics apply only to analysis. Existing execution and `SHOW STATS` behavior is unchanged.

Differential Revision: D118555659


