### PR TITLE
docs: Explain how to test an unlanded Velox change

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -61,7 +61,7 @@ with all dependencies pre-installed. Dependencies are resolved as `SYSTEM`.
 
 Installs minimal dependencies from the Velox setup scripts:
 
-- **Homebrew packages** (`install_velox_deps_from_brew`): gtest, icu4c,
+- **Homebrew packages** (`install_velox_deps_from_brew`): icu4c,
   libevent, libsodium, lz4, openssl, protobuf, simdjson, snappy, xz,
   xxhash, zstd, bison, flex, ninja, cmake.
 - **Built from source** (`install_gflags`, `install_glog`,

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Axiom integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/3ea8fd7bc74e244e21585975a79e58ccf7233b32...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/e527416d7053ed5ce31613b834ea6df1bd3a7862...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that
@@ -337,3 +337,44 @@ git add velox
 Build and run tests to ensure everything works. The pre-commit hook will
 automatically update the Velox compare link in this README. Submit a PR, get
 it approved and merged.
+
+### Test Against an Unlanded Velox Change
+
+CI clones the submodule from the URL in `.gitmodules`, so it cannot see a commit
+that only exists in a Velox fork. Testing a Velox pull request against Axiom
+therefore takes four extra steps.
+
+**1. Put the change on a Velox branch and push it to your Velox fork.** Branch
+from Velox main. If an unrelated breakage on main hides the result, pass the
+commit Axiom pins to `git checkout -b` in place of `origin/main` — `git ls-tree
+HEAD velox`, run from the Axiom root, prints it — and accept that the version
+bump goes untested.
+
+```bash
+cd velox
+git fetch origin main
+git checkout -b <velox-test-branch> origin/main
+git cherry-pick <commit>          # or apply the patch
+git push https://github.com/<your-github-user>/velox.git <velox-test-branch>
+cd ..
+```
+
+**2. Record the new submodule commit and point `.gitmodules` at your fork.**
+Step 1 already left the submodule on the commit to record.
+
+```bash
+git add velox
+# Replace facebookincubator/velox with <your-github-user>/velox.
+$EDITOR .gitmodules
+git add .gitmodules
+git commit -m "test: Point Velox at <the change>"
+```
+
+**3. Push the branch to your Axiom fork and open a pull request inside the
+fork**, against the fork's `main`. The workflows run on `pull_request` and on
+pushes to `main` only, so pushing a branch does not start them, and keeping the
+pull request in the fork leaves the experiment off the upstream repository.
+
+**4. Revert the submodule commit and the `.gitmodules` URL** before opening a
+real pull request. The change lands in Velox first; Axiom picks it up the next
+time the version is advanced.


### PR DESCRIPTION
CI clones the Velox submodule from the URL in `.gitmodules`, so it cannot fetch
a commit that only exists in a fork. Validating a Velox pull request against
Axiom therefore needs both a fork URL in `.gitmodules` and a submodule commit
carrying the change. Neither step is discoverable from the existing "Advance
Velox Version" instructions.

The documented default is Velox main plus the change, since advancing the
version brings everything since the last bump. Branching at the pinned commit
is offered as the fallback for when an unrelated breakage on main hides the
result.

### Drive-by changes

- `.github/workflows/README.md` lists `gtest` among the Homebrew packages the
  macOS job installs. facebookincubator/velox#18885 removes it from
  `MACOS_VELOX_DEPS` because CMake always builds googletest from source, so
  this line is accurate once that lands and the submodule advances past it.
- The `check-velox-readme` pre-commit hook rewrote the Velox compare link in
  `README.md`: it pointed at `3ea8fd7b` while the submodule is at `e527416d`.
  Any pull request touching `README.md` picks this up.
