### PR TITLE
feat(connectors): Report column comments (#1846)

### DIFF
--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(
   axiom_query_id_generator
   velox_connector_registry
   velox_presto_query_config
+  velox_presto_types
   velox_query_config_provider
   axiom_runner_local_runner
   axiom_optimizer_multifragment_plan
@@ -55,7 +56,6 @@ target_link_libraries(
   velox_exec
   velox_exec_test_lib
   velox_function_registry
-  velox_presto_types
   velox_dwio_common
   velox_dwio_parquet_reader
   velox_dwio_native_parquet_reader

--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(
   velox_exec
   velox_exec_test_lib
   velox_function_registry
+  velox_presto_types
   velox_dwio_common
   velox_dwio_parquet_reader
   velox_dwio_native_parquet_reader

--- a/axiom/cli/Connectors.cpp
+++ b/axiom/cli/Connectors.cpp
@@ -39,6 +39,7 @@
 #include "velox/dwio/parquet/RegisterParquetWriter.h"
 #include "velox/dwio/text/RegisterTextReader.h"
 #include "velox/dwio/text/RegisterTextWriter.h"
+#include "velox/functions/prestosql/types/PrestoTypes.h"
 
 namespace facebook::axiom {
 
@@ -235,10 +236,13 @@ void Connectors::registerSystemConnector(
   sessionPropertiesProvider_ =
       std::make_unique<SessionConfigPropertiesProvider>(sessionConfig);
 
+  // The CLI speaks Presto SQL, so information_schema spells types the way
+  // Presto does.
   auto connector = std::make_shared<connector::system::SystemConnector>(
       connectorId,
       /*queryInfoProvider=*/nullptr,
-      sessionPropertiesProvider_.get());
+      sessionPropertiesProvider_.get(),
+      velox::PrestoTypes::displayName);
   registerConnector(connector);
   connector::ConnectorMetadataRegistry::global().insert(
       connector->connectorId(),

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -523,8 +523,8 @@ TEST_F(SqlQueryRunnerTest, showCreateTable) {
     EXPECT_EQ(
         ddl,
         "CREATE TABLE test.\"default\".\"t1\" (\n"
-        "   id INTEGER,\n"
-        "   name VARCHAR\n"
+        "   id integer,\n"
+        "   name varchar\n"
         ")");
   }
 
@@ -538,8 +538,8 @@ TEST_F(SqlQueryRunnerTest, showCreateTable) {
     EXPECT_EQ(
         ddl,
         "CREATE TABLE test.\"default\".\"t2\" (\n"
-        "   a INTEGER,\n"
-        "   b VARCHAR\n"
+        "   a integer,\n"
+        "   b varchar\n"
         ")\n"
         "WITH (\n"
         "   hidden = ARRAY['h1', 'h2']\n"

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -179,17 +179,22 @@ class Column {
   /// @param extraInfo What the connector says about the column's role beyond
   /// its name and type, in its own words, e.g. 'partition key'. Reported to a
   /// client as given.
+  /// @param comment The column's description, as the catalog records it.
+  /// Nullopt when the catalog holds none, which a client distinguishes from
+  /// an empty one.
   Column(
       std::string name,
       velox::TypePtr type,
       bool hidden,
       bool includeInExplainIo = false,
-      std::optional<std::string> extraInfo = std::nullopt)
+      std::optional<std::string> extraInfo = std::nullopt,
+      std::optional<std::string> comment = std::nullopt)
       : name_{std::move(name)},
         type_{std::move(type)},
         hidden_{hidden},
         includeInExplainIo_{includeInExplainIo},
         extraInfo_{std::move(extraInfo)},
+        comment_{std::move(comment)},
         defaultValue_{velox::Variant::null(type_->kind())} {
     VELOX_CHECK_NOT_NULL(type_);
     VELOX_CHECK(!name_.empty());
@@ -202,12 +207,14 @@ class Column {
       bool hidden,
       velox::Variant defaultValue,
       bool includeInExplainIo = false,
-      std::optional<std::string> extraInfo = std::nullopt)
+      std::optional<std::string> extraInfo = std::nullopt,
+      std::optional<std::string> comment = std::nullopt)
       : name_{std::move(name)},
         type_{std::move(type)},
         hidden_{hidden},
         includeInExplainIo_{includeInExplainIo},
         extraInfo_{std::move(extraInfo)},
+        comment_{std::move(comment)},
         defaultValue_{std::move(defaultValue)} {
     VELOX_CHECK_NOT_NULL(type_);
     VELOX_CHECK(!name_.empty());
@@ -250,6 +257,12 @@ class Column {
     return defaultValue_;
   }
 
+  /// The column's description, as the catalog records it. std::nullopt when
+  /// the catalog holds none.
+  const std::optional<std::string>& comment() const {
+    return comment_;
+  }
+
   /// What the connector says about the column's role beyond its name and
   /// type, in its own words, e.g. 'partition key'. std::nullopt when it says
   /// nothing.
@@ -281,6 +294,7 @@ class Column {
   const bool hidden_;
   const bool includeInExplainIo_;
   const std::optional<std::string> extraInfo_;
+  const std::optional<std::string> comment_;
   const velox::Variant defaultValue_;
 
   // The latest element added to 'allStats_'.

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -117,7 +117,8 @@ std::vector<std::unique_ptr<const connector::Column>> makeColumns(
     const velox::RowTypePtr& type,
     bool bucketed,
     bool includeHiddenColumns,
-    const std::vector<std::string>& partitionColumnNames = {}) {
+    const std::vector<std::string>& partitionColumnNames = {},
+    folly::F14FastMap<std::string, std::string> columnComments = {}) {
   const folly::F14FastSet<std::string> partitionColumns(
       partitionColumnNames.begin(), partitionColumnNames.end());
 
@@ -126,6 +127,7 @@ std::vector<std::unique_ptr<const connector::Column>> makeColumns(
 
   for (auto i = 0; i < type->size(); i++) {
     const bool isPartitionColumn = partitionColumns.contains(type->nameOf(i));
+    auto it = columnComments.find(type->nameOf(i));
     columns.emplace_back(
         std::make_unique<connector::Column>(
             type->nameOf(i),
@@ -134,7 +136,11 @@ std::vector<std::unique_ptr<const connector::Column>> makeColumns(
             /*includeInExplainIo=*/isPartitionColumn,
             /*extraInfo=*/
             isPartitionColumn ? std::optional<std::string>(kPartitionKey)
-                              : std::nullopt));
+                              : std::nullopt,
+            /*comment=*/
+            it == columnComments.end()
+                ? std::nullopt
+                : std::optional<std::string>(std::move(it->second))));
   }
 
   if (includeHiddenColumns) {
@@ -171,14 +177,16 @@ HiveTable::HiveTable(
     bool bucketed,
     bool includeHiddenColumns,
     folly::F14FastMap<std::string, velox::Variant> options,
-    std::vector<std::string> partitionColumnNames)
+    std::vector<std::string> partitionColumnNames,
+    folly::F14FastMap<std::string, std::string> columnComments)
     : Table(
           std::move(name),
           hive::makeColumns(
               type,
               bucketed,
               includeHiddenColumns,
-              partitionColumnNames),
+              partitionColumnNames,
+              std::move(columnComments)),
           std::move(options)) {}
 
 std::vector<std::string> HiveTable::ioColumnPriority() const {

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -137,7 +137,8 @@ class HiveTable : public Table {
       bool bucketed,
       bool includeHiddenColumns,
       folly::F14FastMap<std::string, velox::Variant> options,
-      std::vector<std::string> partitionColumnNames = {});
+      std::vector<std::string> partitionColumnNames = {},
+      folly::F14FastMap<std::string, std::string> columnComments = {});
 
   /// Recognizes the ds/ts partition convention and returns those columns
   /// finest-grained first (ts before ds).

--- a/axiom/connectors/system/InformationSchema.cpp
+++ b/axiom/connectors/system/InformationSchema.cpp
@@ -101,6 +101,22 @@ struct RowPosition {
     return table != nullptr || view != nullptr;
   }
 
+  // True when the row describes a view. A view's columns come from its type,
+  // with no connector column behind them.
+  bool isView() const {
+    return view != nullptr;
+  }
+
+  // The column kColumns is describing. Only a table has one, so a caller
+  // checks 'isView' first.
+  const Column& column() const {
+    VELOX_CHECK_NOT_NULL(table, "A view has no columns to describe");
+    const auto& name = rowType()->nameOf(columnIndex);
+    const auto* found = table->findColumn(name);
+    VELOX_CHECK_NOT_NULL(found, "Column not found: {}", name);
+    return *found;
+  }
+
   // Columns of the table being described.
   const velox::RowTypePtr& rowType() const {
     VELOX_CHECK(resolved(), "No table to describe");
@@ -195,23 +211,28 @@ const std::vector<RelationColumn>& columnsColumns() {
          return velox::Variant((*position.typeName)(
              *position.rowType()->childAt(position.columnIndex)));
        }},
-      // Comments are not tracked.
-      {"comment", velox::VARCHAR(), alwaysNull},
+      {"comment",
+       velox::VARCHAR(),
+       [](const RowPosition& position) {
+         if (position.isView()) {
+           // A view's columns carry no description.
+           return nullVarchar();
+         }
+         const auto& comment = position.column().comment();
+         return comment.has_value() ? velox::Variant(comment.value())
+                                    : nullVarchar();
+       }},
       {"extra_info",
        velox::VARCHAR(),
        [](const RowPosition& position) {
-         if (position.table == nullptr) {
+         if (position.isView()) {
            // A view's columns have no connector-assigned role.
            return nullVarchar();
          }
-
          // The connector says what a column's role is, if anything.
-         const auto& name = position.rowType()->nameOf(position.columnIndex);
-         const auto* column = position.table->findColumn(name);
-         VELOX_CHECK_NOT_NULL(column, "Column not found: {}", name);
-         return column->extraInfo().has_value()
-             ? velox::Variant(column->extraInfo().value())
-             : nullVarchar();
+         const auto& extraInfo = position.column().extraInfo();
+         return extraInfo.has_value() ? velox::Variant(extraInfo.value())
+                                      : nullVarchar();
        }},
       {"precision",
        velox::BIGINT(),

--- a/axiom/connectors/system/InformationSchema.cpp
+++ b/axiom/connectors/system/InformationSchema.cpp
@@ -15,7 +15,6 @@
  */
 #include "axiom/connectors/system/InformationSchema.h"
 
-#include <boost/algorithm/string/case_conv.hpp>
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/system/SystemConnector.h"
 #include "velox/core/Expressions.h"
@@ -23,6 +22,7 @@
 #include "velox/type/Filter.h"
 
 namespace facebook::axiom::connector::system {
+
 namespace {
 
 velox::Variant nullVarchar() {
@@ -31,23 +31,6 @@ velox::Variant nullVarchar() {
 
 velox::Variant nullBigint() {
   return velox::Variant::null(velox::TypeKind::BIGINT);
-}
-
-// A type is reported in lower case, e.g. 'bigint'. A decimal is spelled
-// without a space, as a client comparing the text expects.
-std::string dataTypeName(const velox::TypePtr& type) {
-  if (type->isDecimal()) {
-    const auto [precision, scale] = velox::getDecimalPrecisionScale(*type);
-    return fmt::format("decimal({},{})", precision, scale);
-  }
-
-  // A complex type's rendering carries its field names, which lower-casing
-  // would rewrite, so only a scalar's name is lower-cased.
-  if (!type->isPrimitiveType()) {
-    return type->toString();
-  }
-
-  return boost::to_lower_copy(type->toString());
 }
 
 // Number of digits a numeric type holds: the count its range allows for
@@ -94,6 +77,9 @@ struct RowPosition {
   size_t columnIndex{0};
   TablePtr table;
   ViewPtr view;
+
+  // Spelling of the types kColumns reports. Never null while reading.
+  const InformationSchema::TypeNameFormatter* typeName{nullptr};
 
   const std::string& catalog() const {
     return handle->catalog();
@@ -206,8 +192,8 @@ const std::vector<RelationColumn>& columnsColumns() {
       {"data_type",
        velox::VARCHAR(),
        [](const RowPosition& position) {
-         return velox::Variant(
-             dataTypeName(position.rowType()->childAt(position.columnIndex)));
+         return velox::Variant((*position.typeName)(
+             *position.rowType()->childAt(position.columnIndex)));
        }},
       // Comments are not tracked.
       {"comment", velox::VARCHAR(), alwaysNull},
@@ -474,13 +460,14 @@ class InformationSchemaDataSource : public velox::connector::DataSource {
       const velox::RowTypePtr& outputType,
       std::shared_ptr<const InformationSchemaTableHandle> tableHandle,
       const velox::connector::ColumnHandleMap& columnHandles,
-      velox::memory::MemoryPool* pool)
+      velox::memory::MemoryPool* pool,
+      const InformationSchema::TypeNameFormatter& typeName)
       : outputType_{outputType},
         tableHandle_{std::move(tableHandle)},
         relation_{relationColumns(tableHandle_->relation())},
         metadata_{ConnectorMetadataRegistry::get(tableHandle_->catalog())},
         outputColumns_{findOutputColumns(outputType, columnHandles)},
-        position_{.handle = tableHandle_.get()},
+        position_{.handle = tableHandle_.get(), .typeName = &typeName},
         pool_{pool} {}
 
   void addSplit(
@@ -798,13 +785,18 @@ TablePtr InformationSchema::findTable(
   return std::make_shared<InformationSchemaTable>(tableName, schema, serving);
 }
 
+std::string InformationSchema::defaultTypeName(const velox::Type& type) {
+  return type.toString();
+}
+
 std::unique_ptr<velox::connector::DataSource> InformationSchema::makeDataSource(
     const std::shared_ptr<const InformationSchemaTableHandle>& tableHandle,
     const velox::RowTypePtr& outputType,
     const velox::connector::ColumnHandleMap& columnHandles,
-    velox::memory::MemoryPool* pool) {
+    velox::memory::MemoryPool* pool,
+    const TypeNameFormatter& typeName) {
   return std::make_unique<InformationSchemaDataSource>(
-      outputType, tableHandle, columnHandles, pool);
+      outputType, tableHandle, columnHandles, pool, typeName);
 }
 
 } // namespace facebook::axiom::connector::system

--- a/axiom/connectors/system/InformationSchema.h
+++ b/axiom/connectors/system/InformationSchema.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <functional>
+
 #include "axiom/connectors/ConnectorMetadata.h"
 
 namespace facebook::axiom::connector::system {
@@ -93,6 +95,17 @@ class InformationSchemaTableHandle
 /// served for one catalog.
 class InformationSchema {
  public:
+  /// Spells a column's type for information_schema.columns.data_type. A SQL
+  /// dialect that writes types differently registers its own; see
+  /// 'SystemConnector'.
+  using TypeNameFormatter = std::function<std::string(const velox::Type&)>;
+
+  /// The default 'TypeNameFormatter': the type as Velox renders it, e.g.
+  /// 'BIGINT', 'ARRAY<REAL>', 'ROW<x:BIGINT,y:VARCHAR>'. A dialect whose
+  /// clients read these names registers a formatter that writes them its own
+  /// way.
+  static std::string defaultTypeName(const velox::Type& type);
+
   /// Prefix under which a catalog's relations live in this connector's schema
   /// namespace: the relations of catalog 'foo' are the tables of schema
   /// '$info_schema@foo', so the catalog whose metadata produces the rows is
@@ -137,11 +150,14 @@ class InformationSchema {
   /// metadata of the catalog it names. Rows come in batches of the size the
   /// scan asks for: a relation may describe many tables, and kColumns returns
   /// a row per column of each.
+  /// @param typeName Spelling of the types kColumns reports. Must outlive the
+  /// returned data source.
   static std::unique_ptr<velox::connector::DataSource> makeDataSource(
       const std::shared_ptr<const InformationSchemaTableHandle>& tableHandle,
       const velox::RowTypePtr& outputType,
       const velox::connector::ColumnHandleMap& columnHandles,
-      velox::memory::MemoryPool* pool);
+      velox::memory::MemoryPool* pool,
+      const TypeNameFormatter& typeName);
 };
 
 } // namespace facebook::axiom::connector::system

--- a/axiom/connectors/system/SystemConnector.cpp
+++ b/axiom/connectors/system/SystemConnector.cpp
@@ -862,10 +862,14 @@ velox::RowVectorPtr FunctionsDataSource::buildResults() {
 SystemConnector::SystemConnector(
     const std::string& id,
     const QueryInfoProvider* queryInfoProvider,
-    const SessionPropertiesProvider* sessionPropertiesProvider)
+    const SessionPropertiesProvider* sessionPropertiesProvider,
+    InformationSchema::TypeNameFormatter typeName)
     : Connector(id),
       queryInfoProvider_(queryInfoProvider),
-      sessionPropertiesProvider_(sessionPropertiesProvider) {}
+      sessionPropertiesProvider_(sessionPropertiesProvider),
+      typeName_(std::move(typeName)) {
+  VELOX_CHECK(typeName_, "Type name formatter must be callable");
+}
 
 void SystemConnector::registerSerDe() {
   SystemTableHandle::registerSerDe();
@@ -886,7 +890,8 @@ std::unique_ptr<velox::connector::DataSource> SystemConnector::createDataSource(
         infoSchemaHandle,
         outputType,
         columnHandles,
-        connectorQueryCtx->memoryPool());
+        connectorQueryCtx->memoryPool(),
+        typeName_);
   }
 
   const auto* systemHandle = tableHandle->asChecked<SystemTableHandle>();

--- a/axiom/connectors/system/SystemConnector.h
+++ b/axiom/connectors/system/SystemConnector.h
@@ -20,6 +20,7 @@
 #include <optional>
 
 #include "axiom/common/SchemaTableName.h"
+#include "axiom/connectors/system/InformationSchema.h"
 #include "velox/connectors/Connector.h"
 
 namespace facebook::axiom::connector::system {
@@ -219,10 +220,16 @@ struct SystemSplit : public velox::connector::ConnectorSplit {
 /// for reading live query metadata and session properties.
 class SystemConnector : public velox::connector::Connector {
  public:
+  /// @param typeName Spelling of the types information_schema.columns
+  /// reports. Defaults to 'InformationSchema::defaultTypeName'; a SQL dialect
+  /// whose clients read these names registers its own, e.g. Presto's
+  /// 'array(real)'.
   SystemConnector(
       const std::string& id,
       const QueryInfoProvider* queryInfoProvider,
-      const SessionPropertiesProvider* sessionPropertiesProvider = nullptr);
+      const SessionPropertiesProvider* sessionPropertiesProvider = nullptr,
+      InformationSchema::TypeNameFormatter typeName =
+          InformationSchema::defaultTypeName);
 
   ~SystemConnector() override = default;
 
@@ -246,6 +253,7 @@ class SystemConnector : public velox::connector::Connector {
  private:
   const QueryInfoProvider* queryInfoProvider_;
   const SessionPropertiesProvider* sessionPropertiesProvider_;
+  const InformationSchema::TypeNameFormatter typeName_;
 };
 
 } // namespace facebook::axiom::connector::system

--- a/axiom/connectors/system/tests/CMakeLists.txt
+++ b/axiom/connectors/system/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(
   velox_dwio_common_test_utils
   velox_expression
   velox_function_registry
+  velox_presto_types
   velox_vector_test_lib
   GTest::gmock
   GTest::gtest

--- a/axiom/connectors/system/tests/InformationSchemaTest.cpp
+++ b/axiom/connectors/system/tests/InformationSchemaTest.cpp
@@ -22,6 +22,7 @@
 #include "axiom/connectors/system/SystemConnectorMetadata.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
 #include "velox/connectors/ConnectorRegistry.h"
+#include "velox/functions/prestosql/types/PrestoTypes.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 namespace facebook::axiom::connector::system {
@@ -40,15 +41,7 @@ class InformationSchemaTest : public optimizer::test::QueryTestBase {
     useV2_ = true;
     optimizer::test::QueryTestBase::SetUp();
 
-    systemConnector_ = std::make_shared<SystemConnector>(
-        std::string(kSystemConnectorId),
-        /*queryInfoProvider=*/nullptr,
-        /*sessionPropertiesProvider=*/nullptr);
-    velox::connector::ConnectorRegistry::global().insert(
-        std::string(kSystemConnectorId), systemConnector_);
-    ConnectorMetadataRegistry::global().insert(
-        std::string(kSystemConnectorId),
-        std::make_shared<SystemConnectorMetadata>(systemConnector_.get()));
+    registerSystemConnector(velox::PrestoTypes::displayName);
 
     testConnector_->createView(
         SchemaTableName{kDefaultSchema, "nation_names"},
@@ -63,6 +56,28 @@ class InformationSchemaTest : public optimizer::test::QueryTestBase {
     systemConnector_.reset();
 
     optimizer::test::QueryTestBase::TearDown();
+  }
+
+  // Registers the system connector, replacing one already registered, with
+  // 'typeName' spelling the types information_schema.columns reports.
+  void registerSystemConnector(InformationSchema::TypeNameFormatter typeName) {
+    if (systemConnector_ != nullptr) {
+      ConnectorMetadataRegistry::global().erase(
+          std::string(kSystemConnectorId));
+      velox::connector::ConnectorRegistry::global().erase(
+          std::string(kSystemConnectorId));
+    }
+
+    systemConnector_ = std::make_shared<SystemConnector>(
+        std::string(kSystemConnectorId),
+        /*queryInfoProvider=*/nullptr,
+        /*sessionPropertiesProvider=*/nullptr,
+        std::move(typeName));
+    velox::connector::ConnectorRegistry::global().insert(
+        std::string(kSystemConnectorId), systemConnector_);
+    ConnectorMetadataRegistry::global().insert(
+        std::string(kSystemConnectorId),
+        std::make_shared<SystemConnectorMetadata>(systemConnector_.get()));
   }
 
   std::vector<RowVectorPtr> run(std::string_view sql) {
@@ -92,6 +107,45 @@ TEST_F(InformationSchemaTest, view) {
           makeFlatVector<std::string>({"SELECT n_name FROM nation"}),
           makeNullableFlatVector<std::string>({std::nullopt}),
       }),
+      results.at(0));
+}
+
+TEST_F(InformationSchemaTest, complexColumnTypes) {
+  testConnector_->addTable(
+      "u",
+      ROW(
+          {{"a", ARRAY(REAL())},
+           {"m", MAP(VARCHAR(), BIGINT())},
+           {"r", ROW({{"x", BIGINT()}, {"y", VARCHAR()}})}}));
+
+  auto results =
+      run("SELECT column_name, data_type "
+          "FROM information_schema.columns "
+          "WHERE table_schema = 'default' AND table_name = 'u' "
+          "ORDER BY ordinal_position");
+  velox::test::assertEqualVectors(
+      makeRowVector({
+          makeFlatVector<std::string>({"a", "m", "r"}),
+          makeFlatVector<std::string>(
+              {"array(real)",
+               "map(varchar, bigint)",
+               "row(\"x\" bigint, \"y\" varchar)"}),
+      }),
+      results.at(0));
+}
+
+TEST_F(InformationSchemaTest, customTypeName) {
+  // A dialect that writes types differently registers its own spelling.
+  registerSystemConnector(
+      [](const velox::Type& /*type*/) { return "list(float)"; });
+
+  testConnector_->addTable("v", ROW({{"a", ARRAY(REAL())}}));
+
+  auto results =
+      run("SELECT data_type FROM information_schema.columns "
+          "WHERE table_schema = 'default' AND table_name = 'v'");
+  velox::test::assertEqualVectors(
+      makeRowVector({makeFlatVector<std::string>({"list(float)"})}),
       results.at(0));
 }
 

--- a/axiom/connectors/system/tests/InformationSchemaTest.cpp
+++ b/axiom/connectors/system/tests/InformationSchemaTest.cpp
@@ -134,6 +134,29 @@ TEST_F(InformationSchemaTest, complexColumnTypes) {
       results.at(0));
 }
 
+TEST_F(InformationSchemaTest, columnComments) {
+  testConnector_->addTable(
+      "u",
+      ROW({"a", "b"}, BIGINT()),
+      /*hiddenColumns=*/ROW({}),
+      /*bucketSpec=*/std::nullopt,
+      {{"a", "the first column"}});
+
+  // A column the catalog describes reports its description; one it does not
+  // reports null, which a client tells apart from an empty description.
+  auto results =
+      run("SELECT column_name, comment FROM information_schema.columns "
+          "WHERE table_schema = 'default' AND table_name = 'u' "
+          "ORDER BY ordinal_position");
+  velox::test::assertEqualVectors(
+      makeRowVector({
+          makeFlatVector<std::string>({"a", "b"}),
+          makeNullableFlatVector<std::string>(
+              {"the first column", std::nullopt}),
+      }),
+      results.at(0));
+}
+
 TEST_F(InformationSchemaTest, customTypeName) {
   // A dialect that writes types differently registers its own spelling.
   registerSystemConnector(

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -96,17 +96,24 @@ folly::F14FastSet<std::string> extractExplainIoColumns(
 // includeInExplainIo.
 std::vector<std::unique_ptr<const Column>> makeColumnsWithExplainIo(
     const velox::RowTypePtr& schema,
-    const folly::F14FastSet<std::string>& explainIoColumns) {
+    const folly::F14FastSet<std::string>& explainIoColumns,
+    folly::F14FastMap<std::string, std::string> columnComments) {
   std::vector<std::unique_ptr<const Column>> columns;
   columns.reserve(schema->size());
   for (auto i = 0; i < schema->size(); ++i) {
+    auto it = columnComments.find(schema->nameOf(i));
     columns.push_back(
         std::make_unique<const Column>(
             schema->nameOf(i),
             schema->childAt(i),
             /*hidden=*/false,
             /*includeInExplainIo=*/
-            explainIoColumns.contains(schema->nameOf(i))));
+            explainIoColumns.contains(schema->nameOf(i)),
+            /*extraInfo=*/std::nullopt,
+            /*comment=*/
+            it == columnComments.end()
+                ? std::nullopt
+                : std::optional<std::string>(std::move(it->second))));
   }
   return columns;
 }
@@ -130,9 +137,11 @@ namespace {
 std::vector<std::unique_ptr<const Column>> makeTestTableColumns(
     const velox::RowTypePtr& schema,
     const velox::RowTypePtr& hiddenColumns,
-    const folly::F14FastMap<std::string, velox::Variant>& options) {
+    const folly::F14FastMap<std::string, velox::Variant>& options,
+    folly::F14FastMap<std::string, std::string> columnComments) {
   return appendHiddenColumns(
-      makeColumnsWithExplainIo(schema, extractExplainIoColumns(options)),
+      makeColumnsWithExplainIo(
+          schema, extractExplainIoColumns(options), std::move(columnComments)),
       hiddenColumns);
 }
 
@@ -150,10 +159,15 @@ TestTable::TestTable(
     const velox::RowTypePtr& hiddenColumns,
     TestConnector* connector,
     const folly::F14FastMap<std::string, velox::Variant>& options,
-    std::optional<TestBucketSpec> bucketSpec)
+    std::optional<TestBucketSpec> bucketSpec,
+    folly::F14FastMap<std::string, std::string> columnComments)
     : Table(
           std::move(name),
-          makeTestTableColumns(schema, hiddenColumns, options),
+          makeTestTableColumns(
+              schema,
+              hiddenColumns,
+              options,
+              std::move(columnComments)),
           options),
       connector_(connector),
       collectStatistics_(extractCollectStatistics(options)),
@@ -784,7 +798,8 @@ std::shared_ptr<TestTable> TestConnectorMetadata::addTable(
     SchemaTableName tableName,
     const velox::RowTypePtr& schema,
     const velox::RowTypePtr& hiddenColumns,
-    std::optional<TestBucketSpec> bucketSpec) {
+    std::optional<TestBucketSpec> bucketSpec,
+    folly::F14FastMap<std::string, std::string> columnComments) {
   schemas_.insert(tableName.schema);
   auto table = std::make_shared<TestTable>(
       tableName,
@@ -792,7 +807,8 @@ std::shared_ptr<TestTable> TestConnectorMetadata::addTable(
       hiddenColumns,
       connector_,
       folly::F14FastMap<std::string, velox::Variant>{},
-      std::move(bucketSpec));
+      std::move(bucketSpec),
+      std::move(columnComments));
   auto [it, ok] = tables_.emplace(std::move(tableName), std::move(table));
   VELOX_CHECK(ok, "Table already exists: {}", it->first.toString());
   return it->second;
@@ -1111,9 +1127,14 @@ std::shared_ptr<TestTable> TestConnector::addTable(
     SchemaTableName tableName,
     const velox::RowTypePtr& schema,
     const velox::RowTypePtr& hiddenColumns,
-    std::optional<TestBucketSpec> bucketSpec) {
+    std::optional<TestBucketSpec> bucketSpec,
+    folly::F14FastMap<std::string, std::string> columnComments) {
   return metadata_->addTable(
-      std::move(tableName), schema, hiddenColumns, std::move(bucketSpec));
+      std::move(tableName),
+      schema,
+      hiddenColumns,
+      std::move(bucketSpec),
+      std::move(columnComments));
 }
 
 bool TestConnector::dropTableIfExists(const SchemaTableName& name) {

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -180,7 +180,8 @@ class TestTable : public Table {
       const velox::RowTypePtr& hiddenColumns,
       TestConnector* connector,
       const folly::F14FastMap<std::string, velox::Variant>& options,
-      std::optional<TestBucketSpec> bucketSpec = std::nullopt);
+      std::optional<TestBucketSpec> bucketSpec = std::nullopt,
+      folly::F14FastMap<std::string, std::string> columnComments = {});
 
   const std::vector<const TableLayout*>& layouts() const override {
     return layouts_;
@@ -560,11 +561,14 @@ class TestConnectorMetadata : public ConnectorMetadata {
 
   /// Registers a TestTable in the connector metadata. Throws if the name is
   /// already taken. When 'bucketSpec' is set, appended rows are hash-bucketed.
+  /// @param columnComments Descriptions for the named columns, as a catalog
+  /// records them. A column the map does not name has none.
   std::shared_ptr<TestTable> addTable(
       SchemaTableName tableName,
       const velox::RowTypePtr& schema,
       const velox::RowTypePtr& hiddenColumns,
-      std::optional<TestBucketSpec> bucketSpec = std::nullopt);
+      std::optional<TestBucketSpec> bucketSpec = std::nullopt,
+      folly::F14FastMap<std::string, std::string> columnComments = {});
 
   /// Appends data to the table with the specified name.
   void appendData(
@@ -861,19 +865,22 @@ class TestConnector : public velox::connector::Connector {
       SchemaTableName tableName,
       const velox::RowTypePtr& schema,
       const velox::RowTypePtr& hiddenColumns = velox::ROW({}),
-      std::optional<TestBucketSpec> bucketSpec = std::nullopt);
+      std::optional<TestBucketSpec> bucketSpec = std::nullopt,
+      folly::F14FastMap<std::string, std::string> columnComments = {});
 
   /// Convenience overload that uses kDefaultSchema as the schema.
   std::shared_ptr<TestTable> addTable(
       const std::string& name,
       const velox::RowTypePtr& schema,
       const velox::RowTypePtr& hiddenColumns = velox::ROW({}),
-      std::optional<TestBucketSpec> bucketSpec = std::nullopt) {
+      std::optional<TestBucketSpec> bucketSpec = std::nullopt,
+      folly::F14FastMap<std::string, std::string> columnComments = {}) {
     return addTable(
         {std::string(kDefaultSchema), name},
         schema,
         hiddenColumns,
-        std::move(bucketSpec));
+        std::move(bucketSpec),
+        std::move(columnComments));
   }
 
   /// Appends data to the table with the specified name.

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -255,8 +255,8 @@ target_link_libraries(
   axiom_optimizer_tests_sql_test_base
   axiom_optimizer_tests_sql_file
   velox_connector_registry
-  velox_presto_types
   velox_dwio_common_test_utils
+  velox_presto_types
   GTest::gtest
 )
 

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -255,6 +255,7 @@ target_link_libraries(
   axiom_optimizer_tests_sql_test_base
   axiom_optimizer_tests_sql_file
   velox_connector_registry
+  velox_presto_types
   velox_dwio_common_test_utils
   GTest::gtest
 )

--- a/axiom/optimizer/tests/CsvReadWriteTest.cpp
+++ b/axiom/optimizer/tests/CsvReadWriteTest.cpp
@@ -70,8 +70,8 @@ TEST_P(CsvReadWriteTest, createTextTable) {
   EXPECT_EQ(
       showCreateTable("text_test"),
       "CREATE TABLE test-hive.\"default\".\"text_test\" (\n"
-      "   id INTEGER,\n"
-      "   name VARCHAR\n"
+      "   id integer,\n"
+      "   name varchar\n"
       ")\n"
       "WITH (\n"
       "   compression_kind = 'none',\n"
@@ -95,8 +95,8 @@ TEST_P(CsvReadWriteTest, createCsvTable) {
   EXPECT_EQ(
       showCreateTable("csv_test"),
       "CREATE TABLE test-hive.\"default\".\"csv_test\" (\n"
-      "   id INTEGER,\n"
-      "   name VARCHAR\n"
+      "   id integer,\n"
+      "   name varchar\n"
       ")\n"
       "WITH (\n"
       "   field.delim = ',',\n"

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -38,6 +38,7 @@
 #include "velox/dwio/dwrf/RegisterDwrfWriter.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
+#include "velox/functions/prestosql/types/PrestoTypes.h"
 #include "velox/serializers/PrestoSerializer.h"
 
 namespace facebook::axiom::optimizer::test {
@@ -240,12 +241,15 @@ class SqlTest : public SqlTestBase {
       metadata = suiteConnector_->metadata().get();
     }
 
-    // The system connector serves information_schema for every catalog.
+    // The system connector serves information_schema for every catalog. The
+    // tests are written in Presto SQL, so types are spelled the way the CLI
+    // and Axel spell them.
     suiteSystemConnector_ =
         std::make_shared<connector::system::SystemConnector>(
             std::string(kSystemConnectorId),
             /*queryInfoProvider=*/nullptr,
-            /*sessionPropertiesProvider=*/nullptr);
+            /*sessionPropertiesProvider=*/nullptr,
+            velox::PrestoTypes::displayName);
     velox::connector::ConnectorRegistry::global().insert(
         std::string(kSystemConnectorId), suiteSystemConnector_);
     connector::ConnectorMetadataRegistry::global().insert(

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2528,7 +2528,7 @@ SqlStatementPtr parseShowCreateTable(
       ddl << ",\n";
     }
     ddl << "   " << schema->nameOf(i) << " "
-        << PrestoTypes::toSql(schema->childAt(i));
+        << PrestoTypes::displayName(*schema->childAt(i));
   }
   ddl << "\n)";
 


### PR DESCRIPTION
Summary:

`information_schema.columns.comment` was NULL for every column: `connector::Column` had nowhere to keep a column's description.

`Column` now takes an optional `comment`, the Hive connector accepts one per column, and the `columns` data source returns it. A view's columns carry no description and report NULL.

Reviewed By: amitkdutta

Differential Revision: D119098570
