### PR TITLE
feat(optimizer): Fail when a plan drops a join equality

### DIFF
--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -17,6 +17,7 @@
 #include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
 
 namespace facebook::axiom::optimizer {
 namespace {
@@ -166,6 +167,33 @@ TEST_P(JoinTest, derivedCompositeEdgePreservesAllEqualities) {
               .gather()
               .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan.plan, distributedMatcher);
+  }
+}
+
+// A CTE joined to itself on both of its columns matches each row only with
+// itself, so the query returns one row per CTE row and v1 plans it. v2
+// reordering drops one of the two equalities; until it stops doing so the
+// guard fails the query, which is what this pins.
+//
+// TODO: Move to join.sql once v2 keeps both equalities.
+TEST_P(JoinTest, selfJoinOnEveryColumn) {
+  const auto query =
+      "WITH "
+      "  ids (id) AS (VALUES (1)), "
+      "  labels (id, label) AS (VALUES (1, 'a'), (1, 'b')), "
+      "  extra (id) AS (VALUES (1)), "
+      "  labeled AS ("
+      "    SELECT ids.id, labels.label FROM ids "
+      "    JOIN labels ON labels.id = ids.id "
+      "    LEFT JOIN extra ON extra.id = ids.id) "
+      "SELECT count(*) FROM labeled AS x "
+      "JOIN labeled AS y ON x.id = y.id AND x.label = y.label";
+
+  if (useV2_) {
+    VELOX_ASSERT_THROW(
+        toSingleNodePlan(query), "Plan does not enforce a join equality");
+  } else {
+    ASSERT_NO_THROW(toSingleNodePlan(query));
   }
 }
 

--- a/axiom/optimizer/v2/DPhyp.cpp
+++ b/axiom/optimizer/v2/DPhyp.cpp
@@ -1229,6 +1229,42 @@ class Enumerator {
   std::vector<std::unique_ptr<MemoOp>>& enforcementOps_;
 };
 
+// Collects the edges `plan` applies.
+void collectAppliedEdges(MemoOpCP plan, folly::F14FastSet<size_t>& applied) {
+  switch (plan->kind()) {
+    case MemoOpKind::kLeaf:
+      return;
+    case MemoOpKind::kJoin: {
+      const auto* join = plan->as<JoinOp>();
+      applied.insert(join->edgeIndex);
+      applied.insert(join->extraEdges.begin(), join->extraEdges.end());
+      collectAppliedEdges(join->left, applied);
+      collectAppliedEdges(join->right, applied);
+      return;
+    }
+    case MemoOpKind::kUnnest: {
+      const auto* unnest = plan->as<UnnestOp>();
+      applied.insert(unnest->edgeIndex);
+      applied.insert(unnest->extraEdges.begin(), unnest->extraEdges.end());
+      collectAppliedEdges(unnest->input, applied);
+      return;
+    }
+    case MemoOpKind::kExchange:
+      collectAppliedEdges(plan->as<ExchangeOp>()->input, applied);
+      return;
+  }
+}
+
+// Throws unless `plan` enforces every equality the query states.
+void checkEdgesEnforced(const JoinHypergraph& graph, MemoOpCP plan) {
+  if (plan == nullptr) {
+    return;
+  }
+  folly::F14FastSet<size_t> applied;
+  collectAppliedEdges(plan, applied);
+  graph.checkEdgesEnforced(applied);
+}
+
 } // namespace
 
 const MemoOp* DPhyp::enumerate() {
@@ -1256,7 +1292,9 @@ const MemoOp* DPhyp::enumerate() {
   if (budgetExceeded) {
     // The graph is too dense for exhaustive DP; restart greedily.
     memo_.clear();
-    return enumerator.greedy(allRelations);
+    MemoOpCP greedyRoot = enumerator.greedy(allRelations);
+    checkEdgesEnforced(graph_, greedyRoot);
+    return greedyRoot;
   }
 
   const auto rootIt = memo_.find(allRelations);
@@ -1265,7 +1303,9 @@ const MemoOp* DPhyp::enumerate() {
     // The caller falls back to the query's syntactic join order.
     return nullptr;
   }
-  return rootIt->second.cheapest();
+  MemoOpCP root = rootIt->second.cheapest();
+  checkEdgesEnforced(graph_, root);
+  return root;
 }
 
 std::vector<MemoOpCP> DPhyp::enumerate(
@@ -1301,6 +1341,15 @@ std::vector<MemoOpCP> DPhyp::enumerate(
     }
     roots.push_back(root);
   }
+
+  // Components partition the relations, so every edge lies inside one of them
+  // and the roots together must apply all of them.
+  folly::F14FastSet<size_t> applied;
+  for (MemoOpCP root : roots) {
+    collectAppliedEdges(root, applied);
+  }
+  graph_.checkEdgesEnforced(applied);
+
   return roots;
 }
 

--- a/axiom/optimizer/v2/JoinHypergraph.cpp
+++ b/axiom/optimizer/v2/JoinHypergraph.cpp
@@ -282,4 +282,60 @@ void JoinHypergraph::addEdge(JoinEdge edge, RelationSet tes) {
   invalidateCoverCaches();
 }
 
+void JoinHypergraph::checkEdgesEnforced(
+    const folly::F14FastSet<size_t>& appliedEdges) const {
+  // Union-find over key expressions. An applied edge that proves its keys
+  // equal merges their classes, so an edge whose keys land in one class is
+  // enforced even where the plan does not apply that edge.
+  folly::F14FastMap<ExprCP, ExprCP> parent;
+  auto find = [&](ExprCP expr) {
+    parent.try_emplace(expr, expr);
+    ExprCP root = expr;
+    while (parent[root] != root) {
+      root = parent[root];
+    }
+    while (expr != root) {
+      ExprCP next = parent[expr];
+      parent[expr] = root;
+      expr = next;
+    }
+    return root;
+  };
+
+  for (size_t index : appliedEdges) {
+    const JoinEdge& edge = edges_[index];
+    if (edge.isUnnest() || !provesKeyEquality(edge.joinType())) {
+      continue;
+    }
+    for (size_t i = 0; i < edge.leftKeys().size(); ++i) {
+      ExprCP left = find(edge.leftKeys()[i]);
+      ExprCP right = find(edge.rightKeys()[i]);
+      if (left != right) {
+        parent[left] = right;
+      }
+    }
+  }
+
+  for (size_t index = 0; index < edges_.size(); ++index) {
+    const JoinEdge& edge = edges_[index];
+    if (edge.isUnnest() || !provesKeyEquality(edge.joinType())) {
+      // An Unnest produces the rows it expands, and an unmatched or
+      // null-padded row has unequal keys, so nothing stands in for these.
+      VELOX_CHECK(
+          appliedEdges.contains(index),
+          "Plan does not apply a join edge: {} {}",
+          index,
+          edge.joinTypeName());
+      continue;
+    }
+    for (size_t i = 0; i < edge.leftKeys().size(); ++i) {
+      VELOX_CHECK(
+          find(edge.leftKeys()[i]) == find(edge.rightKeys()[i]),
+          "Plan does not enforce a join equality: {} = {}",
+          edge.leftKeys()[i]->toString(),
+          edge.rightKeys()[i]->toString());
+    }
+  }
+}
+
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinHypergraph.h
+++ b/axiom/optimizer/v2/JoinHypergraph.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
 
 #include "axiom/optimizer/PlanObject.h"
 #include "axiom/optimizer/QueryGraphContext.h"
@@ -91,6 +92,18 @@ class JoinHypergraph {
   /// `edge.left() ∪ edge.right()`, and every relation referenced
   /// by `edge` or `tes` must already be in `relations()`.
   void addEdge(JoinEdge edge, RelationSet tes);
+
+  /// Throws unless `appliedEdges` — the edges a finished plan applies, indexed
+  /// into `edges()` — enforce every edge's equalities. A plan that drops one
+  /// returns rows the query excludes.
+  ///
+  /// An edge need not appear in `appliedEdges` itself: equality is transitive,
+  /// so applying `a = b` and `b = c` enforces `a = c`.
+  ///
+  /// The closure is position-insensitive, so an edge applied under the
+  /// null-padding side of an outer join is credited even though its equality
+  /// does not hold on the padded rows.
+  void checkEdgesEnforced(const folly::F14FastSet<size_t>& appliedEdges) const;
 
   /// Appends a filter conjunct. `conjunct.relations` must be
   /// a subset of the relations already in `relations()`.


### PR DESCRIPTION
Summary:
The v2 join enumerator could choose a plan that does not apply every equality the query states, and the query then returned rows it should have excluded. For example:

    WITH ids (id) AS (VALUES (1)),
         labels (id, label) AS (VALUES (1, 'a'), (1, 'b')),
         extra (id) AS (VALUES (1)),
         labeled AS (SELECT ids.id, labels.label FROM ids JOIN labels ON labels.id = ids.id LEFT JOIN extra ON extra.id = ids.id)
    SELECT count(*) FROM labeled AS x JOIN labeled AS y ON x.id = y.id AND x.label = y.label

Each row of `labeled` matches only itself, so the answer is 2. v2 returns 4, having joined on `id` alone.

`JoinHypergraph::checkEdgesEnforced` now rejects such a plan, and `DPhyp` calls it on the plan it picks. It compares equivalence classes rather than membership, because equality is transitive: a plan that applies `a = b` and `b = c` enforces `a = c` without applying that edge, and the closure it builds from the applied edges says so. An Unnest edge and a non-inner edge cannot be implied this way, since an unmatched or null-padded row has unequal keys, so those must be applied directly.

The query still does not plan. A separate change teaches the enumerator to keep the equality; until then the query fails instead of returning wrong rows, which is what the added test pins.

Differential Revision: D118578338
