### PR TITLE
feat(optimizer): Push subfields down to the scan in v2 (#1824)

### DIFF
--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(
   StatsFilterSelectivityEstimator.cpp
   SubfieldTracker.cpp
   ToGraph.cpp
+  ToSubfield.cpp
   ToVelox.cpp
   VeloxHistory.cpp
   WriteStatsBuilder.cpp

--- a/axiom/optimizer/FunctionRegistry.cpp
+++ b/axiom/optimizer/FunctionRegistry.cpp
@@ -394,6 +394,7 @@ void FunctionRegistry::registerPrestoFunctions(std::string_view prefix) {
   {
     auto metadata = std::make_unique<FunctionMetadata>();
     metadata->valuePathToArgPath = rowConstructorSubfield;
+    metadata->isRowConstructor = true;
     metadata->explode = rowConstructorExplode;
     metadata->functionSet = FunctionSet(FunctionSet::kNonDefaultNullBehavior);
     // Presto row_constructor created without prefix, so we register it without

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -131,7 +131,8 @@ constexpr float kDefaultCallCost = 5;
 struct FunctionMetadata {
   bool processSubfields() const {
     return subfieldArg.has_value() || !fieldIndexForArg.empty() ||
-        isArrayConstructor || isMapConstructor || valuePathToArgPath;
+        isArrayConstructor || isMapConstructor || isRowConstructor ||
+        valuePathToArgPath;
   }
 
   const LambdaInfo* lambdaInfo(int32_t index) const {
@@ -158,6 +159,11 @@ struct FunctionMetadata {
   /// If key 'k' in result is accessed, then the argument that corresponds to
   /// this key is accessed.
   bool isMapConstructor{false};
+
+  /// If true, then access of field 'i' in result means that argument 'i' is
+  /// accessed. False for a function that builds a row from something other
+  /// than one argument per field, such as a map and a list of keys.
+  bool isRowConstructor{false};
 
   /// If ordinal fieldIndexForArg_[i] is accessed, then argument argOrdinal_[i]
   /// is accessed.

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -106,15 +106,16 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   int32_t parallelProjectWidth{kParallelProjectWidthDefault};
 
   /// Produces skyline subfield sets of complex type columns as top level
-  /// columns in table scan.
+  /// columns in table scan. v1 only: v2 always pushes subfields down.
   bool pushdownSubfields{kPushdownSubfieldsDefault};
 
   /// Makes all maps for which a known subset of keys is accessed to
-  /// be projected out as structs.
+  /// be projected out as structs. v1 only: v2 reads the subfields where they
+  /// stand and produces no derived columns.
   bool allMapsAsStruct{kAllMapsAsStructDefault};
 
   /// Map from table name to list of map columns to be read as structs unless
-  /// the whole map is accessed as a map.
+  /// the whole map is accessed as a map. v1 only, as for 'allMapsAsStruct'.
   folly::F14FastMap<std::string, std::vector<std::string>> mapAsStruct;
 
   /// A query whose scans are estimated to read at most this many rows in total

--- a/axiom/optimizer/QueryGraphContext.cpp
+++ b/axiom/optimizer/QueryGraphContext.cpp
@@ -276,9 +276,6 @@ void Path::subfieldSkyline(BitSet& subfields) {
     return;
   }
 
-  // Expand the ids to fields and remove subfields where there exists a shorter
-  // prefix.
-
   auto ctx = queryCtx();
   bool allFields = false;
   // Groups paths by their size (number of steps - 1). This allows efficient

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -293,8 +293,14 @@ class Path {
     mutable_ = false;
   }
 
-  /// Removes elements of 'subfields' where the path has a prefix in
-  /// 'subfields'.
+  /// Reduces 'subfields' to the shortest paths that cover it: drops every path
+  /// that has a prefix in 'subfields', since reading the prefix already reads
+  /// the longer path. Given {m[k].a, m[k].a.b, m[k], s.x}, keeps {m[k], s.x}.
+  ///
+  /// An empty result means the whole column is read and no subfield pruning is
+  /// possible. That happens either because 'subfields' was already empty or
+  /// because it held a zero-step path, which stands for the whole column and
+  /// makes every other path redundant.
   static void subfieldSkyline(BitSet& subfields);
 
  private:

--- a/axiom/optimizer/ToSubfield.cpp
+++ b/axiom/optimizer/ToSubfield.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/ToSubfield.h"
+
+namespace facebook::axiom::optimizer {
+
+namespace {
+using PathElementPtr = std::unique_ptr<velox::common::Subfield::PathElement>;
+
+PathElementPtr toSubscript(const Step& step, bool asField) {
+  if (step.allFields) {
+    return std::make_unique<velox::common::Subfield::AllSubscripts>();
+  }
+  if (asField) {
+    return std::make_unique<velox::common::Subfield::NestedField>(
+        step.field ? std::string(step.field) : fmt::format("{}", step.id));
+  }
+  if (step.field) {
+    return std::make_unique<velox::common::Subfield::StringSubscript>(
+        step.field);
+  }
+  return std::make_unique<velox::common::Subfield::LongSubscript>(step.id);
+}
+} // namespace
+
+std::vector<velox::common::Subfield> toSubfields(
+    std::string_view columnName,
+    const PathSet& paths,
+    bool mapKeysAsFields) {
+  std::vector<velox::common::Subfield> subfields;
+  paths.forEachPath([&](PathCP path) {
+    std::vector<PathElementPtr> elements;
+    elements.push_back(
+        std::make_unique<velox::common::Subfield::NestedField>(
+            std::string(columnName)));
+
+    bool first = true;
+    for (const auto& step : path->steps()) {
+      switch (step.kind) {
+        case StepKind::kField:
+          VELOX_CHECK_NOT_NULL(
+              step.field, "Index subfield not suitable for pruning");
+          elements.push_back(
+              std::make_unique<velox::common::Subfield::NestedField>(
+                  step.field));
+          break;
+        case StepKind::kSubscript:
+        case StepKind::kElementAt:
+          elements.push_back(toSubscript(step, mapKeysAsFields && first));
+          break;
+      }
+      first = false;
+    }
+
+    subfields.emplace_back(std::move(elements));
+  });
+
+  return subfields;
+}
+
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ToSubfield.h
+++ b/axiom/optimizer/ToSubfield.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/PathSet.h"
+#include "velox/type/Subfield.h"
+
+namespace facebook::axiom::optimizer {
+
+/// Converts the accessed paths of one column into the subfields a connector
+/// column handle takes. Each path becomes one subfield rooted at 'columnName'.
+///
+/// An empty 'paths' yields no subfields, which is how a caller says the whole
+/// column is read.
+///
+/// @param mapKeysAsFields Renders the first subscript of a map column as a
+/// struct field name rather than a subscript, for a layout that stores the map
+/// as a struct. Applies only to the first step, since only the top-level map
+/// is stored that way.
+std::vector<velox::common::Subfield> toSubfields(
+    std::string_view columnName,
+    const PathSet& paths,
+    bool mapKeysAsFields);
+
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -18,6 +18,7 @@
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/Optimization.h"
+#include "axiom/optimizer/ToSubfield.h"
 #include "axiom/optimizer/WriteStatsBuilder.h"
 #include "velox/core/PlanConsistencyChecker.h"
 #include "velox/core/PlanNode.h"
@@ -108,61 +109,11 @@ bool isIdentityProject(
 std::vector<velox::common::Subfield> columnSubfields(
     BaseTableCP table,
     int32_t id) {
-  auto* optimization = queryCtx()->optimization();
-
   const auto columnName = queryCtx()->objectAt(id)->as<Column>()->name();
-
-  PathSet set = table->columnSubfields(id);
-
-  std::vector<velox::common::Subfield> subfields;
-  set.forEachPath([&](PathCP path) {
-    const auto& steps = path->steps();
-    std::vector<std::unique_ptr<velox::common::Subfield::PathElement>> elements;
-    elements.push_back(
-        std::make_unique<velox::common::Subfield::NestedField>(columnName));
-    bool first = true;
-    for (auto& step : steps) {
-      switch (step.kind) {
-        case StepKind::kField:
-          VELOX_CHECK_NOT_NULL(
-              step.field, "Index subfield not suitable for pruning");
-          elements.push_back(
-              std::make_unique<velox::common::Subfield::NestedField>(
-                  step.field));
-          break;
-        case StepKind::kSubscript:
-        case StepKind::kElementAt:
-          if (step.allFields) {
-            elements.push_back(
-                std::make_unique<velox::common::Subfield::AllSubscripts>());
-            break;
-          }
-          if (first &&
-              optimization->options().isMapAsStruct(
-                  table->schemaTable->name(), columnName)) {
-            elements.push_back(
-                std::make_unique<velox::common::Subfield::NestedField>(
-                    step.field ? std::string(step.field)
-                               : fmt::format("{}", step.id)));
-            break;
-          }
-          if (step.field) {
-            elements.push_back(
-                std::make_unique<velox::common::Subfield::StringSubscript>(
-                    step.field));
-            break;
-          }
-          elements.push_back(
-              std::make_unique<velox::common::Subfield::LongSubscript>(
-                  step.id));
-          break;
-      }
-      first = false;
-    }
-    subfields.emplace_back(std::move(elements));
-  });
-
-  return subfields;
+  const bool mapKeysAsFields =
+      queryCtx()->optimization()->options().isMapAsStruct(
+          table->schemaTable->name(), columnName);
+  return toSubfields(columnName, table->columnSubfields(id), mapKeysAsFields);
 }
 
 // On return, *outGather is set to the inserted gather Repartition, or

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -2063,6 +2063,15 @@ PlanMatcherBuilder& PlanMatcherBuilder::tableScan(
   return *this;
 }
 
+PlanMatcherBuilder& PlanMatcherBuilder::tableScan(
+    const std::string& tableName,
+    OnMatchCallback onMatch) {
+  VELOX_USER_CHECK_NULL(matcher_);
+  matcher_ = std::make_shared<TableScanMatcher>(tableName);
+  matcher_->setOnMatch(std::move(onMatch));
+  return *this;
+}
+
 PlanMatcherBuilder& PlanMatcherBuilder::hiveScan(
     const std::string& tableName,
     common::SubfieldFilters subfieldFilters,

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -288,6 +288,16 @@ class PlanMatcherBuilder {
       const std::string& tableName,
       const RowTypePtr& outputType);
 
+  /// Matches a TableScan node with the specified table name and invokes
+  /// 'onMatch' with it. Lets a test assert something the matchers do not
+  /// cover — a column handle's required subfields, say — on one scan of a
+  /// plan that has several.
+  /// @param tableName The expected table name.
+  /// @param onMatch Invoked with the matched scan node.
+  PlanMatcherBuilder& tableScan(
+      const std::string& tableName,
+      OnMatchCallback onMatch);
+
   /// Matches a Hive TableScan node with the specified table name, subfield
   /// filters, and optional remaining filter.
   /// @param tableName The name of the table.

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <gmock/gmock.h>
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/connectors/hive/LocalTableMetadata.h"
 #include "axiom/logical_plan/PlanBuilder.h"
@@ -115,24 +116,29 @@ class SubfieldTest : public HiveQueriesTestBase,
 
   void SetUp() override {
     HiveQueriesTestBase::SetUp();
+
+    optimizerOptions_ = OptimizerOptions{};
+    optimizerOptions_.traceFlags = FLAGS_optimizer_trace;
+
     switch (GetParam()) {
       case 1:
-        optimizerOptions_ = OptimizerOptions();
+        optimizerOptions_.pushdownSubfields = false;
         break;
       case 2:
-        optimizerOptions_ = OptimizerOptions{};
         optimizerOptions_.pushdownSubfields = true;
         break;
       case 3:
-        optimizerOptions_ = OptimizerOptions{};
         optimizerOptions_.pushdownSubfields = true;
         optimizerOptions_.mapAsStruct["features"] = {
             "float_features", "id_list_features", "id_score_list_features"};
         break;
+      case 4:
+        // `pushdownSubfields` and `mapAsStruct` are v1-only options.
+        useV2_ = true;
+        break;
       default:
         FAIL();
     }
-    optimizerOptions_.traceFlags = FLAGS_optimizer_trace;
   }
 
   void declareGenies() {
@@ -347,35 +353,72 @@ class SubfieldTest : public HiveQueriesTestBase,
 
     SCOPED_TRACE(scanNode->toString(true, true));
 
+    verifyRequiredSubfields(*scanNode, expectedSubfields);
+  }
+
+  using HiveQueriesTestBase::matchHiveScan;
+
+  // Matches a scan of 'table' that reads exactly 'subfields' of each of its
+  // columns. Use when a plan has more than one scan, so that each is checked
+  // where the matcher names it.
+  static core::PlanMatcherBuilder matchHiveScan(
+      const std::string& table,
+      folly::F14FastMap<std::string, std::vector<std::string>> subfields) {
+    return core::PlanMatcherBuilder().tableScan(
+        table,
+        [subfields = std::move(subfields)](const core::PlanNodePtr& scan) {
+          verifyRequiredSubfields(*scan, subfields);
+        });
+  }
+
+  // Asserts the subfields each column of 'scanNode' is read with.
+  static void verifyRequiredSubfields(
+      const core::PlanNode& scanNode,
+      const folly::F14FastMap<std::string, std::vector<std::string>>&
+          expectedSubfields) {
     const auto& assignments =
-        dynamic_cast<const core::TableScanNode*>(scanNode)->assignments();
+        dynamic_cast<const core::TableScanNode&>(scanNode).assignments();
     ASSERT_EQ(assignments.size(), expectedSubfields.size());
 
-    for (const auto& [_, handle] : assignments) {
-      auto hiveHandle =
+    for (const auto& [_, columnHandle] : assignments) {
+      const auto* handle =
           dynamic_cast<const velox::connector::hive::HiveColumnHandle*>(
-              handle.get());
-      ASSERT_TRUE(hiveHandle != nullptr);
+              columnHandle.get());
+      ASSERT_TRUE(handle != nullptr);
 
-      const auto& name = hiveHandle->name();
-      const auto& subfields = hiveHandle->requiredSubfields();
-
-      auto it = expectedSubfields.find(name);
+      const auto& name = handle->name();
+      const auto it = expectedSubfields.find(name);
       ASSERT_TRUE(it != expectedSubfields.end())
           << "Unexpected column: " << name;
-      const auto& expected = it->second;
 
-      ASSERT_EQ(subfields.size(), expected.size()) << hiveHandle->toString();
-
-      for (auto i = 0; i < subfields.size(); ++i) {
-        EXPECT_EQ(
-            subfields[i].toString(), fmt::format("{}{}", name, expected[i]));
+      // Required subfields are a set: the order a column handle lists them in
+      // is not part of the contract.
+      std::vector<std::string> actualNames;
+      for (const auto& subfield : handle->requiredSubfields()) {
+        actualNames.push_back(subfield.toString());
       }
+      std::vector<std::string> expectedNames;
+      for (const auto& suffix : it->second) {
+        expectedNames.push_back(fmt::format("{}{}", name, suffix));
+      }
+      EXPECT_THAT(
+          actualNames, testing::UnorderedElementsAreArray(expectedNames))
+          << handle->toString();
     }
   }
 
   static core::PlanNodePtr extractPlanNode(const PlanAndStats& plan) {
     return plan.plan->fragments().at(0).fragment.planNode;
+  }
+
+  // Creates table 't' with one array column, long enough for the paths these
+  // tests name.
+  void createArrayTable() {
+    createTable(
+        "t",
+        {makeRowVector(
+            {"a"},
+            {makeArrayVectorFromJson<int64_t>({"[1, 2, 3]", "[4, 5, 6]"})})});
   }
 
   std::vector<velox::RowVectorPtr> createFeaturesTable(FeatureOptions& opts) {
@@ -405,20 +448,22 @@ class SubfieldTest : public HiveQueriesTestBase,
 };
 
 TEST_P(SubfieldTest, structs) {
-  auto structType =
-      ROW({"s1", "s2", "s3"},
-          {BIGINT(), ROW({"s2s1"}, {BIGINT()}), ARRAY(BIGINT())});
-  auto rowType = ROW({"s", "i"}, {structType, BIGINT()});
+  auto rowType = ROW({
+      {"s",
+       ROW({
+           {"s1", BIGINT()},
+           {"s2", ROW({{"s2s1", BIGINT()}})},
+           {"s3", ARRAY(BIGINT())},
+       })},
+      {"i", BIGINT()},
+  });
   auto vectors = makeVectors(rowType, 1, 1);
   createTable("structs", vectors);
 
   {
     // Dereference struct fields by name.
-    auto logicalPlan = lp::PlanBuilder(makeContext(), /*enableCoercions=*/true)
-                           .tableScan("structs", rowType->names())
-                           .project({"s.s1 as s1", "s.s3[1]"})
-                           .filter("s1 < 10")
-                           .build();
+    auto logicalPlan =
+        parseSelect("SELECT s.s1, s.s3[1] FROM structs WHERE s.s1 < 10");
     auto fragmentedPlan = planVelox(logicalPlan);
 
     // t2.s = HiveColumnHandle [... requiredSubfields: [ s.s1 s.s3[1] ]]
@@ -456,6 +501,11 @@ TEST_P(SubfieldTest, structs) {
 }
 
 TEST_P(SubfieldTest, anonymousStructs) {
+  if (useV2_) {
+    GTEST_SKIP() << "v2 does not rewrite a field read of a constructed row "
+                    "into the argument that supplies it";
+  }
+
   auto rowType = ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), ARRAY(BIGINT())});
   auto vectors = makeVectors(rowType, 1, 1);
   createTable("anon_structs", vectors);
@@ -496,6 +546,10 @@ TEST_P(SubfieldTest, anonymousStructs) {
 }
 
 TEST_P(SubfieldTest, anonymousStructTableScan) {
+  if (useV2_) {
+    GTEST_SKIP() << "v2 reads an unnamed struct field whole";
+  }
+
   // Simulate filtering or projection on a table scan column with unnamed struct
   // fields and verify that Axiom throws the "Index subfield not suitable for
   // pruning" error as expected.
@@ -529,6 +583,10 @@ TEST_P(SubfieldTest, anonymousStructTableScan) {
 }
 
 TEST_P(SubfieldTest, genie) {
+  if (useV2_) {
+    GTEST_SKIP() << "v2 does not explode a function result into subfields";
+  }
+
   createFeaturesTable();
 
   declareGenies();
@@ -616,7 +674,11 @@ TEST_P(SubfieldTest, genie) {
 TEST_P(SubfieldTest, maps) {
   auto vectors = createFeaturesTable();
 
-  testMakeRowFromMap();
+  if (!useV2_) {
+    // make_row_from_map has no Velox implementation; only v1 removes it
+    // before execution.
+    testMakeRowFromMap();
+  }
 
   {
     lp::PlanBuilder::Context ctx(kHiveConnectorId, kDefaultSchema);
@@ -663,14 +725,13 @@ TEST_P(SubfieldTest, maps) {
         });
   }
   {
-    auto logicalPlan = lp::PlanBuilder(makeContext())
-                           .tableScan("features")
-                           .project(
-                               {"float_features[10000::int] as ff",
-                                "id_score_list_features[200800::int] as sc1",
-                                "id_list_features as idlf"})
-                           .project({"sc1[1::BIGINT] + 1::REAL as score"})
-                           .build();
+    auto logicalPlan = parseSelect(
+        "SELECT sc1[1] + 1e0 AS score FROM ("
+        "  SELECT float_features[10000] AS ff,"
+        "         id_score_list_features[200800] AS sc1,"
+        "         id_list_features AS idlf"
+        "  FROM features"
+        ")");
 
     auto plan = extractPlanNode(planVelox(logicalPlan));
     verifyRequiredSubfields(
@@ -681,36 +742,36 @@ TEST_P(SubfieldTest, maps) {
   }
 
   {
-    auto logicalPlan = lp::PlanBuilder(makeContext())
-                           .tableScan("features")
-                           .project(
-                               {"float_features[10100::int] as ff",
-                                "id_score_list_features[200800::int] as sc1",
-                                "id_list_features as idlf",
-                                "uid"})
-                           .project(
-                               {"sc1[1::BIGINT] + 1::REAL as score",
-                                "idlf[cast(uid % 100 as INTEGER)] as any"})
-                           .build();
+    auto logicalPlan = parseSelect(
+        "SELECT sc1[1] + 1e0 AS score, idlf[CAST(uid % 100 AS INTEGER)] AS any "
+        "FROM ("
+        "  SELECT float_features[10100] AS ff,"
+        "         id_score_list_features[200800] AS sc1,"
+        "         id_list_features AS idlf,"
+        "         uid"
+        "  FROM features"
+        ")");
 
     auto plan = extractPlanNode(planVelox(logicalPlan));
+    // A wildcard with nothing below it reads the whole map. v1 says so with
+    // an explicit `[*]`, v2 by asking for no subfield at all.
+    const std::vector<std::string> everyKey =
+        useV2_ ? std::vector<std::string>{} : std::vector<std::string>{"[*]"};
     verifyRequiredSubfields(
         plan,
         {
             {"uid", {}},
             {"id_score_list_features", {subfield("200800", "[1]")}},
-            {"id_list_features", {"[*]"}},
+            {"id_list_features", everyKey},
         });
   }
 
   {
-    auto builder =
-        lp::PlanBuilder(makeContext())
-            .tableScan("features")
-            .project(
-                {"transform(id_list_features[201800::int], x -> x + 1) as ids"});
+    auto logicalPlan = parseSelect(
+        "SELECT transform(id_list_features[201800], x -> x + 1) AS ids "
+        "FROM features");
 
-    auto result = runVelox(builder.build());
+    auto result = runVelox(logicalPlan);
     auto expected = extractAndIncrementIdList(vectors, 201800);
     assertEqualResults(expected, result.results);
   }
@@ -721,28 +782,28 @@ TEST_P(SubfieldTest, cardinality) {
 
   // cardinality(m) requires the whole map.
   {
-    auto logicalPlan = lp::PlanBuilder(makeContext())
-                           .tableScan("features")
-                           .project({"cardinality(float_features) as n"})
-                           .build();
+    auto logicalPlan =
+        parseSelect("SELECT cardinality(float_features) AS n FROM features");
     auto plan = extractPlanNode(planVelox(logicalPlan));
     verifyRequiredSubfields(plan, {{"float_features", {}}});
   }
 
   // cardinality(m) and m[k] on the same column: the whole map is required.
   {
-    auto logicalPlan = lp::PlanBuilder(makeContext())
-                           .tableScan("features")
-                           .project(
-                               {"cardinality(float_features) as n",
-                                "float_features[10100::int] as v"})
-                           .build();
+    auto logicalPlan = parseSelect(
+        "SELECT cardinality(float_features) AS n, float_features[10100] AS v "
+        "FROM features");
     auto plan = extractPlanNode(planVelox(logicalPlan));
     verifyRequiredSubfields(plan, {{"float_features", {}}});
   }
 }
 
 TEST_P(SubfieldTest, parallelExpr) {
+  if (useV2_) {
+    GTEST_SKIP() << "v2 does not split an expression across parallel "
+                    "projections";
+  }
+
   FeatureOptions opts;
   const auto vectors = createFeaturesTable(opts);
   const auto rowType = vectors[0]->rowType();
@@ -801,48 +862,218 @@ TEST_P(SubfieldTest, unnest) {
           {makeNestedArrayVectorFromJson<int64_t>(
               {"[[1, 2], [3, 4]]", "[]"})})});
 
-  auto logicalPlan = lp::PlanBuilder(makeContext())
-                         .tableScan("t_unnest")
-                         .unnest({"a[1]"})
-                         .map({"a[3]"})
-                         .build();
+  auto logicalPlan = parseSelect(
+      "SELECT u, a[3] FROM t_unnest CROSS JOIN UNNEST(a[1]) AS t(u)");
 
-  auto plan = toSingleNodePlan(logicalPlan);
-
-  auto matcher = core::PlanMatcherBuilder()
-                     .tableScan()
+  auto matcher = matchHiveScan("t_unnest", {{"a", {"[1]", "[3]"}}})
                      .project()
                      .unnest()
                      .project()
                      .build();
-  AXIOM_ASSERT_PLAN(plan, matcher);
 
-  verifyRequiredSubfields(plan, {{"a", {"[1]", "[3]"}}});
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+}
+
+TEST_P(SubfieldTest, aggregateMaskAndOrderKeys) {
+  createTable(
+      "t_agg",
+      {makeRowVector(
+          {"a", "b", "c"},
+          {
+              makeArrayVectorFromJson<int64_t>({"[1, 2]", "[1, 2, 3]"}),
+              makeArrayVectorFromJson<int64_t>({"[10, 20]", "[10, 20, 30]"}),
+              makeArrayVectorFromJson<int64_t>({"[5, 6]", "[5, 6, 7]"}),
+          })});
+
+  // A FILTER mask and an ORDER BY key narrow the scan to the same subfields an
+  // argument does.
+  auto logicalPlan = parseSelect(
+      "SELECT array_agg(a[1] ORDER BY c[1]) FILTER (WHERE b[1] > 0) "
+      "FROM t_agg");
+
+  auto matcher =
+      matchHiveScan("t_agg", {{"a", {"[1]"}}, {"b", {"[1]"}}, {"c", {"[1]"}}})
+          .project()
+          .aggregation()
+          .build();
+
+  AXIOM_ASSERT_PLAN_V2(toSingleNodePlan(logicalPlan), matcher);
+}
+
+TEST_P(SubfieldTest, recursiveCte) {
+  if (!useV2_) {
+    GTEST_SKIP() << "v1 does not implement recursive plans";
+  }
+
+  createArrayTable();
+
+  auto matchAnchor = [](std::vector<std::string> subfields) {
+    return core::PlanMatcherBuilder()
+        .fixedPoint(
+            core::FixedPointMatch("r").outputState(
+                /*append=*/true,
+                matchHiveScan("t", {{"a", std::move(subfields)}})))
+        .project()
+        .build();
+  };
+
+  {
+    // The anchor passes the column through, so the state holds it whole and
+    // the step's path has to reach the anchor's scan.
+    auto logicalPlan = parseSelect(
+        "WITH RECURSIVE r(a) AS ("
+        "  SELECT a FROM t"
+        "  UNION ALL"
+        "  SELECT a FROM r WHERE a[2] > 0)"
+        " SELECT a[1] FROM r");
+
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(logicalPlan), matchAnchor({"[1]", "[2]"}));
+  }
+
+  {
+    // Several paths in the step all reach the anchor's scan.
+    auto logicalPlan = parseSelect(
+        "WITH RECURSIVE r(a) AS ("
+        "  SELECT a FROM t"
+        "  UNION ALL"
+        "  SELECT a FROM r WHERE a[2] > 0 AND a[3] > 0)"
+        " SELECT a[1] FROM r");
+
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(logicalPlan), matchAnchor({"[1]", "[2]", "[3]"}));
+  }
+
+  {
+    // The anchor projects the subfield itself, so the state holds a scalar and
+    // nothing the step does can widen the scan.
+    auto logicalPlan = parseSelect(
+        "WITH RECURSIVE r(x) AS ("
+        "  SELECT a[1] FROM t"
+        "  UNION ALL"
+        "  SELECT x FROM r WHERE x > 0)"
+        " SELECT x FROM r");
+
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(logicalPlan),
+        core::PlanMatcherBuilder()
+            .fixedPoint(
+                core::FixedPointMatch("r").outputState(
+                    /*append=*/true,
+                    matchHiveScan("t", {{"a", {"[1]"}}}).project()))
+            .project()
+            .build());
+  }
+}
+
+TEST_P(SubfieldTest, pushedFilter) {
+  createArrayTable();
+
+  // The predicate moves below the projection that produced it, so the scan
+  // reads what the predicate takes as well as what the query returns.
+  auto logicalPlan = parseSelect(
+      "SELECT k FROM (SELECT a[1] AS v, a[2] AS k FROM t) WHERE v > 0");
+
+  AXIOM_ASSERT_PLAN_V2(
+      toSingleNodePlan(logicalPlan),
+      matchHiveScan("t", {{"a", {"[1]", "[2]"}}}).project().build());
+}
+
+TEST_P(SubfieldTest, mapOfRow) {
+  auto rowType = ROW({
+      {"m", MAP(VARCHAR(), ROW({{"f1", BIGINT()}, {"f2", BIGINT()}}))},
+  });
+  createTable("t_map_of_row", makeVectors(rowType, 1, 1));
+
+  // A constant map key followed by a field reads one key and one field.
+  auto logicalPlan = parseSelect("SELECT m['x'].f1 FROM t_map_of_row");
+
+  AXIOM_ASSERT_PLAN_V2(
+      toSingleNodePlan(logicalPlan),
+      matchHiveScan("t_map_of_row", {{"m", {"[\"x\"].f1"}}}).project().build());
+}
+
+TEST_P(SubfieldTest, negativeArrayIndex) {
+  if (!useV2_) {
+    GTEST_SKIP() << "v1 incorrectly pushes down `a[-1]`";
+  }
+
+  createArrayTable();
+
+  // An index counted from the end of the array names no prefix, so the whole
+  // array is read.
+  {
+    auto logicalPlan = parseSelect("SELECT element_at(a, -1) FROM t");
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(logicalPlan),
+        matchHiveScan("t", {{"a", {}}}).project().build());
+  }
+
+  {
+    auto logicalPlan = parseSelect("SELECT element_at(a, 2) FROM t");
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(logicalPlan),
+        matchHiveScan("t", {{"a", {"[2]"}}}).project().build());
+  }
+}
+
+TEST_P(SubfieldTest, constructedRow) {
+  createFeaturesTable();
+
+  // A map read through a field of a row the query builds is narrowed to the
+  // key, and the row's other arguments are unaffected.
+  auto logicalPlan = parseSelect(
+      "SELECT r.y[10100] FROM ("
+      "  SELECT ROW(uid AS x, float_features AS y) AS r FROM features"
+      ")");
+
+  // TODO Rewrite a field read of a constructed row into the argument that
+  // supplies it, so v2 also drops the arguments no field reads.
+  folly::F14FastMap<std::string, std::vector<std::string>> expected{
+      {"float_features", {subfield("10100")}}};
+  if (useV2_) {
+    expected.emplace("uid", std::vector<std::string>{});
+  }
+
+  verifyRequiredSubfields(toSingleNodePlan(logicalPlan), expected);
+}
+
+TEST_P(SubfieldTest, wholeColumnAndPath) {
+  createArrayTable();
+
+  // A column the query returns is read whole, however narrowly a predicate
+  // reads it.
+  auto logicalPlan = parseSelect("SELECT a FROM t WHERE a[1] > 0");
+
+  verifyRequiredSubfields(toSingleNodePlan(logicalPlan), {{"a", {}}});
+}
+
+TEST_P(SubfieldTest, unionAll) {
+  createArrayTable();
+
+  // Reading one element of a union's output narrows the scan under each leg.
+  auto logicalPlan = parseSelect(
+      "SELECT a[1] FROM (SELECT a FROM t UNION ALL SELECT a FROM t)");
+
+  auto matchLeg = [] { return matchHiveScan("t", {{"a", {"[1]"}}}); };
+  auto matcher =
+      matchLeg().localPartition({matchLeg().project()}).project().build();
+
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
 }
 
 TEST_P(SubfieldTest, orderBy) {
-  createTable(
-      "t_orderby",
-      {makeRowVector(
-          {"a"}, {makeArrayVectorFromJson<int64_t>({"[1, 2]", "[1, 2, 3]"})})});
+  createArrayTable();
 
-  auto logicalPlan = lp::PlanBuilder(makeContext())
-                         .tableScan("t_orderby")
-                         .orderBy({"a[1]"})
-                         .map({"a[3]"})
-                         .build();
+  auto logicalPlan = parseSelect("SELECT a[3] FROM t ORDER BY a[1]");
 
-  auto plan = toSingleNodePlan(logicalPlan);
-
-  auto matcher = core::PlanMatcherBuilder()
-                     .tableScan()
+  auto matcher = matchHiveScan("t", {{"a", {"[1]", "[3]"}}})
                      .project()
                      .orderBy()
                      .project()
                      .build();
-  AXIOM_ASSERT_PLAN(plan, matcher);
 
-  verifyRequiredSubfields(plan, {{"a", {"[1]", "[3]"}}});
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
 }
 
 TEST_P(SubfieldTest, subquery) {
@@ -871,31 +1102,29 @@ TEST_P(SubfieldTest, subquery) {
 
     auto plan = toSingleNodePlan(logicalPlan);
 
-    auto matcher = matchHiveScan("t_subquery")
+    auto matcher = matchHiveScan("t_subquery", {{"a", {".x", ".y"}}})
                        .project()
                        .hashJoin(matchValues().project())
                        .project()
                        .build();
     AXIOM_ASSERT_PLAN(plan, matcher);
-    verifyRequiredSubfields(plan, {{"a", {".x", ".y"}}});
   }
 
   {
     auto logicalPlan = parseSelect(
-        "SELECT 1 FROM t_subquery WHERE a.x = (SELECT count(*) FROM (VALUES 1, 2, 3) as t(n) WHERE n = a.z)",
+        "SELECT 1 FROM t_subquery "
+        "WHERE a.x = (SELECT count(*) FROM (VALUES 1, 2, 3) as t(n) WHERE n = a.z)",
         kHiveConnectorId);
 
     auto plan = toSingleNodePlan(logicalPlan);
 
-    auto matcher = core::PlanMatcherBuilder()
-                       .tableScan()
+    auto matcher = matchHiveScan("t_subquery", {{"a", {".x", ".z"}}})
                        .project()
-                       .hashJoin(matchValues().aggregation().project())
+                       .hashJoin(matchValues().aggregation().projectIf(!useV2_))
                        .filter()
                        .project()
                        .build();
     AXIOM_ASSERT_PLAN(plan, matcher);
-    verifyRequiredSubfields(plan, {{"a", {".x", ".z"}}});
   }
 }
 
@@ -909,19 +1138,19 @@ TEST_P(SubfieldTest, overAggregation) {
               makeArrayVectorFromJson<int64_t>({"[10, 20]", "[10, 20, 30]"}),
           })});
 
-  auto logicalPlan = lp::PlanBuilder(makeContext())
-                         .tableScan("t")
-                         .aggregate({"a"}, {"array_agg(b) as c"})
-                         .map({"a[2]", "c[1]"})
-                         .build();
+  auto logicalPlan = parseSelect(
+      "SELECT a[2], c[1] FROM ("
+      "  SELECT a, array_agg(b) AS c FROM t GROUP BY a"
+      ")");
 
-  auto plan = toSingleNodePlan(logicalPlan);
+  // A grouping key and an aggregate's argument are both read in full, so
+  // neither element read above narrows the scan.
+  auto matcher = matchHiveScan("t", {{"a", {}}, {"b", {}}})
+                     .aggregation()
+                     .project()
+                     .build();
 
-  auto matcher =
-      core::PlanMatcherBuilder().tableScan().aggregation().project().build();
-  AXIOM_ASSERT_PLAN(plan, matcher);
-
-  verifyRequiredSubfields(plan, {{"a", {}}, {"b", {}}});
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
 }
 
 TEST_P(SubfieldTest, blackbox) {
@@ -955,7 +1184,7 @@ TEST_P(SubfieldTest, blackbox) {
 // DT outputs the full struct — subfield pruning does not propagate
 // across the boundary.
 TEST_P(SubfieldTest, subfieldAcrossDtBoundary) {
-  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}));
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
 
   auto logicalPlan = parseSelect(
       "WITH s AS ("
@@ -966,13 +1195,8 @@ TEST_P(SubfieldTest, subfieldAcrossDtBoundary) {
       "SELECT a.x, sum(b) FROM s GROUP BY 1",
       kTestConnectorId);
 
-  auto plan = toSingleNodePlan(logicalPlan);
-  ASSERT_NE(nullptr, plan);
-
-  // The inner aggregation groups by the full struct ROW<x,y>. The outer
-  // aggregation groups by a.x and sums b. One project between the
-  // aggregations extracts .x. With subfield pruning propagation, only .x
-  // would cross the boundary.
+  // A grouping key is compared in full, so the whole struct crosses the
+  // aggregation even though only one of its fields is read above.
   auto matcher = core::PlanMatcherBuilder()
                      .tableScan()
                      .project({"row_constructor(a, b) as r"})
@@ -980,30 +1204,54 @@ TEST_P(SubfieldTest, subfieldAcrossDtBoundary) {
                      .project()
                      .singleAggregation()
                      .build();
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
 }
 
 TEST_P(SubfieldTest, leftJoinWithUnmaterializedSubfield) {
-  testConnector_->addTable("t", ROW({"k", "v"}, INTEGER()));
-  testConnector_->addTable(
-      "u",
-      ROW({"k", "m"}, {INTEGER(), MAP(INTEGER(), MAP(INTEGER(), REAL()))}));
+  createFeaturesTable();
 
+  // Reading one level deeper than a projected subfield narrows the scan to
+  // the whole path.
   auto logicalPlan = parseSelect(
-      "SELECT v, nested[1] "
-      "FROM t "
-      "LEFT JOIN (SELECT k, m[100] as nested FROM u) u ON t.k = u.k",
-      kTestConnectorId);
+      "SELECT ff, nested[1] AS score "
+      "FROM (SELECT uid, float_features[10100] AS ff FROM features) l "
+      "LEFT JOIN "
+      "(SELECT uid, id_score_list_features[200800] AS nested FROM features) r "
+      "ON l.uid = r.uid");
 
-  optimizerOptions_.pushdownSubfields = true;
-  VELOX_ASSERT_THROW(
-      toSingleNodePlan(logicalPlan), "Null expression for join column: nested");
+  if (useV2_) {
+    auto matcher =
+        matchHiveScan(
+            "features",
+            {
+                {"uid", {}},
+                {"float_features", {subfield("10100")}},
+            })
+            .project()
+            .hashJoinLeft(
+                matchHiveScan(
+                    "features",
+                    {
+                        {"uid", {}},
+                        {"id_score_list_features", {subfield("200800", "[1]")}},
+                    })
+                    .project())
+            .project()
+            .build();
+
+    AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+  } else {
+    optimizerOptions_.pushdownSubfields = true;
+    VELOX_ASSERT_THROW(
+        toSingleNodePlan(logicalPlan),
+        "Null expression for join column: nested");
+  }
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(
     SubfieldTests,
     SubfieldTest,
-    testing::ValuesIn(std::vector<int32_t>{1, 2, 3}));
+    testing::ValuesIn(std::vector<int32_t>{1, 2, 3, 4}));
 
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/v2/CMakeLists.txt
+++ b/axiom/optimizer/v2/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   AggregateRecovery.cpp
   AlgebraicProperties.cpp
   Builder.cpp
+  ColumnAccess.cpp
   CostModel.cpp
   DecorrelatePass.cpp
   DPhyp.cpp

--- a/axiom/optimizer/v2/ColumnAccess.cpp
+++ b/axiom/optimizer/v2/ColumnAccess.cpp
@@ -1,0 +1,526 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/ColumnAccess.h"
+
+#include "axiom/optimizer/FunctionRegistry.h"
+#include "axiom/optimizer/PlanUtils.h"
+#include "axiom/optimizer/v2/AppendAll.h"
+#include "axiom/optimizer/v2/NodeVisitor.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+// A dereference selector is an ordinal by the time it reaches here, so the
+// field name comes from the struct being read.
+// Returns null for a field with no name, which no subfield can address.
+Name fieldNameAt(ExprCP base, const Literal& selector) {
+  const int32_t ordinal = selector.literal().value<velox::TypeKind::INTEGER>();
+  const auto& name = base->value().type->asRow().nameOf(ordinal);
+  return name.empty() ? nullptr : toName(name);
+}
+
+// Fills in a subscript's key, or marks the step as reaching every entry when
+// the key has a type no subfield can name.
+void setKey(Step& step, const Literal& key) {
+  if (key.literal().isNull()) {
+    step.allFields = true;
+    return;
+  }
+  switch (key.literal().kind()) {
+    case velox::TypeKind::VARCHAR:
+      step.field = toName(key.literal().value<velox::TypeKind::VARCHAR>());
+      return;
+    case velox::TypeKind::BIGINT:
+    case velox::TypeKind::INTEGER:
+    case velox::TypeKind::SMALLINT:
+    case velox::TypeKind::TINYINT:
+      step.id = integerValue(&key.literal());
+      return;
+    default:
+      step.allFields = true;
+  }
+}
+
+// A step that reaches every entry says nothing once nothing follows it: the
+// level it stands for is read in full either way. Dropping it lets a path that
+// is nothing but wildcards reduce to the whole column.
+void dropTrailingWildcards(std::vector<Step>& steps) {
+  while (!steps.empty() && steps.back().allFields) {
+    steps.pop_back();
+  }
+}
+
+// True when field 'i' of 'call' is its argument 'i'. A function that builds a
+// row some other way -- from a map and a list of keys, say -- declares its own
+// mapping and is not decomposed here.
+bool isRowConstructor(const Call* call) {
+  const auto* metadata = call->metadata();
+  return metadata != nullptr && metadata->isRowConstructor;
+}
+
+// Splits 'tail' by its leading field step, so each argument of a constructed
+// row is visited with the paths read from the field it supplies. A path that
+// does not start with a field reads the row itself, which reads every
+// argument whole.
+template <typename Func>
+void forEachArgumentField(const Call& call, const PathSet& tail, Func func) {
+  const auto& rowType = call.value().type->asRow();
+  folly::F14FastMap<int32_t, PathSet> byArgument;
+  bool wholeRow = false;
+
+  tail.forEachPath([&](PathCP path) {
+    const auto& steps = path->steps();
+    if (steps.empty() || steps.front().kind != StepKind::kField) {
+      wholeRow = true;
+      return;
+    }
+    const auto ordinal = rowType.getChildIdx(steps.front().field);
+    byArgument[ordinal].add(
+        toPath(std::span<const Step>(steps).subspan(1))->id());
+  });
+
+  if (wholeRow) {
+    for (ExprCP arg : call.args()) {
+      func(arg, PathSet{});
+    }
+    return;
+  }
+
+  for (const auto& [ordinal, paths] : byArgument) {
+    func(call.args()[ordinal], paths);
+  }
+}
+
+Name registeredName(const std::optional<std::string>& name) {
+  return name.has_value() ? toName(name.value()) : nullptr;
+}
+
+} // namespace
+
+ColumnAccess::ColumnAccess()
+    : subscript_(registeredName(FunctionRegistry::instance()->subscript())),
+      elementAt_(registeredName(FunctionRegistry::instance()->elementAt())) {}
+
+void ColumnAccess::add(ExprCP expr) {
+  std::vector<Step> steps;
+  // An empty tail means the reader takes the whole result.
+  const PathSet wholeResult;
+  addSteps(expr, steps, wholeResult);
+}
+
+void ColumnAccess::addProducing(ExprCP expr, ColumnCP resultColumn) {
+  const auto it = byColumn_.find(resultColumn);
+  if (it == byColumn_.end()) {
+    // Nothing above narrowed the result, so the expression is read whole.
+    add(expr);
+    return;
+  }
+  // Copied, not referenced: the walk inserts into 'byColumn_', which can
+  // rehash and move the set this came from.
+  const PathSet tail = it->second;
+  std::vector<Step> steps;
+  addSteps(expr, steps, tail);
+}
+
+void ColumnAccess::addAll(const ExprVector& exprs) {
+  for (ExprCP expr : exprs) {
+    add(expr);
+  }
+}
+
+PathSet ColumnAccess::subfieldsOf(ColumnCP column) const {
+  const auto it = byColumn_.find(column);
+  if (it == byColumn_.end()) {
+    return PathSet{};
+  }
+  PathSet paths = it->second;
+  Path::subfieldSkyline(paths);
+  return paths;
+}
+
+void ColumnAccess::addSteps(
+    ExprCP expr,
+    std::vector<Step>& steps,
+    const PathSet& tail) {
+  if (expr->is(PlanType::kColumnExpr)) {
+    addColumn(expr->as<Column>(), steps, tail);
+    return;
+  }
+
+  if (!expr->is(PlanType::kCallExpr) && !expr->is(PlanType::kAggregateExpr) &&
+      !expr->is(PlanType::kWindowExpr)) {
+    addWhole(expr);
+    return;
+  }
+
+  const auto* call = expr->as<Call>();
+  if (isRowConstructor(call) && addRowConstructor(call, steps, tail)) {
+    return;
+  }
+
+  if (addPathStep(call, steps, tail)) {
+    return;
+  }
+
+  addCallInputs(call);
+}
+
+void ColumnAccess::addColumn(
+    ColumnCP column,
+    const std::vector<Step>& steps,
+    const PathSet& tail) {
+  // Reaching a column reverses 'steps' to get the path read from it.
+  const std::vector<Step> prefix(steps.rbegin(), steps.rend());
+  PathSet& paths = byColumn_[column];
+
+  auto addExtendedBy = [&](std::span<const Step> suffix) {
+    std::vector<Step> full = prefix;
+    full.insert(full.end(), suffix.begin(), suffix.end());
+    dropTrailingWildcards(full);
+    paths.add(toPath(full)->id());
+  };
+
+  if (tail.empty()) {
+    addExtendedBy({});
+    return;
+  }
+
+  // Each path the reader takes from the result extends the path taken to
+  // reach this column.
+  tail.forEachPath([&](PathCP suffix) { addExtendedBy(suffix->steps()); });
+}
+
+bool ColumnAccess::addRowConstructor(
+    const Call* call,
+    std::vector<Step>& steps,
+    const PathSet& tail) {
+  // Reading field 'i' of a constructed row reads the argument that supplies
+  // it. The field step arrives in 'tail' when a projection produced the row,
+  // and in 'steps' when the row is dereferenced where it is built.
+  if (!steps.empty() && steps.back().kind == StepKind::kField) {
+    const auto ordinal =
+        call->value().type->asRow().getChildIdx(steps.back().field);
+    Step field = steps.back();
+    steps.pop_back();
+    addSteps(call->args()[ordinal], steps, tail);
+    steps.push_back(field);
+    return true;
+  }
+
+  if (!tail.empty()) {
+    // 'tail' is read from the row this call builds, so its leading field step
+    // selects an argument. A path in 'steps' would sit between the two and
+    // change what the field names.
+    VELOX_CHECK(
+        steps.empty(),
+        "Row constructor reached with both a path to it and paths from it");
+    forEachArgumentField(*call, tail, [&](ExprCP arg, const PathSet& rest) {
+      addSteps(arg, steps, rest);
+    });
+    return true;
+  }
+
+  return false;
+}
+
+bool ColumnAccess::addPathStep(
+    const Call* call,
+    std::vector<Step>& steps,
+    const PathSet& tail) {
+  if (call->args().size() != 2) {
+    return false;
+  }
+  const Name name = call->name();
+  const bool isSubscript = name == subscript_ || name == elementAt_;
+  const bool isDereference = name == SpecialFormCallNames::kDereference;
+  if (!isSubscript && !isDereference) {
+    return false;
+  }
+
+  const StepKind subscriptKind =
+      name == elementAt_ ? StepKind::kElementAt : StepKind::kSubscript;
+  ExprCP operand = call->args()[0];
+
+  Step step;
+  if (call->args()[1]->is(PlanType::kLiteralExpr)) {
+    const auto* key = call->args()[1]->as<Literal>();
+    if (isDereference) {
+      Name field = fieldNameAt(operand, *key);
+      if (field == nullptr) {
+        // An unnamed field cannot be addressed, so the struct is read whole.
+        addWhole(operand);
+        return true;
+      }
+      step = {.kind = StepKind::kField, .field = field};
+    } else {
+      step = {.kind = subscriptKind};
+      setKey(step, *key);
+      // A non-positive array index counts from the end of the array, which no
+      // prefix bound can express, and Velox rejects it outright. Reading every
+      // element is the only sound answer.
+      if (operand->value().type->isArray() && !step.allFields && step.id <= 0) {
+        step.allFields = true;
+        // The key no longer selects anything, and leaving it set would make
+        // two steps that mean the same thing intern as different paths.
+        step.id = 0;
+      }
+    }
+  } else if (isSubscript) {
+    // A key computed at run time selects no entry, so every entry at this
+    // level is read; anything below it still prunes. The key expression is a
+    // read of its own.
+    step = {.kind = subscriptKind, .allFields = true};
+    add(call->args()[1]);
+  } else {
+    return false;
+  }
+
+  steps.push_back(step);
+  addSteps(operand, steps, tail);
+  steps.pop_back();
+  return true;
+}
+
+void ColumnAccess::addCallInputs(const Call* call) {
+  ExprVector reads(call->args().begin(), call->args().end());
+  if (const auto* aggregate = dynamic_cast<const optimizer::Aggregate*>(call)) {
+    if (aggregate->condition() != nullptr) {
+      reads.push_back(aggregate->condition());
+    }
+    appendAll(reads, aggregate->orderKeys());
+  } else if (
+      const auto* window =
+          dynamic_cast<const optimizer::WindowFunction*>(call)) {
+    appendAll(reads, window->partitionKeys());
+    appendAll(reads, window->orderKeys());
+    if (window->frame().startValue != nullptr) {
+      reads.push_back(window->frame().startValue);
+    }
+    if (window->frame().endValue != nullptr) {
+      reads.push_back(window->frame().endValue);
+    }
+  }
+
+  PlanObjectSet decomposed;
+  for (ExprCP read : reads) {
+    decomposed.unionSet(read->columns());
+    add(read);
+  }
+
+  // Every column a call reads is reached by one of the expressions above. A
+  // call that holds one somewhere else must be added there; recording it here
+  // instead would leave the column pruned to whatever another read recorded.
+  PlanObjectSet unreached = call->columns();
+  unreached.except(decomposed);
+  VELOX_CHECK(
+      unreached.empty(),
+      "Call reads a column no walked expression reaches: {}",
+      call->name());
+}
+
+void ColumnAccess::addWhole(ExprCP expr) {
+  expr->columns().forEach<Column>(
+      [&](ColumnCP column) { byColumn_[column].add(toPath({})->id()); });
+}
+
+namespace {
+
+struct CollectContext : public NodeVisitorContext {
+  explicit CollectContext(ColumnAccess& access) : access(access) {}
+
+  ColumnAccess& access;
+};
+
+// Feeds every expression one node evaluates to `ColumnAccess`. A node whose
+// only inputs are columns reads those columns whole, which is what an
+// unrecorded column already reports, so it contributes nothing here.
+class Collector : public NodeVisitor {
+ public:
+  void visit(const Scan& node, NodeVisitorContext& context) const override {}
+
+  void visit(const Filter& node, NodeVisitorContext& context) const override {
+    addAll(context, node.predicates());
+  }
+
+  // Project expressions and aggregate calls are recorded by the pass, once per
+  // return path, from what that path keeps: an expression it prunes must not
+  // contribute the paths it reads.
+  void visit(const Project& node, NodeVisitorContext& context) const override {}
+
+  void visit(const Limit& node, NodeVisitorContext& context) const override {}
+
+  void visit(const Sort& node, NodeVisitorContext& context) const override {
+    addAll(context, node.orderKeys());
+  }
+
+  void visit(const TopN& node, NodeVisitorContext& context) const override {
+    addAll(context, node.orderKeys());
+  }
+
+  // Grouping keys are never pruned, so they are recorded here.
+  void visit(const Aggregate& node, NodeVisitorContext& context)
+      const override {
+    addAll(context, node.groupingKeys());
+  }
+
+  void visit(const GroupId& node, NodeVisitorContext& context) const override {
+    addAll(context, node.groupingKeys());
+    addAll(context, node.aggregationInputs());
+  }
+
+  void visit(const MarkDistinct& node, NodeVisitorContext& context)
+      const override {
+    addAll(context, node.distinctKeys());
+  }
+
+  void visit(const Values& node, NodeVisitorContext& context) const override {}
+
+  void visit(const Unnest& node, NodeVisitorContext& context) const override {
+    addAll(context, node.unnestExpressions());
+  }
+
+  // A leg's column feeds an output column with no expression between them, so
+  // nothing else records that the leg column is read. Leaving it unrecorded
+  // would be safe only while no other part of the plan narrows the same
+  // `Column*`, which a rewrite that duplicates a subtree can arrange.
+  void visit(const UnionAll& node, NodeVisitorContext& context) const override {
+    auto& access = accessOf(context);
+    for (const auto& leg : node.legColumns()) {
+      for (size_t i = 0; i < leg.size(); ++i) {
+        access.addProducing(leg[i], node.outputColumns()[i]);
+      }
+    }
+  }
+
+  void visit(const Join& node, NodeVisitorContext& context) const override {
+    addAll(context, node.leftKeys());
+    addAll(context, node.rightKeys());
+    addAll(context, node.filter());
+  }
+
+  void visit(const Window& node, NodeVisitorContext& context) const override {
+    addAll(context, node.partitionKeys());
+    addAll(context, node.orderKeys());
+    for (const auto& function : node.functions()) {
+      add(context, function.call);
+      add(context, function.frame.startValue);
+      add(context, function.frame.endValue);
+    }
+  }
+
+  void visit(const RowNumber& node, NodeVisitorContext& context)
+      const override {
+    addAll(context, node.partitionKeys());
+  }
+
+  void visit(const TopNRowNumber& node, NodeVisitorContext& context)
+      const override {
+    addAll(context, node.partitionKeys());
+    addAll(context, node.orderKeys());
+  }
+
+  void visit(const Apply& node, NodeVisitorContext& context) const override {
+    addAll(context, node.filter());
+    add(context, node.inLhs());
+    add(context, node.inBodyKey());
+  }
+
+  void visit(const EnforceSingleRow& node, NodeVisitorContext& context)
+      const override {}
+
+  void visit(const AssignUniqueId& node, NodeVisitorContext& context)
+      const override {}
+
+  void visit(const EnforceDistinct& node, NodeVisitorContext& context)
+      const override {
+    addAll(context, node.distinctKeys());
+  }
+
+  void visit(const Exchange& node, NodeVisitorContext& context) const override {
+    addAll(context, node.partitioning().keys);
+    addAll(context, node.partitioning().orderKeys);
+  }
+
+  void visit(const TableWrite& node, NodeVisitorContext& context)
+      const override {
+    addAll(context, node.columnExprs());
+  }
+
+  void visit(const WorkingTable& node, NodeVisitorContext& context)
+      const override {}
+
+  void visit(const FixedPoint& node, NodeVisitorContext& context)
+      const override {}
+
+ protected:
+  static ColumnAccess& accessOf(NodeVisitorContext& context) {
+    return static_cast<CollectContext&>(context).access;
+  }
+
+  static void add(NodeVisitorContext& context, ExprCP expr) {
+    if (expr != nullptr) {
+      accessOf(context).add(expr);
+    }
+  }
+
+  static void addAll(NodeVisitorContext& context, const ExprVector& exprs) {
+    accessOf(context).addAll(exprs);
+  }
+};
+
+} // namespace
+
+void ColumnAccess::add(const Node& node) {
+  CollectContext context{*this};
+  node.accept(Collector{}, context);
+}
+
+namespace {
+
+// Adds what `Collector` leaves to the pass, for a subtree the pass has not
+// walked yet.
+class SubtreeCollector : public Collector {
+ public:
+  void visit(const Project& node, NodeVisitorContext& context) const override {
+    auto& access = accessOf(context);
+    for (size_t i = 0; i < node.exprs().size(); ++i) {
+      access.addProducing(node.exprs()[i], node.outputColumns()[i]);
+    }
+  }
+
+  void visit(const Aggregate& node, NodeVisitorContext& context)
+      const override {
+    Collector::visit(node, context);
+    auto& access = accessOf(context);
+    for (const auto* call : node.aggregates()) {
+      access.add(call);
+    }
+  }
+};
+
+} // namespace
+
+void ColumnAccess::addSubtree(const Node& node) {
+  CollectContext context{*this};
+  node.accept(SubtreeCollector{}, context);
+  for (NodeCP input : node.inputs()) {
+    addSubtree(*input);
+  }
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ColumnAccess.h
+++ b/axiom/optimizer/v2/ColumnAccess.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/PathSet.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Records which parts of each column a query reads, so that a scan can ask
+/// its connector for those parts alone.
+///
+/// `PushdownAndPrunePass` fills one of these as it descends and reads it at
+/// each Scan:
+///
+///   NodeCP rewrite(NodeCP node, PushdownContext& context) override {
+///     access_.add(*node);
+///     return NodeRewriter::rewrite(node, context);
+///   }
+///
+///   // In rewriteProject, once the pass knows which projections it keeps:
+///   access_.addProducing(survivingExprs[i], survivingOutputs[i]);
+///
+///   // At the Scan, negotiating with the connector:
+///   toSubfields(column->name(), access_.subfieldsOf(column), ...);
+///
+/// An expression is decomposed into a column and a path when it is a chain of
+/// struct dereferences and constant subscripts: `m[1].x` reads `[1].x` of `m`.
+/// A chain rooted at anything else contributes the whole of every column it
+/// reaches, which is the current behavior of every read and therefore always
+/// safe. Note that an unrecognized call gives up only its own result: its
+/// arguments are still decomposed, so `f(m[1].x)` still reads one key and one
+/// field.
+///
+/// Absence of a column is not "reads nothing" — a column never passed to
+/// `add` has no entry, and `subfieldsOf` reports the whole column for it.
+///
+/// A node that produces a column from an expression -- a projection, a union
+/// leg -- composes the paths its consumers read with that expression.
+/// Elsewhere a path is recorded against the column the expression reads rather
+/// than the one it produces, which yields a prefix of the true path. A prefix
+/// covers the paths below it, so an uncomposed read is wider than needed and
+/// never narrower — which is what lets the nodes that rename columns leave
+/// composition alone.
+///
+/// The caller must hold to all of:
+///  - `add(const Node&)` runs on each node from the root down, so a node
+///    producing a column is reached after the consumers whose paths it
+///    extends.
+///  - The expressions a pass may prune — a Project's, an Aggregate's — are
+///    recorded by that pass from what it keeps, not by `add(const Node&)`.
+///  - A subtree the descent has yet to reach, but whose reads a Scan above it
+///    will serve, is recorded first with `addSubtree`.
+class ColumnAccess {
+ public:
+  ColumnAccess();
+
+  /// Records the paths 'expr' reads.
+  void add(ExprCP expr);
+
+  /// Records the paths 'expr' reads, given that its result is itself read
+  /// through 'resultColumn'. Composes across a projection: an output column
+  /// read as `[1]`, produced by `m[200800]`, reads `[200800][1]` of `m`.
+  void addProducing(ExprCP expr, ColumnCP resultColumn);
+
+  /// Records the paths each of 'exprs' reads.
+  void addAll(const ExprVector& exprs);
+
+  /// Records the paths every expression 'node' evaluates reads. Call on each
+  /// node from the root down, so that a node producing a column is reached
+  /// after the consumers whose paths it extends. The pass records the
+  /// expressions it may prune -- a Project's and an Aggregate's -- itself,
+  /// from what survives.
+  void add(const Node& node);
+
+  /// Records 'node' and everything below it, including the expressions a
+  /// Project or an Aggregate holds. For a subtree read by a node the pass has
+  /// yet to reach: recording every expression is wider than the pass would
+  /// choose, which is the safe direction.
+  void addSubtree(const Node& node);
+
+  /// The paths read from 'column', reduced to the shortest set that covers
+  /// them. Empty means the whole column is read, which is also what an
+  /// unrecorded column reports.
+  PathSet subfieldsOf(ColumnCP column) const;
+
+ private:
+  // Records the paths reaching 'expr', where 'steps' holds the path from the
+  // reader down to it, outermost first, and 'tail' holds the paths its reader
+  // takes from the result. An empty 'tail' means the result is read whole.
+  void addSteps(ExprCP expr, std::vector<Step>& steps, const PathSet& tail);
+
+  // Records the path reaching 'column', which is 'steps' reversed, extended by
+  // each path in 'tail'.
+  void addColumn(
+      ColumnCP column,
+      const std::vector<Step>& steps,
+      const PathSet& tail);
+
+  // Walks the argument of 'call' that supplies the field being read. Returns
+  // false if no field of the constructed row is read, leaving 'steps'
+  // unchanged.
+  bool addRowConstructor(
+      const Call* call,
+      std::vector<Step>& steps,
+      const PathSet& tail);
+
+  // Walks the operand of 'call' with the step it contributes appended to
+  // 'steps'. Returns false if 'call' is not a subscript or field dereference,
+  // leaving 'steps' unchanged.
+  bool
+  addPathStep(const Call* call, std::vector<Step>& steps, const PathSet& tail);
+
+  // Records that 'call' reads each of its inputs in full, decomposing the
+  // inputs themselves so a path inside one still prunes.
+  void addCallInputs(const Call* call);
+
+  // Records that every column 'expr' reads is read whole.
+  void addWhole(ExprCP expr);
+
+  // Interned names of the calls that decompose into a path step. Null when the
+  // dialect in force registers no such function.
+  const Name subscript_;
+  const Name elementAt_;
+
+  // Paths read from each column, before reduction. A column absent here is
+  // read whole.
+  folly::F14FastMap<ColumnCP, PathSet> byColumn_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "axiom/optimizer/v2/PushdownAndPrunePass.h"
+#include "axiom/optimizer/ToSubfield.h"
+#include "axiom/optimizer/v2/ColumnAccess.h"
 
 #include "axiom/optimizer/v2/ScanHandle.h"
 
@@ -649,13 +651,30 @@ class Pushdown : public NodeRewriter<PushdownContext> {
       Builder& builder,
       velox::core::ExpressionEvaluator& evaluator,
       const OptimizerSession& session,
-      PushdownAndPrunePass::ConnectorPushdown connectorPushdown)
+      PushdownAndPrunePass::ConnectorPushdown connectorPushdown,
+      const ColumnVector& outputColumns)
       : NodeRewriter(builder),
         exprs_(builder),
         evaluator_(evaluator),
         session_(session),
         connectorPushdown_(connectorPushdown),
-        simplifier_(builder, evaluator) {}
+        simplifier_(builder, evaluator) {
+    // The query returns these, so they are read whole however narrowly an
+    // expression below reads them.
+    for (ColumnCP column : outputColumns) {
+      access_.add(column);
+    }
+  }
+
+  using NodeRewriter::rewrite;
+
+  // Records what each node reads on the way down, so that a node producing a
+  // column is reached after the consumers whose paths it extends, and a Scan
+  // sees the finished access when it negotiates with its connector.
+  NodeCP rewrite(NodeCP node, PushdownContext& context) override {
+    access_.add(*node);
+    return NodeRewriter::rewrite(node, context);
+  }
 
  protected:
   // Filter conjuncts (flattened across AND trees) join `pending`; the
@@ -693,6 +712,10 @@ class Pushdown : public NodeRewriter<PushdownContext> {
       }
     }
 
+    // A conjunct pushed below this Project reads the expressions it was
+    // substituted into, and the projection producing them may not survive.
+    access_.addAll(pushable);
+
     PlanObjectSet outputsKept = context.required;
     outputsKept.unionColumns(blocked);
     ExprVector survivingExprs;
@@ -704,6 +727,12 @@ class Pushdown : public NodeRewriter<PushdownContext> {
         survivingExprs.push_back(node->exprs()[i]);
         survivingOutputs.push_back(node->outputColumns()[i]);
       }
+    }
+
+    // Recorded here, not on the way down: an expression this pass prunes must
+    // not contribute the paths it reads.
+    for (size_t i = 0; i < survivingExprs.size(); ++i) {
+      access_.addProducing(survivingExprs[i], survivingOutputs[i]);
     }
 
     PushdownContext childContext;
@@ -784,6 +813,10 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     const bool emitsRowOnEmptyInput =
         node->groupingKeys().empty() || !node->globalGroupingSets().empty();
     if (emitsRowOnEmptyInput) {
+      for (const auto* aggregate : node->aggregates()) {
+        access_.add(aggregate);
+      }
+
       PushdownContext childContext;
       childContext.required = context.required;
       childContext.required.unionColumns(context.pending);
@@ -841,6 +874,10 @@ class Pushdown : public NodeRewriter<PushdownContext> {
         survivingAggregates.push_back(node->aggregates()[i]);
         survivingOutputs.push_back(outputColumn);
       }
+    }
+
+    for (const auto* aggregate : survivingAggregates) {
+      access_.add(aggregate);
     }
 
     PushdownContext childContext;
@@ -1180,7 +1217,10 @@ class Pushdown : public NodeRewriter<PushdownContext> {
       // A rewrite that duplicated a subtree can present one Scan twice. The
       // connector is asked once, so the second visit must be offering the same
       // predicates and reading no more columns; otherwise its predicates would
-      // be silently dropped, or it would read a column with no handle.
+      // be silently dropped or it would read a column with no handle. The
+      // paths are not compared: access accumulates as the walk descends, so
+      // the second visit legitimately sees a superset of what the handle was
+      // built for.
       VELOX_CHECK(
           it->second.filters == filters,
           "Two reads of one table offer the connector different filters: {}",
@@ -1201,6 +1241,12 @@ class Pushdown : public NodeRewriter<PushdownContext> {
             baseTable,
             outputColumns,
             filters,
+            [this](ColumnCP column) {
+              return toSubfields(
+                  column->name(),
+                  access_.subfieldsOf(column),
+                  /*mapKeysAsFields=*/false);
+            },
             session_,
             evaluator_,
             rejectedHere));
@@ -1839,6 +1885,12 @@ class Pushdown : public NodeRewriter<PushdownContext> {
       override {
     // Filtering seed rows is sound only when `p(step(x))` implies `p(x)`;
     // otherwise, a rejected seed can still produce matching descendants.
+    // The step and convergence subtrees read the recursive state through the
+    // same columns the anchor produces, so their paths must be recorded before
+    // the anchor's scan negotiates; the descent reaches them only afterwards.
+    access_.addSubtree(*node->step());
+    access_.addSubtree(*node->convergence());
+
     PushdownContext anchorContext;
     anchorContext.required.unionObjects(node->outputColumns());
     anchorContext.requiredAbove = anchorContext.required;
@@ -2225,6 +2277,11 @@ class Pushdown : public NodeRewriter<PushdownContext> {
   velox::core::ExpressionEvaluator& evaluator_;
   const OptimizerSession& session_;
   const PushdownAndPrunePass::ConnectorPushdown connectorPushdown_;
+
+  // Which parts of each column the plan reads, accumulated as the rewrite
+  // descends.
+  ColumnAccess access_;
+
   ExprSimplifier simplifier_;
 
   // Outcome of one negotiation with the connector.
@@ -2249,7 +2306,7 @@ NodeCP PushdownAndPrunePass::run(
     velox::core::ExpressionEvaluator& evaluator,
     const OptimizerSession& session,
     ConnectorPushdown connectorPushdown) {
-  Pushdown pass{builder, evaluator, session, connectorPushdown};
+  Pushdown pass{builder, evaluator, session, connectorPushdown, outputColumns};
   PushdownContext context;
   context.required = PlanObjectSet::fromObjects(outputColumns);
   context.requiredAbove = context.required;

--- a/axiom/optimizer/v2/ScanHandle.cpp
+++ b/axiom/optimizer/v2/ScanHandle.cpp
@@ -18,6 +18,7 @@
 
 #include "axiom/optimizer/QueryGraph.h"
 #include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/ToSubfield.h"
 #include "axiom/optimizer/v2/ExprEmitter.h"
 
 namespace facebook::axiom::optimizer::v2 {
@@ -26,6 +27,7 @@ ScanHandle ScanHandle::build(
     const BaseTable& baseTable,
     const ColumnVector& outputColumns,
     const ExprVector& filters,
+    const SubfieldsOf& subfieldsOf,
     const OptimizerSession& session,
     velox::core::ExpressionEvaluator& evaluator,
     ExprVector& rejected) {
@@ -53,7 +55,7 @@ ScanHandle ScanHandle::build(
   readSchema.reserve(numColumns);
   const auto addHandle = [&](ColumnCP column) {
     auto handle = layout->createColumnHandle(
-        connectorSession, column->name(), /*subfields=*/{});
+        connectorSession, column->name(), subfieldsOf(column));
     readSchema.push_back(handle);
     return handle;
   };

--- a/axiom/optimizer/v2/ScanHandle.h
+++ b/axiom/optimizer/v2/ScanHandle.h
@@ -25,6 +25,10 @@
 
 namespace facebook::axiom::optimizer::v2 {
 
+/// Returns the parts of 'column' a query reads, empty for the whole column.
+using SubfieldsOf =
+    std::function<std::vector<velox::common::Subfield>(ColumnCP)>;
+
 /// Connector access for a scanned leaf table: the result of negotiating filter
 /// pushdown with the connector. Made once, by the pushdown pass, and pointed
 /// at by the `Scan` from there on.
@@ -33,10 +37,16 @@ struct ScanHandle {
   /// 'baseTable' and returns the handle it builds. Calls into the connector.
   /// Appends to 'rejected' the conjuncts the connector rejected, which the
   /// caller must apply itself.
+  ///
+  /// 'subfieldsOf' gives the parts of one column the query reads, so a complex
+  /// column can be read in part. Returning none reads the column whole. It is
+  /// asked about every column the read needs, including the ones only a filter
+  /// references, which the caller cannot know in advance.
   static ScanHandle build(
       const BaseTable& baseTable,
       const ColumnVector& outputColumns,
       const ExprVector& filters,
+      const SubfieldsOf& subfieldsOf,
       const OptimizerSession& session,
       velox::core::ExpressionEvaluator& evaluator,
       ExprVector& rejected);

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -2694,6 +2694,8 @@ bool producesExactlyOneRow(NodeCP node) {
     }
     case NodeType::kEnforceSingleRow:
       return true;
+    case NodeType::kValues:
+      return node->as<Values>()->cardinality() == 1;
     case NodeType::kProject:
       return producesExactlyOneRow(node->as<Project>()->input());
     default:
@@ -3403,10 +3405,13 @@ Translator::tryEvaluateOverDiscreteValues(const Aggregate* aggregate) {
   const ExprVector& filters =
       filter != nullptr ? filter->predicates() : ExprVector{};
   ExprVector rejected;
+  // This handle only asks the connector for its discrete values; nothing reads
+  // through it, so it requests no subfields.
   ScanHandle handle = ScanHandle::build(
       *scan->baseTable(),
       scan->outputColumns(),
       filters,
+      [](ColumnCP) { return std::vector<velox::common::Subfield>{}; },
       session_,
       evaluator_,
       rejected);

--- a/axiom/optimizer/v2/docs/MapsAndArraysAsTables.md
+++ b/axiom/optimizer/v2/docs/MapsAndArraysAsTables.md
@@ -1,0 +1,199 @@
+# Maps and Arrays as Tables
+
+*Map and array functions as relational operators over a table made of a
+complex value's entries.*
+
+## Motivation
+
+Subfield pruning reads only the parts of a complex column a query touches:
+`m['k'].x` should fetch one key and one field rather than the whole map. That
+requires knowing, for every function standing between the column and the
+access, how an access on the result maps back to the arguments.
+
+The functions that stand there are already relational operators over the
+value's entries. `map_filter` keeps the entries matching a predicate — a
+Filter. `transform_values` rewrites each entry's value — a Project.
+`cardinality` counts them. Read a map as a two-column table of its entries and
+the vocabulary needed is one the optimizer already has.
+
+Presto describes each function's subfield behavior with a per-function
+descriptor: a lambda-binding record, a "result subfields come from argument
+*n*" flag, and a bespoke matcher for constant keys. Those three shapes look
+like special cases of something more general.
+
+`element_at(transform_values(m, f), k)` reaches one key because a filter on the
+key can move below a projection. Presto encodes that single instance as the
+`subfieldArg` flag. If map and array functions are relational operators, it is
+not a flag but an instance of pushing Filter below Project.
+
+## The model
+
+Each complex value is a table:
+
+| Type | Table | Constraints |
+|---|---|---|
+| `ARRAY(T)` | `(ord BIGINT, e T)` | `ord` contiguous from 1, defines order |
+| `MAP(K,V)` | `(k K, v V)` | `k` unique, no order |
+| `ROW(a, b, ...)` | one row, columns `a`, `b`, ... | exactly one row |
+
+`ROW` is the weak member. The only operators over it are Project and
+construct — there is no Filter, no Union, and `count(*)` is always 1 — so
+treating it as a table buys consistent notation rather than reach.
+
+The tables are lateral: one exists per row of the enclosing table, and a
+function over it is evaluated once per outer row.
+
+**Order.** Arrays are ordered bags and maps are unordered, so operators divide
+into those that preserve the position correspondence between input and output
+and those that do not. `slice` preserves it; `array_sort` and array `filter`
+do not, since a given output position may originate from any input position.
+
+`map_keys` and `map_values` are barriers for a different reason: their input
+is a map, which has no order, so there is no input position for an output
+position to correspond to. A bound on `map_values(m)` therefore says nothing
+about which entries of `m` are needed.
+
+### Where a table comes from
+
+A mini-table has two possible origins, and the model does not distinguish them.
+
+**A stored value.** `t.int_map` yields its table by reading the column.
+
+**An operator.** `map_agg(k, v)` yields one by aggregating real rows, running
+the model in reverse — relational to nested. A constant subscript on its
+result, `map_agg(k, v)[42]`, is still a Filter on `k` of the mini-table; that
+Filter simply lands on the aggregate's input rows rather than on a column read.
+
+Constructors such as `map`, `array`, and `map_from_entries` are the degenerate
+operator case, building the table from their arguments.
+
+The same reading therefore covers both "which parts of a stored value are
+needed" and "which rows need to reach an aggregate".
+
+## Catalog
+
+A function earns a place here only if its reading can make some access
+narrower — if it contributes to required-columns or to a key domain. Functions
+that compare whole elements contribute to neither: `array_intersect`,
+`array_union`, `array_except`, `array_distinct`, and comparator-less
+`array_sort` all require equality over entire elements, so their inputs are
+fully required regardless of what the result feeds. They are modelable and
+worthless, and are left out. `array_sort` with a comparator lambda does
+qualify, since the comparator names the fields it reads.
+
+A second kind of exclusion is category rather than value. `arbitrary(m)` is an
+aggregate over the enclosing relation that passes a complex value through
+unchanged; it never reads inside the value, so it is plan-structure
+propagation and not a mini-table operator at all.
+
+A third kind is simply absence. The model does not aim to cover every
+function; one that goes undescribed is opaque, poisons its scope, and is
+correct while doing so.
+
+| Function | Operator | Notes |
+|---|---|---|
+| `map_filter`, `filter` | Filter | |
+| `map_remove_null_values` | Filter `v IS NOT NULL` | |
+| `map_subset` | Filter `k IN (...)` | |
+| `transform`, `transform_keys`, `transform_values` | Project | |
+| `map_keys`, `map_values` | Project one column | array order is unspecified, so none need be chosen |
+| `cardinality` | `count(*)` | |
+| `element_at`, `m[k]`, `a[i]` | Filter to one row, then scalar | relies on key uniqueness; null-versus-throw on a missing key is an assertion neither analysis consults |
+| `array_sort` with a comparator | Sort | |
+| `slice` | Filter on `ord` range | |
+| `concat`, `flatten` | Union all, with `ord` offset | |
+| `map_concat` | Union with last-wins on `k` | the conflict rule defines the operator, it does not qualify the reading |
+| `zip_with`, `zip` | Full outer join on `ord` | |
+| `map_zip_with` | Full outer join on `k` | |
+| `contains` | `x IN (SELECT e ...)` | `IN` is three-valued, so no null rule is needed alongside |
+| `any_match`, `all_match`, `none_match` | `IN` over the projected predicate | `any_match(a, p)` is `TRUE IN (SELECT p(e) FROM a)` |
+| `array_agg`, `map_agg` | Aggregate, producing the table | |
+| `make_row_from_map`, `padded_make_row_from_map` | Row constructor over one `element_at` per key | see below |
+| `s.a` (dereference) | Project one column | |
+| `row(...)` | Construct the one-row table | a projected column maps to the argument that supplied it |
+| `map`, `array`, `map_from_entries` | Construct the table | |
+| `reduce` | none | an ordered fold is an aggregate only if the combiner is associative and commutative, which nothing guarantees |
+
+### Dialect functions outside Presto
+
+The catalog is not Presto-shaped. Koski's `make_row_from_map(m,
+make_array(1, 2), make_array('a', 'b'))` returns `ROW<a, b>` and needs no new
+operator: it is a row constructor over one `element_at` per key, which is
+`row(m[1], m[2])` with the field names supplied by the third argument. Both
+pieces are already in the catalog.
+
+A path `.a.x` on the result therefore resolves the way any constructor
+dereference does — to argument 0, which is `m[1]`, and then to field `x`. The
+key domain is the constant array. `padded_make_row_from_map` differs only in
+what fills an absent key, which `element_at` already yields as null.
+
+Koski's implementation declines to push down when a column feeds two such
+calls. Read as two constructors over one mini-table, the union of their key
+sets is what must be read, so the model covers a case the hand-written rule
+gives up on.
+
+## What a declaration must state
+
+Which operator a function denotes is semantics and cannot be inferred from a
+signature: two functions with identical signatures may differ. The model
+therefore replaces three declaration shapes with one.
+
+A declaration names the arguments that become scopes, the operator, how a
+lambda's parameters bind to a scope's columns (`ord`/`e`, or `k`/`v`), and
+which scope the result corresponds to.
+
+Declaring the operator also settles how the function reaches the scope: a
+Project's only access is its expression, a Filter's is its predicate. Presto
+needs a separate `isAccessingInputValues()` claim because its descriptors
+record a lambda binding without an operator to bound it.
+
+## Rewrites the model makes expressible
+
+A model earns its keep by what it makes expressible, so this list doubles as a
+test of it.
+
+The first group are not rewrites anything performs. They are propagation
+rules the analysis needs in order to see through composition — pushing a key
+domain into `transform_values`' argument, not rebuilding the expression. A
+rule is needed only where something moves or combines; a composition in which
+every operator applies its own rule in place, such as
+`cardinality(map_filter(...))` or nested `transform`, needs none.
+
+There are two such rules, both ordinary pushdown applied one scope down.
+
+**Key-domain pushdown.** A domain established above an operator moves to its
+inputs, and what each operator does with it is the operator's own rule:
+
+| Operator | Behavior | Example |
+|---|---|---|
+| Project | into the lambda's scope | `element_at(transform_values(m, f), k)` reaches one key, subsuming `subfieldArg` |
+| Filter | intersect with the filter's own domain | `map_filter(map_filter(m, P), Q)` gives `P AND Q` |
+| Union | to every input | `map_concat(m1, m2)[k]` needs `k` from both |
+| Join | to both sides | `map_zip_with(m1, m2, f)[k]` needs `k` from both |
+
+**Bound propagation.** An array bound moves only through operators that
+preserve position, which transform it — `slice(a, 1, 3)[2]` yields a bound of
+3. Every other operator drops it, so `array_sort(a)[1]` leaves the bound
+unrestricted. Only this rule involves order; marking operators as barriers is
+enough for it, and full ordered-bag semantics would be needed only by a
+rewrite that reorders operators.
+
+A few are worth materializing as plan changes, because they remove work rather
+than narrowing a read:
+
+| Rewrite | Example | Effect |
+|---|---|---|
+| Empty domain eliminates the read | `map_filter(m, (k,v) -> k = 1 AND k = 2)` | domain is empty, so the column is not read |
+| Aggregate over a constructor | `cardinality(array[a, b, c])` | 3, and `a`, `b`, `c` go unreferenced |
+| Filter into an aggregate's input | `map_agg(k, v)[42]` | rows eliminated upstream |
+
+The second entry is not constant folding: `a`, `b`, `c` need not be constants,
+and what is statically known is the constructed table's row count, taken from
+the constructor's arity. For a map constructor it holds only when the keys are
+distinct.
+
+The second table is where the model reaches past subfield pruning. The last
+entry narrows no complex value at all: it turns a subscript into an ordinary
+predicate on the aggregate's input, which then travels by normal filter
+pushdown and may reach a scan, where partition and row-group pruning apply. A
+subscript on an aggregated map can therefore eliminate files.


### PR DESCRIPTION
Summary:

v2 read every complex column whole. For

    SELECT float_features[100] FROM t

the scan returned all of `float_features` and the projection took one key from it. v2 now asks the connector for `[100]` alone, which is what v1 does under `pushdownSubfields`.

`ColumnAccess` records, for each column, the paths a query reads from it. `PushdownAndPrunePass` feeds it every expression on the way down, so a node producing a column is reached after the consumers whose paths it extends, and a projection composes the two: an output column read as `[1]`, produced by `m[200800]`, reads `[200800][1]` of `m`. A scan asks for its columns' paths when it negotiates with its connector. A column nobody records is read whole, so an expression the walk does not recognize stays correct.

Extraction is not implemented. v1 can project a map's keys or a struct's fields out of the scan as separate columns, driven by `mapAsStruct` and `allMapsAsStruct`. v2 reads subfields where they stand and produces no derived columns, so `map_keys`, `map_values` and `cardinality` still read the whole column.

Moves the path-to-`Subfield` conversion out of `ToVelox.cpp` into `ToSubfield`, so both optimizers share it.

Reviewed By: amitkdutta

Differential Revision: D118735701


