### PR TITLE
fix(parser): Canonicalize function names when resolving

### DIFF
--- a/axiom/logical_plan/NameMappings.cpp
+++ b/axiom/logical_plan/NameMappings.cpp
@@ -104,6 +104,14 @@ std::vector<NameMappings::QualifiedName> NameMappings::reverseLookup(
   return names;
 }
 
+void NameMappings::clearAliases() {
+  folly::erase_if(mappings_, [](const auto& entry) {
+    return entry.first.alias.has_value();
+  });
+
+  rebuildReverseIndex();
+}
+
 void NameMappings::setAlias(const std::string& alias) {
   std::vector<std::pair<std::string, std::string>> names;
   for (auto it = mappings_.begin(); it != mappings_.end();) {
@@ -121,8 +129,10 @@ void NameMappings::setAlias(const std::string& alias) {
     mappings_.emplace(std::move(qualified), std::move(id));
   }
 
-  // Rebuild from mappings_ so both surviving unqualified entries and the
-  // newly-added qualified entries appear in reverseIndex_.
+  rebuildReverseIndex();
+}
+
+void NameMappings::rebuildReverseIndex() {
   reverseIndex_.clear();
   for (const auto& [name, id] : mappings_) {
     reverseIndex_[id].push_back(name);

--- a/axiom/logical_plan/NameMappings.h
+++ b/axiom/logical_plan/NameMappings.h
@@ -70,6 +70,12 @@ class NameMappings {
   /// Used in PlanBuilder::as() API.
   void setAlias(const std::string& alias);
 
+  /// Drops all qualified names, leaving only unqualified access. Columns that
+  /// were reachable only through an alias are no longer accessible by name.
+  ///
+  /// Used in PlanBuilder::clearAliases() API.
+  void clearAliases();
+
   /// Merges mappings and user names from 'other' into this. Removes
   /// unqualified access to non-unique names.
   ///
@@ -117,6 +123,9 @@ class NameMappings {
   struct QualifiedNameHasher {
     size_t operator()(const QualifiedName& value) const;
   };
+
+  // Re-derives reverseIndex_ from mappings_.
+  void rebuildReverseIndex();
 
   // Mapping from names to IDs. Unique names may appear twice: w/ and w/o an
   // alias.

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -2015,6 +2015,11 @@ PlanBuilder& PlanBuilder::as(const std::string& alias) {
   return *this;
 }
 
+PlanBuilder& PlanBuilder::clearAliases() {
+  outputMapping_->clearAliases();
+  return *this;
+}
+
 std::string PlanBuilder::newName(const std::string& hint) {
   return nameAllocator_->newName(hint);
 }

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -694,6 +694,13 @@ class PlanBuilder {
   /// "alias.column" in subsequent operations.
   PlanBuilder& as(const std::string& alias);
 
+  /// Drops the relation aliases of this builder's own columns, so
+  /// "alias.column" no longer resolves against them. An enclosing query's
+  /// aliases still resolve through the outer scope. A column that was
+  /// reachable only through an alias, because its unqualified name was
+  /// ambiguous, becomes unreferenceable.
+  PlanBuilder& clearAliases();
+
   /// Captures the current name-resolution scope into 'scope' so it can be
   /// passed to an inner PlanBuilder for correlated subqueries.
   ///

--- a/axiom/sql/presto/ColumnsExpansion.cpp
+++ b/axiom/sql/presto/ColumnsExpansion.cpp
@@ -49,6 +49,9 @@ core::ExprPtr replaceInputs(
   return changed ? expr->replaceInputs(std::move(newInputs)) : expr;
 }
 
+// Resolved expressions carry canonical, lower-case function names.
+constexpr std::string_view kColumnsFunctionName = "columns";
+
 // Searches an expression tree for COLUMNS('regex') pseudo-function calls.
 // Appends each found call (node pointer + regex pattern) to 'results'.
 void findColumnsCalls(
@@ -56,7 +59,7 @@ void findColumnsCalls(
     std::vector<std::pair<const core::IExpr*, std::string>>& results) {
   if (expr->is(core::IExpr::Kind::kCall)) {
     auto* callExpr = expr->as<core::CallExpr>();
-    if (callExpr->name() == "COLUMNS") {
+    if (callExpr->name() == kColumnsFunctionName) {
       // The grammar guarantees COLUMNS takes a single string literal argument.
       VELOX_CHECK_EQ(callExpr->inputs().size(), 1);
 

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -1585,12 +1585,13 @@ lp::ExprApi ExpressionPlanner::toExpr(
       }
 
       // A qualified (multi-part) name denotes a connector-defined SQL-invoked
-      // function. Encode it with a leading '.' so downstream resolution can
-      // distinguish it from a builtin; a plain builtin keeps its bare name.
+      // function; encode it with a leading '.' so downstream resolution can
+      // distinguish it from a builtin, which keeps its bare name. Both are
+      // lower-cased because function names are case-insensitive.
       auto callExpr = lp::Call(
           call->name()->parts().size() > 1
-              ? "." + call->name()->fullyQualifiedName()
-              : funcName,
+              ? canonicalizeName("." + call->name()->fullyQualifiedName())
+              : lowerFuncName,
           args);
 
       if (call->window() != nullptr) {

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -528,7 +528,7 @@ class RelationPlanner : public AstVisitor {
   // left side through the builder's outer scope.
   void processLateral(const Lateral& lateral) {
     processQuery(lateral.query()->as<Query>());
-    displayNames_.accumulate(*builder_, /*relationAlias=*/std::nullopt);
+    finishDerivedRelation();
   }
 
   void processQueryBody(const QueryBodyPtr& queryBody) {
@@ -865,12 +865,21 @@ class RelationPlanner : public AstVisitor {
     builder_->as(alias);
   }
 
+  // A query used as a relation exposes only its column names. The relation
+  // aliases used inside it stay inside, so the enclosing query may reuse one.
+  void finishDerivedRelation() {
+    // Output naming reads the names the inner query produced, so it runs
+    // before those names are narrowed to the enclosing query's scope.
+    displayNames_.accumulate(*builder_, /*relationAlias=*/std::nullopt);
+    builder_->clearAliases();
+  }
+
   void processTableSubquery(const TableSubquery& subquery) {
     auto query = subquery.query();
 
     if (query->is(NodeType::kQuery)) {
       processQuery(query->as<Query>());
-      displayNames_.accumulate(*builder_, /*relationAlias=*/std::nullopt);
+      finishDerivedRelation();
       return;
     }
 

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -934,6 +934,13 @@ TEST_F(AggregationParserTest, groupingKeyExpr) {
         "SELECT substr(n_name, 1, 2), count(1) FROM nation GROUP BY 1",
         matcher);
 
+    // A SELECT expression matches a grouping key that spells the function
+    // differently; function names are case-insensitive.
+    testSelect(
+        "SELECT SUBSTR(n_name, 1, 2), count(1) "
+        "FROM nation GROUP BY substr(n_name, 1, 2)",
+        matcher);
+
     testSelect(
         "SELECT r_regionkey IN (SELECT n_regionkey FROM nation), count(1) "
         "FROM region GROUP BY 1",

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1544,6 +1544,43 @@ TEST_F(PrestoParserTest, duplicateAliases) {
       "Cannot resolve column: u");
 }
 
+// A derived table exposes only column names. The relation aliases used inside
+// it are not visible outside, so the enclosing query may reuse one.
+TEST_F(PrestoParserTest, derivedTableHidesInnerAlias) {
+  auto matcher =
+      matchValues().project().project().unnest().project().output({"a", "b"});
+  testSelect(
+      "SELECT a, t.b "
+      "FROM (SELECT a, b FROM (VALUES (1, ARRAY[10, 20])) AS t(a, b)) "
+      "CROSS JOIN UNNEST(b) AS t(b)",
+      matcher);
+
+  VELOX_ASSERT_THROW(
+      parseSql("SELECT t.a FROM (SELECT a FROM (VALUES 1) AS t(a))"),
+      "Cannot resolve column: t");
+
+  // A column whose unqualified name is ambiguous is reachable only through an
+  // alias inside the derived table, and so not reachable at all outside it.
+  testSelect(
+      "SELECT * FROM "
+      "(SELECT * FROM (VALUES 1) AS t1(a), (VALUES 2) AS t2(a))",
+      matchValues()
+          .project()
+          .join(matchValues().project().build())
+          .output({"a", "a"}));
+
+  VELOX_ASSERT_THROW(
+      parseSql(
+          "SELECT a FROM (SELECT * FROM (VALUES 1) AS t1(a), (VALUES 2) AS t2(a))"),
+      "Cannot resolve column: a");
+
+  VELOX_ASSERT_THROW(
+      parseSql(
+          "SELECT t.a FROM (VALUES 1) AS x(z), "
+          "LATERAL (SELECT a FROM (VALUES 2) AS t(a))"),
+      "Cannot resolve column: t");
+}
+
 // An UNNEST is applied to every row of the other side, which only a CROSS or
 // comma join expresses. Any other join type is rejected whatever its ON clause
 // says, matching Presto.

--- a/axiom/sql/presto/tests/SqlFunctionTest.cpp
+++ b/axiom/sql/presto/tests/SqlFunctionTest.cpp
@@ -68,6 +68,13 @@ TEST_F(SqlFunctionTest, inlines) {
       "SELECT tc.default.identity(n_nationkey + 123) FROM nation",
       matchScan("nation").project({"n_nationkey + 123::bigint"}).output());
 
+  // Capitalization does not change the resolved expression, so a SELECT
+  // expression still matches a grouping key that spells the name differently.
+  testSelect(
+      "SELECT TC.Default.Identity(n_nationkey), count(1) FROM nation "
+      "GROUP BY tc.default.identity(n_nationkey)",
+      matchScan("nation").aggregate().output());
+
   // f(a, b) := a + b
   metadata_->addFunction(
       {"default", "combine"},


### PR DESCRIPTION
Summary:
A query whose GROUP BY spelled a function differently from the SELECT list failed to plan. For example:

    SELECT abs(x) FROM (VALUES (1)) AS t(x) GROUP BY ABS(x)

failed with:

    Cannot resolve column: x not in [expr -> expr]

Matching a SELECT expression against a GROUP BY key compares resolved expressions. `ABS(x)` and `abs(x)` resolved to different expressions, so the SELECT expression missed the grouping key and was resolved against the post-aggregation scope, where `x` no longer exists.

A resolved call now carries the canonical, lower-case function name, for both builtins and qualified connector functions. Two pseudo-functions are recognized by that name: `COLUMNS` was matched by its upper-case spelling and now matches the canonical form, and `GROUPING` already used it. Each was previously recognized in only one capitalization and now works in both.

Differential Revision: D119261649
