### PR TITLE
feat(connectors): Expose $row_id on Hive tables (#1839)

### DIFF
--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -122,7 +122,7 @@ std::vector<std::unique_ptr<const connector::Column>> makeColumns(
       partitionColumnNames.begin(), partitionColumnNames.end());
 
   std::vector<std::unique_ptr<const connector::Column>> columns;
-  columns.reserve(type->size() + 2 + (bucketed ? 1 : 0));
+  columns.reserve(type->size() + 3 + (bucketed ? 1 : 0));
 
   for (auto i = 0; i < type->size(); i++) {
     const bool isPartitionColumn = partitionColumns.contains(type->nameOf(i));
@@ -150,6 +150,9 @@ std::vector<std::unique_ptr<const connector::Column>> makeColumns(
           std::make_unique<connector::Column>(
               HiveTable::kBucket, velox::INTEGER(), /*hidden=*/true));
     }
+    columns.emplace_back(
+        std::make_unique<connector::Column>(
+            HiveTable::kRowId, HiveTable::rowIdType(), /*hidden=*/true));
   }
 
   return columns;
@@ -266,6 +269,9 @@ velox::connector::hive::HiveColumnHandle::ColumnType columnType(
     const HiveTableLayout& layout,
     const facebook::axiom::connector::Column* column) {
   if (column->hidden()) {
+    if (column->name() == HiveTable::kRowId) {
+      return velox::connector::hive::HiveColumnHandle::ColumnType::kRowId;
+    }
     return velox::connector::hive::HiveColumnHandle::ColumnType::kSynthesized;
   }
 

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -105,6 +105,23 @@ class HiveTable : public Table {
   static constexpr auto kPath = "$path";
   static constexpr auto kFileSize = "$file_size";
   static constexpr auto kBucket = "$bucket";
+  static constexpr auto kRowId = "$row_id";
+
+  /// Type of kRowId, a contract with the connector's execution side: it takes
+  /// a 5-field ROW and addresses the fields by position, filling the first
+  /// from the reader and the rest from the split. The two change together.
+  /// The fields identify a row to the delete logic and are not meant to be
+  /// read for anything else.
+  static const velox::RowTypePtr& rowIdType() {
+    static const velox::RowTypePtr kType = velox::ROW({
+        {"rownumber", velox::BIGINT()},
+        {"rowgroupid", velox::VARCHAR()},
+        {"metadataversion", velox::BIGINT()},
+        {"partitionid", velox::BIGINT()},
+        {"rowguid", velox::VARCHAR()},
+    });
+    return kType;
+  }
 
   HiveTable(
       SchemaTableName name,
@@ -354,8 +371,8 @@ class HiveConnectorMetadata : public ConnectorMetadata {
  public:
   /// @param includeHiddenColumns is an indicator to include hidden columns in
   /// HiveTable creation, i.e. including cols: HiveTable::kPath,
-  /// HiveTable::kBucket, HiveTable::kFileSize apart from the original physical
-  /// schema.
+  /// HiveTable::kBucket, HiveTable::kFileSize, HiveTable::kRowId apart from
+  /// the original physical schema.
   explicit HiveConnectorMetadata(
       velox::connector::hive::HiveConnector* hiveConnector,
       bool includeHiddenColumns = true)

--- a/axiom/connectors/hive/README.md
+++ b/axiom/connectors/hive/README.md
@@ -23,6 +23,8 @@ a local directory.
   - `$path` — file path of the data file.
   - `$bucket` — bucket number for bucketed tables.
   - `$file_size` — size of the data file in bytes.
+  - `$row_id` — a row's physical identity, used for row-level deletes. Not
+    implemented yet.
 - Filter pushdown: the optimizer pushes filters down to the connector, which
   evaluates them during scan. This includes partition pruning (skipping
   entire files based on partition key values) and within-file filtering.

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -98,7 +98,8 @@ class LocalHiveConnectorMetadataTest
                  v1.end(),
                  v2.begin(),
                  [](const Column* a, const Column* b) {
-                   return (a->name() == b->name()) && (a->type() == b->type());
+                   return (a->name() == b->name()) &&
+                       (*a->type() == *b->type());
                  });
     };
 

--- a/axiom/optimizer/tests/DeleteTest.cpp
+++ b/axiom/optimizer/tests/DeleteTest.cpp
@@ -148,5 +148,17 @@ TEST_F(DeleteTest, unpartitionedTable) {
   EXPECT_EQ(0, runCount("FROM test"));
 }
 
+// $row_id resolves, so a row-level delete parses. The optimizer rejects it:
+// it supports only deletes the connector can carry out as a metadata change.
+TEST_F(DeleteTest, rowLevelDelete) {
+  const auto plan = parseDelete(
+      "DELETE FROM nation WHERE \"$row_id\" IN "
+      "(SELECT \"$row_id\" FROM nation WHERE n_regionkey = 1)");
+  ASSERT_NE(plan, nullptr);
+
+  VELOX_ASSERT_USER_THROW(
+      planVelox(plan), "DELETE requires a scan with an optional filter");
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -164,8 +164,11 @@ TEST_P(SubqueryTest, inListWithMixedSubqueries) {
             .nestedLoopJoin(
                 matchHiveScan("region")
                     .singleAggregation({}, {"max(r_regionkey) as max_key"})
-                    .nestedLoopJoin(matchHiveScan("region").singleAggregation(
-                        {}, {"min(r_regionkey_2) as min_key"})),
+                    .nestedLoopJoin(
+                        matchHiveScan("region")
+                            .aliases({"region_key"})
+                            .singleAggregation(
+                                {}, {"min(region_key) as min_key"})),
                 core::JoinType::kInner,
                 "\"in\"(n_regionkey, max_key, min_key)")
             .build());


### PR DESCRIPTION
Summary:

A delete that names row identity failed before it could be judged. For example:

    DELETE FROM t
    WHERE "$row_id" IN (SELECT "$row_id" FROM t WHERE ds = '2026-09-03')

failed with `Cannot resolve column: $row_id` during name resolution, never reaching the optimizer that decides whether such a delete is supported.

The Hive connector now declares `$row_id` the way it already declares `$path` and `$file_size`, and classifies it so the execution side treats it as the row id rather than as a synthesized column. Its type is the five-field row that side addresses by position. Prism inherits it.

Row-level delete itself stays unimplemented: the optimizer accepts only deletes the connector can carry out as a metadata change, and rejects this one. Exposing the column moves the failure from name resolution to that decision.

Also fixes the column comparison in the Hive metadata test, which compared `TypePtr` identity and so held only for the scalar types Velox interns. The first composite column type reaching it would have broken it.

Reviewed By: amitkdutta

Differential Revision: D118958701


