### PR TITLE
fix(optimizer): Simplify AND/OR with constant arguments (#1847)

### DIFF
--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -194,6 +194,84 @@ TEST_P(PlanTest, rejectedFilters) {
   }
 }
 
+TEST_P(PlanTest, booleanSimplification) {
+  if (!useV2_) {
+    GTEST_SKIP() << "Only supported by the V2 optimizer";
+  }
+
+  testConnector_->addTable("numbers", ROW({"a", "b", "c"}, BIGINT()));
+
+  struct TestCase {
+    std::string expression;
+    // Expected filter. std::nullopt means the filter is statically true and is
+    // removed; kFalse and kNull mean it admits no rows.
+    std::optional<std::string> expectedFilter;
+    // Expected projection of the same expression.
+    std::string expectedProjection;
+  };
+
+  const std::string kFalse{"false"};
+  const std::string kNull{"null"};
+
+  // Templated dashboards generate predicates whose branches are selected by
+  // comparing literals, leaving branches that reference columns the query
+  // never needs.
+  std::vector<TestCase> testCases = {
+      {"a > 1 and true", "a > 1", "a > 1"},
+      {"a > 1 or false", "a > 1", "a > 1"},
+      {"a > 1 and false", kFalse, "false"},
+      {"a > 1 or true", std::nullopt, "true"},
+      {"(a > 1 and true) and (b > 2 and true)",
+       "a > 1 and b > 2",
+       "a > 1 and b > 2"},
+      {"('x' in ('x') and a > 1) or ('y' in ('x') and b > 2)",
+       "a > 1",
+       "a > 1"},
+      // A null argument is not dropped. A filter passes only on TRUE, so it
+      // then admits no rows, while a projection keeps the expression.
+      {"a > 1 and cast(null as boolean)", kNull, "a > 1 and null"},
+  };
+
+  for (const auto& [expr, expectedFilter, expectedProjection] : testCases) {
+    {
+      SCOPED_TRACE("Filter: " + expr);
+      auto logicalPlan = lp::PlanBuilder(makeContext())
+                             .tableScan("numbers")
+                             .filter(expr)
+                             .map({"a + 2"})
+                             .build();
+
+      std::shared_ptr<velox::core::PlanMatcher> matcher;
+      if (!expectedFilter.has_value()) {
+        matcher = matchScan("numbers").project().build();
+      } else if (
+          expectedFilter.value() == kFalse || expectedFilter.value() == kNull) {
+        // A filter that folds to a constant admitting no rows leaves nothing
+        // to read, so the scan is replaced with an empty Values.
+        matcher = matchValues().project().build();
+      } else {
+        matcher = matchScan("numbers")
+                      .filter(expectedFilter.value())
+                      .project()
+                      .build();
+      }
+
+      AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+    }
+
+    {
+      SCOPED_TRACE("Project: " + expr);
+      auto logicalPlan = lp::PlanBuilder(makeContext())
+                             .tableScan("numbers")
+                             .map({expr})
+                             .build();
+
+      auto matcher = matchScan("numbers").project({expectedProjection}).build();
+      AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
+    }
+  }
+}
+
 TEST_P(PlanTest, specialFormConstantFold) {
   testConnector_->addTable("numbers", ROW({"a", "b", "c"}, BIGINT()));
 

--- a/axiom/optimizer/v2/ExprSimplifier.cpp
+++ b/axiom/optimizer/v2/ExprSimplifier.cpp
@@ -116,10 +116,63 @@ bool tryFactorOr(
   return true;
 }
 
+// Returns the value of `expr` if it is a non-null boolean literal.
+std::optional<bool> constantBoolean(ExprCP expr) {
+  if (!expr->is(PlanType::kLiteralExpr)) {
+    return std::nullopt;
+  }
+  const auto& variant = expr->as<Literal>()->literal();
+  if (variant.isNull() || variant.kind() != velox::TypeKind::BOOLEAN) {
+    return std::nullopt;
+  }
+  return variant.value<bool>();
+}
+
 } // namespace
 
 ExprCP ExprSimplifier::simplify(ExprCP expr) {
-  return tryFoldConstant(expr);
+  return tryFoldConjunct(tryFoldConstant(expr));
+}
+
+ExprCP ExprSimplifier::tryFoldConjunct(ExprCP expr) {
+  if (!expr->is(PlanType::kCallExpr)) {
+    return expr;
+  }
+  const auto* call = expr->as<Call>();
+  const bool isAnd = call->name() == SpecialFormCallNames::kAnd;
+  if (!isAnd && call->name() != SpecialFormCallNames::kOr) {
+    return expr;
+  }
+
+  ExprVector remaining;
+  remaining.reserve(call->args().size());
+  for (ExprCP arg : call->args()) {
+    const auto value = constantBoolean(arg);
+    if (!value.has_value()) {
+      remaining.push_back(arg);
+    } else if (value.value() != isAnd) {
+      // AND is false as soon as one argument is false, even if the others are
+      // null or throw; OR is the mirror image.
+      return arg;
+    }
+  }
+
+  if (remaining.size() == call->args().size()) {
+    return expr;
+  }
+  if (remaining.empty()) {
+    return builder_.makeLiteral(
+        velox::Variant(isAnd), toType(velox::BOOLEAN()));
+  }
+  if (remaining.size() == 1) {
+    return remaining.front();
+  }
+  const FunctionSet functions = Call::unionArgFunctions(
+      functionBits(call->name(), /*specialForm=*/true), remaining);
+  // A literal argument is never the one that determined the call's
+  // cardinality, so dropping it leaves `value()` valid.
+  return builder_.makeCall(
+      call->name(), call->value(), std::move(remaining), functions);
 }
 
 bool ExprSimplifier::simplifyFilter(ExprCP predicate, ExprVector& into) {

--- a/axiom/optimizer/v2/ExprSimplifier.h
+++ b/axiom/optimizer/v2/ExprSimplifier.h
@@ -61,6 +61,12 @@ class ExprSimplifier {
   bool simplifyFilter(ExprCP predicate, ExprVector& into);
 
  private:
+  // Simplifies an AND or OR call with boolean literal arguments. Returns
+  // `expr` unchanged for any other call. Looks only at the call's own
+  // arguments: callers translate bottom-up, so nested calls are already
+  // simplified.
+  ExprCP tryFoldConjunct(ExprCP expr);
+
   // Folds `expr` to a `Literal` when it has no column refs and the
   // evaluator produces a single constant value. Otherwise returns
   // `expr` unchanged.


### PR DESCRIPTION
Summary:

A templated query picks its filter branches by comparing literals:

    WHERE ('x' IN ('x') AND a > 1)
       OR ('y' IN ('x') AND b > 2)

Both `IN` leaves fold to constants, but the branches around them survive into the plan. The scan keeps a remaining filter of `or(and(true, ...), and(false, ...))` and lists `b` as a filter column, although no surviving branch reads it. Such a column also reaches the DWRF reader, which faults on it; that fault is a separate defect, and this change removes the plan that triggers it.

`ExprSimplifier::tryFoldConstant` gives up on any expression that references a column, which is every expression a dead branch hides in. `simplify` now applies the boolean identities as well: a `false` argument determines an `AND`, a `true` argument determines an `OR`, and a constant of the opposite value drops out. A null argument stays, since `AND(null, x)` is not `null`. The filter above collapses to `a > 1`, which pushes down as a range filter, so the scan carries neither a remaining filter nor `b`.

The rule inspects only a call's own arguments. Expressions translate bottom-up, so nested calls are already simplified by the time their parent is; a constant exposed later by substitution during pushdown is simplified only when it lands at the top of a conjunct.

Reviewed By: amitkdutta

Differential Revision: D119239592


