### PR TITLE
fix(parser): Plan subqueries in the scope their clause is evaluated in (#1835)

### DIFF
--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -920,6 +920,12 @@ class TestConnector : public velox::connector::Connector {
         {std::string(kDefaultSchema), std::string(tableName)});
   }
 
+  void dropTablesIfExists(std::initializer_list<std::string_view> tableNames) {
+    for (auto tableName : tableNames) {
+      dropTableIfExists(tableName);
+    }
+  }
+
   static void registerSerDe();
 
   void addTpchTables();

--- a/axiom/logical_plan/ExprApi.h
+++ b/axiom/logical_plan/ExprApi.h
@@ -72,11 +72,14 @@ class SubqueryExpr : public core::IExpr {
   }
 
   bool operator==(const IExpr& other) const override {
-    if (!other.is(Kind::kSubquery)) {
+    // Checked cast, not just the kind: a dialect may define another
+    // Kind::kSubquery expression, such as a placeholder for a subquery it has
+    // yet to plan.
+    const auto* otherSubquery = other.as<SubqueryExpr>();
+    if (otherSubquery == nullptr) {
       return false;
     }
 
-    auto* otherSubquery = other.as<SubqueryExpr>();
     // Compare the subquery plan pointers. Two SubqueryExprs are equal if they
     // reference the same logical plan node.
     return subquery_ == otherSubquery->subquery_ &&

--- a/axiom/logical_plan/ExprResolver.cpp
+++ b/axiom/logical_plan/ExprResolver.cpp
@@ -199,6 +199,9 @@ ExprPtr applyCoercion(
 
     VELOX_CHECK_EQ(subquery->outputType()->size(), 1);
 
+    // TODO: The coerced column takes the name of the one it reads, so the plan
+    // holds two columns of that name with different types, one directly above
+    // the other. Names in a plan tree must be unique.
     return std::make_shared<SubqueryExpr>(std::make_shared<ProjectNode>(
         planNodeIdGenerator->next(),
         subquery,

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -598,8 +598,15 @@ void PlanBuilder::resolveProjections(
     std::vector<std::string>& outputNames,
     std::vector<ExprPtr>& exprs,
     NameMappings& mappings) {
-  std::unordered_set<std::string> seenColumnIds;
+  // 'with' passes the input's columns through before this runs, so they are
+  // already in 'outputNames' and 'mappings'. A projection that reads one of
+  // them adds a copy, and a name one of them already carries is a duplicate.
+  std::unordered_set<std::string> seenColumnIds{
+      outputNames.begin(), outputNames.end()};
   NameTracker nameTracker(allowAmbiguousOutputNames_, mappings);
+  for (const auto& [id, name] : mappings.uniqueNames()) {
+    nameTracker.track(name);
+  }
 
   // Track all projection names for duplicate detection. For identity
   // projections without explicit aliases (e.g. Col("x") from SELECT *),
@@ -646,19 +653,37 @@ void PlanBuilder::resolveProjections(
       continue;
     }
 
-    if (expr->isInputReference() &&
-        (!alias.has_value() ||
-         alias.value() == expr->as<InputReferenceExpr>()->name())) {
+    const auto* inputReference =
+        expr->isInputReference() ? expr->as<InputReferenceExpr>() : nullptr;
+
+    // The names the input has for the column this projection passes through.
+    const auto inputNames = inputReference != nullptr
+        ? outputMapping_->reverseLookup(inputReference->name())
+        : std::vector<NameMappings::QualifiedName>{};
+
+    // A column reference carries the column's unqualified name as an alias, so
+    // the alias alone does not say whether the user renamed the column or just
+    // referred to it: `p.x` and `x` both alias "x". An alias the input already
+    // uses for the column is a reference, and the column keeps all of the
+    // input's names for it, including the qualified one an expression above
+    // this node may use. Any other alias renames, and replaces them.
+    const bool renames =
+        alias.has_value() &&
+        std::none_of(
+            inputNames.begin(), inputNames.end(), [&](const auto& name) {
+              return name.name == alias.value();
+            });
+
+    if (inputReference != nullptr &&
+        (!alias.has_value() || alias.value() == inputReference->name())) {
       // Identity projection without rename.
-      const auto& id = expr->as<InputReferenceExpr>()->name();
+      const auto& id = inputReference->name();
       if (seenColumnIds.emplace(id).second) {
         outputNames.push_back(id);
-        if (alias.has_value()) {
-          // An explicit alias overrides any name the source exposed for
-          // this column.
+        if (renames) {
           nameTracker.add(alias.value(), outputNames.back());
         } else {
-          for (const auto& name : outputMapping_->reverseLookup(id)) {
+          for (const auto& name : inputNames) {
             nameTracker.add(name, outputNames.back());
           }
         }
@@ -678,7 +703,18 @@ void PlanBuilder::resolveProjections(
       }
     } else if (alias.has_value()) {
       outputNames.push_back(newName(alias.value()));
+
       nameTracker.addNamed(alias.value(), outputNames.back());
+
+      if (!renames) {
+        // The alias restates one of the input's names for the column, so the
+        // qualified ones keep naming it too.
+        for (const auto& name : inputNames) {
+          if (name.alias.has_value()) {
+            nameTracker.add(name, outputNames.back());
+          }
+        }
+      }
     } else {
       outputNames.push_back(newName(kExprHint));
     }

--- a/axiom/logical_plan/tests/PlanBuilderTest.cpp
+++ b/axiom/logical_plan/tests/PlanBuilderTest.cpp
@@ -27,6 +27,8 @@ using namespace facebook::velox;
 namespace facebook::axiom::logical_plan {
 namespace {
 
+using Name = PlanBuilder::OutputColumnName;
+
 class PlanBuilderTest : public testing::Test {
  public:
   static void SetUpTestCase() {
@@ -59,8 +61,6 @@ TEST_F(PlanBuilderTest, anonymousOutputNames) {
               ROW({"a"}, BIGINT()), std::vector<Variant>{Variant::row({123LL})})
           .project({"a + 1", "a + 2 as b"});
 
-  using Name = PlanBuilder::OutputColumnName;
-
   EXPECT_EQ(2, builder.numOutput());
   EXPECT_EQ((Name{std::nullopt, "expr"}), builder.findOrAssignOutputNameAt(0));
   EXPECT_EQ((Name{std::nullopt, "b"}), builder.findOrAssignOutputNameAt(1));
@@ -91,7 +91,6 @@ TEST_F(PlanBuilderTest, ambiguousOutputNamesFullOverlap) {
   auto builder =
       buildValues("t").join(buildValues("u"), "t.a = u.a", JoinType::kInner);
 
-  using Name = PlanBuilder::OutputColumnName;
   auto names = builder.findOrAssignOutputNames();
   EXPECT_THAT(
       names,
@@ -124,8 +123,6 @@ TEST_F(PlanBuilderTest, ambiguousOutputNamesPartialOverlap) {
                      .join(buildValues("u"), "t.a = u.a", JoinType::kInner);
 
   auto names = builder.findOrAssignOutputNames();
-
-  using Name = PlanBuilder::OutputColumnName;
 
   // "a" is ambiguous — both tables have it. "c" and "b" are unique.
   EXPECT_THAT(
@@ -162,6 +159,21 @@ TEST_F(PlanBuilderTest, duplicateAliasAllowed) {
     EXPECT_EQ(4, names.size());
     EXPECT_EQ("x", names[2].name);
     EXPECT_TRUE(names[3].name.starts_with("x_"));
+  }
+
+  // The duplicate is a column passed through rather than another projection.
+  {
+    auto builder =
+        makeBuilder()
+            .values(ROW({"a", "b"}, BIGINT()), ValuesNode::Variants{})
+            .as("u")
+            .with({"u.a as a"});
+
+    auto names = builder.findOrAssignOutputNames();
+    EXPECT_EQ(3, names.size());
+    EXPECT_EQ("a", names[0].name);
+    EXPECT_EQ("b", names[1].name);
+    EXPECT_TRUE(names[2].name.starts_with("a_"));
   }
 
   // Lookup on duplicate name fails.
@@ -248,6 +260,21 @@ TEST_F(PlanBuilderTest, emptyAliasAllowed) {
       makeValues(ROW("a", ARRAY(BIGINT())))
           .unnest({Col("a").unnestAs("elem")}, Ordinality().as("")),
       {"a", "elem", ""});
+}
+
+TEST_F(PlanBuilderTest, qualifiedNameAfterAggregate) {
+  auto builder = PlanBuilder()
+                     .values(ROW({"ds", "v"}, BIGINT()), ValuesNode::Variants{})
+                     .as("e")
+                     .aggregate({"ds"}, {"sum(v) as total"});
+
+  // Grouping by 'ds' of relation 'e' leaves the key reachable as 'e.ds' above
+  // the aggregation.
+  EXPECT_NO_THROW(builder.project({"e.ds", "total"}));
+
+  // 'as day' renames the column, so 'e.ds' no longer names it.
+  builder.project({"e.ds as day"});
+  VELOX_ASSERT_THROW(builder.project({"e.ds"}), "Cannot resolve column");
 }
 
 TEST_F(PlanBuilderTest, duplicateAliasThrows) {

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -1249,3 +1249,50 @@ WHERE a > (SELECT max(x) FROM (VALUES (0), (1)) s(x))
     SELECT 1 FROM (VALUES (2), (3)) w(y)
     WHERE y > (SELECT max(x) FROM (VALUES (0), (1)) s(x))
   )
+----
+-- A correlated subquery in a clause evaluated above an aggregation binds to
+-- the grouping key's output column. Both tables name the column 'a', so the
+-- key's name is disambiguated across the aggregation.
+SELECT (SELECT 1 WHERE v.a = 2)
+FROM u, v
+GROUP BY v.a
+----
+-- The same correlation in HAVING.
+SELECT v.a
+FROM u, v
+GROUP BY v.a
+HAVING (SELECT v.a) > 4
+----
+-- And in ORDER BY.
+-- ordered
+SELECT v.a
+FROM u, v
+GROUP BY v.a
+ORDER BY (SELECT v.a) DESC
+----
+-- An aggregate's argument is evaluated by the aggregation, so a correlation
+-- there reads the aggregation's input rather than its output.
+SELECT sum((SELECT v.a))
+FROM u, v
+GROUP BY v.a
+----
+-- The same holds for an aggregate carrying a FILTER, whose predicate the
+-- aggregation also evaluates.
+SELECT sum((SELECT v.a)) FILTER (WHERE (SELECT v.a) > 4)
+FROM u, v
+GROUP BY v.a
+----
+-- A correlated subquery that is both a DISTINCT output and the ORDER BY key
+-- is one expression, so the sort key pairs with the output it sorts.
+-- ordered
+SELECT DISTINCT (SELECT v.a)
+FROM u, v
+GROUP BY v.a
+ORDER BY (SELECT v.a)
+----
+-- A correlation written with the table qualifier resolves against a grouping
+-- key written without one. Single-table, so the key keeps its column name and
+-- the aggregation has to publish the qualified name alongside it.
+SELECT (SELECT 1 WHERE v.a = 2)
+FROM v
+GROUP BY a

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -42,6 +42,68 @@ namespace axiom::sql::presto {
 
 using namespace facebook::velox;
 
+// Stands in for a subquery until the scope it belongs to exists. Planning a
+// subquery binds its correlated references to physical column names, so one
+// read from a clause evaluated above an AggregateNode has to wait for that
+// node: names taken from the pre-aggregation scope do not exist above it.
+//
+// Invariants:
+// - Carries no plan, and never reaches PlanBuilder. Every marker is planned
+//   through ExpressionPlanner::planIfMarker, at a point where the
+//   builder is on the scope the marker's clause is evaluated in.
+// - A childless leaf of Kind::kSubquery, so expression walks treat it as the
+//   opaque leaf a planned subquery is.
+// - Identity is the AST node, so a marker equals only itself. One subquery
+//   serving as both a grouping key and a SELECT item is therefore one
+//   expression, which the post-aggregate rewrite can replace wholesale with
+//   the key's output column.
+class SubqueryMarkerExpr : public core::IExpr {
+ public:
+  SubqueryMarkerExpr(const SubqueryExpression* subquery, bool scalar)
+      : IExpr(Kind::kSubquery, {}), subquery_{subquery}, scalar_{scalar} {
+    VELOX_CHECK_NOT_NULL(subquery_);
+  }
+
+  const SubqueryExpression* subquery() const {
+    return subquery_;
+  }
+
+  // False for an EXISTS body, which skips the single-column check a scalar
+  // subquery gets. An IN body is planned as scalar.
+  bool scalar() const {
+    return scalar_;
+  }
+
+  std::string toString() const override {
+    return "<subquery marker>";
+  }
+
+  core::ExprPtr replaceInputs(
+      std::vector<core::ExprPtr> newInputs) const override {
+    VELOX_CHECK_EQ(newInputs.size(), 0);
+    return std::make_shared<SubqueryMarkerExpr>(subquery_, scalar_);
+  }
+
+  core::ExprPtr dropAlias() const final {
+    return std::make_shared<SubqueryMarkerExpr>(subquery_, scalar_);
+  }
+
+  bool operator==(const IExpr& other) const override {
+    const auto* otherMarker = other.as<SubqueryMarkerExpr>();
+    return otherMarker != nullptr && subquery_ == otherMarker->subquery_ &&
+        compareAliasAndInputs(other);
+  }
+
+ protected:
+  size_t localHash() const override {
+    return std::hash<const SubqueryExpression*>{}(subquery_);
+  }
+
+ private:
+  const SubqueryExpression* const subquery_;
+  const bool scalar_;
+};
+
 namespace {
 
 // Translates a Presto call already recognized as the metadata aggregate 'kind'
@@ -1084,7 +1146,8 @@ lp::ExprApi ExpressionPlanner::toExpr(
     }
 
     case NodeType::kSubqueryExpression: {
-      return planSubquery(node->as<SubqueryExpression>(), /*scalar=*/true);
+      return planSubquery(
+          node->as<SubqueryExpression>(), /*scalar=*/true, options);
     }
 
     case NodeType::kComparisonExpression: {
@@ -1173,7 +1236,9 @@ lp::ExprApi ExpressionPlanner::toExpr(
     case NodeType::kExistsPredicate: {
       auto* exists = node->as<ExistsPredicate>();
       return lp::Exists(planSubquery(
-          exists->subquery()->as<SubqueryExpression>(), /*scalar=*/false));
+          exists->subquery()->as<SubqueryExpression>(),
+          /*scalar=*/false,
+          options));
     }
 
     case NodeType::kQuantifiedComparisonExpression: {
@@ -1459,10 +1524,20 @@ lp::ExprApi ExpressionPlanner::toExpr(
     case NodeType::kFunctionCall: {
       auto* call = node->as<FunctionCall>();
 
-      auto args = translateArgs(call->arguments(), options);
-
       const auto& funcName = call->name()->suffix();
       const auto lowerFuncName = canonicalizeName(funcName);
+
+      // An aggregate's arguments, FILTER and ORDER BY are evaluated by the
+      // AggregateNode, so the scope they need is the one in place here. Only
+      // what an aggregating block evaluates above that node is deferred.
+      auto argOptions = options;
+      if (call->window() == nullptr &&
+          (exec::getAggregateFunctionEntry(lowerFuncName) != nullptr ||
+           specialAggregateKind(lowerFuncName).has_value())) {
+        argOptions.deferSubqueries = false;
+      }
+
+      auto args = translateArgs(call->arguments(), argOptions);
 
       if (lowerFuncName == "nullif") {
         AXIOM_PRESTO_SEMANTIC_CHECK(
@@ -1481,7 +1556,7 @@ lp::ExprApi ExpressionPlanner::toExpr(
       // DISTINCT / FILTER / ORDER BY modifiers mark an aggregate call.
       if (call->isDistinct() || call->filter() || call->orderBy()) {
         if (exec::getAggregateFunctionEntry(lowerFuncName) != nullptr) {
-          return toAggregateCallExpr(call, funcName, args, options);
+          return toAggregateCallExpr(call, funcName, args);
         }
         // On a scalar function Presto ignores DISTINCT but rejects FILTER and
         // ORDER BY. Match that: DISTINCT falls through to the scalar path
@@ -1737,7 +1812,8 @@ core::ExprPtr wrapAggregatesWithFilter(
 
 lp::ExprApi ExpressionPlanner::planSubquery(
     const SubqueryExpression* subquery,
-    bool scalar) {
+    bool scalar,
+    ExprOptions options) {
   auto query = subquery->query();
 
   if (!query->is(NodeType::kQuery)) {
@@ -1749,6 +1825,22 @@ lp::ExprApi ExpressionPlanner::planSubquery(
 
   VELOX_CHECK_NOT_NULL(
       subqueryPlanner_, "Subquery expressions require a SubqueryPlanner");
+
+  // An outer-scope aggregate lift rewrites the subquery into aggregates of the
+  // enclosing block, which have to reach the AggregateNode being built, so it
+  // cannot be deferred past that node. The lift only runs for a scalar
+  // subquery, so only that case is held back.
+  const bool liftsAggregates =
+      scalar && isOuterScopeAggregateLiftCandidate(query->as<Query>());
+
+  if (options.deferSubqueries && !liftsAggregates) {
+    auto& markers = markersByQuery_[query];
+    auto& marker = scalar ? markers.scalar : markers.predicate;
+    if (marker == nullptr) {
+      marker = std::make_shared<SubqueryMarkerExpr>(subquery, scalar);
+    }
+    return lp::ExprApi(marker);
+  }
 
   // Look up first; if not cached, plan and insert. Do not hold an
   // iterator across subqueryPlanner_ because it may recursively plan
@@ -1810,6 +1902,25 @@ lp::ExprApi ExpressionPlanner::planSubquery(
     subqueryCache_.emplace(query, expr);
   }
   return expr;
+}
+
+void ExpressionPlanner::pushMarkerScope() {
+  enclosingMarkers_.push_back(std::exchange(markersByQuery_, {}));
+}
+
+void ExpressionPlanner::popMarkerScope() {
+  markersByQuery_ = std::move(enclosingMarkers_.back());
+  enclosingMarkers_.pop_back();
+}
+
+std::optional<lp::ExprApi> ExpressionPlanner::planIfMarker(
+    const core::ExprPtr& expr) {
+  const auto* marker = expr->as<SubqueryMarkerExpr>();
+  if (marker == nullptr) {
+    return std::nullopt;
+  }
+
+  return planSubquery(marker->subquery(), marker->scalar(), {});
 }
 
 std::optional<lp::ExprApi> ExpressionPlanner::tryLiftPureOuterAggregate(
@@ -1895,8 +2006,7 @@ std::vector<lp::ExprApi> ExpressionPlanner::translateArgs(
 lp::ExprApi ExpressionPlanner::toAggregateCallExpr(
     const FunctionCall* call,
     const std::string& funcName,
-    const std::vector<lp::ExprApi>& args,
-    ExprOptions /*options*/) {
+    const std::vector<lp::ExprApi>& args) {
   core::ExprPtr filterExpr;
   if (call->filter() != nullptr) {
     filterExpr = toExpr(call->filter(), {}).expr();

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -53,7 +53,17 @@ struct ExprOptions {
   /// Whether GROUPING() expressions are allowed. Defaults to false so that
   /// GROUPING() is rejected unless explicitly enabled by the GROUP BY path.
   bool allowGrouping{false};
+
+  /// Whether subqueries are left unplanned, as SubqueryMarkerExpr markers, so
+  /// that they can be planned in the scope their clause is evaluated in. Set
+  /// for what an aggregating block evaluates above its AggregateNode; an
+  /// aggregate call's arguments clear it, the node evaluating them itself.
+  bool deferSubqueries{false};
 };
+
+// Defined in the .cpp: callers reach markers only through
+// 'planIfMarker'.
+class SubqueryMarkerExpr;
 
 /// Translates Presto SQL AST expression nodes into logical plan ExprApi
 /// objects. Handles all expression types (literals, comparisons, arithmetic,
@@ -167,7 +177,44 @@ class ExpressionPlanner {
     columnNames_ = nullptr;
   }
 
+  /// Plans 'expr' against the current scope if it is a marker, and returns
+  /// the planned subquery; returns nullopt if it is not a marker. The result
+  /// carries the name lp::Subquery derives from the subquery's output column.
+  /// The caller decides when to call, and so which scope the subquery's
+  /// correlated references bind to.
+  ///
+  /// Not memoized per marker: one marker can stand for occurrences on both
+  /// sides of an AggregateNode, which need plans bound to different scopes.
+  /// Callers substituting several occurrences in one position memoize.
+  std::optional<lp::ExprApi> planIfMarker(
+      const facebook::velox::core::ExprPtr& expr);
+
+  /// Bounds the lifetime of the markers a query block hands out. Markers are
+  /// shared within one of these and never across, so a block shares none with
+  /// a sibling already planned, and a subquery body none with the block
+  /// around it. Construct one per query block.
+  class [[nodiscard]] MarkerScope {
+   public:
+    explicit MarkerScope(ExpressionPlanner& planner) : planner_{planner} {
+      planner_.pushMarkerScope();
+    }
+
+    ~MarkerScope() {
+      planner_.popMarkerScope();
+    }
+
+    MarkerScope(const MarkerScope&) = delete;
+    MarkerScope& operator=(const MarkerScope&) = delete;
+
+   private:
+    ExpressionPlanner& planner_;
+  };
+
  private:
+  // Start and end of one MarkerScope.
+  void pushMarkerScope();
+  void popMarkerScope();
+
   // Walks an IExpr tree collecting WindowCallExpr nodes. Stops recursion at
   // kWindow nodes (does not descend into window function arguments).
   static void findWindowExprs(
@@ -188,12 +235,12 @@ class ExpressionPlanner {
       ExprOptions options = {});
 
   // Builds an AggregateCallExpr from a FunctionCall AST node that has
-  // DISTINCT, FILTER, or ORDER BY.
+  // DISTINCT, FILTER, or ORDER BY. FILTER and ORDER BY are evaluated by the
+  // AggregateNode, so they translate in the aggregate's own scope.
   lp::ExprApi toAggregateCallExpr(
       const FunctionCall* call,
       const std::string& funcName,
-      const std::vector<lp::ExprApi>& args,
-      ExprOptions options);
+      const std::vector<lp::ExprApi>& args);
 
   // Plans `subquery` via `subqueryPlanner_` and wraps the resulting
   // plan as an `lp::Subquery` expression, caching by AST identity.
@@ -203,7 +250,12 @@ class ExpressionPlanner {
   // as a scalar expression must return exactly one column. EXISTS
   // (which only checks row presence) passes false to skip those
   // checks.
-  lp::ExprApi planSubquery(const SubqueryExpression* subquery, bool scalar);
+  // Returns a SubqueryMarkerExpr instead when 'options' defers subqueries
+  // and the body is not an outer-scope-aggregate lift candidate.
+  lp::ExprApi planSubquery(
+      const SubqueryExpression* subquery,
+      bool scalar,
+      ExprOptions options);
 
   // SQL binds an aggregate to the innermost query block containing all
   // its column references. A scalar subquery body whose aggregates all
@@ -267,6 +319,27 @@ class ExpressionPlanner {
   folly::
       F14FastMap<StatementPtr, lp::ExprApi, SubqueryAstHash, SubqueryAstEqual>
           subqueryCache_;
+
+  // The markers handed out for one subquery text. A scalar use and an EXISTS
+  // use are validated differently, so each gets its own.
+  struct QueryMarkers {
+    std::shared_ptr<const SubqueryMarkerExpr> scalar;
+    std::shared_ptr<const SubqueryMarkerExpr> predicate;
+  };
+
+  // Markers handed out while resolving one block's clauses, so that textually
+  // identical subqueries share one marker and stay one expression for
+  // grouping-key matching. Sharing is safe because a marker binds no names;
+  // each planning of it binds to the scope in place at that point, which is
+  // how one marker can serve occurrences on both sides of an aggregation.
+  // Swapped out by MarkerScope so a nested block starts with none.
+  folly::
+      F14FastMap<StatementPtr, QueryMarkers, SubqueryAstHash, SubqueryAstEqual>
+          markersByQuery_;
+
+  // Markers of the blocks enclosing the one being planned, restored as each
+  // MarkerScope goes out of scope.
+  std::vector<decltype(markersByQuery_)> enclosingMarkers_;
 
   // Lateral column alias mappings. When non-null, Identifier nodes matching
   // a key are resolved to the corresponding expression, unless the name also

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -354,6 +354,78 @@ std::vector<std::vector<lp::ExprApi>> crossProductGroupingSets(
 
 constexpr std::string_view kGroupingSetIdColumn = "$grouping_set_id";
 
+// Markers this call site has already planned, keyed by marker. Holds the
+// planned ExprApi, not just its expression, because lp::Subquery names the
+// expression after the subquery's output column and that name is the one a
+// whole-expression marker takes.
+using PlannedMarkers = core::ExprMap<lp::ExprApi>;
+
+// Plans 'expr' if it is a marker, reusing the plan if this call site already
+// made one. Returns nullopt if it is not a marker.
+std::optional<lp::ExprApi> planMarker(
+    const core::ExprPtr& expr,
+    ExpressionPlanner& exprPlanner,
+    PlannedMarkers& planned) {
+  // Only a marker can be in 'planned', and hashing an expression walks all of
+  // its inputs, so look no further than the leaves that could match.
+  if (!expr->is(core::IExpr::Kind::kSubquery)) {
+    return std::nullopt;
+  }
+
+  if (auto it = planned.find(expr); it != planned.end()) {
+    return it->second;
+  }
+
+  auto subquery = exprPlanner.planIfMarker(expr);
+  if (subquery.has_value()) {
+    planned.emplace(expr, *subquery);
+  }
+  return subquery;
+}
+
+// Plans and substitutes every marker under 'expr'. A
+// marker's correlated references bind to the enclosing block's plan as it
+// stands when this runs, so the call site decides that scope: before the
+// AggregateNode is built for its grouping keys, after it for the clauses that
+// read its output.
+//
+// Call sites planning in different scopes must pass different 'planned' maps:
+// one marker can stand for occurrences on both sides of the aggregate, and
+// each side needs its own plan.
+core::ExprPtr planMarkers(
+    const core::ExprPtr& expr,
+    ExpressionPlanner& exprPlanner,
+    PlannedMarkers& planned) {
+  if (auto subquery = planMarker(expr, exprPlanner, planned)) {
+    return subquery->expr();
+  }
+
+  std::vector<core::ExprPtr> newInputs;
+  newInputs.reserve(expr->inputs().size());
+  bool changed{false};
+  for (const auto& input : expr->inputs()) {
+    newInputs.push_back(planMarkers(input, exprPlanner, planned));
+    changed |= newInputs.back().get() != input.get();
+  }
+
+  return changed ? expr->replaceInputs(std::move(newInputs)) : expr;
+}
+
+// As above, and a marker that is the whole expression also keeps the planned
+// subquery's name unless 'item' has one of its own.
+lp::ExprApi planMarkers(
+    const lp::ExprApi& item,
+    ExpressionPlanner& exprPlanner,
+    PlannedMarkers& planned) {
+  if (auto subquery = planMarker(item.expr(), exprPlanner, planned)) {
+    return item.name().has_value() ? lp::ExprApi(subquery->expr(), item.name())
+                                   : *subquery;
+  }
+
+  return lp::ExprApi(
+      planMarkers(item.expr(), exprPlanner, planned), item.name());
+}
+
 const core::CallExpr* FOLLY_NULLABLE asGroupingCall(const core::ExprPtr& expr) {
   if (expr->is(core::IExpr::Kind::kCall)) {
     auto* call = expr->as<core::CallExpr>();
@@ -505,7 +577,8 @@ bool GroupByPlanner::tryPlanGlobalAgg(
   selectExprs.reserve(selectItems.size());
   for (const auto& item : selectItems) {
     auto* singleColumn = item->as<SingleColumn>();
-    auto expr = exprPlanner_.toExpr(singleColumn->expression());
+    auto expr = exprPlanner_.toExpr(
+        singleColumn->expression(), {.deferSubqueries = true});
     if (singleColumn->alias() != nullptr) {
       expr = expr.as(canonicalizeIdentifier(*singleColumn->alias()));
     }
@@ -620,7 +693,8 @@ void GroupByPlanner::collectAggregates(
   }
 
   if (having != nullptr) {
-    lp::ExprApi expr = exprPlanner_.toExpr(having, {.allowGrouping = true});
+    lp::ExprApi expr = exprPlanner_.toExpr(
+        having, {.allowGrouping = true, .deferSubqueries = true});
     findAggregates(expr.expr(), aggregates_, aggregateSet);
     filter_ = expr;
   }
@@ -628,7 +702,8 @@ void GroupByPlanner::collectAggregates(
   if (orderBy != nullptr) {
     const auto& sortItems = orderBy->sortItems();
     for (const auto& item : sortItems) {
-      auto expr = exprPlanner_.toExpr(item->sortKey(), {.allowGrouping = true});
+      auto expr = exprPlanner_.toExpr(
+          item->sortKey(), {.allowGrouping = true, .deferSubqueries = true});
       findAggregates(expr.expr(), aggregates_, aggregateSet);
       sortingKeyExprs_.emplace_back(expr);
     }
@@ -659,7 +734,22 @@ folly::F14FastSet<std::string> outputNamesOf(
 } // namespace
 
 void GroupByPlanner::addAggregate(bool useGroupingSets) {
-  const auto groupingKeyNames = outputNamesOf(groupingKeys_);
+  // The AggregateNode evaluates its grouping keys, so their subqueries are
+  // planned against the scope below it. Only these copies carry the plans:
+  // 'groupingKeys_' keeps the markers, because they key the post-aggregate
+  // rewrite, which has to match a clause above the aggregate holding the
+  // same marker.
+  PlannedMarkers planned;
+
+  std::vector<lp::ExprApi> groupingKeyExprs;
+  groupingKeyExprs.reserve(groupingKeys_.size());
+  for (const auto& key : groupingKeys_) {
+    groupingKeyExprs.push_back(planMarkers(key, exprPlanner_, planned));
+  }
+
+  // Taken from the planned keys: a key that is a subquery is named only once
+  // planned, and that name is what a SELECT alias can shadow.
+  const auto groupingKeyNames = outputNamesOf(groupingKeyExprs);
 
   // SQL lets an aggregate's SELECT alias shadow a grouping-key name with
   // the same text. PlanBuilder rejects this collision when binding the
@@ -678,12 +768,12 @@ void GroupByPlanner::addAggregate(bool useGroupingSets) {
 
   if (useGroupingSets) {
     builder_->aggregate(
-        groupingKeys_,
+        groupingKeyExprs,
         groupingSetsIndices_,
         aggregateExprs,
         std::string(kGroupingSetIdColumn));
   } else {
-    builder_->aggregate(groupingKeys_, aggregateExprs);
+    builder_->aggregate(groupingKeyExprs, aggregateExprs);
   }
 
   auto outputColumns = builder_->findOrAssignOutputNames();
@@ -722,25 +812,26 @@ void GroupByPlanner::rewritePostAggregateExprs() {
     keyInputs.emplace(groupingSetIdCol, groupingSetIdCol);
   }
 
-  if (filter_.has_value()) {
-    filter_ = replaceInputs(
-        filter_.value().expr(),
-        keyInputs,
-        aggregateInputs,
-        [](const core::FieldAccessExpr& expr) {
-          VELOX_USER_FAIL(
-              "HAVING clause cannot reference column: {}", expr.name());
-        });
-  }
-
   // Rewrites an IExpr to reference post-aggregate columns.
   auto rewriteIExpr = [&](const core::ExprPtr& expr) {
     return replaceInputs(expr, keyInputs, aggregateInputs);
   };
 
+  // A marker the substitution leaves behind is a subquery the clause
+  // evaluates for itself rather than one the aggregate already computed, so
+  // it is planned against the aggregate's output. That is also what makes a
+  // correlation to a column that is not a grouping key fail to resolve, as
+  // SQL requires.
+  PlannedMarkers planned;
+  auto substituteAndPlan = [&](const core::ExprPtr& expr) {
+    return planMarkers(rewriteIExpr(expr), exprPlanner_, planned);
+  };
+
   // Project nested window functions (e.g. sum(sum(a)) OVER () inside
-  // sum(a) / sum(sum(a)) OVER ()) and add replacements to keyInputs.
-  projectNestedWindows(rewriteIExpr, keyInputs);
+  // sum(a) / sum(sum(a)) OVER ()) and add replacements to keyInputs. These
+  // reach PlanBuilder here rather than through the rewrite below, so they are
+  // planned, not just substituted.
+  projectNestedWindows(substituteAndPlan, keyInputs);
 
   // Rewrite projections and sorting keys to reference post-aggregate columns.
   // Top-level windows need rewriteWindowExpr to rewrite args and
@@ -753,11 +844,27 @@ void GroupByPlanner::rewritePostAggregateExprs() {
 
   auto rewriteExpr = [&](lp::ExprApi& item) {
     if (item.expr()->is(core::IExpr::Kind::kWindow)) {
-      item = rewriteWindowExpr(item, rewriteIExpr);
+      item = rewriteWindowExpr(item, substituteAndPlan);
     } else {
-      item = lp::ExprApi(rewriteIExpr(item.expr()), item.name());
+      item = lp::ExprApi(substituteAndPlan(item.expr()), item.name());
     }
   };
+
+  // HAVING takes the same two steps as the clauses below, but a column it
+  // cannot resolve is an error rather than a name to leave alone.
+  if (filter_.has_value()) {
+    auto substituted = replaceInputs(
+        filter_.value().expr(),
+        keyInputs,
+        aggregateInputs,
+        [](const core::FieldAccessExpr& expr) {
+          VELOX_USER_FAIL(
+              "HAVING clause cannot reference column: {}", expr.name());
+        });
+    filter_ = lp::ExprApi(
+        planMarkers(std::move(substituted), exprPlanner_, planned),
+        filter_->alias());
+  }
 
   for (auto& item : projections_) {
     rewriteExpr(item);
@@ -870,7 +977,10 @@ lp::ExprApi GroupByPlanner::resolveGroupingExpression(
         "GROUP BY position is not in select list");
     return selectExprs.at(n - 1);
   }
-  return exprPlanner_.toExpr(expr);
+  // Deferred so that a subquery written in both GROUP BY and SELECT is one
+  // marker on both sides, and the SELECT occurrence therefore resolves to
+  // this key's output column.
+  return exprPlanner_.toExpr(expr, {.deferSubqueries = true});
 }
 
 lp::ExprApi GroupByPlanner::resolveWithCache(

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1303,9 +1303,13 @@ class RelationPlanner : public AstVisitor {
     std::vector<bool> nullsFirst;
   };
 
+  // 'options' must match the options 'projections' were resolved with: a sort
+  // key is matched against them by expression, so a subquery deferred in one
+  // and planned in the other would no longer pair up.
   SortKeyExpansion buildSortKeyExprs(
       const OrderByPtr& orderBy,
-      const std::vector<lp::ExprApi>& projections) {
+      const std::vector<lp::ExprApi>& projections,
+      ExprOptions options) {
     const size_t numSelectItems = projections.size();
     SortKeyExpansion result;
     for (const auto& item : orderBy->sortItems()) {
@@ -1329,7 +1333,7 @@ class RelationPlanner : public AstVisitor {
         result.ascending.push_back(item->isAscending());
         result.nullsFirst.push_back(item->isNullsFirst());
       } else {
-        auto expr = toExpr(sortExpr);
+        auto expr = toExpr(sortExpr, options);
         auto expanded =
             ColumnsExpansion::expand(expr, *builder_, sortExpr->location());
         if (!expanded.empty()) {
@@ -1372,7 +1376,7 @@ class RelationPlanner : public AstVisitor {
     }
 
     const size_t numSelectItems = projections->size();
-    auto expansion = buildSortKeyExprs(orderBy, projections.value());
+    auto expansion = buildSortKeyExprs(orderBy, projections.value(), {});
 
     auto ordinals = SortProjection::widenProjections(
         expansion.sortKeyExprs, expansion.preResolved, projections.value());
@@ -1413,7 +1417,7 @@ class RelationPlanner : public AstVisitor {
 
     std::optional<SortKeyExpansion> sortKeys;
     if (orderBy != nullptr) {
-      sortKeys = buildSortKeyExprs(orderBy, selectExprs);
+      sortKeys = buildSortKeyExprs(orderBy, selectExprs, {});
     }
 
     extractNestedWindows(projections.value());
@@ -1676,6 +1680,10 @@ class RelationPlanner : public AstVisitor {
   void visitQuerySpecification(
       QuerySpecification* node,
       const OrderByPtr& orderBy) {
+    // Deferred-subquery markers belong to this block. The scope nests, so a
+    // subquery body planned from here gets its own.
+    ExpressionPlanner::MarkerScope markers{exprPlanner_};
+
     // FROM t -> builder.tableScan(t)
     processFrom(node->from());
 
@@ -1690,15 +1698,18 @@ class RelationPlanner : public AstVisitor {
     const bool distinct = node->select()->isDistinct();
 
     if (auto groupBy = node->groupBy()) {
-      auto selectExprs =
-          expandSelectExprs(selectItems, {.allowGrouping = true});
+      auto selectExprs = expandSelectExprs(
+          selectItems, {.allowGrouping = true, .deferSubqueries = true});
 
       // Sort keys of a DISTINCT are built here, before GroupByPlanner
       // projects and aggregates: a qualified key like `t.a` names a column of
       // the relation the SELECT list reads from.
       std::optional<SortKeyExpansion> sortKeys;
       if (distinct && orderBy != nullptr) {
-        sortKeys = buildSortKeyExprs(orderBy, selectExprs);
+        sortKeys = buildSortKeyExprs(
+            orderBy,
+            selectExprs,
+            {.allowGrouping = true, .deferSubqueries = true});
       }
 
       // When DISTINCT is also present, skip ORDER BY in the GROUP BY

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -325,7 +325,10 @@ TEST_F(AggregationParserTest, groupByOrdinalWithSelectStar) {
       "SELECT * REPLACE (n_name || '_x' AS n_name) FROM nation GROUP BY 1, 2, 3, 4",
       matchScan()
           .aggregate(
-              {"n_nationkey", "concat(n_name, _x)", "n_regionkey", "n_comment"},
+              {"n_nationkey",
+               "concat(n_name, '_x')",
+               "n_regionkey",
+               "n_comment"},
               {})
           .output());
 }
@@ -511,7 +514,7 @@ TEST_F(AggregationParserTest, groupingFunction) {
       "SELECT GROUPING(s.x.y), count(1) FROM s "
       "GROUP BY GROUPING SETS ((s.x.y), ())",
       matchScan("s")
-          .aggregate({"DEREFERENCE(x, y)"}, {"count(1)"}, {{0}, {}})
+          .aggregate({"x.y"}, {"count(1)"}, {{0}, {}})
           .project({grouping({0, 1}), "count"}, kIntegerLiterals)
           .output());
 
@@ -947,6 +950,89 @@ TEST_F(AggregationParserTest, scalarSubqueryRepeatedInSelectAndGroupBy) {
       matcher);
 }
 
+TEST_F(AggregationParserTest, correlatedSubqueryWithGroupBy) {
+  connector_->addTable("t", ROW("x", INTEGER()));
+  connector_->addTable("u", ROW("x", INTEGER()));
+  SCOPE_EXIT {
+    connector_->dropTablesIfExists({"t", "u"});
+  };
+
+  // Both tables call the column 'x', so the join generates a name for u's.
+  // Capturing it as 'ux' lets the grouping key be asserted without naming it.
+  const auto scanJoinAggregate = [] {
+    return matchScan("t")
+        .join(matchScan("u").build(), {"tx", "ux"})
+        .aggregate({"ux"}, {});
+  };
+
+  // A correlation to a grouping key resolves in SELECT, HAVING and ORDER BY.
+  testSelect(
+      "SELECT (SELECT 1 WHERE u.x = 1) FROM t, u GROUP BY u.x",
+      scanJoinAggregate().project().output());
+  testSelect(
+      "SELECT u.x FROM t, u GROUP BY u.x HAVING (SELECT u.x) = 1",
+      scanJoinAggregate().filter().output());
+  testSelect(
+      "SELECT u.x FROM t, u GROUP BY u.x ORDER BY (SELECT u.x)",
+      scanJoinAggregate().project().sort().project().output());
+
+  // A correlation to a column that is neither a grouping key nor an aggregate
+  // is not allowed.
+  VELOX_ASSERT_THROW(
+      parseSql("SELECT (SELECT 1 WHERE t.x = 1) FROM t, u GROUP BY u.x"),
+      "Cannot resolve column: t");
+}
+
+TEST_F(AggregationParserTest, subqueryEvaluatedByAggregation) {
+  connector_->addTable("t", ROW("x", INTEGER()));
+  connector_->addTable("u", ROW("x", INTEGER()));
+  SCOPE_EXIT {
+    connector_->dropTablesIfExists({"t", "u"});
+  };
+
+  // An aggregate's argument is evaluated by the aggregation, over its input,
+  // so a correlation there reaches the join's columns.
+  testSelect(
+      "SELECT sum((SELECT u.x)) FROM t, u GROUP BY u.x",
+      matchScan("t")
+          .join(matchScan("u").build())
+          .aggregate()
+          .project()
+          .output());
+
+  // So is a grouping key, including one reached by ordinal.
+  testSelect(
+      "SELECT (SELECT 1 WHERE u.x = 1) FROM t, u GROUP BY 1",
+      matchScan("t").join(matchScan("u").build()).aggregate().output());
+
+  // A subquery that is only part of a grouping key is not itself a grouping
+  // key, so SELECT cannot read it.
+  VELOX_ASSERT_THROW(
+      parseSql("SELECT (SELECT u.x) FROM t, u GROUP BY (SELECT u.x) + 1"),
+      "Cannot resolve column: u");
+}
+
+TEST_F(AggregationParserTest, subqueryGroupingKeyOutputName) {
+  connector_->addTable("t", ROW("x", INTEGER()));
+  connector_->addTable("u", ROW("y", INTEGER()));
+  SCOPE_EXIT {
+    connector_->dropTablesIfExists({"t", "u"});
+  };
+
+  // A subquery grouping key is named after the column it selects, both when
+  // the subquery is planned for the key and when the same one is read again
+  // above the aggregation.
+  testSelect(
+      "SELECT (SELECT count(*) AS c FROM u) FROM t GROUP BY 1",
+      matchScan("t").aggregate().output({"c"}));
+  // Both occurrences are one key, fanned back out to two columns, and the
+  // generated names they take are not asserted here.
+  testSelect(
+      "SELECT (SELECT count(*) AS c FROM u), (SELECT count(*) AS c FROM u) "
+      "FROM t GROUP BY 1, 2",
+      matchScan("t").aggregate().project().output({"c", "c"}));
+}
+
 TEST_F(AggregationParserTest, having) {
   auto matcher = matchScan().aggregate().filter().project().output();
 
@@ -1203,8 +1289,7 @@ TEST_F(AggregationParserTest, groupByWithWindowFunction) {
   connector_->addTable("t", ROW({"a", "b"}, BIGINT()));
   connector_->addTable("u", ROW({"a", "c"}, BIGINT()));
   SCOPE_EXIT {
-    connector_->dropTableIfExists("t");
-    connector_->dropTableIfExists("u");
+    connector_->dropTablesIfExists({"t", "u"});
   };
 
   // Window function in SELECT with GROUP BY.
@@ -1556,8 +1641,7 @@ TEST_F(AggregationParserTest, columnCanonicalization) {
     connector_->addTable("t", ROW({"a", "b"}, BIGINT()));
     connector_->addTable("u", ROW({"a", "c"}, BIGINT()));
     SCOPE_EXIT {
-      connector_->dropTableIfExists("t");
-      connector_->dropTableIfExists("u");
+      connector_->dropTablesIfExists({"t", "u"});
     };
 
     testSelect(

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
@@ -413,9 +413,16 @@ class AggregateMatcher : public LogicalPlanMatcherImpl<AggregateNode> {
     EXPECT_EQ(groupingKeys_.size(), plan.groupingKeys().size());
     AXIOM_RETURN_IF_FAILURE;
 
+    velox::parse::DuckSqlExpressionsParser parser(parseOptions_);
+
     for (auto i = 0; i < groupingKeys_.size(); ++i) {
-      EXPECT_EQ(groupingKeys_[i], plan.groupingKeys()[i]->toString())
-          << "at grouping key index " << i;
+      auto expected = parser.parseScalarOrWindowExpr(groupingKeys_[i]);
+      if (!symbols.empty()) {
+        expected = rewriteInputNames(expected, symbols);
+      }
+
+      SCOPED_TRACE("grouping key at index " + std::to_string(i));
+      ExprMatcher::match(plan.groupingKeys()[i], expected->dropAlias());
       AXIOM_RETURN_IF_FAILURE;
     }
 
@@ -424,8 +431,6 @@ class AggregateMatcher : public LogicalPlanMatcherImpl<AggregateNode> {
 
     std::unordered_map<std::string, std::string> newSymbols = symbols;
     auto numGroupingKeys = plan.groupingKeys().size();
-
-    velox::parse::DuckSqlExpressionsParser parser(parseOptions_);
     for (auto i = 0; i < aggregates_.size(); ++i) {
       velox::core::ExprPtr parsed = parser.parseAggregateExpr(aggregates_[i]);
 


### PR DESCRIPTION
Summary:

A correlated subquery in the SELECT, HAVING or ORDER BY of a grouping query produced a plan that referenced a column the aggregation does not output. For example:

    SELECT (SELECT 1 WHERE u.x = 1) FROM t, u GROUP BY u.x

planned, then failed in the optimizer with `Column not found in scope or outer scopes: x_0`. The subquery bound `u.x` to the name the join gave it, but those clauses are evaluated above the AggregateNode, which publishes its own names.

The parser used to plan a subquery the moment it read it, which fixes its correlated references to whatever names were in scope at that point. It now leaves a marker instead, and plans it once the enclosing block has reached the scope the clause is evaluated in: below the AggregateNode for grouping keys and aggregate arguments, above it for the clauses that read the aggregate's output. Binding above the aggregation is also what makes a correlation to a column that is neither a grouping key nor an aggregate fail to resolve, as SQL requires.

`PlanBuilder` now keeps a column's qualified name across a node when the alias only restates a name the input already has for that column. A reference carries the column's unqualified name as an alias, so `p.x` and `x` both alias `"x"`; treating that as a rename dropped `p.x`, and an expression above the node could no longer use it.

Deferred: a subquery in a window's PARTITION BY or ORDER BY still fails, with `Subquery encountered in an expression position with no relational input above which to lift Apply`. That is a pre-existing gap in the optimizer, which does not thread a lift target through window specs.

Reviewed By: amitkdutta

Differential Revision: D118889518


