### PR TITLE
fix(sql): Type GROUPING() by its column count (#1823)

### DIFF
--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -929,14 +929,25 @@ core::ExprPtr GroupByPlanner::rewriteGroupingMarker(const core::ExprPtr& expr) {
     VELOX_USER_CHECK(
         !columnIndices.empty(),
         "GROUPING() requires at least one column argument");
-    // Bitmask is int64, so at most 63 columns (sign bit excluded).
+    // Presto types GROUPING() by the number of column arguments: the bitmask
+    // is INTEGER while it fits in int32, then BIGINT, with the sign bit
+    // excluded in both cases.
+    constexpr size_t kMaxGroupingArgsInteger = 31;
+    constexpr size_t kMaxGroupingArgsBigint = 63;
+
     VELOX_USER_CHECK_LE(
         columnIndices.size(),
-        63,
-        "GROUPING() supports up to 63 column arguments");
+        kMaxGroupingArgsBigint,
+        "Too many GROUPING() column arguments");
+
+    const auto literal = [&](int64_t value) {
+      return columnIndices.size() <= kMaxGroupingArgsInteger
+          ? Variant(static_cast<int32_t>(value))
+          : Variant(value);
+    };
 
     if (groupingSetsIndices_.size() == 1) {
-      return lp::Lit(static_cast<int64_t>(0)).expr();
+      return lp::Lit(literal(0)).expr();
     }
 
     // MSB = leftmost arg. Bit is 0 when column is present in the
@@ -955,7 +966,7 @@ core::ExprPtr GroupByPlanner::rewriteGroupingMarker(const core::ExprPtr& expr) {
               ~static_cast<int64_t>(1ULL << (columnIndices.size() - 1 - i));
         }
       }
-      bitmaskValues.emplace_back(bitmask);
+      bitmaskValues.push_back(literal(bitmask));
     }
 
     // element_at is 1-indexed; $grouping_set_id is 0-based.

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/format.h>
 #include <fmt/ranges.h>
+#include <numeric>
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
 
@@ -385,13 +386,15 @@ TEST_F(AggregationParserTest, groupingFunction) {
         "element_at([{}], \"$grouping_set_id\" + 1)", fmt::join(bitmasks, ","));
   };
 
+  const parse::ParseOptions kIntegerLiterals{.parseIntegerAsBigint = false};
+
   // GROUPING() with two grouping sets.
   testSelect(
       "SELECT GROUPING(n_regionkey), count(1) FROM nation "
       "GROUP BY GROUPING SETS ((n_regionkey), ())",
       matchScan()
           .aggregate({"n_regionkey"}, {"count(1)"}, {{0}, {}})
-          .project({grouping({0, 1}), "count"})
+          .project({grouping({0, 1}), "count"}, kIntegerLiterals)
           .output());
 
   // GROUPING() inside a window PARTITION BY is rewritten like GROUPING() in
@@ -401,8 +404,10 @@ TEST_F(AggregationParserTest, groupingFunction) {
       "FROM nation GROUP BY GROUPING SETS ((n_regionkey), ())",
       matchScan()
           .aggregate({"n_regionkey"}, {"sum(n_nationkey)"}, {{0}, {}})
-          .project({fmt::format(
-              "sum(sum) OVER (PARTITION BY {})", grouping({0, 1}))})
+          .project(
+              {fmt::format(
+                  "sum(sum) OVER (PARTITION BY {})", grouping({0, 1}))},
+              kIntegerLiterals)
           .output());
 
   // GROUPING() inside a window ORDER BY is rewritten as well.
@@ -412,7 +417,8 @@ TEST_F(AggregationParserTest, groupingFunction) {
       matchScan()
           .aggregate({"n_regionkey"}, {"sum(n_nationkey)"}, {{0}, {}})
           .project(
-              {fmt::format("sum(sum) OVER (ORDER BY {})", grouping({0, 1}))})
+              {fmt::format("sum(sum) OVER (ORDER BY {})", grouping({0, 1}))},
+              kIntegerLiterals)
           .output());
 
   // GROUPING() with two columns, three grouping sets.
@@ -421,7 +427,7 @@ TEST_F(AggregationParserTest, groupingFunction) {
       "GROUP BY GROUPING SETS ((n_regionkey, n_name), (n_regionkey), ())",
       matchScan()
           .aggregate({"n_regionkey", "n_name"}, {"count(1)"}, {{0, 1}, {0}, {}})
-          .project({grouping({0, 1, 3}), "count"})
+          .project({grouping({0, 1, 3}), "count"}, kIntegerLiterals)
           .output());
 
   // GROUPING() in SELECT with other columns (ROLLUP).
@@ -430,7 +436,9 @@ TEST_F(AggregationParserTest, groupingFunction) {
       "FROM nation GROUP BY ROLLUP(n_regionkey, n_name)",
       matchScan()
           .aggregate({"n_regionkey", "n_name"}, {"count(1)"}, {{0, 1}, {0}, {}})
-          .project({"n_regionkey", "n_name", grouping({0, 1, 3}), "count"})
+          .project(
+              {"n_regionkey", "n_name", grouping({0, 1, 3}), "count"},
+              kIntegerLiterals)
           .output());
 
   // Two separate GROUPING() calls (CUBE).
@@ -445,7 +453,8 @@ TEST_F(AggregationParserTest, groupingFunction) {
                "n_name",
                grouping({0, 0, 1, 1}),
                grouping({0, 1, 0, 1}),
-               "count"})
+               "count"},
+              kIntegerLiterals)
           .output());
 
   // GROUPING() with plain GROUP BY resolves to constant 0 (single set).
@@ -455,7 +464,10 @@ TEST_F(AggregationParserTest, groupingFunction) {
       matchScan()
           .aggregate({"n_regionkey"}, {"count(1)"})
           .project({"n_regionkey", "0", "count"})
-          .output());
+          // A single grouping set yields INTEGER, like the multi-set form.
+          .output([](const auto& node) {
+            EXPECT_EQ(*node->outputType()->childAt(1), *INTEGER());
+          }));
 
   VELOX_ASSERT_THROW(
       parseSelect(
@@ -469,7 +481,7 @@ TEST_F(AggregationParserTest, groupingFunction) {
       "FROM nation GROUP BY ROLLUP(n_regionkey)",
       matchScan()
           .aggregate({"n_regionkey"}, {"count(1)"}, {{0}, {}})
-          .project({"n_regionkey", grouping({0, 3}), "count"})
+          .project({"n_regionkey", grouping({0, 3}), "count"}, kIntegerLiterals)
           .output());
 
   // Two columns with the same leaf name across a join stay distinct grouping
@@ -482,7 +494,7 @@ TEST_F(AggregationParserTest, groupingFunction) {
           .join(matchScan("nation").build())
           .filter()
           .aggregate({"n_regionkey", "n_regionkey_2"}, {"count(1)"}, {{0}, {1}})
-          .project({grouping({1, 2}), "count"})
+          .project({grouping({1, 2}), "count"}, kIntegerLiterals)
           .output());
 
   // A qualified GROUPING() argument that is not a grouping key still fails.
@@ -500,7 +512,7 @@ TEST_F(AggregationParserTest, groupingFunction) {
       "GROUP BY GROUPING SETS ((s.x.y), ())",
       matchScan("s")
           .aggregate({"DEREFERENCE(x, y)"}, {"count(1)"}, {{0}, {}})
-          .project({grouping({0, 1}), "count"})
+          .project({grouping({0, 1}), "count"}, kIntegerLiterals)
           .output());
 
   AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
@@ -540,7 +552,7 @@ TEST_F(AggregationParserTest, groupingFunction) {
       "GROUP BY GROUPING SETS ((n_regionkey), ())",
       matchScan()
           .aggregate({"n_regionkey"}, {"count(1)"}, {{0}, {}})
-          .project({grouping({0, 1}), "count"})
+          .project({grouping({0, 1}), "count"}, kIntegerLiterals)
           .output());
 
   // GROUPING() in FILTER clause of aggregate.
@@ -574,6 +586,41 @@ TEST_F(AggregationParserTest, groupingFunction) {
           "SELECT n_regionkey FROM nation n1 "
           "JOIN nation n2 ON GROUPING(n1.n_regionkey) = 0"),
       "not allowed in this context");
+
+  // Past 31 columns the bitmask no longer fits in int32, so it becomes BIGINT.
+  // Past 63 it does not fit at all.
+  {
+    std::vector<std::string> names;
+    names.reserve(64);
+    for (int32_t i = 0; i < 64; ++i) {
+      names.push_back(fmt::format("c{}", i));
+    }
+    connector_->addTable("wide", ROW(names, BIGINT()));
+
+    const auto query = [&](int32_t numColumns) {
+      const auto columns = fmt::to_string(
+          fmt::join(names.begin(), names.begin() + numColumns, ", "));
+      return fmt::format(
+          "SELECT GROUPING({0}), count(1) FROM wide "
+          "GROUP BY GROUPING SETS (({0}), ())",
+          columns);
+    };
+
+    std::vector<std::string> keys(names.begin(), names.begin() + 32);
+    std::vector<int32_t> allKeys(keys.size());
+    std::iota(allKeys.begin(), allKeys.end(), 0);
+
+    // Expected literals parse as BIGINT, which is what the plan holds here.
+    testSelect(
+        query(32),
+        matchScan("wide")
+            .aggregate(keys, {"count(1)"}, {allKeys, {}})
+            .project({grouping({0, (1LL << 32) - 1}), "count"})
+            .output());
+
+    VELOX_ASSERT_THROW(
+        parseSelect(query(64)), "Too many GROUPING() column arguments");
+  }
 }
 
 TEST_F(AggregationParserTest, rollup) {

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
@@ -219,16 +219,18 @@ class FilterMatcher : public LogicalPlanMatcherImpl<FilterNode> {
  public:
   FilterMatcher(
       const std::shared_ptr<LogicalPlanMatcher>& inputMatcher,
-      std::string expression)
+      std::string expression,
+      velox::parse::ParseOptions parseOptions)
       : LogicalPlanMatcherImpl<FilterNode>(inputMatcher, nullptr),
-        expression_{std::move(expression)} {}
+        expression_{std::move(expression)},
+        parseOptions_{std::move(parseOptions)} {}
 
  private:
   MatchResult matchDetails(
       const FilterNode& plan,
       const std::unordered_map<std::string, std::string>& symbols)
       const override {
-    velox::parse::DuckSqlExpressionsParser parser;
+    velox::parse::DuckSqlExpressionsParser parser(parseOptions_);
     auto expected = parser.parseScalarOrWindowExpr(expression_);
 
     if (!symbols.empty()) {
@@ -240,6 +242,7 @@ class FilterMatcher : public LogicalPlanMatcherImpl<FilterNode> {
   }
 
   const std::string expression_;
+  const velox::parse::ParseOptions parseOptions_;
 };
 
 class SetMatcher : public LogicalPlanMatcherImpl<SetNode> {
@@ -324,9 +327,11 @@ class ProjectMatcher : public LogicalPlanMatcherImpl<ProjectNode> {
  public:
   ProjectMatcher(
       const std::shared_ptr<LogicalPlanMatcher>& inputMatcher,
-      std::vector<std::string> expressions)
+      std::vector<std::string> expressions,
+      velox::parse::ParseOptions parseOptions)
       : LogicalPlanMatcherImpl<ProjectNode>(inputMatcher, nullptr),
-        expressionStrings_{std::move(expressions)} {}
+        expressionStrings_{std::move(expressions)},
+        parseOptions_{std::move(parseOptions)} {}
 
   ProjectMatcher(
       const std::shared_ptr<LogicalPlanMatcher>& inputMatcher,
@@ -348,9 +353,7 @@ class ProjectMatcher : public LogicalPlanMatcherImpl<ProjectNode> {
     // Inherit aliases captured below so a name bound at a descendant (e.g. an
     // aggregate output) stays resolvable above this projection.
     std::unordered_map<std::string, std::string> newSymbols = symbols;
-    velox::parse::ParseOptions parseOptions;
-    parseOptions.correctWindowFrameDefault = true;
-    velox::parse::DuckSqlExpressionsParser parser(parseOptions);
+    velox::parse::DuckSqlExpressionsParser parser(parseOptions_);
 
     for (auto i = 0; i < numExprs; ++i) {
       const auto& actual = plan.expressionAt(i);
@@ -385,6 +388,7 @@ class ProjectMatcher : public LogicalPlanMatcherImpl<ProjectNode> {
 
   const std::vector<std::string> expressionStrings_;
   const std::vector<ExprApi> expressionApis_;
+  const velox::parse::ParseOptions parseOptions_;
 };
 
 class AggregateMatcher : public LogicalPlanMatcherImpl<AggregateNode> {
@@ -393,11 +397,13 @@ class AggregateMatcher : public LogicalPlanMatcherImpl<AggregateNode> {
       const std::shared_ptr<LogicalPlanMatcher>& inputMatcher,
       std::vector<std::string> groupingKeys,
       std::vector<std::string> aggregates,
-      std::vector<std::vector<int32_t>> groupingSets = {})
+      std::vector<std::vector<int32_t>> groupingSets,
+      velox::parse::ParseOptions parseOptions)
       : LogicalPlanMatcherImpl<AggregateNode>(inputMatcher, nullptr),
         groupingKeys_{std::move(groupingKeys)},
         aggregates_{std::move(aggregates)},
-        groupingSets_{std::move(groupingSets)} {}
+        groupingSets_{std::move(groupingSets)},
+        parseOptions_{std::move(parseOptions)} {}
 
  private:
   MatchResult matchDetails(
@@ -419,7 +425,7 @@ class AggregateMatcher : public LogicalPlanMatcherImpl<AggregateNode> {
     std::unordered_map<std::string, std::string> newSymbols = symbols;
     auto numGroupingKeys = plan.groupingKeys().size();
 
-    velox::parse::DuckSqlExpressionsParser parser;
+    velox::parse::DuckSqlExpressionsParser parser(parseOptions_);
     for (auto i = 0; i < aggregates_.size(); ++i) {
       velox::core::ExprPtr parsed = parser.parseAggregateExpr(aggregates_[i]);
 
@@ -455,6 +461,7 @@ class AggregateMatcher : public LogicalPlanMatcherImpl<AggregateNode> {
   const std::vector<std::string> groupingKeys_;
   const std::vector<std::string> aggregates_;
   const std::vector<std::vector<int32_t>> groupingSets_;
+  const velox::parse::ParseOptions parseOptions_;
 };
 
 class DistinctMatcher : public LogicalPlanMatcherImpl<AggregateNode> {
@@ -522,9 +529,11 @@ class SortMatcher : public LogicalPlanMatcherImpl<SortNode> {
   SortMatcher(
       const std::shared_ptr<LogicalPlanMatcher>& inputMatcher,
       std::vector<std::string> ordering,
-      std::function<void(const LogicalPlanNodePtr&)> onMatch)
+      std::function<void(const LogicalPlanNodePtr&)> onMatch,
+      velox::parse::ParseOptions parseOptions)
       : LogicalPlanMatcherImpl<SortNode>(inputMatcher, std::move(onMatch)),
-        ordering_{std::move(ordering)} {}
+        ordering_{std::move(ordering)},
+        parseOptions_{std::move(parseOptions)} {}
 
  private:
   MatchResult matchDetails(
@@ -535,7 +544,7 @@ class SortMatcher : public LogicalPlanMatcherImpl<SortNode> {
     EXPECT_EQ(actualOrdering.size(), ordering_.size());
     AXIOM_RETURN_IF_FAILURE;
 
-    velox::parse::DuckSqlExpressionsParser parser;
+    velox::parse::DuckSqlExpressionsParser parser(parseOptions_);
     for (size_t i = 0; i < ordering_.size(); ++i) {
       auto expected = parser.parseOrderByExpr(ordering_[i]);
       auto expectedExpr = expected.expr;
@@ -562,6 +571,7 @@ class SortMatcher : public LogicalPlanMatcherImpl<SortNode> {
   }
 
   const std::vector<std::string> ordering_;
+  const velox::parse::ParseOptions parseOptions_;
 };
 
 #undef AXIOM_RETURN_IF_FAILURE
@@ -619,9 +629,10 @@ LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::filter(
 }
 
 LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::filter(
-    const std::string& expression) {
+    const std::string& expression,
+    const velox::parse::ParseOptions& options) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
-  matcher_ = std::make_shared<FilterMatcher>(matcher_, expression);
+  matcher_ = std::make_shared<FilterMatcher>(matcher_, expression, options);
   return *this;
 }
 
@@ -634,9 +645,10 @@ LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::project(
 }
 
 LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::project(
-    const std::vector<std::string>& expressions) {
+    const std::vector<std::string>& expressions,
+    const velox::parse::ParseOptions& options) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
-  matcher_ = std::make_shared<ProjectMatcher>(matcher_, expressions);
+  matcher_ = std::make_shared<ProjectMatcher>(matcher_, expressions, options);
   return *this;
 }
 
@@ -659,10 +671,11 @@ LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::aggregate(
 LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::aggregate(
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates,
-    const std::vector<std::vector<int32_t>>& groupingSets) {
+    const std::vector<std::vector<int32_t>>& groupingSets,
+    const velox::parse::ParseOptions& options) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<AggregateMatcher>(
-      matcher_, groupingKeys, aggregates, groupingSets);
+      matcher_, groupingKeys, aggregates, groupingSets, options);
   return *this;
 }
 
@@ -890,10 +903,11 @@ LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::sort(
 
 LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::sort(
     const std::vector<std::string>& ordering,
-    OnMatchCallback onMatch) {
+    OnMatchCallback onMatch,
+    const velox::parse::ParseOptions& options) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
-  matcher_ =
-      std::make_shared<SortMatcher>(matcher_, ordering, std::move(onMatch));
+  matcher_ = std::make_shared<SortMatcher>(
+      matcher_, ordering, std::move(onMatch), options);
   return *this;
 }
 

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.h
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.h
@@ -19,6 +19,7 @@
 #include <unordered_map>
 #include "axiom/logical_plan/ExprApi.h"
 #include "axiom/logical_plan/LogicalPlanNode.h"
+#include "velox/parse/ExpressionsParser.h"
 
 namespace facebook::axiom::logical_plan::test {
 
@@ -111,6 +112,14 @@ class LogicalPlanMatcher {
 ///       .tableScan()
 ///       .join(right)
 ///       .project();
+///
+/// Parse options:
+/// -------------
+/// Methods that take expression text parse it with DuckDB and accept
+/// 'options'. Bare integer literals parse as BIGINT, which the constant
+/// comparison tolerates against a plan's INTEGER. That tolerance does not
+/// reach inside a complex constant, so pass '{.parseIntegerAsBigint = false}'
+/// to compare against an INTEGER array.
 class LogicalPlanMatcherBuilder {
  public:
   /// Callback invoked when a node matches. Use to capture or inspect the
@@ -141,7 +150,9 @@ class LogicalPlanMatcherBuilder {
   /// expression is parsed with DuckDB and matched structurally against the
   /// filter expression, so `ExprMatcher` wildcards apply. Supports symbol
   /// rewriting.
-  LogicalPlanMatcherBuilder& filter(const std::string& expression);
+  LogicalPlanMatcherBuilder& filter(
+      const std::string& expression,
+      const velox::parse::ParseOptions& options = {});
 
   /// Matches a ProjectNode.
   LogicalPlanMatcherBuilder& project(OnMatchCallback onMatch = nullptr);
@@ -150,7 +161,8 @@ class LogicalPlanMatcherBuilder {
   /// expression is parsed with DuckDB and matched structurally against
   /// expressionAt(i), so `ExprMatcher` wildcards apply.
   LogicalPlanMatcherBuilder& project(
-      const std::vector<std::string>& expressions);
+      const std::vector<std::string>& expressions,
+      const velox::parse::ParseOptions& options = {});
 
   /// Matches a ProjectNode with the specified ExprApi expressions. Each
   /// expected expression is compared directly against
@@ -168,7 +180,8 @@ class LogicalPlanMatcherBuilder {
   LogicalPlanMatcherBuilder& aggregate(
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
-      const std::vector<std::vector<int32_t>>& groupingSets = {});
+      const std::vector<std::vector<int32_t>>& groupingSets = {},
+      const velox::parse::ParseOptions& options = {});
 
   /// Matches an AggregateNode used for deduplication (no aggregate functions,
   /// no grouping sets, all output columns are grouping keys).
@@ -269,7 +282,8 @@ class LogicalPlanMatcherBuilder {
   /// is a sorting expression in DuckDB SQL syntax.
   LogicalPlanMatcherBuilder& sort(
       const std::vector<std::string>& ordering,
-      OnMatchCallback onMatch = nullptr);
+      OnMatchCallback onMatch = nullptr,
+      const velox::parse::ParseOptions& options = {});
 
   /// Matches any LimitNode.
   LogicalPlanMatcherBuilder& limit(OnMatchCallback onMatch = nullptr);


### PR DESCRIPTION
Summary:

`GROUPING()` returned BIGINT for every query. Presto returns INTEGER until the bitmask stops fitting in int32:

    SELECT typeof(grouping(a)) FROM t GROUP BY GROUPING SETS ((a), ())

returns `integer` in Presto and returned `bigint` here. The width follows the number of column arguments: INTEGER up to 31, BIGINT from 32 to 63, an error above that.

The bitmask is computed in int64 and was emitted as one. It is now emitted as int32 while the column count allows.

Pinning the narrower literal needs the expected expression text in a plan test to parse its integers as INTEGER, so `LogicalPlanMatcherBuilder` methods that take expression text accept `velox::parse::ParseOptions`, as `axiom/optimizer/tests/PlanMatcher.h` already does. `ProjectMatcher` also stops forcing `correctWindowFrameDefault`; the post-parse correction beside it already covers that.

Reviewed By: amitkdutta, natashasehgal

Differential Revision: D118633948
