### PR TITLE
fix(cli): Open a session without a default schema

### DIFF
--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -26,6 +26,7 @@
 #include "axiom/cli/Connectors.h"
 #include "axiom/cli/Console.h"
 #include "axiom/cli/SystemUser.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestTableJson.h"
 #include "velox/common/base/Exceptions.h"
 
@@ -51,7 +52,7 @@ int main(int argc, char** argv) {
   folly::FunctionScheduler progressScheduler;
   axiom::sql::SqlQueryRunner runner{
       axiom::sql::SystemUser::resolve(), &progressScheduler, FLAGS_v2};
-  runner.initialize([&]() {
+  auto initializeConnectors = [&]() {
     VELOX_USER_CHECK(
         FLAGS_data_path.empty() || FLAGS_etc_dir.empty(),
         "--data_path and --etc_dir are mutually exclusive. Use --data_path for "
@@ -116,29 +117,47 @@ int main(int argc, char** argv) {
       connectorId = defaultConnector->connectorId();
     }
 
+    // Not every catalog has a built-in default schema. Leave the schema empty
+    // instead of refusing to start: only bare table names need it, and the
+    // session can set one later with `use <catalog>.<schema>`.
     std::string schema = FLAGS_schema;
     if (schema.empty()) {
-      auto defaultSchemaIterator = defaultSchemas.find(connectorId);
-      VELOX_USER_CHECK(
-          defaultSchemaIterator != defaultSchemas.end() &&
-              !defaultSchemaIterator->second.empty(),
-          "Schema must be specified for connector {}",
-          connectorId);
-      schema = defaultSchemaIterator->second;
+      if (const auto it = defaultSchemas.find(connectorId);
+          it != defaultSchemas.end()) {
+        schema = it->second;
+      }
     }
 
     return std::make_pair(connectorId, schema);
-  });
+  };
 
-  // Register after initialize() so sessionConfig() is available.
-  connectors.registerSystemConnector(runner.sessionConfig());
-  connectors.registerFileConnector();
-
-  axiom::sql::Console console{runner};
-  console.initialize();
-  // Invalid CLI flags throw VeloxUserError; surface them as a clean
-  // 'Error: ...' line and a non-zero exit.
+  // Both connector registration and the console throw VeloxUserError on bad
+  // flags or catalog properties. Keep them inside the handler so either one
+  // prints an 'Error: ' line and exits non-zero instead of escaping main.
   try {
+    runner.initialize(initializeConnectors);
+
+    // Register after initialize() so sessionConfig() is available.
+    connectors.registerSystemConnector(runner.sessionConfig());
+    connectors.registerFileConnector();
+
+    // --catalog is only checked here because the system and file catalogs are
+    // registered above, after the connectors the flag usually names.
+    const auto& catalog = runner.defaultConnectorId();
+    VELOX_USER_CHECK_NOT_NULL(
+        facebook::axiom::connector::ConnectorMetadataRegistry::tryGet(catalog),
+        "Catalog does not exist: {}",
+        catalog);
+
+    if (runner.defaultSchema().empty()) {
+      std::cerr << "Catalog '" << catalog
+                << "' has no default schema. Qualify table names as "
+                   "'<schema>.<table>', or run 'use "
+                << catalog << ".<schema>' to set one." << std::endl;
+    }
+
+    axiom::sql::Console console{runner};
+    console.initialize();
     console.run();
   } catch (const facebook::velox::VeloxUserError& e) {
     std::cerr << "Error: " << e.message() << std::endl;

--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -19,6 +19,7 @@
 #include <folly/executors/FunctionScheduler.h>
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
+#include <csignal>
 #include <filesystem>
 #include <iostream>
 #include <set>
@@ -151,13 +152,18 @@ int main(int argc, char** argv) {
 
     axiom::sql::Console console{runner};
     console.initialize();
-    if (!console.run()) {
-      return 1;
+    switch (console.run()) {
+      case axiom::sql::Console::Outcome::kSucceeded:
+        return 0;
+      case axiom::sql::Console::Outcome::kFailed:
+        return 1;
+      case axiom::sql::Console::Outcome::kCancelled:
+        // What a shell reports for a process that Ctrl+C ended.
+        return 128 + SIGINT;
     }
+    VELOX_UNREACHABLE();
   } catch (const facebook::velox::VeloxUserError& e) {
     std::cerr << "Error: " << e.message() << std::endl;
     return 1;
   }
-
-  return 0;
 }

--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -149,16 +149,11 @@ int main(int argc, char** argv) {
         "Catalog does not exist: {}",
         catalog);
 
-    if (runner.defaultSchema().empty()) {
-      std::cerr << "Catalog '" << catalog
-                << "' has no default schema. Qualify table names as "
-                   "'<schema>.<table>', or run 'use "
-                << catalog << ".<schema>' to set one." << std::endl;
-    }
-
     axiom::sql::Console console{runner};
     console.initialize();
-    console.run();
+    if (!console.run()) {
+      return 1;
+    }
   } catch (const facebook::velox::VeloxUserError& e) {
     std::cerr << "Error: " << e.message() << std::endl;
     return 1;

--- a/axiom/cli/Console.cpp
+++ b/axiom/cli/Console.cpp
@@ -143,7 +143,23 @@ void Console::initialize() {
   FLAGS_logtostderr = FLAGS_debug;
 }
 
-void Console::run() {
+namespace {
+// Tells the user how to reach tables when the session opened without a default
+// schema. Interactive only: scripted runs emit query output and nothing else.
+void printMissingSchemaHint(const SqlQueryRunner& runner) {
+  if (!runner.defaultSchema().empty()) {
+    return;
+  }
+
+  const auto& catalog = runner.defaultConnectorId();
+  std::cout << "Catalog '" << catalog
+            << "' has no default schema. Qualify table names as "
+               "'<schema>.<table>', or run 'use "
+            << catalog << ".<schema>' to set one." << std::endl;
+}
+} // namespace
+
+bool Console::run() {
   gflags::CommandLineFlagInfo repeatInfo;
   gflags::GetCommandLineFlagInfo("repeat", &repeatInfo);
 
@@ -161,7 +177,9 @@ void Console::run() {
     std::string sql;
     auto success = folly::readFile(FLAGS_init.c_str(), sql);
     VELOX_USER_CHECK(success, "Cannot open init file: {}", FLAGS_init);
-    runMultiple(sql, FLAGS_print_timing, /*showProgress=*/false);
+    if (!runMultiple(sql, FLAGS_print_timing, /*showProgress=*/false)) {
+      return false;
+    }
   }
 
   const bool interactive = isatty(STDIN_FILENO);
@@ -183,17 +201,15 @@ void Console::run() {
 
   if (!userSql.empty()) {
     if (repeatInfo.is_default) {
-      runMultiple(
+      return runMultiple(
           userSql,
           FLAGS_print_timing,
           FLAGS_show_live_progress && terminalProgress);
-    } else {
-      // Explicit --repeat: treat the input as a single statement. Skip the
-      // progress grid so its periodic redraws do not perturb the timing this
-      // mode exists to measure.
-      runRepeat(userSql, FLAGS_repeat, FLAGS_print_timing);
     }
-    return;
+    // Explicit --repeat: treat the input as a single statement. Skip the
+    // progress grid so its periodic redraws do not perturb the timing this
+    // mode exists to measure.
+    return runRepeat(userSql, FLAGS_repeat, FLAGS_print_timing);
   }
 
   // No user SQL: enter interactive REPL.
@@ -203,8 +219,13 @@ void Console::run() {
     std::cout << "Axiom SQL. Type statement and end with ;.\n"
                  "Type .help for available commands."
               << std::endl;
+    printMissingSchemaHint(runner_);
   }
   readCommands("SQL> ", interactive || FLAGS_print_timing, terminalProgress);
+
+  // A statement typed into the REPL that fails has already been reported to
+  // the user; it does not make the session itself a failure.
+  return true;
 }
 
 namespace {
@@ -306,7 +327,7 @@ bool Console::runOnce(
   }
 }
 
-void Console::runMultiple(
+bool Console::runMultiple(
     std::string_view sql,
     bool printTiming,
     bool showProgress) {
@@ -318,17 +339,19 @@ void Console::runMultiple(
       continue;
     }
     if (!runOnce(sqlText, printTiming, showProgress)) {
-      return;
+      return false;
     }
   }
+  return true;
 }
 
-void Console::runRepeat(std::string_view sql, int repeat, bool printTiming) {
+bool Console::runRepeat(std::string_view sql, int repeat, bool printTiming) {
   for (int i = 0; i < repeat; ++i) {
     if (!runOnce(sql, printTiming, /*showProgress=*/false)) {
-      return;
+      return false;
     }
   }
+  return true;
 }
 
 void Console::readCommands(

--- a/axiom/cli/Console.cpp
+++ b/axiom/cli/Console.cpp
@@ -173,16 +173,28 @@ bool Console::run() {
     interrupt_ = nullptr;
   };
 
+  const bool interactive = isatty(STDIN_FILENO);
+
+  // What follows --init: the REPL when there is no SQL to run instead.
+  const bool entersRepl = FLAGS_query.empty() && interactive;
+
   if (!FLAGS_init.empty()) {
     std::string sql;
     auto success = folly::readFile(FLAGS_init.c_str(), sql);
     VELOX_USER_CHECK(success, "Cannot open init file: {}", FLAGS_init);
     if (!runMultiple(sql, FLAGS_print_timing, /*showProgress=*/false)) {
-      return false;
+      // A script cannot act on a half-built session, so stop. A user at a
+      // prompt can: --init may have built something expensive, and the failure
+      // is on screen right above. Say that the setup is incomplete, since a
+      // greeting and a prompt otherwise look like an ordinary start.
+      if (!entersRepl) {
+        return false;
+      }
+      std::cerr << "--init did not finish, so the session is only partly set "
+                   "up. Opening the prompt anyway."
+                << std::endl;
     }
   }
-
-  const bool interactive = isatty(STDIN_FILENO);
 
   // The live progress grid renders on stderr and is erased before results
   // print, so it needs stderr to be a terminal and the runner to report

--- a/axiom/cli/Console.cpp
+++ b/axiom/cli/Console.cpp
@@ -159,7 +159,7 @@ void printMissingSchemaHint(const SqlQueryRunner& runner) {
 }
 } // namespace
 
-bool Console::run() {
+Console::Outcome Console::run() {
   gflags::CommandLineFlagInfo repeatInfo;
   gflags::GetCommandLineFlagInfo("repeat", &repeatInfo);
 
@@ -182,13 +182,15 @@ bool Console::run() {
     std::string sql;
     auto success = folly::readFile(FLAGS_init.c_str(), sql);
     VELOX_USER_CHECK(success, "Cannot open init file: {}", FLAGS_init);
-    if (!runMultiple(sql, FLAGS_print_timing, /*showProgress=*/false)) {
+    if (const auto outcome =
+            runMultiple(sql, FLAGS_print_timing, /*showProgress=*/false);
+        outcome != Outcome::kSucceeded) {
       // A script cannot act on a half-built session, so stop. A user at a
       // prompt can: --init may have built something expensive, and the failure
       // is on screen right above. Say that the setup is incomplete, since a
       // greeting and a prompt otherwise look like an ordinary start.
       if (!entersRepl) {
-        return false;
+        return outcome;
       }
       std::cerr << "--init did not finish, so the session is only partly set "
                    "up. Opening the prompt anyway."
@@ -237,7 +239,7 @@ bool Console::run() {
 
   // A statement typed into the REPL that fails has already been reported to
   // the user; it does not make the session itself a failure.
-  return true;
+  return Outcome::kSucceeded;
 }
 
 namespace {
@@ -253,10 +255,8 @@ std::string formatTiming(
 }
 } // namespace
 
-bool Console::runOnce(
-    std::string_view sql,
-    bool printTiming,
-    bool showProgress) {
+Console::Outcome
+Console::runOnce(std::string_view sql, bool printTiming, bool showProgress) {
   QueryCompletionInfo completionInfo;
 
   SqlQueryRunner::RunOptions options{
@@ -315,14 +315,14 @@ bool Console::runOnce(
       std::cout << "Query ID: " << completionInfo.startInfo.queryId << " | "
                 << formatTiming(completionInfo.timing, cpuTiming) << std::endl;
     }
-    return true;
+    return Outcome::kSucceeded;
   } catch (const QueryCancelledError&) {
     // A user cancellation (Ctrl+C) is reported plainly.
     if (progress) {
       progress->clear();
     }
     std::cerr << "Query cancelled." << std::endl;
-    return false;
+    return Outcome::kCancelled;
   } catch (const std::exception&) {
     if (progress) {
       progress->clear();
@@ -335,11 +335,11 @@ bool Console::runOnce(
       std::cerr << "Query ID: " << completionInfo.startInfo.queryId << " | "
                 << formatTiming(completionInfo.timing, cpuTiming) << std::endl;
     }
-    return false;
+    return Outcome::kFailed;
   }
 }
 
-bool Console::runMultiple(
+Console::Outcome Console::runMultiple(
     std::string_view sql,
     bool printTiming,
     bool showProgress) {
@@ -350,20 +350,23 @@ bool Console::runMultiple(
     if (sqlText.empty()) {
       continue;
     }
-    if (!runOnce(sqlText, printTiming, showProgress)) {
-      return false;
+    if (const auto outcome = runOnce(sqlText, printTiming, showProgress);
+        outcome != Outcome::kSucceeded) {
+      return outcome;
     }
   }
-  return true;
+  return Outcome::kSucceeded;
 }
 
-bool Console::runRepeat(std::string_view sql, int repeat, bool printTiming) {
+Console::Outcome
+Console::runRepeat(std::string_view sql, int repeat, bool printTiming) {
   for (int i = 0; i < repeat; ++i) {
-    if (!runOnce(sql, printTiming, /*showProgress=*/false)) {
-      return false;
+    if (const auto outcome = runOnce(sql, printTiming, /*showProgress=*/false);
+        outcome != Outcome::kSucceeded) {
+      return outcome;
     }
   }
-  return true;
+  return Outcome::kSucceeded;
 }
 
 void Console::readCommands(

--- a/axiom/cli/Console.h
+++ b/axiom/cli/Console.h
@@ -43,7 +43,7 @@ class QueryInterruptHandler;
 ///   SqlQueryRunner runner{user, &scheduler};
 ///   Console console{runner};
 ///   console.initialize();
-///   return console.run() ? 0 : 1;
+///   const Console::Outcome outcome = console.run();
 /// @endcode
 ///
 /// Invariants:
@@ -54,6 +54,17 @@ class QueryInterruptHandler;
 ///   value; only invalid CLI flags throw.
 class Console {
  public:
+  /// How a run ended, for the caller to turn into an exit status.
+  enum class Outcome {
+    /// Every statement succeeded, or the session ended at the interactive
+    /// prompt, whatever was typed there.
+    kSucceeded,
+    /// A statement failed.
+    kFailed,
+    /// Ctrl+C cancelled a statement.
+    kCancelled,
+  };
+
   explicit Console(SqlQueryRunner& runner);
 
   /// Initializes the CLI with usage message and logging settings.
@@ -63,32 +74,32 @@ class Console {
   /// stdin if non-interactive, otherwise enters the interactive REPL.
   /// Honors `--repeat` for `--query` and piped-stdin paths.
   ///
-  /// Returns false if a statement from `--init`, `--query` or piped stdin
-  /// failed or was cancelled, so that the caller can exit non-zero; the
-  /// statements after it are skipped. A failed `--init` still opens the
-  /// interactive prompt, where the user can act on it, and leaves the return
-  /// value true. Statements typed at the prompt are reported the same way and
-  /// never affect the return value.
+  /// Returns how the run ended. A statement from `--init`, `--query` or piped
+  /// stdin that fails or is cancelled ends the run, skipping the statements
+  /// after it, and decides the outcome. A failed or cancelled `--init` still
+  /// opens the interactive prompt, where the user can act on it, and the
+  /// session then ends kSucceeded like any other. Statements typed at the
+  /// prompt are reported the same way and never affect the outcome.
   ///
   /// Throws VeloxUserError on invalid CLI flags. Query failures during
   /// execution are caught internally and printed to stderr; they do
   /// not throw.
-  bool run();
+  Outcome run();
 
  private:
-  // Runs a single SQL statement and prints results/timing. Returns true on
-  // success, false if the query threw. Draws the live progress grid when
-  // 'showProgress' is set.
-  bool runOnce(std::string_view sql, bool printTiming, bool showProgress);
+  // Runs a single SQL statement and prints results/timing. Draws the live
+  // progress grid when 'showProgress' is set.
+  Outcome runOnce(std::string_view sql, bool printTiming, bool showProgress);
 
   // Splits 'sql' into individual statements and runs each one in sequence.
-  // Stops on the first failure and returns false. Passes 'showProgress'
-  // through to each.
-  bool runMultiple(std::string_view sql, bool printTiming, bool showProgress);
+  // Stops at the first that does not succeed and returns its outcome. Passes
+  // 'showProgress' through to each.
+  Outcome
+  runMultiple(std::string_view sql, bool printTiming, bool showProgress);
 
-  // Runs 'sql' (a single SQL statement) 'repeat' times back-to-back.
-  // Stops on the first failure and returns false.
-  bool runRepeat(std::string_view sql, int repeat, bool printTiming);
+  // Runs 'sql' (a single SQL statement) 'repeat' times back-to-back. Stops at
+  // the first run that does not succeed and returns its outcome.
+  Outcome runRepeat(std::string_view sql, int repeat, bool printTiming);
 
   // Reads and executes commands from standard input in interactive mode.
   // Passes 'showProgress' through to the statements it runs.

--- a/axiom/cli/Console.h
+++ b/axiom/cli/Console.h
@@ -65,8 +65,10 @@ class Console {
   ///
   /// Returns false if a statement from `--init`, `--query` or piped stdin
   /// failed or was cancelled, so that the caller can exit non-zero; the
-  /// statements after it are skipped. Statements typed into the interactive
-  /// REPL are reported the same way but do not affect the return value.
+  /// statements after it are skipped. A failed `--init` still opens the
+  /// interactive prompt, where the user can act on it, and leaves the return
+  /// value true. Statements typed at the prompt are reported the same way and
+  /// never affect the return value.
   ///
   /// Throws VeloxUserError on invalid CLI flags. Query failures during
   /// execution are caught internally and printed to stderr; they do

--- a/axiom/cli/Console.h
+++ b/axiom/cli/Console.h
@@ -43,14 +43,15 @@ class QueryInterruptHandler;
 ///   SqlQueryRunner runner{user, &scheduler};
 ///   Console console{runner};
 ///   console.initialize();
-///   console.run();
+///   return console.run() ? 0 : 1;
 /// @endcode
 ///
 /// Invariants:
 /// - `runner` must outlive the Console.
 /// - run() owns process-wide stdin/stdout/stderr while it executes; do not
 ///   write to them concurrently.
-/// - Query failures are caught and printed; only invalid CLI flags throw.
+/// - Query failures are caught and printed, then reported by run()'s return
+///   value; only invalid CLI flags throw.
 class Console {
  public:
   explicit Console(SqlQueryRunner& runner);
@@ -62,10 +63,15 @@ class Console {
   /// stdin if non-interactive, otherwise enters the interactive REPL.
   /// Honors `--repeat` for `--query` and piped-stdin paths.
   ///
+  /// Returns false if a statement from `--init`, `--query` or piped stdin
+  /// failed or was cancelled, so that the caller can exit non-zero; the
+  /// statements after it are skipped. Statements typed into the interactive
+  /// REPL are reported the same way but do not affect the return value.
+  ///
   /// Throws VeloxUserError on invalid CLI flags. Query failures during
   /// execution are caught internally and printed to stderr; they do
   /// not throw.
-  void run();
+  bool run();
 
  private:
   // Runs a single SQL statement and prints results/timing. Returns true on
@@ -74,12 +80,13 @@ class Console {
   bool runOnce(std::string_view sql, bool printTiming, bool showProgress);
 
   // Splits 'sql' into individual statements and runs each one in sequence.
-  // Stops on the first failure. Passes 'showProgress' through to each.
-  void runMultiple(std::string_view sql, bool printTiming, bool showProgress);
+  // Stops on the first failure and returns false. Passes 'showProgress'
+  // through to each.
+  bool runMultiple(std::string_view sql, bool printTiming, bool showProgress);
 
   // Runs 'sql' (a single SQL statement) 'repeat' times back-to-back.
-  // Stops on the first failure.
-  void runRepeat(std::string_view sql, int repeat, bool printTiming);
+  // Stops on the first failure and returns false.
+  bool runRepeat(std::string_view sql, int repeat, bool printTiming);
 
   // Reads and executes commands from standard input in interactive mode.
   // Passes 'showProgress' through to the statements it runs.

--- a/axiom/cli/README.md
+++ b/axiom/cli/README.md
@@ -26,8 +26,8 @@ The examples below use `axiom_sql` for brevity. With Buck, replace
 |------|---------|-------------|
 | `--query` | | SQL text to execute. Supports multiple semicolon-separated statements. If not specified, enters interactive mode. If set to an empty string (`--query ""`), reads semicolon-separated SQL statements from stdin. |
 | `--init` | | Path to a SQL file with semicolon-separated statements to execute on startup before entering interactive mode or running `--query`. |
-| `--catalog` | | Default catalog (connector). If not specified, defaults to `hive` when `--data_path` is set, `tpch` otherwise. |
-| `--schema` | | Default schema. If not specified, defaults to `tiny` for TPC-H and `default` for Hive and Test connectors. |
+| `--catalog` | | Default catalog (connector). If not specified, defaults to `hive` when `--data_path` is set, `tpch` otherwise. Startup fails if the catalog is not registered. |
+| `--schema` | | Default schema. If not specified, defaults to `tiny` for TPC-H and `default` for Hive and Test connectors. Other catalogs, such as `system`, have no default schema: qualify table names as `<schema>.<table>`, or run `use <catalog>.<schema>`. |
 | `--etc_dir` | | Path to a directory of catalog `.properties` files. Mutually exclusive with `--data_path`. External catalogs are not selected automatically; use `--catalog` or fully-qualified names in SQL. |
 | `--data_path` | | Hive specific: root path for Hive-style partitioned data. Registers local Hive connector. Mutually exclusive with `--etc_dir`. |
 | `--data_format` | `parquet` | Hive specific: data format, `parquet`, `dwrf`, or `text`. |

--- a/axiom/cli/README.md
+++ b/axiom/cli/README.md
@@ -298,8 +298,10 @@ At the prompt, with no query running:
 | Condition | Exit code |
 |-----------|-----------|
 | Invalid flags or catalog configuration | 1 |
-| `--init`, `--query` or piped stdin: every statement succeeded | 0 |
-| `--init`, `--query` or piped stdin: a statement failed or was cancelled | 1 |
+| `--query` or piped stdin: every statement succeeded | 0 |
+| `--query` or piped stdin: a statement failed or was cancelled | 1 |
+| `--init` failed, with `--query` or piped stdin to follow | 1 |
+| `--init` failed, with the REPL to follow — the prompt still opens | 0 |
 | Interactive REPL: left with `.exit`, `.quit` or Ctrl+D | 0 |
 
 Bad configuration is rejected before any statement runs and prints a
@@ -312,13 +314,21 @@ Once statements start running, a failure prints `Query failed: ...` to
 stderr — `Query cancelled.` if Ctrl+C ended it — and what happens next
 depends on where that statement came from:
 
-- **`--init`, `--query` or piped stdin** — the run stops there: the
-  statements after it are skipped and the CLI exits 1. Because `--init`
-  runs first, a failure in it exits without running `--query` and
-  without opening the prompt.
+- **`--query` or piped stdin** — the run stops there: the statements
+  after it are skipped and the CLI exits 1.
 - **Typed at the REPL prompt** — only that statement ends. The prompt
   returns, the session stays open, and it exits 0 whatever its
   statements did.
+
+`--init` runs before both, and what a failure in it costs depends on
+what was going to follow. With `--query` or piped stdin, neither runs
+and the CLI exits 1. With the REPL, the prompt opens anyway: `--init`
+often builds something expensive, and the prompt is where the user can
+look at what went wrong and finish the job by hand. The rest of the
+`--init` file is skipped either way, so the CLI says so before the
+greeting:
+
+    --init did not finish, so the session is only partly set up. Opening the prompt anyway.
 
 ## Query History
 

--- a/axiom/cli/README.md
+++ b/axiom/cli/README.md
@@ -297,13 +297,28 @@ At the prompt, with no query running:
 
 | Condition | Exit code |
 |-----------|-----------|
-| Invalid CLI flags (e.g. `--repeat 0`, `--repeat` in interactive mode) | 1 |
-| All statements completed | 0 |
-| One or more statements failed at parse / optimize / execute | 0 |
+| Invalid flags or catalog configuration | 1 |
+| `--init`, `--query` or piped stdin: every statement succeeded | 0 |
+| `--init`, `--query` or piped stdin: a statement failed or was cancelled | 1 |
+| Interactive REPL: left with `.exit`, `.quit` or Ctrl+D | 0 |
 
-Query failures print `Query failed: ...` to stderr but do not change
-the exit code. Wrap the CLI in shell tooling if you need to detect
-query failure (e.g. grep for `Query failed:` in stderr).
+Bad configuration is rejected before any statement runs and prints a
+single `Error: ...` line to stderr. This covers `--repeat 0`, `--repeat`
+in interactive mode, `--data_path` together with `--etc_dir`, a
+`--catalog` that names an unregistered catalog, and an `--init` file that
+cannot be read.
+
+Once statements start running, a failure prints `Query failed: ...` to
+stderr — `Query cancelled.` if Ctrl+C ended it — and what happens next
+depends on where that statement came from:
+
+- **`--init`, `--query` or piped stdin** — the run stops there: the
+  statements after it are skipped and the CLI exits 1. Because `--init`
+  runs first, a failure in it exits without running `--query` and
+  without opening the prompt.
+- **Typed at the REPL prompt** — only that statement ends. The prompt
+  returns, the session stays open, and it exits 0 whatever its
+  statements did.
 
 ## Query History
 

--- a/axiom/cli/README.md
+++ b/axiom/cli/README.md
@@ -284,7 +284,8 @@ Query cancelled.
 Cancellation works on every execution path — `--init`, `--query`, piped stdin,
 `--repeat`, and the interactive REPL. In the REPL the prompt returns and the
 session stays alive; on the non-interactive paths the cancelled statement ends
-the run, so any remaining statements or `--repeat` iterations are skipped.
+the run: any remaining statements or `--repeat` iterations are skipped, and the
+CLI exits 130.
 
 At the prompt, with no query running:
 
@@ -299,8 +300,9 @@ At the prompt, with no query running:
 |-----------|-----------|
 | Invalid flags or catalog configuration | 1 |
 | `--query` or piped stdin: every statement succeeded | 0 |
-| `--query` or piped stdin: a statement failed or was cancelled | 1 |
-| `--init` failed, with `--query` or piped stdin to follow | 1 |
+| `--query` or piped stdin: a statement failed | 1 |
+| `--query` or piped stdin: Ctrl+C cancelled a statement | 130 |
+| `--init` failed, with `--query` or piped stdin to follow | 1, or 130 if Ctrl+C cancelled it |
 | `--init` failed, with the REPL to follow — the prompt still opens | 0 |
 | Interactive REPL: left with `.exit`, `.quit` or Ctrl+D | 0 |
 
@@ -315,18 +317,20 @@ stderr — `Query cancelled.` if Ctrl+C ended it — and what happens next
 depends on where that statement came from:
 
 - **`--query` or piped stdin** — the run stops there: the statements
-  after it are skipped and the CLI exits 1.
+  after it are skipped and the CLI exits 1. Ctrl+C exits 130 instead,
+  the code a shell reports for a process that Ctrl+C ended, so a script
+  can tell a stopped run from a broken one.
 - **Typed at the REPL prompt** — only that statement ends. The prompt
   returns, the session stays open, and it exits 0 whatever its
   statements did.
 
 `--init` runs before both, and what a failure in it costs depends on
-what was going to follow. With `--query` or piped stdin, neither runs
-and the CLI exits 1. With the REPL, the prompt opens anyway: `--init`
-often builds something expensive, and the prompt is where the user can
-look at what went wrong and finish the job by hand. The rest of the
-`--init` file is skipped either way, so the CLI says so before the
-greeting:
+what was going to follow. With `--query` or piped stdin, neither runs,
+and the CLI exits as it would for a failure there. With the REPL, the
+prompt opens anyway: `--init` often builds something expensive, and the
+prompt is where the user can look at what went wrong and finish the job
+by hand. The rest of the `--init` file is skipped either way, so the CLI
+says so before the greeting:
 
     --init did not finish, so the session is only partly set up. Opening the prompt anyway.
 

--- a/axiom/cli/tests/CliRepeatTest.md
+++ b/axiom/cli/tests/CliRepeatTest.md
@@ -32,6 +32,13 @@ $ $CLI --query "SELECT * FROM nonexistent_table" --repeat 3 --print_timing 2>&1 
 Query ID: * | Parsing: (glob)
 ```
 
+## --repeat reports a failed run in the exit code
+
+```scrut
+$ $CLI --query "SELECT * FROM nonexistent_table" --repeat 3 2>/dev/null
+[1]
+```
+
 ## --repeat without --print_timing runs the query N times silently
 
 ```scrut
@@ -41,7 +48,7 @@ $ $CLI --query "SELECT 1 as a" --repeat 3 2>/dev/null | grep 'rows in 1 batches'
 (1 rows in 1 batches)
 ```
 
-## --repeat with multi-statement input fails (CLI exits 0; error to stderr)
+## --repeat with multi-statement input fails
 
 ```scrut
 $ $CLI --query "SELECT 1; SELECT 2" --repeat 2 2>&1 >/dev/null | grep -oE 'Expected a single statement.*'

--- a/axiom/cli/tests/CliTest.md
+++ b/axiom/cli/tests/CliTest.md
@@ -179,6 +179,22 @@ $ $CLI --query "USE blah.default" 2>&1 | grep Reason
 Reason: Catalog does not exist: blah
 ```
 
+## --catalog naming an unregistered catalog fails before any statement runs
+
+```scrut
+$ $CLI --catalog nosuch --query "SELECT 1" 2>&1 1>/dev/null
+Error: Catalog does not exist: nosuch
+[1]
+```
+
+## --data_path and --etc_dir are mutually exclusive
+
+```scrut
+$ $CLI --data_path /tmp --etc_dir /tmp --query "SELECT 1" 2>&1 1>/dev/null
+Error: --data_path and --etc_dir are mutually exclusive. Use --data_path for the local Hive shorthand or --etc_dir for catalog .properties files.
+[1]
+```
+
 ## Time and timestamp types display formatted values
 
 Verify that current_timestamp, localtime, and current_time display the same
@@ -321,11 +337,66 @@ $ $CLI --query "SELECT * FROM nonexistent_table" 2>&1 >/dev/null | grep 'Query f
 Query failed: * (glob)
 ```
 
-## Query failure does not change the CLI exit code
+## Query failure exits non-zero
 
 ```scrut
 $ $CLI --query "SELECT * FROM nonexistent_table" 2>/dev/null
-[0]
+[1]
+```
+
+## A failed statement stops the statements after it
+
+```scrut
+$ $CLI --query "SELECT 1 AS a; SELECT * FROM nonexistent_table; SELECT 2 AS b" 2>/dev/null
+-
+a
+-
+1
+(1 rows in 1 batches)
+
+[1]
+```
+
+## Piped stdin reports a failed statement in the exit code
+
+```scrut
+$ echo "SELECT * FROM nonexistent_table;" | $CLI --query "" 2>/dev/null
+[1]
+```
+
+## A failed --init statement stops the run before --query
+
+```scrut
+$ echo "SELECT * FROM nonexistent_table;" | $CLI --init /dev/stdin --query "SELECT 1 AS a" 2>/dev/null
+[1]
+```
+
+## A schemaless catalog resolves qualified names
+
+```scrut
+$ $CLI --catalog system --query "SELECT count(*) > 0 AS ok FROM metadata.functions" 2>/dev/null
+----
+  ok
+----
+true
+(1 rows in 1 batches)
+
+```
+
+## A bare table name in a schemaless catalog fails detectably
+
+```scrut
+$ $CLI --catalog system --query "SELECT * FROM functions" 2>&1 >/dev/null
+Query failed: * (glob)
+[1]
+```
+
+## The missing-schema hint stays out of scripted runs
+
+```scrut
+$ $CLI --catalog system --query "SELECT 1 AS a" 2>&1 >/dev/null | grep -c 'has no default schema'
+0
+[1]
 ```
 
 ## Cleanly log dictionary wrapped result vectors (window functions produce encoded vectors)

--- a/axiom/cli/tests/ConsoleTest.cpp
+++ b/axiom/cli/tests/ConsoleTest.cpp
@@ -24,6 +24,7 @@
 #include <signal.h>
 #include <atomic>
 #include <chrono>
+#include <optional>
 #include <thread>
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
@@ -181,7 +182,8 @@ TEST_F(ConsoleTest, sigintCancelsRunningQuery) {
   ASSERT_EQ(sigaction(SIGINT, &ignore, nullptr), 0);
 
   testing::internal::CaptureStderr();
-  std::thread queryThread([&] { console.run(); });
+  std::optional<Console::Outcome> outcome;
+  std::thread queryThread([&] { outcome = console.run(); });
   // Join on any early exit (e.g. an ASSERT failure below) so the thread is
   // never destroyed while joinable -- that would std::terminate the test
   // process.
@@ -200,6 +202,7 @@ TEST_F(ConsoleTest, sigintCancelsRunningQuery) {
 
   // run() carried Console's per-query token through RunOptions into co_run.
   EXPECT_TRUE(runner->sawCancellableToken());
+  EXPECT_EQ(outcome, Console::Outcome::kCancelled);
 
   const std::string captured = testing::internal::GetCapturedStderr();
   EXPECT_NE(captured.find("Query cancelled."), std::string::npos);


### PR DESCRIPTION
```
axiom_sql --etc_dir <dir> --catalog <name>` aborted before the prompt:

    Reason: Schema must be specified for connector iceberg
```

Only three connector names carry a built-in default schema, a catalog with no default could not be opened at all. The session already sets a schema at any point with `use <catalog>.<schema>`, and a qualified table name needs none.
With this patch, the missing default now leaves the schema empty and prints what to run instead of refusing to start.
And a session now opens with an empty default schema. Only bare table names need one, so tables are reached either by qualifying them or by setting a schema for the session:

```
    SELECT count(*) FROM metadata.functions
    USE system.metadata
```

The REPL prints a one-line reminder of that after its greeting. Scripted runs stay quiet.

Two changes carry it:

- Connector setup and a new catalog-exists check move inside the `try` that prints `Error: ...`, so a startup problem exits 1 instead of aborting.
- `Console::run()` return status code, so a failed statement reaches `main`'s exit code rather than being swallowed.

These two changes the exit codes:

**Startup, before any session open**

| Condition | Before | After |
|---|---|---|
| `--data_path` + `--etc_dir` | **134 (SIGABRT)** | 1, `Error: … mutually exclusive` |
| `--catalog nosuch` | **134 (SIGABRT)** | 1, `Error: Catalog does not exist: nosuch` |
| `--catalog system` (no default schema) | **134 (SIGABRT)** | starts normally, 0 scripted, prompt + hint interactive |
| `--repeat 0`, `--repeat` with no SQL, unreadable `--init` | 1 | 1 |

**Non-interactive — `--query`, or piped stdin**

| Condition | Before | After |
|---|---|---|
| a statement fails | 0 | **1** |
| multi-statement, middle fails (rest skipped either way) | 0 | **1** |
| `--repeat N`, a run fails | 0 | **1** |
| Ctrl+C during the query | 0 | **130** |
| all statements succeed | 0 | 0 |

**Interactive REPL — nothing changed**

| Condition | Before | After |
|---|---|---|
| a statement typed at the prompt fails | 0 | 0 |
| Ctrl+C during a query (session continues) | 0 | 0 |
| `.exit` / `.quit` / Ctrl+D | 0 | 0 |

**`--init` — runs in both modes**

| Condition | Before | After |
|---|---|---|
| `--init` statement fails, then `--query` | 0, **`--query` still ran** | **1**, `--query` skipped |
| `--init` statement fails, interactive | 0, prompt opened with no warning | 0, prompt opens after an `--init did not finish` notice |
| Ctrl+C during `--init`, then `--query` | 0, **`--query` still run** | **130**, `--query` skipped |