### PR TITLE
fix(optimizer): Dedup Unnest replicated columns

### DIFF
--- a/axiom/optimizer/ConstantFold.cpp
+++ b/axiom/optimizer/ConstantFold.cpp
@@ -30,6 +30,8 @@ namespace facebook::axiom::optimizer {
 DiscreteLayout findDiscreteLayout(
     const ColumnVector& columns,
     const BaseTable& baseTable) {
+  VELOX_CHECK(!columns.empty());
+
   for (auto* layout : baseTable.schemaTable->connectorTable->layouts()) {
     const auto& discreteColumns = layout->discretePredicateColumns();
     if (discreteColumns.empty()) {

--- a/axiom/optimizer/ConstantFold.h
+++ b/axiom/optimizer/ConstantFold.h
@@ -42,7 +42,7 @@ struct DiscreteLayout {
 };
 
 /// Finds the first layout of 'baseTable' whose discrete-predicate columns cover
-/// every column in 'columns'.
+/// every column in 'columns'. 'columns' must not be empty.
 DiscreteLayout findDiscreteLayout(
     const ColumnVector& columns,
     const BaseTable& baseTable);

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -407,10 +407,14 @@ Literal* tryFoldConstantDt(DerivedTableP dt) {
     }
   }
 
+  auto* baseTable = dt->tables[0]->as<BaseTable>();
+  if (baseTable->columns.empty()) {
+    return nullptr;
+  }
+
   // The fold works only when every base-table column is a discrete-predicate
   // (e.g. partition) column. The listing enumerates those columns, so the
   // table's filters reference only them and can be pushed into the listing.
-  auto* baseTable = dt->tables[0]->as<BaseTable>();
   auto discreteLayout = findDiscreteLayout(baseTable->columns, *baseTable);
   if (discreteLayout.layout == nullptr) {
     return nullptr;

--- a/axiom/optimizer/tests/SubqueryFoldTest.cpp
+++ b/axiom/optimizer/tests/SubqueryFoldTest.cpp
@@ -304,6 +304,27 @@ TEST_P(SubqueryFoldTest, foldableAggregationOverPartitions) {
         matchHiveScan("pt").singleAggregation({}, {"count(*) as c"}).build());
   }
 
+  // An aggregation whose value is never read emits its single row without
+  // reading the table.
+  {
+    auto plan =
+        toSingleNodePlan("SELECT count(*) FROM (SELECT max(ds) FROM pt)");
+    AXIOM_ASSERT_PLAN_V2(
+        plan,
+        matchValues(velox::ROW({}, {}))
+            .singleAggregation({}, {"count(*) as c"})
+            .build());
+  }
+
+  // An aggregate over a constant reads no column, so the listing holds nothing
+  // that answers it.
+  {
+    auto plan = toSingleNodePlan("SELECT max(1) FROM pt");
+    AXIOM_ASSERT_PLAN_V2(
+        plan,
+        matchHiveScan("pt").singleAggregation({}, {"max(1) as m"}).build());
+  }
+
   // 'x' is not a partition key, so the listing does not hold its values.
   {
     auto plan = toSingleNodePlan("SELECT max(x) FROM pt");

--- a/axiom/optimizer/tests/sql/partitionFold.sql
+++ b/axiom/optimizer/tests/sql/partitionFold.sql
@@ -23,6 +23,9 @@ SELECT max(ds) AS m FROM t UNION ALL SELECT min(ds) AS m FROM t
 -- count() counts rows, not partitions.
 SELECT count(*) FROM t
 ----
+-- An aggregation whose value is never read still produces its single row.
+SELECT count(*) FROM (SELECT max(ds) FROM t)
+----
 -- The folded value restricts the outer scan.
 SELECT v FROM t WHERE ds = (SELECT max(ds) FROM t)
 ----

--- a/axiom/optimizer/tests/sql/window.sql
+++ b/axiom/optimizer/tests/sql/window.sql
@@ -279,3 +279,13 @@ FROM (VALUES (1), (2)) AS t(x)
 -- columns holding the same constant.
 SELECT sum(x) OVER (PARTITION BY x, x, a, b ORDER BY x)
 FROM (SELECT y AS x, 'All' AS a, 'All' AS b FROM (VALUES (1), (2), (2)) AS t(y)) AS u
+----
+-- A window aggregate whose argument is computed, over UNNEST of an aggregated
+-- array, with two columns holding the same constant.
+SELECT a, b, sum(v + 1) OVER (PARTITION BY d) AS r
+FROM (
+    SELECT 'All' AS a, 'All' AS b, d, array_agg(i) AS vals
+    FROM (VALUES ('x', 1)) AS s(d, i)
+    GROUP BY d
+) AS t
+CROSS JOIN UNNEST(vals) AS n(v)

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -760,6 +760,11 @@ class Translator {
   std::optional<std::vector<velox::Variant>> tryEvaluateOverDiscreteValues(
       const Aggregate* aggregate);
 
+  // Source-less `Values` carrying 'row' as its only row.
+  const Values* makeSingleRowValues(
+      std::vector<velox::Variant> row,
+      ColumnVector outputColumns);
+
   // Translates each lp expression in 'expressions' against 'scope'.
   ExprVector translateAll(
       const std::vector<lp::ExprPtr>& expressions,
@@ -1918,6 +1923,12 @@ Translated Translator::translateAggregate(
   }
 
   if (groupingSets.empty()) {
+    // A global aggregate with no aggregate calls emits one empty row for any
+    // input, including no rows at all, so the input is dead.
+    if (groupingKeys.empty() && keptAggregateIndices.empty()) {
+      return {makeSingleRowValues({}, ColumnVector{}), std::move(newScope)};
+    }
+
     AggregateCP aggNode = builder_.make<Aggregate>(
         {.input = currentInput,
          .groupingKeys = std::move(groupingKeys),
@@ -1925,14 +1936,7 @@ Translated Translator::translateAggregate(
          .outputColumns = std::move(outputColumns)});
     NodeCP node = aggNode;
     if (auto row = tryEvaluateOverDiscreteValues(aggNode)) {
-      std::vector<velox::Variant> rows;
-      rows.push_back(velox::Variant::row(std::move(*row)));
-      node = builder_.makeValues(
-          /*source=*/nullptr,
-          queryCtx()->registerVariant(
-              std::make_unique<velox::Variant>(
-                  velox::Variant::array(std::move(rows)))),
-          aggNode->outputColumns());
+      node = makeSingleRowValues(std::move(*row), aggNode->outputColumns());
     }
     return {
         appendConstantColumns(node, foldedColumns, foldedExprs),
@@ -3358,6 +3362,19 @@ ExprCP Translator::tryScalarFromValues(NodeCP body) {
   return builder_.makeLiteral(velox::Variant(row[values->channels()[0]]), type);
 }
 
+const Values* Translator::makeSingleRowValues(
+    std::vector<velox::Variant> row,
+    ColumnVector outputColumns) {
+  std::vector<velox::Variant> rows;
+  rows.push_back(velox::Variant::row(std::move(row)));
+  return builder_.makeValues(
+      /*source=*/nullptr,
+      queryCtx()->registerVariant(
+          std::make_unique<velox::Variant>(
+              velox::Variant::array(std::move(rows)))),
+      std::move(outputColumns));
+}
+
 std::optional<std::vector<velox::Variant>>
 Translator::tryEvaluateOverDiscreteValues(const Aggregate* aggregate) {
   // A correlated body reads columns of an enclosing scope, which the listing
@@ -3389,6 +3406,9 @@ Translator::tryEvaluateOverDiscreteValues(const Aggregate* aggregate) {
     return std::nullopt;
   }
   const auto* scan = input->as<Scan>();
+  if (scan->outputColumns().empty()) {
+    return std::nullopt;
+  }
 
   // The fold works only when every scanned column is a discrete-predicate
   // column; then the subquery's filters reference only those and can narrow the

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -2173,6 +2173,8 @@ Translated Translator::translateUnnest(
   // doesn't need; always emit unnest-expression outputs and ordinality.
   ColumnVector replicatedColumns;
   replicatedColumns.reserve(inputType.size());
+
+  PlanObjectSet replicated;
   for (size_t i = 0; i < inputType.size(); ++i) {
     const auto& name = inputType.nameOf(i);
     if (!required.contains(name)) {
@@ -2180,8 +2182,13 @@ Translated Translator::translateUnnest(
     }
     auto it = input.scope.find(name);
     VELOX_CHECK(it != input.scope.end());
-    replicatedColumns.push_back(it->second);
-    newScope[name] = it->second;
+
+    ColumnCP column = it->second;
+    if (!replicated.contains(column)) {
+      replicated.add(column);
+      replicatedColumns.push_back(column);
+    }
+    newScope[name] = column;
   }
 
   QGVector<ColumnVector> unnestColumns;


### PR DESCRIPTION
Summary:
An UNNEST whose input binds two names to one column replicated that column twice, and a window reading it failed to plan:

    WITH t AS (
        SELECT 'ALL' AS a, 'ALL' AS b, d, array_agg(i) AS vals
        FROM (VALUES ('x', 1)) AS s(d, i)
        GROUP BY d
    )
    SELECT a, b, sum(v + 1) OVER (PARTITION BY d) AS r
    FROM t CROSS JOIN UNNEST(vals) AS n(v)

Planning failed on a check of `!seen_.contains(expr)` in `PrecomputeProjections`, and in an opt build on duplicate output names in the emitted plan.

`a` and `b` hold the same constant, so both bind to one column. The unnest prunes its replicated columns to those the consumer still needs, so it rebuilds that list by resolving each input name, and pushed the shared column once per name. `Node.h` requires a node's outputs to hold no duplicate columns. A consumer that passes columns through by copying its input's vector, such as a window, inherits a list that already satisfies this.

The unnest now replicates a column once and binds every name to it, as `translateGroupingKeys` already does for repeated grouping keys.

Differential Revision: D118847827
