### PR TITLE
fix(optimizer): Drop pre-grouped keys after multi-driver MarkDistinct

### DIFF
--- a/axiom/optimizer/tests/DistinctAggregationTest.cpp
+++ b/axiom/optimizer/tests/DistinctAggregationTest.cpp
@@ -463,6 +463,39 @@ TEST_P(DistinctAggregationTest, markDistinctMixedDistinctAndNonDistinct) {
           .build());
 }
 
+TEST_P(DistinctAggregationTest, markDistinctPreGroupedInput) {
+  testConnector_->addTable("t", ROW({"a", "b", "c"}, BIGINT()));
+  SCOPE_EXIT {
+    testConnector_->dropTableIfExists("t");
+  };
+
+  auto logicalPlan = parseSelect(
+      "SELECT q.a, count(DISTINCT q.d), sum(q.z) "
+      "FROM (SELECT a, max(b) AS d, sum(c) AS z FROM t GROUP BY a) q "
+      "GROUP BY q.a",
+      kTestConnectorId);
+
+  AXIOM_ASSERT_PLAN_V2(
+      toSingleNodePlan(logicalPlan, /*numDrivers=*/1),
+      matchScan("t")
+          .singleAggregation({"a"}, {"max(b)", "sum(c)"})
+          .markDistinct({"a", "d"}, {"m0"})
+          .streamingAggregation({"a"}, {"count(d) filter (where m0)", "sum(z)"})
+          .build());
+
+  AXIOM_ASSERT_PLAN_V2(
+      toSingleNodePlan(logicalPlan, /*numDrivers=*/4),
+      matchScan("t")
+          .partialAggregation({"a"}, {"max(b)", "sum(c)"})
+          .localPartition({"a"})
+          .finalAggregation()
+          .localPartition({"a", "d"})
+          .markDistinct({"a", "d"}, {"m0"})
+          .localPartition({"a"})
+          .singleAggregation({"a"}, {"count(d) filter (where m0)", "sum(z)"})
+          .build());
+}
+
 // V1 is better: it plans MarkDistinct distribution before selecting the outer
 // Aggregate stages, enabling distributed deduplication and partial aggregation.
 // TODO: Make V2 lower DISTINCT-to-MarkDistinct inside physical aggregation

--- a/axiom/optimizer/tests/sql/distinctAggregation.sql
+++ b/axiom/optimizer/tests/sql/distinctAggregation.sql
@@ -60,6 +60,12 @@ SELECT a, covar_pop(DISTINCT c, CAST(b AS DOUBLE)), covar_samp(DISTINCT CAST(b A
 -- DISTINCT: mix of DISTINCT and non-DISTINCT aggregates.
 SELECT a, count(DISTINCT c), sum(CAST(b AS DOUBLE)) FROM t GROUP BY a
 ----
+-- DISTINCT: mixed aggregates after a join expands pre-grouped input.
+SELECT q.a, count(DISTINCT u.b), sum(u.c)
+FROM (SELECT a FROM t GROUP BY a) q
+LEFT JOIN t u ON q.a >= u.a
+GROUP BY q.a
+----
 -- DISTINCT: global aggregation with multiple DISTINCT sets.
 SELECT count(DISTINCT c), sum(DISTINCT CAST(b AS DOUBLE)) FROM t
 ----

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -412,6 +412,11 @@ class Emitter {
   velox::core::PlanNodePtr emitSingleAggregation(const Aggregate& aggregate);
   velox::core::PlanNodePtr emitPartialAggregation(const Aggregate& aggregate);
   velox::core::PlanNodePtr emitFinalAggregation(const Aggregate& aggregate);
+  // Returns local grouping keys that remain valid after emission-time
+  // operators absent from the V2 IR have been inserted.
+  ExprVector preGroupedKeysForEmission(
+      NodeCP input,
+      const ExprVector& groupingKeys) const;
   // Builds an AggregationNode, carrying the grouping-set default-row info
   // (`globalGroupingSets`/`groupId`) from `aggregate` when present.
   velox::core::PlanNodePtr makeAggregationNode(
@@ -948,6 +953,17 @@ buildAggregates(
 
 } // namespace
 
+ExprVector Emitter::preGroupedKeysForEmission(
+    NodeCP input,
+    const ExprVector& groupingKeys) const {
+  // Multi-driver MarkDistinct emission inserts an unmodeled local repartition
+  // on its distinct keys, invalidating inherited grouping and order.
+  if (options_.numDrivers > 1 && input->is(NodeType::kMarkDistinct)) {
+    return {};
+  }
+  return computePreGroupedKeys(input->physicalProperties().local, groupingKeys);
+}
+
 velox::core::PlanNodePtr Emitter::emitAggregation(const Aggregate& aggregate) {
   switch (aggregate.step()) {
     case AggregateStep::kPartial:
@@ -1011,9 +1027,7 @@ velox::core::PlanNodePtr Emitter::emitSingleAggregation(
   // An aggregation over input already grouped on (a prefix of) the keys streams
   // instead of building a full hash table.
   auto preGroupedKeys = toFieldAccessList(
-      computePreGroupedKeys(
-          aggregate.input()->physicalProperties().local,
-          aggregate.groupingKeys()),
+      preGroupedKeysForEmission(aggregate.input(), aggregate.groupingKeys()),
       "Pre-grouped key");
 
   // At numDrivers > 1 a group's rows must all reach one driver. Skip the local
@@ -1642,8 +1656,7 @@ velox::core::PlanNodePtr Emitter::emitEnforceDistinct(
   // Stream (no hash table) over input already grouped on a prefix of the
   // distinct keys, mirroring how the aggregation derives its pre-grouped keys.
   auto preGroupedKeys = toFieldAccessList(
-      computePreGroupedKeys(
-          node.input()->physicalProperties().local, node.distinctKeys()),
+      preGroupedKeysForEmission(node.input(), node.distinctKeys()),
       "EnforceDistinct pre-grouped key");
   // At numDrivers > 1 each distinct-key group must be complete in one driver.
   // Skip when the input is pre-grouped on the keys: a local grouping guarantees


### PR DESCRIPTION
Summary:
With multiple drivers, the following query could return separate partial results for the same `a` group:

    SELECT q.a, count(DISTINCT q.d), sum(q.z)
    FROM (SELECT a, max(b) AS d, sum(c) AS z FROM t GROUP BY a) q
    GROUP BY q.a

This is because although `MarkDistinct` repartitioned the input by `(a, d)`, which could split one `a` group across drivers, the following aggregation still incorrectly inherited the earlier pre-grouped state and therefore skipped repartitioning by `a`.

This PR fixes this bug by dropping the inherited pre-grouped keys when multi-driver emission inserts the local repartition. The following aggregation then local-repartitions by its grouping keys. Single-driver plans is unaffected. It retain the pre-grouped keys and remain using streaming aggregation.

Differential Revision: D118759973


