### PR TITLE
feat(connectors): Serve the row identity columns

### DIFF
--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -122,7 +122,7 @@ std::vector<std::unique_ptr<const connector::Column>> makeColumns(
       partitionColumnNames.begin(), partitionColumnNames.end());
 
   std::vector<std::unique_ptr<const connector::Column>> columns;
-  columns.reserve(type->size() + 2 + (bucketed ? 1 : 0));
+  columns.reserve(type->size() + 3 + (bucketed ? 1 : 0));
 
   for (auto i = 0; i < type->size(); i++) {
     const bool isPartitionColumn = partitionColumns.contains(type->nameOf(i));
@@ -150,6 +150,9 @@ std::vector<std::unique_ptr<const connector::Column>> makeColumns(
           std::make_unique<connector::Column>(
               HiveTable::kBucket, velox::INTEGER(), /*hidden=*/true));
     }
+    columns.emplace_back(
+        std::make_unique<connector::Column>(
+            HiveTable::kRowId, HiveTable::rowIdType(), /*hidden=*/true));
   }
 
   return columns;
@@ -266,6 +269,9 @@ velox::connector::hive::HiveColumnHandle::ColumnType columnType(
     const HiveTableLayout& layout,
     const facebook::axiom::connector::Column* column) {
   if (column->hidden()) {
+    if (column->name() == HiveTable::kRowId) {
+      return velox::connector::hive::HiveColumnHandle::ColumnType::kRowId;
+    }
     return velox::connector::hive::HiveColumnHandle::ColumnType::kSynthesized;
   }
 

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -122,7 +122,7 @@ std::vector<std::unique_ptr<const connector::Column>> makeColumns(
       partitionColumnNames.begin(), partitionColumnNames.end());
 
   std::vector<std::unique_ptr<const connector::Column>> columns;
-  columns.reserve(type->size() + 3 + (bucketed ? 1 : 0));
+  columns.reserve(type->size() + 5 + (bucketed ? 1 : 0));
 
   for (auto i = 0; i < type->size(); i++) {
     const bool isPartitionColumn = partitionColumns.contains(type->nameOf(i));
@@ -153,6 +153,12 @@ std::vector<std::unique_ptr<const connector::Column>> makeColumns(
     columns.emplace_back(
         std::make_unique<connector::Column>(
             HiveTable::kRowId, HiveTable::rowIdType(), /*hidden=*/true));
+    columns.emplace_back(
+        std::make_unique<connector::Column>(
+            HiveTable::kRowNumber, velox::BIGINT(), /*hidden=*/true));
+    columns.emplace_back(
+        std::make_unique<connector::Column>(
+            HiveTable::kRowGroupId, velox::VARCHAR(), /*hidden=*/true));
   }
 
   return columns;
@@ -271,6 +277,9 @@ velox::connector::hive::HiveColumnHandle::ColumnType columnType(
   if (column->hidden()) {
     if (column->name() == HiveTable::kRowId) {
       return velox::connector::hive::HiveColumnHandle::ColumnType::kRowId;
+    }
+    if (column->name() == HiveTable::kRowNumber) {
+      return velox::connector::hive::HiveColumnHandle::ColumnType::kRowIndex;
     }
     return velox::connector::hive::HiveColumnHandle::ColumnType::kSynthesized;
   }

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -105,6 +105,23 @@ class HiveTable : public Table {
   static constexpr auto kPath = "$path";
   static constexpr auto kFileSize = "$file_size";
   static constexpr auto kBucket = "$bucket";
+  static constexpr auto kRowId = "$row_id";
+
+  /// Type of kRowId, a contract with the connector's execution side: it takes
+  /// a 5-field ROW and addresses the fields by position, filling the first
+  /// from the reader and the rest from the split. The two change together.
+  /// The fields identify a row to the delete logic and are not meant to be
+  /// read for anything else.
+  static const velox::RowTypePtr& rowIdType() {
+    static const velox::RowTypePtr kType = velox::ROW({
+        {"rownumber", velox::BIGINT()},
+        {"rowgroupid", velox::VARCHAR()},
+        {"metadataversion", velox::BIGINT()},
+        {"partitionid", velox::BIGINT()},
+        {"rowguid", velox::VARCHAR()},
+    });
+    return kType;
+  }
 
   HiveTable(
       SchemaTableName name,
@@ -354,8 +371,8 @@ class HiveConnectorMetadata : public ConnectorMetadata {
  public:
   /// @param includeHiddenColumns is an indicator to include hidden columns in
   /// HiveTable creation, i.e. including cols: HiveTable::kPath,
-  /// HiveTable::kBucket, HiveTable::kFileSize apart from the original physical
-  /// schema.
+  /// HiveTable::kBucket, HiveTable::kFileSize, HiveTable::kRowId apart from
+  /// the original physical schema.
   explicit HiveConnectorMetadata(
       velox::connector::hive::HiveConnector* hiveConnector,
       bool includeHiddenColumns = true)

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -107,6 +107,14 @@ class HiveTable : public Table {
   static constexpr auto kBucket = "$bucket";
   static constexpr auto kRowId = "$row_id";
 
+  /// Zero-based position of the row within the file it was read from. Unique
+  /// within a file, not within the table.
+  static constexpr auto kRowNumber = "$row_number";
+
+  /// Identifies the file a row was read from. With kRowNumber it addresses a
+  /// row physically, which is what a row-level delete records.
+  static constexpr auto kRowGroupId = "$row_group_id";
+
   /// Type of kRowId, a contract with the connector's execution side: it takes
   /// a 5-field ROW and addresses the fields by position, filling the first
   /// from the reader and the rest from the split. The two change together.

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -316,6 +316,7 @@ std::shared_ptr<SplitSource> LocalHiveSplitManager::getSplitSource(
       std::move(selectedFiles),
       layout->fileFormat(),
       layout->connector()->connectorId(),
+      tableHandle->name(),
       layout->serdeParameters(),
       partitionType);
 }
@@ -343,6 +344,17 @@ folly::coro::Task<SplitBatch> LocalHiveSplitSource::co_getSplits(
                          .fileFormat(format_)
                          .start(splitWithinFile_ * splitSize)
                          .length(splitSize);
+
+      // $row_group_id names the file, matching the row group the reader puts
+      // in $row_id. This connector has no versioning or partition ids, so the
+      // file and row number carry the whole identity.
+      const auto lastSlash = filePath.rfind('/');
+      builder.infoColumn(
+          HiveTable::kRowGroupId,
+          lastSlash == std::string::npos ? filePath
+                                         : filePath.substr(lastSlash + 1));
+      builder.rowIdProperties(
+          {.metadataVersion = 0, .partitionId = 0, .tableGuid = tableName_});
 
       auto* info = files_[fileIdx_];
       if (info->bucketNumber.has_value()) {

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -37,10 +37,12 @@ class LocalHiveSplitSource : public SplitSource {
       std::vector<const FileInfo*> files,
       velox::dwio::common::FileFormat format,
       const std::string& connectorId,
+      std::string tableName,
       std::unordered_map<std::string, std::string> serdeParameters,
       std::shared_ptr<PartitionType> partitionType)
       : format_(format),
         connectorId_(connectorId),
+        tableName_(std::move(tableName)),
         files_(std::move(files)),
         serdeParameters_(std::move(serdeParameters)),
         partitionType_(std::move(partitionType)) {}
@@ -53,6 +55,9 @@ class LocalHiveSplitSource : public SplitSource {
 
   const velox::dwio::common::FileFormat format_;
   const std::string connectorId_;
+  // Stands in for a table-unique id in $row_id. This connector has no
+  // versioning or partition ids, so the file and row number carry the identity.
+  const std::string tableName_;
   std::vector<const FileInfo*> files_;
   const std::unordered_map<std::string, std::string> serdeParameters_;
   // When non-null, used to assign a groupId to each split for bucketed

--- a/axiom/connectors/hive/README.md
+++ b/axiom/connectors/hive/README.md
@@ -23,8 +23,12 @@ a local directory.
   - `$path` — file path of the data file.
   - `$bucket` — bucket number for bucketed tables.
   - `$file_size` — size of the data file in bytes.
-  - `$row_id` — a row's physical identity, used for row-level deletes. Not
-    implemented yet.
+  - `$row_number` — zero-based position of the row within its file.
+  - `$row_group_id` — name of the file the row was read from.
+  - `$row_id` — the two above plus the identity of the table and partition
+    version they are relative to, as one struct. Used for row-level deletes.
+    This connector has no versioning or partition ids, so it fills those fields
+    with zeroes and the table name.
 - Filter pushdown: the optimizer pushes filters down to the connector, which
   evaluates them during scan. This includes partition pruning (skipping
   entire files based on partition key values) and within-file filtering.

--- a/axiom/connectors/hive/README.md
+++ b/axiom/connectors/hive/README.md
@@ -23,6 +23,8 @@ a local directory.
   - `$path` — file path of the data file.
   - `$bucket` — bucket number for bucketed tables.
   - `$file_size` — size of the data file in bytes.
+  - `$row_id` — a row's physical identity, used for row-level deletes. Not
+    implemented yet.
 - Filter pushdown: the optimizer pushes filters down to the connector, which
   evaluates them during scan. This includes partition pruning (skipping
   entire files based on partition key values) and within-file filtering.

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -98,7 +98,8 @@ class LocalHiveConnectorMetadataTest
                  v1.end(),
                  v2.begin(),
                  [](const Column* a, const Column* b) {
-                   return (a->name() == b->name()) && (a->type() == b->type());
+                   return (a->name() == b->name()) &&
+                       (*a->type() == *b->type());
                  });
     };
 

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -123,6 +123,7 @@ add_executable(
   FilteredTableStatsTest.cpp
   FiltersTest.cpp
   FixedPointTest.cpp
+  HiveRowIdentityTest.cpp
   JoinFilterProjectionTest.cpp
   JoinTest.cpp
   LimitTest.cpp

--- a/axiom/optimizer/tests/DeleteTest.cpp
+++ b/axiom/optimizer/tests/DeleteTest.cpp
@@ -148,5 +148,17 @@ TEST_F(DeleteTest, unpartitionedTable) {
   EXPECT_EQ(0, runCount("FROM test"));
 }
 
+// $row_id resolves, so a row-level delete parses. The optimizer rejects it:
+// it supports only deletes the connector can carry out as a metadata change.
+TEST_F(DeleteTest, rowLevelDelete) {
+  const auto plan = parseDelete(
+      "DELETE FROM nation WHERE \"$row_id\" IN "
+      "(SELECT \"$row_id\" FROM nation WHERE n_regionkey = 1)");
+  ASSERT_NE(plan, nullptr);
+
+  VELOX_ASSERT_USER_THROW(
+      planVelox(plan), "DELETE requires a scan with an optional filter");
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/HiveRowIdentityTest.cpp
+++ b/axiom/optimizer/tests/HiveRowIdentityTest.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+// The hidden columns addressing a row physically: $row_number, $row_group_id,
+// and $row_id, which repeats both. A query names one explicitly; SELECT *
+// leaves them out. File names carry generated ids, so the assertions relate
+// the columns to each other rather than to a literal.
+//
+// TODO: Cover a filter on $row_number and on $row_id. Velox's makeScanSpec
+// projects both columns but rejects a subfield filter on either, so a
+// predicate the optimizer pushes into the scan fails there.
+class HiveRowIdentityTest : public test::HiveQueriesTestBase {
+ protected:
+  static void SetUpTestCase() {
+    test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables({velox::tpch::Table::TBL_REGION});
+  }
+
+  int64_t runCount(std::string_view fromClause) {
+    const auto sql = fmt::format("SELECT count(*) {}", fromClause);
+    SCOPED_TRACE(sql);
+    return runVelox(parseSelect(sql)).getOnlyResult<int64_t>();
+  }
+};
+
+TEST_F(HiveRowIdentityTest, rowIdentity) {
+  // region is written as a single file of 5 rows, so the positions run 0..4
+  // and every row shares one row group.
+  checkSameSingleNode(
+      parseSelect(R"(SELECT "$row_number" FROM region)"),
+      {makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})})});
+
+  auto files = runVelox(
+      parseSelect(R"(SELECT DISTINCT "$path", "$row_group_id" FROM region)"));
+  ASSERT_EQ(1, files.countRows());
+  const auto& file = *files.results.at(0);
+  const auto path = file.childAt(0)->variantAt(0).value<std::string>();
+  const auto rowGroupId = file.childAt(1)->variantAt(0).value<std::string>();
+  EXPECT_TRUE(path.ends_with("/" + rowGroupId)) << path << " vs " << rowGroupId;
+
+  EXPECT_EQ(0, runCount(R"(FROM region
+          WHERE "$row_number" <> "$row_id".rownumber
+             OR "$row_group_id" <> "$row_id".rowgroupid)"));
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -164,8 +164,11 @@ TEST_P(SubqueryTest, inListWithMixedSubqueries) {
             .nestedLoopJoin(
                 matchHiveScan("region")
                     .singleAggregation({}, {"max(r_regionkey) as max_key"})
-                    .nestedLoopJoin(matchHiveScan("region").singleAggregation(
-                        {}, {"min(r_regionkey_2) as min_key"})),
+                    .nestedLoopJoin(
+                        matchHiveScan("region")
+                            .aliases({"region_key"})
+                            .singleAggregation(
+                                {}, {"min(region_key) as min_key"})),
                 core::JoinType::kInner,
                 "\"in\"(n_regionkey, max_key, min_key)")
             .build());


### PR DESCRIPTION
Summary:
A query can now read where a row physically lives:

    SELECT "$row_number", "$row_group_id" FROM region

`$row_number` is the row's zero-based position in its file and `$row_group_id` names the file. `$row_id` combines those two with the identity of the table and the partition version. It was declared before this change, but a scan of it failed because nothing put that identity on the split. It now returns values.

A connector supplies the identity when it builds a split: the file name as an info column, and the partition's recorded identity where one exists.

Two gaps remain. A filter on `$row_number` or `$row_id` fails — Velox projects both columns but rejects a subfield filter on either. And a partition with no recorded identity fails inside the reader, with a message naming neither the table nor the column.

Differential Revision: D118978240
