### PR TITLE
refactor(connectors): Adopt downcast helpers (#1828)

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -26,6 +26,7 @@
 #include "axiom/logical_plan/LogicalPlanNode.h"
 #include "folly/CppAttributes.h"
 #include "folly/coro/Task.h"
+#include "velox/common/Casts.h"
 #include "velox/connectors/Connector.h"
 #include "velox/type/Subfield.h"
 #include "velox/type/Type.h"
@@ -343,6 +344,12 @@ class PartitionType {
   const T* as() const {
     return dynamic_cast<const T*>(this);
   }
+
+  /// Returns this object as type 'T'. Throws if it is not of that type.
+  template <typename T>
+  const T* asChecked() const {
+    return velox::checkedPointerCast<const T>(this);
+  }
 };
 
 // TODO Move to velox/type/Subfield.h
@@ -656,6 +663,12 @@ class TableLayout {
     return dynamic_cast<const T*>(this);
   }
 
+  /// Returns this object as type 'T'. Throws if it is not of that type.
+  template <typename T>
+  const T* asChecked() const {
+    return velox::checkedPointerCast<const T>(this);
+  }
+
   /// Samples a fraction of rows and applies filters from 'handle'. Returns the
   /// number of rows sampled and the number matching the filters.
   virtual SampleResult sample(
@@ -929,6 +942,12 @@ class Table : public std::enable_shared_from_this<Table> {
     return dynamic_cast<const T*>(this);
   }
 
+  /// Returns this object as type 'T'. Throws if it is not of that type.
+  template <typename T>
+  const T* asChecked() const {
+    return velox::checkedPointerCast<const T>(this);
+  }
+
  private:
   const SchemaTableName name_;
   const velox::RowTypePtr type_;
@@ -1028,6 +1047,12 @@ class ConnectorWriteHandle {
   template <typename T>
   const T* as() const {
     return dynamic_cast<const T*>(this);
+  }
+
+  /// Returns this object as type 'T'. Throws if it is not of that type.
+  template <typename T>
+  const T* asChecked() const {
+    return velox::checkedPointerCast<const T>(this);
   }
 
  protected:
@@ -1440,6 +1465,12 @@ class ConnectorMetadata {
   template <typename T>
   const T* as() const {
     return dynamic_cast<const T*>(this);
+  }
+
+  /// Returns this object as type 'T'. Throws if it is not of that type.
+  template <typename T>
+  const T* asChecked() const {
+    return velox::checkedPointerCast<const T>(this);
   }
 };
 

--- a/axiom/connectors/file/FileConnector.cpp
+++ b/axiom/connectors/file/FileConnector.cpp
@@ -18,6 +18,7 @@
 
 #include "axiom/connectors/file/FileHandler.h"
 #include "axiom/connectors/file/core/FileTable.h"
+#include "velox/common/Casts.h"
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::axiom::connector::file {
@@ -27,8 +28,7 @@ std::unique_ptr<velox::connector::DataSource> FileConnector::createDataSource(
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const velox::connector::ColumnHandleMap& columnHandles,
     velox::connector::ConnectorQueryCtx* connectorQueryCtx) {
-  auto* fileHandle = dynamic_cast<const FileTableHandle*>(tableHandle.get());
-  VELOX_CHECK_NOT_NULL(fileHandle, "Expected FileTableHandle");
+  const auto* fileHandle = tableHandle->asChecked<FileTableHandle>();
 
   auto& fileHandler = handler(fileHandle->schemaTableName().schema);
   return fileHandler.create(

--- a/axiom/connectors/file/core/FileConnectorMetadata.cpp
+++ b/axiom/connectors/file/core/FileConnectorMetadata.cpp
@@ -18,6 +18,7 @@
 
 #include "axiom/connectors/file/FileHandler.h"
 #include "axiom/connectors/file/core/FileTable.h"
+#include "velox/common/Casts.h"
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::axiom::connector::file {
@@ -101,8 +102,7 @@ FileConnectorMetadata::SplitManager::getSplitSource(
   VELOX_USER_CHECK(
       !samplePercentage.has_value(),
       "SYSTEM sampling is not supported by this connector");
-  auto* fileHandle = dynamic_cast<const FileTableHandle*>(tableHandle.get());
-  VELOX_CHECK_NOT_NULL(fileHandle, "Expected FileTableHandle");
+  const auto* fileHandle = tableHandle->asChecked<FileTableHandle>();
   // The file list was resolved once during planning (see findTable); reuse it
   // rather than listing the directory again here.
   return std::make_shared<FileSplitSource>(

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -22,6 +22,7 @@
 #include <folly/String.h>
 #include <algorithm>
 #include <utility>
+#include "velox/common/Casts.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
@@ -172,8 +173,7 @@ HiveTable::HiveTable(
           std::move(options)) {}
 
 std::vector<std::string> HiveTable::ioColumnPriority() const {
-  const auto* hiveLayout = dynamic_cast<const HiveTableLayout*>(layouts()[0]);
-  VELOX_CHECK_NOT_NULL(hiveLayout);
+  const auto* hiveLayout = layouts()[0]->asChecked<HiveTableLayout>();
 
   bool hasDs = false;
   bool hasTs = false;
@@ -495,10 +495,9 @@ std::shared_ptr<velox::connector::hive::LocationHandle> makeLocationHandle(
 velox::common::SubfieldFilters deleteFilters(
     const HiveTableLayout& layout,
     const velox::connector::ConnectorTableHandlePtr& scanHandle) {
-  auto hiveScan =
-      std::dynamic_pointer_cast<const velox::connector::hive::HiveTableHandle>(
-          scanHandle);
-  VELOX_USER_CHECK_NOT_NULL(hiveScan, "DELETE requires a scan of the table");
+  VELOX_USER_CHECK_NOT_NULL(scanHandle, "DELETE requires a scan of the table");
+  const auto* hiveScan =
+      scanHandle->asChecked<velox::connector::hive::HiveTableHandle>();
 
   VELOX_USER_CHECK_NULL(
       hiveScan->remainingFilter(),
@@ -543,8 +542,7 @@ ConnectorWriteHandlePtr HiveConnectorMetadata::beginWrite(
       "Only CREATE/INSERT/DELETE supported, not {}",
       WriteKindName::toName(kind));
 
-  auto* hiveLayout = dynamic_cast<const HiveTableLayout*>(table->layouts()[0]);
-  VELOX_CHECK_NOT_NULL(hiveLayout);
+  const auto* hiveLayout = table->layouts()[0]->asChecked<HiveTableLayout>();
 
   if (kind == WriteKind::kDelete) {
     return makeDeleteWriteHandle(table, deleteFilters(*hiveLayout, scanHandle));

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -25,6 +25,7 @@
 #include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/connectors/hive/LocalTableMetadata.h"
 #include "axiom/optimizer/JsonUtil.h"
+#include "velox/common/Casts.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
@@ -303,13 +304,10 @@ std::shared_ptr<SplitSource> LocalHiveSplitManager::getSplitSource(
        tableHandle->name()});
   VELOX_CHECK_NOT_NULL(
       table, "Could not find {} in its ConnectorMetadata", tableHandle->name());
-  auto* layout = dynamic_cast<const LocalHiveTableLayout*>(table->layouts()[0]);
-  VELOX_CHECK_NOT_NULL(layout);
+  const auto* layout = table->layouts()[0]->asChecked<LocalHiveTableLayout>();
 
-  auto* hiveTableHandle =
-      dynamic_cast<const velox::connector::hive::HiveTableHandle*>(
-          tableHandle.get());
-  VELOX_CHECK_NOT_NULL(hiveTableHandle);
+  const auto* hiveTableHandle =
+      tableHandle->asChecked<velox::connector::hive::HiveTableHandle>();
 
   auto selectedFiles =
       filterFilesByTableHandle(layout->files(), *hiveTableHandle);
@@ -361,8 +359,8 @@ folly::coro::Task<SplitBatch> LocalHiveSplitSource::co_getSplits(
         VELOX_CHECK(
             info->bucketNumber.has_value(),
             "Bucketed scan requires bucketNumber on every file");
-        const auto* hivePartitionType = partitionType_->as<HivePartitionType>();
-        VELOX_CHECK_NOT_NULL(hivePartitionType, "Expected HivePartitionType");
+        const auto* hivePartitionType =
+            partitionType_->asChecked<HivePartitionType>();
         groupId =
             hivePartitionType->mapBucketToPartition(info->bucketNumber.value());
       }
@@ -516,8 +514,7 @@ std::pair<int64_t, int64_t> LocalHiveTableLayout::sample(
 
   auto metadataPtr = ConnectorMetadataRegistry::get(connector()->connectorId());
   auto connectorQueryCtx =
-      dynamic_cast<const LocalHiveConnectorMetadata*>(metadataPtr.get())
-          ->connectorQueryCtx();
+      metadataPtr->asChecked<LocalHiveConnectorMetadata>()->connectorQueryCtx();
 
   // Treat unknown row count as "no cap" (scan all selected files).
   const auto numRows = table().numRows();
@@ -526,10 +523,8 @@ std::pair<int64_t, int64_t> LocalHiveTableLayout::sample(
       : std::nullopt;
 
   // Filter files based on $path and $bucket filters from tableHandle.
-  auto* hiveTableHandle =
-      dynamic_cast<const velox::connector::hive::HiveTableHandle*>(
-          tableHandle.get());
-  VELOX_CHECK_NOT_NULL(hiveTableHandle);
+  const auto* hiveTableHandle =
+      tableHandle->asChecked<velox::connector::hive::HiveTableHandle>();
   auto selectedFiles = filterFilesByTableHandle(files_, *hiveTableHandle);
 
   int64_t passingRows = 0;
@@ -578,10 +573,8 @@ LocalHiveTableLayout::co_estimateStats(
     velox::connector::ConnectorTableHandlePtr tableHandle,
     std::vector<std::string> columns,
     const FilterSelectivityEstimator& estimator) const {
-  auto hiveHandle =
-      std::dynamic_pointer_cast<const velox::connector::hive::HiveTableHandle>(
-          tableHandle);
-  VELOX_CHECK_NOT_NULL(hiveHandle, "Expected HiveTableHandle");
+  const auto* hiveHandle =
+      tableHandle->asChecked<velox::connector::hive::HiveTableHandle>();
 
   folly::F14FastMap<std::string, const Column*> partitionColumnsByName;
   for (const auto* column : hivePartitionColumns()) {
@@ -634,10 +627,8 @@ LocalHiveTableLayout::co_metadataCounts(
     velox::connector::ConnectorTableHandlePtr tableHandle,
     std::vector<std::string> groupingColumns,
     std::vector<std::string> columns) const {
-  auto hiveHandle =
-      std::dynamic_pointer_cast<const velox::connector::hive::HiveTableHandle>(
-          tableHandle);
-  VELOX_CHECK_NOT_NULL(hiveHandle, "Expected HiveTableHandle");
+  const auto* hiveHandle =
+      tableHandle->asChecked<velox::connector::hive::HiveTableHandle>();
 
   folly::F14FastMap<std::string, const Column*> partitionColumnsByName;
   for (const auto* column : hivePartitionColumns()) {
@@ -779,10 +770,8 @@ std::unique_ptr<DiscretePredicates> LocalHiveTableLayout::discretePredicates(
     }
   }
 
-  auto hiveHandle =
-      std::dynamic_pointer_cast<const velox::connector::hive::HiveTableHandle>(
-          tableHandle);
-  VELOX_CHECK_NOT_NULL(hiveHandle);
+  const auto* hiveHandle =
+      tableHandle->asChecked<velox::connector::hive::HiveTableHandle>();
   const auto& subfieldFilters = hiveHandle->subfieldFilters();
 
   folly::F14FastMap<std::string_view, const Column*> partitionColumnsByName;
@@ -1720,9 +1709,7 @@ std::optional<int64_t> LocalHiveConnectorMetadata::removePartitions(
   // no reader sees the table between the two.
   std::lock_guard<std::mutex> l(mutex_);
   const auto& table = *handle.table();
-  const auto* layout =
-      dynamic_cast<const HiveTableLayout*>(table.layouts().at(0));
-  VELOX_CHECK_NOT_NULL(layout);
+  const auto* layout = table.layouts().at(0)->asChecked<HiveTableLayout>();
   const fs::path path = tablePath(table.name());
 
   const auto& partitionColumns = layout->hivePartitionColumns();
@@ -1812,13 +1799,10 @@ RowsFuture LocalHiveConnectorMetadata::finishWrite(
     }
   }
   std::lock_guard<std::mutex> l(mutex_);
-  auto hiveHandle =
-      std::dynamic_pointer_cast<const HiveConnectorWriteHandle>(handle);
-  VELOX_CHECK_NOT_NULL(hiveHandle, "expecting a Hive write handle");
-  auto veloxHandle = std::dynamic_pointer_cast<
-      const velox::connector::hive::HiveInsertTableHandle>(
-      handle->veloxHandle());
-  VELOX_CHECK_NOT_NULL(veloxHandle, "expecting a Hive insert handle");
+  const auto* hiveHandle = handle->asChecked<HiveConnectorWriteHandle>();
+  const auto* veloxHandle =
+      handle->veloxHandle()
+          ->asChecked<velox::connector::hive::HiveInsertTableHandle>();
   const auto& targetPath = veloxHandle->locationHandle()->targetPath();
   const auto& writePath = veloxHandle->locationHandle()->writePath();
 
@@ -1884,13 +1868,10 @@ velox::ContinueFuture LocalHiveConnectorMetadata::abortWrite(
   }
 
   std::lock_guard<std::mutex> l(mutex_);
-  auto hiveHandle =
-      std::dynamic_pointer_cast<const HiveConnectorWriteHandle>(handle);
-  VELOX_CHECK_NOT_NULL(hiveHandle, "expecting a Hive write handle");
-  auto veloxHandle = std::dynamic_pointer_cast<
-      const velox::connector::hive::HiveInsertTableHandle>(
-      handle->veloxHandle());
-  VELOX_CHECK_NOT_NULL(veloxHandle, "expecting a Hive insert handle");
+  const auto* hiveHandle = handle->asChecked<HiveConnectorWriteHandle>();
+  const auto* veloxHandle =
+      handle->veloxHandle()
+          ->asChecked<velox::connector::hive::HiveInsertTableHandle>();
   const auto& writePath = veloxHandle->locationHandle()->writePath();
   deleteDirectoryRecursive(writePath);
 

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -82,7 +82,7 @@ class LocalHiveConnectorMetadataTest
   static const LocalHiveTableLayout* getLayout(const TablePtr& table) {
     auto& layouts = table->layouts();
     EXPECT_EQ(1, layouts.size());
-    auto* layout = dynamic_cast<const LocalHiveTableLayout*>(layouts[0]);
+    const auto* layout = layouts[0]->as<LocalHiveTableLayout>();
     EXPECT_TRUE(layout != nullptr);
     return layout;
   }
@@ -262,7 +262,7 @@ TEST_F(LocalHiveConnectorMetadataTest, basic) {
   fields.push_back(std::move(*c0));
   HashStringAllocator allocator(pool_.get());
   std::vector<std::unique_ptr<StatisticsBuilder>> statsBuilders;
-  auto* localLayout = dynamic_cast<const LocalHiveTableLayout*>(layout);
+  const auto* localLayout = layout->as<LocalHiveTableLayout>();
   ASSERT_NE(localLayout, nullptr);
   auto pair =
       localLayout->sample(tableHandle, 100, fields, &allocator, &statsBuilders);
@@ -274,7 +274,7 @@ TEST_F(LocalHiveConnectorMetadataTest, basic) {
 TEST_F(LocalHiveConnectorMetadataTest, sampleWithPathFilter) {
   auto table = metadata_->findTable({kDefaultSchema, "t"});
   ASSERT_TRUE(table != nullptr);
-  auto* layout = dynamic_cast<const LocalHiveTableLayout*>(table->layouts()[0]);
+  const auto* layout = table->layouts()[0]->as<LocalHiveTableLayout>();
   ASSERT_TRUE(layout != nullptr);
   const auto& files = layout->files();
   ASSERT_GT(files.size(), 1);
@@ -501,8 +501,7 @@ TEST_F(LocalHiveConnectorMetadataTest, addColumn) {
   ASSERT_FALSE(updated->layouts().empty());
 
   // Partition columns should be preserved.
-  auto* layout =
-      dynamic_cast<const LocalHiveTableLayout*>(updated->layouts()[0]);
+  const auto* layout = updated->layouts()[0]->as<LocalHiveTableLayout>();
   ASSERT_NE(layout, nullptr);
   EXPECT_EQ(1, layout->hivePartitionColumns().size());
   EXPECT_EQ("ds", layout->hivePartitionColumns()[0]->name());

--- a/axiom/connectors/system/SystemConnector.cpp
+++ b/axiom/connectors/system/SystemConnector.cpp
@@ -22,6 +22,7 @@
 #include <folly/json/json.h>
 
 #include "axiom/connectors/system/SystemConnectorMetadata.h"
+#include "velox/common/Casts.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/WindowFunction.h"
@@ -888,9 +889,7 @@ std::unique_ptr<velox::connector::DataSource> SystemConnector::createDataSource(
         connectorQueryCtx->memoryPool());
   }
 
-  auto* systemHandle =
-      dynamic_cast<const SystemTableHandle*>(tableHandle.get());
-  VELOX_CHECK_NOT_NULL(systemHandle, "Expected SystemTableHandle");
+  const auto* systemHandle = tableHandle->asChecked<SystemTableHandle>();
 
   const auto& schemaTableName = systemHandle->schemaTableName();
 

--- a/axiom/connectors/system/tests/SystemConnectorSerDeTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorSerDeTest.cpp
@@ -48,10 +48,9 @@ class SystemConnectorSerDeTest : public testing::Test {
     ASSERT_EQ(handle.name(), clone->name());
     ASSERT_EQ(handle.columnHandles().size(), clone->columnHandles().size());
     for (size_t i = 0; i < handle.columnHandles().size(); ++i) {
-      auto* original = dynamic_cast<const SystemColumnHandle*>(
-          handle.columnHandles()[i].get());
-      auto* cloned = dynamic_cast<const SystemColumnHandle*>(
-          clone->columnHandles()[i].get());
+      const auto* original =
+          handle.columnHandles()[i]->as<SystemColumnHandle>();
+      const auto* cloned = clone->columnHandles()[i]->as<SystemColumnHandle>();
       ASSERT_NE(original, nullptr);
       ASSERT_NE(cloned, nullptr);
       ASSERT_EQ(original->name(), cloned->name());

--- a/axiom/connectors/tests/ConnectorMetadataRegistryTest.cpp
+++ b/axiom/connectors/tests/ConnectorMetadataRegistryTest.cpp
@@ -150,8 +150,8 @@ TEST_F(ConnectorMetadataRegistryTest, duplicateRegistration) {
   // Duplicate registration is a no-op — first registration wins.
   ConnectorMetadata::registerMetadata("catalog", second);
 
-  auto* result = dynamic_cast<StubConnectorMetadata*>(
-      ConnectorMetadata::metadata("catalog"));
+  const auto* result =
+      ConnectorMetadata::metadata("catalog")->as<StubConnectorMetadata>();
   ASSERT_NE(result, nullptr);
   EXPECT_EQ(result->label(), "first");
 }

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -23,6 +23,7 @@
 
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestTableJson.h"
+#include "velox/common/Casts.h"
 #include "velox/exec/HashPartitionFunction.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/tpch/gen/TpchGen.h"
@@ -438,8 +439,7 @@ namespace {
 const TestTable& findTestTableForHandle(
     const velox::connector::ConnectorTableHandlePtr& tableHandle) {
   auto testHandle =
-      std::dynamic_pointer_cast<const TestTableHandle>(tableHandle);
-  VELOX_CHECK(testHandle, "Expected TestTableHandle");
+      velox::checkedPointerCast<const TestTableHandle>(tableHandle);
   auto table = ConnectorMetadataRegistry::get(testHandle->connectorId())
                    ->findTable(testHandle->schemaTableName());
   VELOX_CHECK(table, "Table does not exist: {}", testHandle->name());
@@ -488,10 +488,7 @@ std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(
     folly::F14FastSet<int32_t> selectedBuckets;
     for (const auto& partition : partitions) {
       auto testPartition =
-          std::dynamic_pointer_cast<const TestPartitionHandle>(partition);
-      VELOX_CHECK(
-          testPartition != nullptr,
-          "Bucketed scans require TestPartitionHandle");
+          velox::checkedPointerCast<const TestPartitionHandle>(partition);
       selectedBuckets.insert(testPartition->bucketNumber);
     }
     const auto& bucketIds = testTable.dataBucketIds();
@@ -1015,9 +1012,7 @@ TestDataSource::TestDataSource(
     TablePtr table,
     velox::memory::MemoryPool* pool)
     : outputType_(outputType), pool_(pool) {
-  auto maybeTable = std::dynamic_pointer_cast<const TestTable>(table);
-  VELOX_CHECK(
-      maybeTable, "Table is not a TestTable: {}", table->name().toString());
+  auto maybeTable = velox::checkedPointerCast<const TestTable>(table);
   data_ = maybeTable->data();
 
   auto tableType = table->type();
@@ -1084,9 +1079,7 @@ std::unique_ptr<velox::connector::DataSource> TestConnector::createDataSource(
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const velox::connector::ColumnHandleMap& columnHandles,
     velox::connector::ConnectorQueryCtx* connectorQueryCtx) {
-  auto* testHandle = dynamic_cast<const TestTableHandle*>(tableHandle.get());
-  VELOX_CHECK_NOT_NULL(
-      testHandle, "Expected TestTableHandle, got: {}", tableHandle->name());
+  const auto* testHandle = tableHandle->asChecked<TestTableHandle>();
   auto table = metadata_->findTable(testHandle->schemaTableName());
   VELOX_CHECK(
       table,
@@ -1102,9 +1095,7 @@ std::unique_ptr<velox::connector::DataSink> TestConnector::createDataSink(
     velox::connector::ConnectorQueryCtx* connectorQueryCtx,
     velox::connector::CommitStrategy) {
   VELOX_CHECK(tableHandle, "table handle must be non-null");
-  auto* testHandle =
-      dynamic_cast<const TestInsertTableHandle*>(tableHandle.get());
-  VELOX_CHECK_NOT_NULL(testHandle, "Expected TestInsertTableHandle");
+  const auto* testHandle = tableHandle->asChecked<TestInsertTableHandle>();
   auto table = metadata_->findTableInternal(testHandle->tableName());
   VELOX_CHECK(
       table,

--- a/axiom/connectors/tests/TestConnectorSerDeTest.cpp
+++ b/axiom/connectors/tests/TestConnectorSerDeTest.cpp
@@ -53,10 +53,8 @@ class TestConnectorSerDeTest : public testing::Test {
     ASSERT_EQ(handle.size(), clone->size());
     ASSERT_EQ(handle.columnHandles().size(), clone->columnHandles().size());
     for (size_t i = 0; i < handle.columnHandles().size(); ++i) {
-      auto* original = dynamic_cast<const TestColumnHandle*>(
-          handle.columnHandles()[i].get());
-      auto* cloned = dynamic_cast<const TestColumnHandle*>(
-          clone->columnHandles()[i].get());
+      const auto* original = handle.columnHandles()[i]->as<TestColumnHandle>();
+      const auto* cloned = clone->columnHandles()[i]->as<TestColumnHandle>();
       ASSERT_NE(original, nullptr);
       ASSERT_NE(cloned, nullptr);
       ASSERT_EQ(original->name(), cloned->name());

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/connectors/tpch/TpchConnectorMetadata.h"
 
+#include "velox/common/Casts.h"
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/tpch/TpchConnector.h"
 #include "velox/connectors/tpch/TpchConnectorSplit.h"
@@ -93,11 +94,8 @@ std::shared_ptr<SplitSource> TpchSplitManager::getSplitSource(
   VELOX_USER_CHECK(
       !samplePercentage.has_value(),
       "SYSTEM sampling is not supported by this connector");
-  auto* tpchTableHandle =
-      dynamic_cast<const velox::connector::tpch::TpchTableHandle*>(
-          tableHandle.get());
-  VELOX_CHECK_NOT_NULL(
-      tpchTableHandle, "Expected TpchTableHandle for TPCH connector");
+  const auto* tpchTableHandle =
+      tableHandle->asChecked<velox::connector::tpch::TpchTableHandle>();
 
   return std::make_shared<TpchSplitSource>(
       tpchTableHandle->getTable(),

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -131,9 +131,8 @@ TEST_F(TpchConnectorMetadataTest, createColumnHandle) {
       /*session=*/nullptr, "orderkey");
   ASSERT_NE(columnHandle, nullptr);
 
-  auto* tpchColumnHandle =
-      dynamic_cast<const velox::connector::tpch::TpchColumnHandle*>(
-          columnHandle.get());
+  const auto* tpchColumnHandle =
+      columnHandle->as<velox::connector::tpch::TpchColumnHandle>();
   ASSERT_NE(tpchColumnHandle, nullptr);
   EXPECT_EQ(tpchColumnHandle->name(), "orderkey");
 }
@@ -143,8 +142,7 @@ TEST_F(TpchConnectorMetadataTest, createTableHandle) {
   ASSERT_NE(table, nullptr);
   const auto& layouts = table->layouts();
   ASSERT_EQ(layouts.size(), 1);
-  auto* tpchLayout =
-      dynamic_cast<const connector::tpch::TpchTableLayout*>(layouts[0]);
+  const auto* tpchLayout = layouts[0]->as<connector::tpch::TpchTableLayout>();
 
   std::vector<velox::connector::ColumnHandlePtr> columnHandles;
   std::vector<velox::core::TypedExprPtr> empty;
@@ -159,9 +157,8 @@ TEST_F(TpchConnectorMetadataTest, createTableHandle) {
       rejectedFilterIndices);
   ASSERT_NE(tableHandle, nullptr);
 
-  auto* tpchTableHandle =
-      dynamic_cast<const velox::connector::tpch::TpchTableHandle*>(
-          tableHandle.get());
+  const auto* tpchTableHandle =
+      tableHandle->as<velox::connector::tpch::TpchTableHandle>();
   ASSERT_NE(tpchTableHandle, nullptr);
 
   EXPECT_EQ(tpchTableHandle->getTable(), tpchLayout->getTpchTable());

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -240,8 +240,7 @@ class HiveScanMatcher : public PlanMatcherImpl<TableScanNode> {
         fmt::format("HiveScanMatcher: {}", plan.toString(true, false)));
 
     const auto* hiveTableHandle =
-        dynamic_cast<const connector::hive::HiveTableHandle*>(
-            plan.tableHandle().get());
+        plan.tableHandle()->as<connector::hive::HiveTableHandle>();
     EXPECT_TRUE(hiveTableHandle != nullptr);
     AXIOM_TEST_RETURN_IF_FAILURE
 

--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -382,8 +382,7 @@ class SubfieldTest : public HiveQueriesTestBase,
 
     for (const auto& [_, columnHandle] : assignments) {
       const auto* handle =
-          dynamic_cast<const velox::connector::hive::HiveColumnHandle*>(
-              columnHandle.get());
+          columnHandle->as<velox::connector::hive::HiveColumnHandle>();
       ASSERT_TRUE(handle != nullptr);
 
       const auto& name = handle->name();


### PR DESCRIPTION
Summary:

Downcasting a connector object took a free-function cast plus a null check:

    auto hiveHandle = std::dynamic_pointer_cast<const HiveTableHandle>(tableHandle);
    VELOX_CHECK_NOT_NULL(hiveHandle, "Expected HiveTableHandle");

which is now one call that throws naming the actual type:

    tableHandle->asChecked<HiveTableHandle>()

A cast that only reads a field no longer builds a `shared_ptr` for a pointer discarded at the end of the call; casts whose result outlives the call still take one. Type tests that built a pointer only to compare it against null are now `is<T>()`.

Reviewed By: amitkdutta

Differential Revision: D118802892
