### PR TITLE
Preserve stats through column aliases

### DIFF
--- a/axiom/optimizer/v2/EstimateProvider.cpp
+++ b/axiom/optimizer/v2/EstimateProvider.cpp
@@ -329,8 +329,24 @@ Estimate EstimateProvider::compute(NodeCP node) {
       return result;
     }
 
+    case NodeType::kProject: {
+      const auto* project = node->as<Project>();
+      const auto& input = estimate(project->input());
+      Estimate result;
+      result.cardinality = input.cardinality;
+      const auto& expressions = project->exprs();
+      const auto& outputColumns = project->outputColumns();
+      // Preserve statistics across column aliases.
+      for (size_t i = 0; i < expressions.size(); ++i) {
+        if (expressions[i]->isColumn()) {
+          result.constraints.insert_or_assign(
+              outputColumns[i]->id(), value(input.constraints, expressions[i]));
+        }
+      }
+      return result;
+    }
+
     // Cardinality-neutral operators: pass the input's estimate through.
-    case NodeType::kProject:
     case NodeType::kSort:
     case NodeType::kWindow:
     case NodeType::kGroupId:


### PR DESCRIPTION
Summary: Preserve statistics when a projection aliases a column by remapping them to the output column identity.

Differential Revision: D118820244


