### PR TITLE
fix(parser): Resolve a qualified ORDER BY key to its column (#1837)

### DIFF
--- a/axiom/optimizer/tests/sql/sort.sql
+++ b/axiom/optimizer/tests/sql/sort.sql
@@ -37,6 +37,15 @@ FROM (VALUES (1, 10), (2, 5)) x(k, v)
 JOIN (VALUES (1, 200), (2, 300)) y(k, v) ON x.k = y.k
 ORDER BY x.v DESC
 ----
+-- An enclosing query reads back an output column whose name a sort key over a
+-- different expression also uses.
+SELECT a FROM (
+  SELECT v.a AS a
+  FROM (VALUES (1, 10), (2, 5)) u(k, a)
+  JOIN (VALUES (1, 200), (2, 300)) v(k, a) ON u.k = v.k
+  ORDER BY u.a DESC
+)
+----
 -- SELECT DISTINCT ordered by a qualified key.
 -- ordered
 SELECT DISTINCT t.a FROM t ORDER BY t.a DESC

--- a/axiom/optimizer/tests/sql/sort.sql
+++ b/axiom/optimizer/tests/sql/sort.sql
@@ -37,6 +37,26 @@ FROM (VALUES (1, 10), (2, 5)) x(k, v)
 JOIN (VALUES (1, 200), (2, 300)) y(k, v) ON x.k = y.k
 ORDER BY x.v DESC
 ----
+-- ORDER BY a lambda parameter whose name an output column also uses. The
+-- parameter shadows the output column inside the lambda body.
+-- ordered
+SELECT -a AS s
+FROM (VALUES (1), (2)) t(a)
+ORDER BY filter(array[a], s -> s > -2)
+----
+-- ORDER BY an output alias that shadows an input column of the same name. The
+-- alias wins.
+-- ordered
+SELECT -a AS a FROM (VALUES (1), (2)) t(a) ORDER BY a
+----
+-- ORDER BY a qualified key whose column name an output column also uses. The
+-- key names the input column, not the output one.
+-- ordered
+SELECT v.b AS a
+FROM (VALUES (1, 10), (2, 20)) u(k, a)
+JOIN (VALUES (1, 200), (2, 100)) v(k, b) ON u.k = v.k
+ORDER BY u.a DESC
+----
 -- An enclosing query reads back an output column whose name a sort key over a
 -- different expression also uses.
 SELECT a FROM (

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -1064,14 +1064,25 @@ lp::ExprApi ExpressionPlanner::toExpr(
   switch (node->type()) {
     case NodeType::kIdentifier: {
       auto name = canonicalizeIdentifier(*node->as<Identifier>());
-      // Lateral column alias: resolve to the alias expression if the name
-      // matches an alias and is NOT a known column (columns take priority).
-      if (aliasExprs_ != nullptr) {
-        bool isColumn = columnNames_ != nullptr && columnNames_->contains(name);
-        if (!isColumn) {
-          if (auto it = aliasExprs_->find(name); it != aliasExprs_->end()) {
-            return lp::ExprApi(it->second);
-          }
+      // An output alias resolves to the expression its SELECT item projects,
+      // unless a column of that name outranks it, or a lambda parameter of
+      // that name shadows it. Lambda parameters are searched innermost-first
+      // to match SQL lexical scoping.
+      if (outputAliases_.exprs != nullptr &&
+          !(outputAliases_.columnNames != nullptr &&
+            outputAliases_.columnNames->contains(name)) &&
+          std::find(
+              lambdaParamScope_.rbegin(), lambdaParamScope_.rend(), name) ==
+              lambdaParamScope_.rend()) {
+        AXIOM_PRESTO_SEMANTIC_CHECK(
+            outputAliases_.ambiguous == nullptr ||
+                !outputAliases_.ambiguous->contains(name),
+            node->location(),
+            name,
+            "Column is ambiguous");
+        if (auto it = outputAliases_.exprs->find(name);
+            it != outputAliases_.exprs->end()) {
+          return lp::ExprApi(it->second);
         }
       }
       return lp::Col(name);
@@ -1849,17 +1860,13 @@ lp::ExprApi ExpressionPlanner::planSubquery(
     return it->second;
   }
 
-  // Lateral column aliases belong to the enclosing SELECT block only. Clear
-  // them while the subquery is planned so a bare column reference inside the
-  // subquery resolves against the subquery's own FROM (and then the outer
-  // scope's columns for correlation), not an outer SELECT alias.
-  const auto* savedAliasExprs = aliasExprs_;
-  const auto* savedColumnNames = columnNames_;
-  aliasExprs_ = nullptr;
-  columnNames_ = nullptr;
+  // Output aliases belong to the enclosing SELECT block only. Clear them while
+  // the subquery is planned so a bare column reference inside the subquery
+  // resolves against the subquery's own FROM (and then the outer scope's
+  // columns for correlation), not an outer SELECT alias.
+  const auto savedAliases = std::exchange(outputAliases_, {});
   SCOPE_EXIT {
-    aliasExprs_ = savedAliasExprs;
-    columnNames_ = savedColumnNames;
+    outputAliases_ = savedAliases;
   };
 
   auto result = subqueryPlanner_(query->as<Query>());
@@ -1902,6 +1909,28 @@ lp::ExprApi ExpressionPlanner::planSubquery(
     subqueryCache_.emplace(query, expr);
   }
   return expr;
+}
+
+ExpressionPlanner::OutputAliasScope::OutputAliasScope(
+    ExpressionPlanner& planner,
+    const std::vector<lp::ExprApi>& projections)
+    : planner_{planner}, saved_{planner.outputAliases_} {
+  core::IExprEqual exprEqual;
+  for (const auto& projection : projections) {
+    if (!projection.alias().has_value()) {
+      continue;
+    }
+    auto [it, inserted] =
+        aliasExprs_.emplace(projection.alias().value(), projection.expr());
+    if (!inserted && !exprEqual(it->second, projection.expr())) {
+      ambiguousAliases_.insert(projection.alias().value());
+    }
+  }
+
+  planner_.setOutputAliases(
+      {.exprs = &aliasExprs_,
+       .columnNames = nullptr,
+       .ambiguous = &ambiguousAliases_});
 }
 
 void ExpressionPlanner::pushMarkerScope() {

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -18,6 +18,7 @@
 #include <span>
 
 #include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
 #include <functional>
 #include <unordered_map>
 #include <unordered_set>
@@ -158,23 +159,34 @@ class ExpressionPlanner {
   /// Rejects expressions nested deeper than the configured limit.
   lp::ExprApi toExpr(const ExpressionPtr& node, ExprOptions options = {});
 
-  /// Sets alias-to-expression mappings for lateral column alias resolution.
-  /// When set, Identifier nodes matching an alias key are resolved to the
-  /// alias's expression instead of being treated as column references.
-  /// Column names take priority over aliases — if a name exists in both
-  /// 'columnNames' and 'aliasExprs', it is treated as a column reference.
-  void setLateralAliases(
-      const std::unordered_map<std::string, facebook::velox::core::ExprPtr>*
-          aliasExprs,
-      const std::unordered_set<std::string>* columnNames) {
-    aliasExprs_ = aliasExprs;
-    columnNames_ = columnNames;
+  /// The output aliases in effect for one clause's translation. Held as one
+  /// value so saving and restoring cannot miss a field.
+  struct OutputAliases {
+    /// Alias name to the expression the SELECT item projects.
+    const folly::F14FastMap<std::string, facebook::velox::core::ExprPtr>* exprs{
+        nullptr};
+
+    /// Names that stay column references even when they name an alias.
+    /// Lateral column aliases pass it; ORDER BY, where an output alias
+    /// outranks a column of the same name, leaves it null.
+    const folly::F14FastSet<std::string>* columnNames{nullptr};
+
+    /// Alias names several output columns carry with different values. An
+    /// Identifier naming one fails rather than picking a column.
+    const folly::F14FastSet<std::string>* ambiguous{nullptr};
+  };
+
+  /// Sets the aliases an Identifier resolves against. An Identifier naming one
+  /// resolves to the alias's expression rather than to a column. A qualified
+  /// reference is a dereference, never an Identifier, so it always names a
+  /// column of an input relation.
+  void setOutputAliases(const OutputAliases& aliases) {
+    outputAliases_ = aliases;
   }
 
-  /// Clears lateral column alias mappings.
-  void clearLateralAliases() {
-    aliasExprs_ = nullptr;
-    columnNames_ = nullptr;
+  /// Clears output alias mappings.
+  void clearOutputAliases() {
+    outputAliases_ = {};
   }
 
   /// Plans 'expr' against the current scope if it is a marker, and returns
@@ -208,6 +220,29 @@ class ExpressionPlanner {
 
    private:
     ExpressionPlanner& planner_;
+  };
+
+  /// Installs the SELECT output aliases for the duration of the scope, so an
+  /// ORDER BY key naming one resolves to that item's expression rather than to
+  /// a column of an input relation. See 'setOutputAliases'.
+  class [[nodiscard]] OutputAliasScope {
+   public:
+    OutputAliasScope(
+        ExpressionPlanner& planner,
+        const std::vector<lp::ExprApi>& projections);
+
+    ~OutputAliasScope() {
+      planner_.setOutputAliases(saved_);
+    }
+
+    OutputAliasScope(const OutputAliasScope&) = delete;
+    OutputAliasScope& operator=(const OutputAliasScope&) = delete;
+
+   private:
+    ExpressionPlanner& planner_;
+    OutputAliases saved_;
+    folly::F14FastMap<std::string, facebook::velox::core::ExprPtr> aliasExprs_;
+    folly::F14FastSet<std::string> ambiguousAliases_;
   };
 
  private:
@@ -341,12 +376,8 @@ class ExpressionPlanner {
   // MarkerScope goes out of scope.
   std::vector<decltype(markersByQuery_)> enclosingMarkers_;
 
-  // Lateral column alias mappings. When non-null, Identifier nodes matching
-  // a key are resolved to the corresponding expression, unless the name also
-  // appears in columnNames_ (column names take priority).
-  const std::unordered_map<std::string, facebook::velox::core::ExprPtr>*
-      aliasExprs_{nullptr};
-  const std::unordered_set<std::string>* columnNames_{nullptr};
+  // Output aliases the clause being translated resolves names against.
+  OutputAliases outputAliases_;
 
   // Lambda parameters currently in scope. Entries are appended on entering a
   // lambda body and dropped on exit, so the vector grows from outermost

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -700,6 +700,8 @@ void GroupByPlanner::collectAggregates(
   }
 
   if (orderBy != nullptr) {
+    ExpressionPlanner::OutputAliasScope aliasScope{exprPlanner_, projections_};
+
     const auto& sortItems = orderBy->sortItems();
     for (const auto& item : sortItems) {
       auto expr = exprPlanner_.toExpr(

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1129,18 +1129,19 @@ class RelationPlanner : public AstVisitor {
     // later items. Populated left-to-right as aliases are encountered.
     // Column names take priority over aliases to preserve backward
     // compatibility (e.g., SELECT a AS b, b FROM t — second b is column b).
-    std::unordered_map<std::string, core::ExprPtr> aliasExprs;
-    std::unordered_set<std::string> columnNames;
+    folly::F14FastMap<std::string, core::ExprPtr> aliasExprs;
+    folly::F14FastSet<std::string> columnNames;
     if (options_.friendlySql) {
       for (const auto& name : builder_->outputNames()) {
         if (name.has_value()) {
           columnNames.insert(name.value());
         }
       }
-      exprPlanner_.setLateralAliases(&aliasExprs, &columnNames);
+      exprPlanner_.setOutputAliases(
+          {.exprs = &aliasExprs, .columnNames = &columnNames});
     }
     SCOPE_EXIT {
-      exprPlanner_.clearLateralAliases();
+      exprPlanner_.clearOutputAliases();
     };
 
     std::vector<lp::ExprApi> exprs;
@@ -1291,7 +1292,7 @@ class RelationPlanner : public AstVisitor {
   }
 
   // Build sort key expressions. Ordinals are resolved to the corresponding
-  // SELECT projection expression so widenProjectionsForSort can match them
+  // SELECT projection expression so the sort key matches its SELECT item
   // by expression identity. COLUMNS() calls are expanded to multiple sort
   // keys. Returns the expanded sort key expressions, pre-resolved ordinals,
   // and sort ordering info (since expansion may produce more keys than
@@ -1311,6 +1312,9 @@ class RelationPlanner : public AstVisitor {
       const std::vector<lp::ExprApi>& projections,
       ExprOptions options) {
     const size_t numSelectItems = projections.size();
+
+    ExpressionPlanner::OutputAliasScope aliasScope{exprPlanner_, projections};
+
     SortKeyExpansion result;
     for (const auto& item : orderBy->sortItems()) {
       const auto& sortExpr = item->sortKey();

--- a/axiom/sql/presto/SortProjection.cpp
+++ b/axiom/sql/presto/SortProjection.cpp
@@ -15,9 +15,7 @@
  */
 #include "axiom/sql/presto/SortProjection.h"
 
-#include "folly/container/F14Map.h"
 #include "folly/container/F14Set.h"
-#include "velox/parse/Expressions.h"
 #include "velox/parse/IExpr.h"
 
 namespace axiom::sql::presto {
@@ -27,71 +25,22 @@ namespace lp = facebook::axiom::logical_plan;
 namespace {
 namespace core = facebook::velox::core;
 
-// Indexes the SELECT-list projections by expression and by output name for
-// matching ORDER BY sort keys. A name whose ordinal is 0 is ambiguous —
-// two or more projections share the name but produce different expressions
-// — and using it as a sort key fails. Two projections that share a name
-// but produce equal expressions (e.g. `SELECT t.a, t.a`) do not collide.
+// Indexes the SELECT-list projections by expression for matching ORDER BY
+// sort keys. A sort key naming an output alias had it substituted during
+// translation, so it arrives as that item's expression and matches here.
 struct ProjectionIndex {
   core::ExprMap<size_t> byExpr;
-  folly::F14FastMap<std::string, size_t> byAlias;
+  folly::F14FastSet<std::string> aliases;
 
   explicit ProjectionIndex(const std::vector<lp::ExprApi>& projections) {
-    core::IExprEqual exprEqual;
     for (size_t i = 0; i < projections.size(); ++i) {
       byExpr.emplace(projections[i].expr(), i + 1);
       if (projections[i].alias().has_value()) {
-        auto [iter, inserted] =
-            byAlias.emplace(projections[i].alias().value(), i + 1);
-        if (!inserted && iter->second != 0) {
-          // Two projections share the same output name. This is only
-          // ambiguous if they project different expressions; if both
-          // resolve to the same expression (e.g. `SELECT t.a, t.a`),
-          // either ordinal works for ORDER BY.
-          if (!exprEqual(
-                  projections[iter->second - 1].expr(),
-                  projections[i].expr())) {
-            iter->second = 0;
-          }
-        }
+        aliases.insert(projections[i].alias().value());
       }
     }
   }
 };
-
-// Recursively replaces root FieldAccessExpr nodes that match an output alias
-// with the alias's underlying expression. Throws if the alias is ambiguous.
-core::ExprPtr replaceAliases(
-    const core::ExprPtr& expr,
-    const folly::F14FastMap<std::string, size_t>& aliasMap,
-    const std::vector<lp::ExprApi>& projections) {
-  if (const auto* field = core::FieldAccessExpr::tryAsRootColumn(expr)) {
-    auto alias = aliasMap.find(field->name());
-    if (alias != aliasMap.end()) {
-      VELOX_USER_CHECK_NE(
-          alias->second, 0, "Column is ambiguous: {}", field->name());
-      return projections[alias->second - 1].expr();
-    }
-    return expr;
-  }
-
-  const auto& inputs = expr->inputs();
-  if (inputs.empty()) {
-    return expr;
-  }
-
-  std::vector<core::ExprPtr> newInputs;
-  bool changed = false;
-  for (const auto& input : inputs) {
-    auto newInput = replaceAliases(input, aliasMap, projections);
-    if (newInput.get() != input.get()) {
-      changed = true;
-    }
-    newInputs.push_back(std::move(newInput));
-  }
-
-  return changed ? expr->replaceInputs(std::move(newInputs)) : expr;
-}
 
 // Looks up a single sort key in 'index'. Returns the matching 1-based
 // ordinal, or 0 if not present (caller decides whether to widen or fail).
@@ -100,26 +49,12 @@ core::ExprPtr replaceAliases(
 size_t lookupSortKey(
     const lp::ExprApi& sortKey,
     size_t preResolvedOrdinal,
-    const std::vector<lp::ExprApi>& projections,
     const ProjectionIndex& index) {
   if (preResolvedOrdinal != 0) {
     return preResolvedOrdinal;
   }
 
-  // Only an unqualified name can match a SELECT output name. A qualified key
-  // (`t.a`) names a column of an input relation, so it resolves by expression
-  // below even when two inputs put that name in the output.
-  if (sortKey.alias().has_value() &&
-      core::FieldAccessExpr::tryAsRootColumn(sortKey.expr()) != nullptr) {
-    auto it = index.byAlias.find(sortKey.alias().value());
-    if (it != index.byAlias.end()) {
-      VELOX_USER_CHECK_NE(it->second, 0, "Column is ambiguous: {}", it->first);
-      return it->second;
-    }
-  }
-
-  auto resolved = replaceAliases(sortKey.expr(), index.byAlias, projections);
-  auto it = index.byExpr.find(resolved);
+  auto it = index.byExpr.find(sortKey.expr());
   return it != index.byExpr.end() ? it->second : 0;
 }
 } // namespace
@@ -139,22 +74,20 @@ std::vector<size_t> SortProjection::widenProjections(
 
   // Output names already claimed, by a SELECT item or by a key widened below.
   folly::F14FastSet<std::string> claimedNames;
-  for (const auto& [name, _] : index.byAlias) {
+  for (const auto& name : index.aliases) {
     claimedNames.insert(name);
   }
 
   for (size_t i = 0; i < sortKeyExprs.size(); ++i) {
-    auto ordinal = lookupSortKey(
-        sortKeyExprs[i], preResolvedOrdinals[i], projections, index);
+    auto ordinal =
+        lookupSortKey(sortKeyExprs[i], preResolvedOrdinals[i], index);
     if (ordinal != 0) {
       ordinals.push_back(ordinal);
       continue;
     }
     // Sort key not present in the SELECT list; widen the projection.
-    auto resolved =
-        replaceAliases(sortKeyExprs[i].expr(), index.byAlias, projections);
     ordinal = projections.size() + 1;
-    index.byExpr.emplace(resolved, ordinal);
+    index.byExpr.emplace(sortKeyExprs[i].expr(), ordinal);
 
     // A name another output column already carries would leave both
     // unresolvable, so the column is projected unnamed and trimmed after the
@@ -165,7 +98,7 @@ std::vector<size_t> SortProjection::widenProjections(
       alias = "";
     }
 
-    projections.emplace_back(std::move(resolved), std::move(alias));
+    projections.emplace_back(sortKeyExprs[i].expr(), std::move(alias));
     ordinals.push_back(ordinal);
   }
 
@@ -187,8 +120,8 @@ std::vector<size_t> SortProjection::resolveSortKeys(
   ordinals.reserve(sortKeyExprs.size());
 
   for (size_t i = 0; i < sortKeyExprs.size(); ++i) {
-    auto ordinal = lookupSortKey(
-        sortKeyExprs[i], preResolvedOrdinals[i], projections, index);
+    auto ordinal =
+        lookupSortKey(sortKeyExprs[i], preResolvedOrdinals[i], index);
     if (ordinal == 0) {
       onUnresolved(i);
       VELOX_FAIL("onUnresolved callback must throw");

--- a/axiom/sql/presto/SortProjection.cpp
+++ b/axiom/sql/presto/SortProjection.cpp
@@ -16,6 +16,7 @@
 #include "axiom/sql/presto/SortProjection.h"
 
 #include "folly/container/F14Map.h"
+#include "folly/container/F14Set.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/IExpr.h"
 
@@ -136,6 +137,12 @@ std::vector<size_t> SortProjection::widenProjections(
   std::vector<size_t> ordinals;
   ordinals.reserve(sortKeyExprs.size());
 
+  // Output names already claimed, by a SELECT item or by a key widened below.
+  folly::F14FastSet<std::string> claimedNames;
+  for (const auto& [name, _] : index.byAlias) {
+    claimedNames.insert(name);
+  }
+
   for (size_t i = 0; i < sortKeyExprs.size(); ++i) {
     auto ordinal = lookupSortKey(
         sortKeyExprs[i], preResolvedOrdinals[i], projections, index);
@@ -148,7 +155,17 @@ std::vector<size_t> SortProjection::widenProjections(
         replaceAliases(sortKeyExprs[i].expr(), index.byAlias, projections);
     ordinal = projections.size() + 1;
     index.byExpr.emplace(resolved, ordinal);
-    projections.emplace_back(std::move(resolved), sortKeyExprs[i].alias());
+
+    // A name another output column already carries would leave both
+    // unresolvable, so the column is projected unnamed and trimmed after the
+    // sort. Empty, not nullopt: nullopt makes a column reference an identity
+    // projection, which keeps the very name being avoided here.
+    std::optional<std::string> alias{sortKeyExprs[i].alias()};
+    if (alias.has_value() && !claimedNames.insert(alias.value()).second) {
+      alias = "";
+    }
+
+    projections.emplace_back(std::move(resolved), std::move(alias));
     ordinals.push_back(ordinal);
   }
 

--- a/axiom/sql/presto/SortProjection.h
+++ b/axiom/sql/presto/SortProjection.h
@@ -25,8 +25,9 @@ namespace axiom::sql::presto {
 
 class SortProjection {
  public:
-  /// Matches sort key expressions against items in the SELECT list, including
-  /// aliased expressions. For unmatched expressions, appends them to
+  /// Matches sort key expressions against items in the SELECT list. A key that
+  /// names an output alias arrives as that item's expression, so matching is by
+  /// expression alone. For unmatched expressions, appends them to
   /// `projections`, widening the projection list. Returns a 1-based ordinal for
   /// each sort key in the widened projection list.
   ///

--- a/axiom/sql/presto/SortProjection.h
+++ b/axiom/sql/presto/SortProjection.h
@@ -39,7 +39,8 @@ class SortProjection {
   /// (1-based).
   /// @param projections Mutable list of expressions from the SELECT list. This
   /// is where unmatched sort key expressions are appended. All pre-resolved
-  /// ordinals should match to a projection here.
+  /// ordinals should match to a projection here. An appended expression is
+  /// left unnamed when another output column already uses its name.
   static std::vector<size_t> widenProjections(
       const std::vector<facebook::axiom::logical_plan::ExprApi>& sortKeyExprs,
       const std::vector<size_t>& preResolvedOrdinals,

--- a/axiom/sql/presto/tests/SortParserTest.cpp
+++ b/axiom/sql/presto/tests/SortParserTest.cpp
@@ -215,8 +215,8 @@ TEST_F(SortParserTest, windowInOrderBy) {
 TEST_F(SortParserTest, ambiguousAlias) {
   connector_->addTable("t", ROW({"a", "b", "c"}, INTEGER()));
 
-  VELOX_ASSERT_THROW(
-      parseSql("SELECT a as b, b FROM t ORDER BY b"), "Column is ambiguous: b");
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("SELECT a as b, b FROM t ORDER BY b"), "Column is ambiguous");
 
   testSelect(
       "SELECT a as b, b FROM t ORDER BY c",
@@ -542,9 +542,9 @@ TEST_F(SortParserTest, outputAliasInExpression) {
           .project({"x"})
           .output({"x"}));
 
-  VELOX_ASSERT_THROW(
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql("SELECT 1 AS a, a FROM t2 ORDER BY a + 1"),
-      "Column is ambiguous: a");
+      "Column is ambiguous");
 
   testSelect(
       "SELECT 1 AS a, a FROM t2 ORDER BY b + 1",

--- a/axiom/sql/presto/tests/SortParserTest.cpp
+++ b/axiom/sql/presto/tests/SortParserTest.cpp
@@ -310,6 +310,23 @@ TEST_F(SortParserTest, qualifiedSortKeyWithDuplicateOutputNames) {
           .output({"k", "v", "k", "v"}));
 }
 
+// An enclosing query can reference an output column whose name a sort key over
+// a different expression also uses.
+TEST_F(SortParserTest, sortKeyShadowsOutputName) {
+  connector_->addTable("t", ROW({"k", "a"}, INTEGER()));
+
+  testSelect(
+      "SELECT a FROM ("
+      "  SELECT v.a AS a FROM t u JOIN t v ON u.k = v.k ORDER BY u.a DESC)",
+      matchScan()
+          .join(matchScan().build(), {"left_k", "left_a", "right_k", "right_a"})
+          .project({"right_a as out", "left_a as sortKey"})
+          .sort({"sortKey desc"})
+          .project({"out as trimmed"})
+          .project({"trimmed"})
+          .output({"a"}));
+}
+
 // Under SELECT DISTINCT a qualified sort key picks the side of the join it
 // names, even though both sides contribute an output column of that name.
 TEST_F(SortParserTest, distinctQualifiedSortKeyOnJoin) {


### PR DESCRIPTION
Summary:

A qualified ORDER BY key was sorted by a SELECT output column that happened to share its name. For example:

    SELECT v.b AS a
    FROM (VALUES (1, 10), (2, 20)) u(k, a)
    JOIN (VALUES (1, 200), (2, 100)) v(k, b) ON u.k = v.k
    ORDER BY u.a DESC

returned `200, 100` — sorted by `v.b`. Sorting by `u.a`, as the key names, gives `100, 200`.

A column reference loses its table qualifier during translation whenever the bare name is unambiguous, so by the time sort keys were matched against the SELECT list, `u.a` and `a` were the same expression and the match went to the output alias. Output aliases now resolve during translation instead, where a qualified reference is still a dereference and so never names one. Sort keys then match the SELECT list by expression alone.

Resolving names earlier also puts them under the scoping rules that apply there: a lambda parameter shadows an alias of the same name, and a subquery body sees none of the enclosing block's aliases.

Differential Revision: D118917970


