### PR TITLE
fix(optimizer): Plan a query with an unused aggregation

### DIFF
--- a/axiom/optimizer/ConstantFold.cpp
+++ b/axiom/optimizer/ConstantFold.cpp
@@ -30,6 +30,8 @@ namespace facebook::axiom::optimizer {
 DiscreteLayout findDiscreteLayout(
     const ColumnVector& columns,
     const BaseTable& baseTable) {
+  VELOX_CHECK(!columns.empty());
+
   for (auto* layout : baseTable.schemaTable->connectorTable->layouts()) {
     const auto& discreteColumns = layout->discretePredicateColumns();
     if (discreteColumns.empty()) {

--- a/axiom/optimizer/ConstantFold.h
+++ b/axiom/optimizer/ConstantFold.h
@@ -42,7 +42,7 @@ struct DiscreteLayout {
 };
 
 /// Finds the first layout of 'baseTable' whose discrete-predicate columns cover
-/// every column in 'columns'.
+/// every column in 'columns'. 'columns' must not be empty.
 DiscreteLayout findDiscreteLayout(
     const ColumnVector& columns,
     const BaseTable& baseTable);

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -407,10 +407,14 @@ Literal* tryFoldConstantDt(DerivedTableP dt) {
     }
   }
 
+  auto* baseTable = dt->tables[0]->as<BaseTable>();
+  if (baseTable->columns.empty()) {
+    return nullptr;
+  }
+
   // The fold works only when every base-table column is a discrete-predicate
   // (e.g. partition) column. The listing enumerates those columns, so the
   // table's filters reference only them and can be pushed into the listing.
-  auto* baseTable = dt->tables[0]->as<BaseTable>();
   auto discreteLayout = findDiscreteLayout(baseTable->columns, *baseTable);
   if (discreteLayout.layout == nullptr) {
     return nullptr;

--- a/axiom/optimizer/tests/SubqueryFoldTest.cpp
+++ b/axiom/optimizer/tests/SubqueryFoldTest.cpp
@@ -304,6 +304,27 @@ TEST_P(SubqueryFoldTest, foldableAggregationOverPartitions) {
         matchHiveScan("pt").singleAggregation({}, {"count(*) as c"}).build());
   }
 
+  // An aggregation whose value is never read emits its single row without
+  // reading the table.
+  {
+    auto plan =
+        toSingleNodePlan("SELECT count(*) FROM (SELECT max(ds) FROM pt)");
+    AXIOM_ASSERT_PLAN_V2(
+        plan,
+        matchValues(velox::ROW({}, {}))
+            .singleAggregation({}, {"count(*) as c"})
+            .build());
+  }
+
+  // An aggregate over a constant reads no column, so the listing holds nothing
+  // that answers it.
+  {
+    auto plan = toSingleNodePlan("SELECT max(1) FROM pt");
+    AXIOM_ASSERT_PLAN_V2(
+        plan,
+        matchHiveScan("pt").singleAggregation({}, {"max(1) as m"}).build());
+  }
+
   // 'x' is not a partition key, so the listing does not hold its values.
   {
     auto plan = toSingleNodePlan("SELECT max(x) FROM pt");

--- a/axiom/optimizer/tests/sql/partitionFold.sql
+++ b/axiom/optimizer/tests/sql/partitionFold.sql
@@ -23,6 +23,9 @@ SELECT max(ds) AS m FROM t UNION ALL SELECT min(ds) AS m FROM t
 -- count() counts rows, not partitions.
 SELECT count(*) FROM t
 ----
+-- An aggregation whose value is never read still produces its single row.
+SELECT count(*) FROM (SELECT max(ds) FROM t)
+----
 -- The folded value restricts the outer scan.
 SELECT v FROM t WHERE ds = (SELECT max(ds) FROM t)
 ----

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -760,6 +760,11 @@ class Translator {
   std::optional<std::vector<velox::Variant>> tryEvaluateOverDiscreteValues(
       const Aggregate* aggregate);
 
+  // Source-less `Values` carrying 'row' as its only row.
+  const Values* makeSingleRowValues(
+      std::vector<velox::Variant> row,
+      ColumnVector outputColumns);
+
   // Translates each lp expression in 'expressions' against 'scope'.
   ExprVector translateAll(
       const std::vector<lp::ExprPtr>& expressions,
@@ -1918,6 +1923,12 @@ Translated Translator::translateAggregate(
   }
 
   if (groupingSets.empty()) {
+    // A global aggregate with no aggregate calls emits one empty row for any
+    // input, including no rows at all, so the input is dead.
+    if (groupingKeys.empty() && keptAggregateIndices.empty()) {
+      return {makeSingleRowValues({}, ColumnVector{}), std::move(newScope)};
+    }
+
     AggregateCP aggNode = builder_.make<Aggregate>(
         {.input = currentInput,
          .groupingKeys = std::move(groupingKeys),
@@ -1925,14 +1936,7 @@ Translated Translator::translateAggregate(
          .outputColumns = std::move(outputColumns)});
     NodeCP node = aggNode;
     if (auto row = tryEvaluateOverDiscreteValues(aggNode)) {
-      std::vector<velox::Variant> rows;
-      rows.push_back(velox::Variant::row(std::move(*row)));
-      node = builder_.makeValues(
-          /*source=*/nullptr,
-          queryCtx()->registerVariant(
-              std::make_unique<velox::Variant>(
-                  velox::Variant::array(std::move(rows)))),
-          aggNode->outputColumns());
+      node = makeSingleRowValues(std::move(*row), aggNode->outputColumns());
     }
     return {
         appendConstantColumns(node, foldedColumns, foldedExprs),
@@ -3358,6 +3362,19 @@ ExprCP Translator::tryScalarFromValues(NodeCP body) {
   return builder_.makeLiteral(velox::Variant(row[values->channels()[0]]), type);
 }
 
+const Values* Translator::makeSingleRowValues(
+    std::vector<velox::Variant> row,
+    ColumnVector outputColumns) {
+  std::vector<velox::Variant> rows;
+  rows.push_back(velox::Variant::row(std::move(row)));
+  return builder_.makeValues(
+      /*source=*/nullptr,
+      queryCtx()->registerVariant(
+          std::make_unique<velox::Variant>(
+              velox::Variant::array(std::move(rows)))),
+      std::move(outputColumns));
+}
+
 std::optional<std::vector<velox::Variant>>
 Translator::tryEvaluateOverDiscreteValues(const Aggregate* aggregate) {
   // A correlated body reads columns of an enclosing scope, which the listing
@@ -3389,6 +3406,9 @@ Translator::tryEvaluateOverDiscreteValues(const Aggregate* aggregate) {
     return std::nullopt;
   }
   const auto* scan = input->as<Scan>();
+  if (scan->outputColumns().empty()) {
+    return std::nullopt;
+  }
 
   // The fold works only when every scanned column is a discrete-predicate
   // column; then the subquery's filters reference only those and can narrow the


### PR DESCRIPTION
Summary:
A query that reads none of an aggregation's output failed to plan:

    SELECT count(*) FROM (SELECT max(ds) FROM t)

Planning failed on a check of `!columns_.empty()` in `DiscretePredicates`, where `t` is partitioned on `ds`.

Column pruning drops the unused `max(ds)` and the `ds` it reads, leaving a global aggregation with no aggregate calls over a scan with no columns. `findDiscreteLayout` reports that an empty column set is covered by any layout, so the partition-listing fold asks the connector to list no columns.

A global aggregation with no grouping keys and no aggregate calls emits one empty row for any input, so v2 now rewrites it to `Values` and drops its input. The query above no longer reads `t` at all.

`findDiscreteLayout` now requires a non-empty column set, and both folds check before calling it. That check still matters for an aggregate that reads no column, such as `SELECT max(1) FROM t`.

Differential Revision: D118836676
