### PR TITLE
fix(connectors): Spell types the way the dialect does (#1845)

### DIFF
--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(
   velox_exec
   velox_exec_test_lib
   velox_function_registry
+  velox_presto_types
   velox_dwio_common
   velox_dwio_parquet_reader
   velox_dwio_native_parquet_reader

--- a/axiom/cli/Connectors.cpp
+++ b/axiom/cli/Connectors.cpp
@@ -39,6 +39,7 @@
 #include "velox/dwio/parquet/RegisterParquetWriter.h"
 #include "velox/dwio/text/RegisterTextReader.h"
 #include "velox/dwio/text/RegisterTextWriter.h"
+#include "velox/functions/prestosql/types/PrestoTypes.h"
 
 namespace facebook::axiom {
 
@@ -235,10 +236,13 @@ void Connectors::registerSystemConnector(
   sessionPropertiesProvider_ =
       std::make_unique<SessionConfigPropertiesProvider>(sessionConfig);
 
+  // The CLI speaks Presto SQL, so information_schema spells types the way
+  // Presto does.
   auto connector = std::make_shared<connector::system::SystemConnector>(
       connectorId,
       /*queryInfoProvider=*/nullptr,
-      sessionPropertiesProvider_.get());
+      sessionPropertiesProvider_.get(),
+      velox::PrestoTypes::displayName);
   registerConnector(connector);
   connector::ConnectorMetadataRegistry::global().insert(
       connector->connectorId(),

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -523,8 +523,8 @@ TEST_F(SqlQueryRunnerTest, showCreateTable) {
     EXPECT_EQ(
         ddl,
         "CREATE TABLE test.\"default\".\"t1\" (\n"
-        "   id INTEGER,\n"
-        "   name VARCHAR\n"
+        "   id integer,\n"
+        "   name varchar\n"
         ")");
   }
 
@@ -538,8 +538,8 @@ TEST_F(SqlQueryRunnerTest, showCreateTable) {
     EXPECT_EQ(
         ddl,
         "CREATE TABLE test.\"default\".\"t2\" (\n"
-        "   a INTEGER,\n"
-        "   b VARCHAR\n"
+        "   a integer,\n"
+        "   b varchar\n"
         ")\n"
         "WITH (\n"
         "   hidden = ARRAY['h1', 'h2']\n"

--- a/axiom/connectors/system/InformationSchema.cpp
+++ b/axiom/connectors/system/InformationSchema.cpp
@@ -15,7 +15,6 @@
  */
 #include "axiom/connectors/system/InformationSchema.h"
 
-#include <boost/algorithm/string/case_conv.hpp>
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/system/SystemConnector.h"
 #include "velox/core/Expressions.h"
@@ -23,6 +22,7 @@
 #include "velox/type/Filter.h"
 
 namespace facebook::axiom::connector::system {
+
 namespace {
 
 velox::Variant nullVarchar() {
@@ -31,23 +31,6 @@ velox::Variant nullVarchar() {
 
 velox::Variant nullBigint() {
   return velox::Variant::null(velox::TypeKind::BIGINT);
-}
-
-// A type is reported in lower case, e.g. 'bigint'. A decimal is spelled
-// without a space, as a client comparing the text expects.
-std::string dataTypeName(const velox::TypePtr& type) {
-  if (type->isDecimal()) {
-    const auto [precision, scale] = velox::getDecimalPrecisionScale(*type);
-    return fmt::format("decimal({},{})", precision, scale);
-  }
-
-  // A complex type's rendering carries its field names, which lower-casing
-  // would rewrite, so only a scalar's name is lower-cased.
-  if (!type->isPrimitiveType()) {
-    return type->toString();
-  }
-
-  return boost::to_lower_copy(type->toString());
 }
 
 // Number of digits a numeric type holds: the count its range allows for
@@ -94,6 +77,9 @@ struct RowPosition {
   size_t columnIndex{0};
   TablePtr table;
   ViewPtr view;
+
+  // Spelling of the types kColumns reports. Never null while reading.
+  const InformationSchema::TypeNameFormatter* typeName{nullptr};
 
   const std::string& catalog() const {
     return handle->catalog();
@@ -206,8 +192,8 @@ const std::vector<RelationColumn>& columnsColumns() {
       {"data_type",
        velox::VARCHAR(),
        [](const RowPosition& position) {
-         return velox::Variant(
-             dataTypeName(position.rowType()->childAt(position.columnIndex)));
+         return velox::Variant((*position.typeName)(
+             *position.rowType()->childAt(position.columnIndex)));
        }},
       // Comments are not tracked.
       {"comment", velox::VARCHAR(), alwaysNull},
@@ -474,13 +460,14 @@ class InformationSchemaDataSource : public velox::connector::DataSource {
       const velox::RowTypePtr& outputType,
       std::shared_ptr<const InformationSchemaTableHandle> tableHandle,
       const velox::connector::ColumnHandleMap& columnHandles,
-      velox::memory::MemoryPool* pool)
+      velox::memory::MemoryPool* pool,
+      const InformationSchema::TypeNameFormatter& typeName)
       : outputType_{outputType},
         tableHandle_{std::move(tableHandle)},
         relation_{relationColumns(tableHandle_->relation())},
         metadata_{ConnectorMetadataRegistry::get(tableHandle_->catalog())},
         outputColumns_{findOutputColumns(outputType, columnHandles)},
-        position_{.handle = tableHandle_.get()},
+        position_{.handle = tableHandle_.get(), .typeName = &typeName},
         pool_{pool} {}
 
   void addSplit(
@@ -798,13 +785,18 @@ TablePtr InformationSchema::findTable(
   return std::make_shared<InformationSchemaTable>(tableName, schema, serving);
 }
 
+std::string InformationSchema::defaultTypeName(const velox::Type& type) {
+  return type.toString();
+}
+
 std::unique_ptr<velox::connector::DataSource> InformationSchema::makeDataSource(
     const std::shared_ptr<const InformationSchemaTableHandle>& tableHandle,
     const velox::RowTypePtr& outputType,
     const velox::connector::ColumnHandleMap& columnHandles,
-    velox::memory::MemoryPool* pool) {
+    velox::memory::MemoryPool* pool,
+    const TypeNameFormatter& typeName) {
   return std::make_unique<InformationSchemaDataSource>(
-      outputType, tableHandle, columnHandles, pool);
+      outputType, tableHandle, columnHandles, pool, typeName);
 }
 
 } // namespace facebook::axiom::connector::system

--- a/axiom/connectors/system/InformationSchema.h
+++ b/axiom/connectors/system/InformationSchema.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <functional>
+
 #include "axiom/connectors/ConnectorMetadata.h"
 
 namespace facebook::axiom::connector::system {
@@ -93,6 +95,17 @@ class InformationSchemaTableHandle
 /// served for one catalog.
 class InformationSchema {
  public:
+  /// Spells a column's type for information_schema.columns.data_type. A SQL
+  /// dialect that writes types differently registers its own; see
+  /// 'SystemConnector'.
+  using TypeNameFormatter = std::function<std::string(const velox::Type&)>;
+
+  /// The default 'TypeNameFormatter': the type as Velox renders it, e.g.
+  /// 'BIGINT', 'ARRAY<REAL>', 'ROW<x:BIGINT,y:VARCHAR>'. A dialect whose
+  /// clients read these names registers a formatter that writes them its own
+  /// way.
+  static std::string defaultTypeName(const velox::Type& type);
+
   /// Prefix under which a catalog's relations live in this connector's schema
   /// namespace: the relations of catalog 'foo' are the tables of schema
   /// '$info_schema@foo', so the catalog whose metadata produces the rows is
@@ -137,11 +150,14 @@ class InformationSchema {
   /// metadata of the catalog it names. Rows come in batches of the size the
   /// scan asks for: a relation may describe many tables, and kColumns returns
   /// a row per column of each.
+  /// @param typeName Spelling of the types kColumns reports. Must outlive the
+  /// returned data source.
   static std::unique_ptr<velox::connector::DataSource> makeDataSource(
       const std::shared_ptr<const InformationSchemaTableHandle>& tableHandle,
       const velox::RowTypePtr& outputType,
       const velox::connector::ColumnHandleMap& columnHandles,
-      velox::memory::MemoryPool* pool);
+      velox::memory::MemoryPool* pool,
+      const TypeNameFormatter& typeName);
 };
 
 } // namespace facebook::axiom::connector::system

--- a/axiom/connectors/system/SystemConnector.cpp
+++ b/axiom/connectors/system/SystemConnector.cpp
@@ -862,10 +862,14 @@ velox::RowVectorPtr FunctionsDataSource::buildResults() {
 SystemConnector::SystemConnector(
     const std::string& id,
     const QueryInfoProvider* queryInfoProvider,
-    const SessionPropertiesProvider* sessionPropertiesProvider)
+    const SessionPropertiesProvider* sessionPropertiesProvider,
+    InformationSchema::TypeNameFormatter typeName)
     : Connector(id),
       queryInfoProvider_(queryInfoProvider),
-      sessionPropertiesProvider_(sessionPropertiesProvider) {}
+      sessionPropertiesProvider_(sessionPropertiesProvider),
+      typeName_(std::move(typeName)) {
+  VELOX_CHECK(typeName_, "Type name formatter must be callable");
+}
 
 void SystemConnector::registerSerDe() {
   SystemTableHandle::registerSerDe();
@@ -886,7 +890,8 @@ std::unique_ptr<velox::connector::DataSource> SystemConnector::createDataSource(
         infoSchemaHandle,
         outputType,
         columnHandles,
-        connectorQueryCtx->memoryPool());
+        connectorQueryCtx->memoryPool(),
+        typeName_);
   }
 
   const auto* systemHandle = tableHandle->asChecked<SystemTableHandle>();

--- a/axiom/connectors/system/SystemConnector.h
+++ b/axiom/connectors/system/SystemConnector.h
@@ -20,6 +20,7 @@
 #include <optional>
 
 #include "axiom/common/SchemaTableName.h"
+#include "axiom/connectors/system/InformationSchema.h"
 #include "velox/connectors/Connector.h"
 
 namespace facebook::axiom::connector::system {
@@ -219,10 +220,16 @@ struct SystemSplit : public velox::connector::ConnectorSplit {
 /// for reading live query metadata and session properties.
 class SystemConnector : public velox::connector::Connector {
  public:
+  /// @param typeName Spelling of the types information_schema.columns
+  /// reports. Defaults to 'InformationSchema::defaultTypeName'; a SQL dialect
+  /// whose clients read these names registers its own, e.g. Presto's
+  /// 'array(real)'.
   SystemConnector(
       const std::string& id,
       const QueryInfoProvider* queryInfoProvider,
-      const SessionPropertiesProvider* sessionPropertiesProvider = nullptr);
+      const SessionPropertiesProvider* sessionPropertiesProvider = nullptr,
+      InformationSchema::TypeNameFormatter typeName =
+          InformationSchema::defaultTypeName);
 
   ~SystemConnector() override = default;
 
@@ -246,6 +253,7 @@ class SystemConnector : public velox::connector::Connector {
  private:
   const QueryInfoProvider* queryInfoProvider_;
   const SessionPropertiesProvider* sessionPropertiesProvider_;
+  const InformationSchema::TypeNameFormatter typeName_;
 };
 
 } // namespace facebook::axiom::connector::system

--- a/axiom/connectors/system/tests/CMakeLists.txt
+++ b/axiom/connectors/system/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(
   velox_dwio_common_test_utils
   velox_expression
   velox_function_registry
+  velox_presto_types
   velox_vector_test_lib
   GTest::gmock
   GTest::gtest

--- a/axiom/connectors/system/tests/InformationSchemaTest.cpp
+++ b/axiom/connectors/system/tests/InformationSchemaTest.cpp
@@ -22,6 +22,7 @@
 #include "axiom/connectors/system/SystemConnectorMetadata.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
 #include "velox/connectors/ConnectorRegistry.h"
+#include "velox/functions/prestosql/types/PrestoTypes.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 namespace facebook::axiom::connector::system {
@@ -40,15 +41,7 @@ class InformationSchemaTest : public optimizer::test::QueryTestBase {
     useV2_ = true;
     optimizer::test::QueryTestBase::SetUp();
 
-    systemConnector_ = std::make_shared<SystemConnector>(
-        std::string(kSystemConnectorId),
-        /*queryInfoProvider=*/nullptr,
-        /*sessionPropertiesProvider=*/nullptr);
-    velox::connector::ConnectorRegistry::global().insert(
-        std::string(kSystemConnectorId), systemConnector_);
-    ConnectorMetadataRegistry::global().insert(
-        std::string(kSystemConnectorId),
-        std::make_shared<SystemConnectorMetadata>(systemConnector_.get()));
+    registerSystemConnector(velox::PrestoTypes::displayName);
 
     testConnector_->createView(
         SchemaTableName{kDefaultSchema, "nation_names"},
@@ -63,6 +56,28 @@ class InformationSchemaTest : public optimizer::test::QueryTestBase {
     systemConnector_.reset();
 
     optimizer::test::QueryTestBase::TearDown();
+  }
+
+  // Registers the system connector, replacing one already registered, with
+  // 'typeName' spelling the types information_schema.columns reports.
+  void registerSystemConnector(InformationSchema::TypeNameFormatter typeName) {
+    if (systemConnector_ != nullptr) {
+      ConnectorMetadataRegistry::global().erase(
+          std::string(kSystemConnectorId));
+      velox::connector::ConnectorRegistry::global().erase(
+          std::string(kSystemConnectorId));
+    }
+
+    systemConnector_ = std::make_shared<SystemConnector>(
+        std::string(kSystemConnectorId),
+        /*queryInfoProvider=*/nullptr,
+        /*sessionPropertiesProvider=*/nullptr,
+        std::move(typeName));
+    velox::connector::ConnectorRegistry::global().insert(
+        std::string(kSystemConnectorId), systemConnector_);
+    ConnectorMetadataRegistry::global().insert(
+        std::string(kSystemConnectorId),
+        std::make_shared<SystemConnectorMetadata>(systemConnector_.get()));
   }
 
   std::vector<RowVectorPtr> run(std::string_view sql) {
@@ -92,6 +107,45 @@ TEST_F(InformationSchemaTest, view) {
           makeFlatVector<std::string>({"SELECT n_name FROM nation"}),
           makeNullableFlatVector<std::string>({std::nullopt}),
       }),
+      results.at(0));
+}
+
+TEST_F(InformationSchemaTest, complexColumnTypes) {
+  testConnector_->addTable(
+      "u",
+      ROW(
+          {{"a", ARRAY(REAL())},
+           {"m", MAP(VARCHAR(), BIGINT())},
+           {"r", ROW({{"x", BIGINT()}, {"y", VARCHAR()}})}}));
+
+  auto results =
+      run("SELECT column_name, data_type "
+          "FROM information_schema.columns "
+          "WHERE table_schema = 'default' AND table_name = 'u' "
+          "ORDER BY ordinal_position");
+  velox::test::assertEqualVectors(
+      makeRowVector({
+          makeFlatVector<std::string>({"a", "m", "r"}),
+          makeFlatVector<std::string>(
+              {"array(real)",
+               "map(varchar, bigint)",
+               "row(\"x\" bigint, \"y\" varchar)"}),
+      }),
+      results.at(0));
+}
+
+TEST_F(InformationSchemaTest, customTypeName) {
+  // A dialect that writes types differently registers its own spelling.
+  registerSystemConnector(
+      [](const velox::Type& /*type*/) { return "list(float)"; });
+
+  testConnector_->addTable("v", ROW({{"a", ARRAY(REAL())}}));
+
+  auto results =
+      run("SELECT data_type FROM information_schema.columns "
+          "WHERE table_schema = 'default' AND table_name = 'v'");
+  velox::test::assertEqualVectors(
+      makeRowVector({makeFlatVector<std::string>({"list(float)"})}),
       results.at(0));
 }
 

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -255,6 +255,7 @@ target_link_libraries(
   axiom_optimizer_tests_sql_test_base
   axiom_optimizer_tests_sql_file
   velox_connector_registry
+  velox_presto_types
   velox_dwio_common_test_utils
   GTest::gtest
 )

--- a/axiom/optimizer/tests/CsvReadWriteTest.cpp
+++ b/axiom/optimizer/tests/CsvReadWriteTest.cpp
@@ -70,8 +70,8 @@ TEST_P(CsvReadWriteTest, createTextTable) {
   EXPECT_EQ(
       showCreateTable("text_test"),
       "CREATE TABLE test-hive.\"default\".\"text_test\" (\n"
-      "   id INTEGER,\n"
-      "   name VARCHAR\n"
+      "   id integer,\n"
+      "   name varchar\n"
       ")\n"
       "WITH (\n"
       "   compression_kind = 'none',\n"
@@ -95,8 +95,8 @@ TEST_P(CsvReadWriteTest, createCsvTable) {
   EXPECT_EQ(
       showCreateTable("csv_test"),
       "CREATE TABLE test-hive.\"default\".\"csv_test\" (\n"
-      "   id INTEGER,\n"
-      "   name VARCHAR\n"
+      "   id integer,\n"
+      "   name varchar\n"
       ")\n"
       "WITH (\n"
       "   field.delim = ',',\n"

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -38,6 +38,7 @@
 #include "velox/dwio/dwrf/RegisterDwrfWriter.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
+#include "velox/functions/prestosql/types/PrestoTypes.h"
 #include "velox/serializers/PrestoSerializer.h"
 
 namespace facebook::axiom::optimizer::test {
@@ -240,12 +241,15 @@ class SqlTest : public SqlTestBase {
       metadata = suiteConnector_->metadata().get();
     }
 
-    // The system connector serves information_schema for every catalog.
+    // The system connector serves information_schema for every catalog. The
+    // tests are written in Presto SQL, so types are spelled the way the CLI
+    // and Axel spell them.
     suiteSystemConnector_ =
         std::make_shared<connector::system::SystemConnector>(
             std::string(kSystemConnectorId),
             /*queryInfoProvider=*/nullptr,
-            /*sessionPropertiesProvider=*/nullptr);
+            /*sessionPropertiesProvider=*/nullptr,
+            velox::PrestoTypes::displayName);
     velox::connector::ConnectorRegistry::global().insert(
         std::string(kSystemConnectorId), suiteSystemConnector_);
     connector::ConnectorMetadataRegistry::global().insert(

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2528,7 +2528,7 @@ SqlStatementPtr parseShowCreateTable(
       ddl << ",\n";
     }
     ddl << "   " << schema->nameOf(i) << " "
-        << PrestoTypes::toSql(schema->childAt(i));
+        << PrestoTypes::displayName(*schema->childAt(i));
   }
   ddl << "\n)";
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/axel/pull/312

`information_schema.columns.data_type` reported a complex type the way Velox prints it, and the rest of the column in a third style of its own:

    SELECT column_name, data_type FROM information_schema.columns
    WHERE table_schema = 'ad_metrics' AND table_name = 't'

answered `ARRAY<REAL>` where Presto answers `array(real)`, alongside a lower-cased `bigint` and a `decimal(10,2)` spelled without its space. Scalars were lower-cased and decimals given a SQL shape, but complex types were left as Velox rendered them.

The connector no longer decides how a type reads. It reports the type as Velox renders it, and whoever registers `SystemConnector` may supply a formatter instead; the two spellings the column used to mix are gone. The CLI and the two test harnesses parse Presto SQL, so they register Presto's spelling, `PrestoTypes::displayName`. Spelling a type is a dialect's business, and a Spark client would want `array<float>` for the same column.

`SHOW CREATE TABLE` moves to `displayName` as well, off the deprecated `PrestoTypes::toSql`, so its DDL reads `array(real)` rather than `ARRAY(REAL)`. Its type names now match Presto; its column names still do not, as Presto quotes those and Axiom does not.

Reviewed By: amitkdutta

Differential Revision: D119094065
