### PR TITLE
fix(parser): Keep the output name when a sort key shadows it (#1836)

### DIFF
--- a/axiom/optimizer/tests/sql/sort.sql
+++ b/axiom/optimizer/tests/sql/sort.sql
@@ -37,6 +37,15 @@ FROM (VALUES (1, 10), (2, 5)) x(k, v)
 JOIN (VALUES (1, 200), (2, 300)) y(k, v) ON x.k = y.k
 ORDER BY x.v DESC
 ----
+-- An enclosing query reads back an output column whose name a sort key over a
+-- different expression also uses.
+SELECT a FROM (
+  SELECT v.a AS a
+  FROM (VALUES (1, 10), (2, 5)) u(k, a)
+  JOIN (VALUES (1, 200), (2, 300)) v(k, a) ON u.k = v.k
+  ORDER BY u.a DESC
+)
+----
 -- SELECT DISTINCT ordered by a qualified key.
 -- ordered
 SELECT DISTINCT t.a FROM t ORDER BY t.a DESC

--- a/axiom/sql/presto/SortProjection.cpp
+++ b/axiom/sql/presto/SortProjection.cpp
@@ -16,6 +16,7 @@
 #include "axiom/sql/presto/SortProjection.h"
 
 #include "folly/container/F14Map.h"
+#include "folly/container/F14Set.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/IExpr.h"
 
@@ -136,6 +137,12 @@ std::vector<size_t> SortProjection::widenProjections(
   std::vector<size_t> ordinals;
   ordinals.reserve(sortKeyExprs.size());
 
+  // Output names already claimed, by a SELECT item or by a key widened below.
+  folly::F14FastSet<std::string> claimedNames;
+  for (const auto& [name, _] : index.byAlias) {
+    claimedNames.insert(name);
+  }
+
   for (size_t i = 0; i < sortKeyExprs.size(); ++i) {
     auto ordinal = lookupSortKey(
         sortKeyExprs[i], preResolvedOrdinals[i], projections, index);
@@ -148,7 +155,17 @@ std::vector<size_t> SortProjection::widenProjections(
         replaceAliases(sortKeyExprs[i].expr(), index.byAlias, projections);
     ordinal = projections.size() + 1;
     index.byExpr.emplace(resolved, ordinal);
-    projections.emplace_back(std::move(resolved), sortKeyExprs[i].alias());
+
+    // A name another output column already carries would leave both
+    // unresolvable, so the column is projected unnamed and trimmed after the
+    // sort. Empty, not nullopt: nullopt makes a column reference an identity
+    // projection, which keeps the very name being avoided here.
+    std::optional<std::string> alias{sortKeyExprs[i].alias()};
+    if (alias.has_value() && !claimedNames.insert(alias.value()).second) {
+      alias = "";
+    }
+
+    projections.emplace_back(std::move(resolved), std::move(alias));
     ordinals.push_back(ordinal);
   }
 

--- a/axiom/sql/presto/SortProjection.h
+++ b/axiom/sql/presto/SortProjection.h
@@ -39,7 +39,8 @@ class SortProjection {
   /// (1-based).
   /// @param projections Mutable list of expressions from the SELECT list. This
   /// is where unmatched sort key expressions are appended. All pre-resolved
-  /// ordinals should match to a projection here.
+  /// ordinals should match to a projection here. An appended expression is
+  /// left unnamed when another output column already uses its name.
   static std::vector<size_t> widenProjections(
       const std::vector<facebook::axiom::logical_plan::ExprApi>& sortKeyExprs,
       const std::vector<size_t>& preResolvedOrdinals,

--- a/axiom/sql/presto/tests/SortParserTest.cpp
+++ b/axiom/sql/presto/tests/SortParserTest.cpp
@@ -310,6 +310,23 @@ TEST_F(SortParserTest, qualifiedSortKeyWithDuplicateOutputNames) {
           .output({"k", "v", "k", "v"}));
 }
 
+// An enclosing query can reference an output column whose name a sort key over
+// a different expression also uses.
+TEST_F(SortParserTest, sortKeyShadowsOutputName) {
+  connector_->addTable("t", ROW({"k", "a"}, INTEGER()));
+
+  testSelect(
+      "SELECT a FROM ("
+      "  SELECT v.a AS a FROM t u JOIN t v ON u.k = v.k ORDER BY u.a DESC)",
+      matchScan()
+          .join(matchScan().build(), {"left_k", "left_a", "right_k", "right_a"})
+          .project({"right_a as out", "left_a as sortKey"})
+          .sort({"sortKey desc"})
+          .project({"out as trimmed"})
+          .project({"trimmed"})
+          .output({"a"}));
+}
+
 // Under SELECT DISTINCT a qualified sort key picks the side of the join it
 // names, even though both sides contribute an output column of that name.
 TEST_F(SortParserTest, distinctQualifiedSortKeyOnJoin) {


### PR DESCRIPTION
Summary:

An enclosing query could not read back a column when the inner query's ORDER BY named a different expression by that same name. For example:

    SELECT a FROM (
      SELECT v.a AS a
      FROM (VALUES (1, 10), (2, 5)) u(k, a)
      JOIN (VALUES (1, 200), (2, 300)) v(k, a) ON u.k = v.k
      ORDER BY u.a DESC)

failed with `Cannot resolve column: a` — the only column the subquery offered was an internally generated name.

A sort key that is not in the SELECT list is projected alongside it and trimmed after the sort. That extra column took its own name, so two columns were named `a`. Duplicate output names resolve to neither column, which left the trim with no name to give the surviving one. The extra column is now left unnamed whenever a SELECT item already uses its name.

Differential Revision: D118915067


