### PR TITLE
fix(parser): Keep qualified names for repeated column names

### DIFF
--- a/axiom/logical_plan/NameMappings.cpp
+++ b/axiom/logical_plan/NameMappings.cpp
@@ -27,17 +27,44 @@ std::string NameMappings::QualifiedName::toString() const {
   return name;
 }
 
-void NameMappings::add(const QualifiedName& name, const std::string& id) {
-  bool ok = mappings_.emplace(name, id).second;
-  VELOX_CHECK(ok, "Duplicate name: {}", name.toString());
+bool NameMappings::insert(const QualifiedName& name, const std::string& id) {
+  if (ambiguousNames_.contains(name)) {
+    return false;
+  }
+  if (!mappings_.emplace(name, id).second) {
+    return false;
+  }
   reverseIndex_[id].push_back(name);
+  return true;
+}
+
+void NameMappings::add(const QualifiedName& name, const std::string& id) {
+  VELOX_CHECK(!mappings_.contains(name), "Duplicate name: {}", name.toString());
+  insert(name, id);
 }
 
 void NameMappings::add(const std::string& name, const std::string& id) {
-  QualifiedName qualified{.alias = {}, .name = name};
-  bool ok = mappings_.emplace(qualified, id).second;
-  VELOX_CHECK(ok, "Duplicate name: {}", name);
-  reverseIndex_[id].push_back(std::move(qualified));
+  add(QualifiedName{.alias = {}, .name = name}, id);
+}
+
+void NameMappings::markAmbiguous(const QualifiedName& name) {
+  ambiguousNames_.insert(name);
+
+  auto it = mappings_.find(name);
+  if (it == mappings_.end()) {
+    return;
+  }
+
+  if (auto entry = reverseIndex_.find(it->second);
+      entry != reverseIndex_.end()) {
+    auto& names = entry->second;
+    std::erase(names, name);
+    if (names.empty()) {
+      reverseIndex_.erase(entry);
+    }
+  }
+
+  mappings_.erase(it);
 }
 
 void NameMappings::markHidden(const std::string& id) {
@@ -125,8 +152,7 @@ void NameMappings::setAlias(const std::string& alias) {
 
   // Every surviving entry gets the new alias.
   for (auto& [name, id] : names) {
-    QualifiedName qualified{.alias = alias, .name = std::move(name)};
-    mappings_.emplace(std::move(qualified), std::move(id));
+    insert(QualifiedName{.alias = alias, .name = std::move(name)}, id);
   }
 
   rebuildReverseIndex();
@@ -156,16 +182,7 @@ void NameMappings::merge(const NameMappings& other) {
       // both sides reuse a relation alias. Referencing a dropped name later
       // fails as unresolved, matching Presto's report-at-reference-time
       // behavior.
-      const auto& existingId = existing->second;
-      if (auto entry = reverseIndex_.find(existingId);
-          entry != reverseIndex_.end()) {
-        auto& names = entry->second;
-        std::erase(names, name);
-        if (names.empty()) {
-          reverseIndex_.erase(entry);
-        }
-      }
-      mappings_.erase(existing);
+      markAmbiguous(name);
     } else if (
         !name.alias.has_value() && leftQualifiedNames.contains(name.name)) {
       // Don't add an unqualified name from the right side if the left side
@@ -173,8 +190,7 @@ void NameMappings::merge(const NameMappings& other) {
       // across joined tables even though the left's unqualified entry was
       // removed by an earlier merge.
     } else {
-      mappings_.emplace(name, id);
-      reverseIndex_[id].push_back(name);
+      insert(name, id);
     }
   }
 

--- a/axiom/logical_plan/NameMappings.cpp
+++ b/axiom/logical_plan/NameMappings.cpp
@@ -104,6 +104,14 @@ std::vector<NameMappings::QualifiedName> NameMappings::reverseLookup(
   return names;
 }
 
+void NameMappings::clearAliases() {
+  folly::erase_if(mappings_, [](const auto& entry) {
+    return entry.first.alias.has_value();
+  });
+
+  rebuildReverseIndex();
+}
+
 void NameMappings::setAlias(const std::string& alias) {
   std::vector<std::pair<std::string, std::string>> names;
   for (auto it = mappings_.begin(); it != mappings_.end();) {
@@ -121,8 +129,10 @@ void NameMappings::setAlias(const std::string& alias) {
     mappings_.emplace(std::move(qualified), std::move(id));
   }
 
-  // Rebuild from mappings_ so both surviving unqualified entries and the
-  // newly-added qualified entries appear in reverseIndex_.
+  rebuildReverseIndex();
+}
+
+void NameMappings::rebuildReverseIndex() {
   reverseIndex_.clear();
   for (const auto& [name, id] : mappings_) {
     reverseIndex_[id].push_back(name);

--- a/axiom/logical_plan/NameMappings.h
+++ b/axiom/logical_plan/NameMappings.h
@@ -39,10 +39,17 @@ class NameMappings {
   };
 
   /// Adds a mapping from 'name' to 'id'. Throws if 'name' already exists.
+  /// Does nothing if 'name' was marked ambiguous, so a caller may not assume
+  /// that 'name' resolves once this returns.
   void add(const QualifiedName& name, const std::string& id);
 
-  /// Adds a mapping from 'name' to 'id'. Throws if 'name' already exists.
+  /// @overload
   void add(const std::string& name, const std::string& id);
+
+  /// Drops the mapping for 'name' and marks it ambiguous: it names more than
+  /// one column, so it names none. The columns stay in the output, reachable
+  /// by their other names. The mark lasts until 'reset'.
+  void markAmbiguous(const QualifiedName& name);
 
   /// Marks the specified 'id' as hidden. The 'id' must have been added earlier
   /// via 'add' API.
@@ -117,6 +124,7 @@ class NameMappings {
     mappings_.clear();
     reverseIndex_.clear();
     userNames_.clear();
+    ambiguousNames_.clear();
   }
 
  private:
@@ -127,6 +135,11 @@ class NameMappings {
   // Re-derives reverseIndex_ from mappings_.
   void rebuildReverseIndex();
 
+  // Adds a mapping unless 'name' is marked ambiguous. Every insertion into
+  // mappings_ goes through here, so a marked name cannot be reinstated.
+  // Returns true if the mapping was added.
+  bool insert(const QualifiedName& name, const std::string& id);
+
   // Mapping from names to IDs. Unique names may appear twice: w/ and w/o an
   // alias.
   folly::F14FastMap<QualifiedName, std::string, QualifiedNameHasher> mappings_;
@@ -134,6 +147,9 @@ class NameMappings {
   // Inverse of mappings_: each ID maps to the QualifiedName(s) that resolve
   // to it (at most 2: with and without alias). Kept in sync with mappings_.
   folly::F14FastMap<std::string, std::vector<QualifiedName>> reverseIndex_;
+
+  // Names that resolved to more than one column.
+  folly::F14FastSet<QualifiedName, QualifiedNameHasher> ambiguousNames_;
 
   // IDs of hidden columns.
   folly::F14FastSet<std::string> hiddenIds_;

--- a/axiom/logical_plan/NameMappings.h
+++ b/axiom/logical_plan/NameMappings.h
@@ -70,6 +70,12 @@ class NameMappings {
   /// Used in PlanBuilder::as() API.
   void setAlias(const std::string& alias);
 
+  /// Drops all qualified names, leaving only unqualified access. Columns that
+  /// were reachable only through an alias are no longer accessible by name.
+  ///
+  /// Used in PlanBuilder::clearAliases() API.
+  void clearAliases();
+
   /// Merges mappings and user names from 'other' into this. Removes
   /// unqualified access to non-unique names.
   ///
@@ -117,6 +123,9 @@ class NameMappings {
   struct QualifiedNameHasher {
     size_t operator()(const QualifiedName& value) const;
   };
+
+  // Re-derives reverseIndex_ from mappings_.
+  void rebuildReverseIndex();
 
   // Mapping from names to IDs. Unique names may appear twice: w/ and w/o an
   // alias.

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -2015,6 +2015,11 @@ PlanBuilder& PlanBuilder::as(const std::string& alias) {
   return *this;
 }
 
+PlanBuilder& PlanBuilder::clearAliases() {
+  outputMapping_->clearAliases();
+  return *this;
+}
+
 std::string PlanBuilder::newName(const std::string& hint) {
   return nameAllocator_->newName(hint);
 }

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -533,10 +533,14 @@ class NameTracker {
   // Adds a mapping from qualified 'name' (with optional alias) to 'id'. Skips
   // duplicates if allowDuplicates is set.
   void add(const NameMappings::QualifiedName& name, const std::string& id) {
-    if (isDuplicate(name.name)) {
+    if (!name.alias.has_value()) {
+      if (isDuplicate(name.name)) {
+        return;
+      }
+      mappings_.add(name, id);
       return;
     }
-    mappings_.add(name, id);
+    addQualified(name, id);
   }
 
   // Adds mappings from both unqualified 'name' and qualified 'alias.name' to
@@ -546,6 +550,10 @@ class NameTracker {
       const std::string& id,
       const std::optional<std::string>& alias) {
     if (isDuplicate(name)) {
+      if (alias.has_value()) {
+        addQualified(
+            NameMappings::QualifiedName{.alias = alias, .name = name}, id);
+      }
       return;
     }
     addWithAlias(name, id, alias);
@@ -572,6 +580,25 @@ class NameTracker {
     return allowDuplicates_ && duplicates_.contains(name);
   }
 
+  // Adds a qualified 'name', which must carry an alias. A base name repeated
+  // under different aliases stays resolvable through each alias; one alias.name
+  // bound to two columns resolves to neither. Re-adding the column already
+  // named is a no-op.
+  void addQualified(
+      const NameMappings::QualifiedName& name,
+      const std::string& id) {
+    VELOX_CHECK(name.alias.has_value());
+    const std::optional<std::string> existing =
+        mappings_.lookup(name.alias.value(), name.name);
+    if (existing.has_value()) {
+      if (existing.value() != id) {
+        mappings_.markAmbiguous(name);
+      }
+      return;
+    }
+    mappings_.add(name, id);
+  }
+
   // Adds mappings from both unqualified 'name' and qualified 'alias.name' to
   // 'id'. Does not check for duplicates.
   void addWithAlias(
@@ -580,7 +607,7 @@ class NameTracker {
       const std::optional<std::string>& alias) {
     mappings_.add(name, id);
     if (alias.has_value()) {
-      mappings_.add(
+      addQualified(
           NameMappings::QualifiedName{.alias = alias, .name = name}, id);
     }
   }

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -694,6 +694,13 @@ class PlanBuilder {
   /// "alias.column" in subsequent operations.
   PlanBuilder& as(const std::string& alias);
 
+  /// Drops the relation aliases of this builder's own columns, so
+  /// "alias.column" no longer resolves against them. An enclosing query's
+  /// aliases still resolve through the outer scope. A column that was
+  /// reachable only through an alias, because its unqualified name was
+  /// ambiguous, becomes unreferenceable.
+  PlanBuilder& clearAliases();
+
   /// Captures the current name-resolution scope into 'scope' so it can be
   /// passed to an inner PlanBuilder for correlated subqueries.
   ///

--- a/axiom/logical_plan/tests/NameMappingsTest.cpp
+++ b/axiom/logical_plan/tests/NameMappingsTest.cpp
@@ -202,4 +202,31 @@ TEST(NameMappingsTest, chainedMerge) {
   EXPECT_EQ(a.lookup("c", "x"), "x_c");
 }
 
+TEST(NameMappingsTest, markAmbiguous) {
+  NameMappings mappings;
+  mappings.add("x", "x_1");
+  mappings.markAmbiguous({.alias = std::nullopt, .name = "x"});
+
+  EXPECT_EQ(mappings.lookup("x"), std::nullopt);
+
+  // A name that resolved to more than one column resolves to none, whatever
+  // order the columns claiming it are added in.
+  mappings.add("x", "x_2");
+  EXPECT_EQ(mappings.lookup("x"), std::nullopt);
+
+  // Merging in another relation does not reinstate it either.
+  NameMappings other;
+  other.add("x", "x_3");
+  mappings.merge(other);
+  EXPECT_EQ(mappings.lookup("x"), std::nullopt);
+
+  // An unrelated name is unaffected, and 'reset' clears the mark.
+  mappings.add("y", "y_1");
+  EXPECT_EQ(mappings.lookup("y"), "y_1");
+
+  mappings.reset();
+  mappings.add("x", "x_4");
+  EXPECT_EQ(mappings.lookup("x"), "x_4");
+}
+
 } // namespace facebook::axiom::logical_plan

--- a/axiom/sql/presto/ColumnsExpansion.cpp
+++ b/axiom/sql/presto/ColumnsExpansion.cpp
@@ -49,6 +49,9 @@ core::ExprPtr replaceInputs(
   return changed ? expr->replaceInputs(std::move(newInputs)) : expr;
 }
 
+// Resolved expressions carry canonical, lower-case function names.
+constexpr std::string_view kColumnsFunctionName = "columns";
+
 // Searches an expression tree for COLUMNS('regex') pseudo-function calls.
 // Appends each found call (node pointer + regex pattern) to 'results'.
 void findColumnsCalls(
@@ -56,7 +59,7 @@ void findColumnsCalls(
     std::vector<std::pair<const core::IExpr*, std::string>>& results) {
   if (expr->is(core::IExpr::Kind::kCall)) {
     auto* callExpr = expr->as<core::CallExpr>();
-    if (callExpr->name() == "COLUMNS") {
+    if (callExpr->name() == kColumnsFunctionName) {
       // The grammar guarantees COLUMNS takes a single string literal argument.
       VELOX_CHECK_EQ(callExpr->inputs().size(), 1);
 

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -1585,12 +1585,13 @@ lp::ExprApi ExpressionPlanner::toExpr(
       }
 
       // A qualified (multi-part) name denotes a connector-defined SQL-invoked
-      // function. Encode it with a leading '.' so downstream resolution can
-      // distinguish it from a builtin; a plain builtin keeps its bare name.
+      // function; encode it with a leading '.' so downstream resolution can
+      // distinguish it from a builtin, which keeps its bare name. Both are
+      // lower-cased because function names are case-insensitive.
       auto callExpr = lp::Call(
           call->name()->parts().size() > 1
-              ? "." + call->name()->fullyQualifiedName()
-              : funcName,
+              ? canonicalizeName("." + call->name()->fullyQualifiedName())
+              : lowerFuncName,
           args);
 
       if (call->window() != nullptr) {

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -492,7 +492,7 @@ void GroupByPlanner::plan(
   // Walk SELECT, HAVING, and ORDER BY expressions to collect aggregate
   // function calls, then add the Aggregate plan node.
   // Populates: aggregates_, projections_, filter_,
-  //   sortingKeyExprs_, outputNames_.
+  //   sortingKeyExprs_, outputColumns_.
   collectAggregates(selectExprs, having, orderBy);
 
   for (const auto& agg : aggregates_) {
@@ -773,16 +773,7 @@ void GroupByPlanner::addAggregate(bool useGroupingSets) {
     builder_->aggregate(groupingKeyExprs, aggregateExprs);
   }
 
-  auto outputColumns = builder_->findOrAssignOutputNames();
-  outputNames_.clear();
-  outputNames_.reserve(outputColumns.size());
-  for (const auto& column : outputColumns) {
-    VELOX_CHECK(
-        !column.alias.has_value(),
-        "Unexpected ambiguous column after aggregate: {}",
-        column.name);
-    outputNames_.emplace_back(column.name);
-  }
+  outputColumns_ = builder_->findOrAssignOutputNames();
 }
 
 void GroupByPlanner::rewritePostAggregateExprs() {
@@ -791,13 +782,13 @@ void GroupByPlanner::rewritePostAggregateExprs() {
 
   size_t index = 0;
   for (const auto& key : groupingKeys_) {
-    flatInputs_.emplace_back(lp::Col(outputNames_.at(index)));
+    flatInputs_.emplace_back(outputColumns_.at(index).toCol());
     keyInputs.emplace(key.expr(), flatInputs_.back().expr());
     ++index;
   }
 
   for (const auto& agg : aggregates_) {
-    flatInputs_.emplace_back(lp::Col(outputNames_.at(index)));
+    flatInputs_.emplace_back(outputColumns_.at(index).toCol());
     aggregateInputs.emplace(agg.expr(), flatInputs_.back().expr());
     ++index;
   }
@@ -950,7 +941,7 @@ bool GroupByPlanner::isIdentityProjection() const {
     }
 
     const auto& alias = projections_.at(i).alias();
-    if (alias.has_value() && alias.value() != outputNames_.at(i)) {
+    if (alias.has_value() && alias.value() != outputColumns_.at(i).name) {
       return false;
     }
   }

--- a/axiom/sql/presto/GroupByPlanner.h
+++ b/axiom/sql/presto/GroupByPlanner.h
@@ -127,7 +127,9 @@ class GroupByPlanner {
 
   std::optional<lp::ExprApi> filter_;
   std::vector<lp::ExprApi> sortingKeyExprs_;
-  std::vector<std::string> outputNames_;
+  // Names of the aggregate's output columns, in output order. A column whose
+  // bare name is ambiguous is reachable only through its relation alias.
+  std::vector<lp::PlanBuilder::OutputColumnName> outputColumns_;
 };
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -528,7 +528,7 @@ class RelationPlanner : public AstVisitor {
   // left side through the builder's outer scope.
   void processLateral(const Lateral& lateral) {
     processQuery(lateral.query()->as<Query>());
-    displayNames_.accumulate(*builder_, /*relationAlias=*/std::nullopt);
+    finishDerivedRelation();
   }
 
   void processQueryBody(const QueryBodyPtr& queryBody) {
@@ -865,12 +865,21 @@ class RelationPlanner : public AstVisitor {
     builder_->as(alias);
   }
 
+  // A query used as a relation exposes only its column names. The relation
+  // aliases used inside it stay inside, so the enclosing query may reuse one.
+  void finishDerivedRelation() {
+    // Output naming reads the names the inner query produced, so it runs
+    // before those names are narrowed to the enclosing query's scope.
+    displayNames_.accumulate(*builder_, /*relationAlias=*/std::nullopt);
+    builder_->clearAliases();
+  }
+
   void processTableSubquery(const TableSubquery& subquery) {
     auto query = subquery.query();
 
     if (query->is(NodeType::kQuery)) {
       processQuery(query->as<Query>());
-      displayNames_.accumulate(*builder_, /*relationAlias=*/std::nullopt);
+      finishDerivedRelation();
       return;
     }
 

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -934,6 +934,13 @@ TEST_F(AggregationParserTest, groupingKeyExpr) {
         "SELECT substr(n_name, 1, 2), count(1) FROM nation GROUP BY 1",
         matcher);
 
+    // A SELECT expression matches a grouping key that spells the function
+    // differently; function names are case-insensitive.
+    testSelect(
+        "SELECT SUBSTR(n_name, 1, 2), count(1) "
+        "FROM nation GROUP BY substr(n_name, 1, 2)",
+        matcher);
+
     testSelect(
         "SELECT r_regionkey IN (SELECT n_regionkey FROM nation), count(1) "
         "FROM region GROUP BY 1",

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -994,6 +994,20 @@ TEST_F(AggregationParserTest, correlatedSubqueryWithGroupBy) {
       "SELECT u.x FROM t, u GROUP BY u.x ORDER BY (SELECT u.x)",
       scanJoinAggregate().project().sort().project().output());
 
+  // Both columns are grouping keys, so the bare name is ambiguous while each
+  // alias still names one column. The correlation resolves through the alias.
+  testSelect(
+      "SELECT (SELECT 1 WHERE u.x = 1) FROM t, u GROUP BY t.x, u.x",
+      matchScan("t")
+          .join(matchScan("u").build(), {"tx", "ux"})
+          .aggregate({"tx", "ux"}, {})
+          .project()
+          .output());
+
+  VELOX_ASSERT_THROW(
+      parseSql("SELECT x FROM t, u GROUP BY t.x, u.x"),
+      "Cannot resolve column: x");
+
   // A correlation to a column that is neither a grouping key nor an aggregate
   // is not allowed.
   VELOX_ASSERT_THROW(

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1544,6 +1544,43 @@ TEST_F(PrestoParserTest, duplicateAliases) {
       "Cannot resolve column: u");
 }
 
+// A derived table exposes only column names. The relation aliases used inside
+// it are not visible outside, so the enclosing query may reuse one.
+TEST_F(PrestoParserTest, derivedTableHidesInnerAlias) {
+  auto matcher =
+      matchValues().project().project().unnest().project().output({"a", "b"});
+  testSelect(
+      "SELECT a, t.b "
+      "FROM (SELECT a, b FROM (VALUES (1, ARRAY[10, 20])) AS t(a, b)) "
+      "CROSS JOIN UNNEST(b) AS t(b)",
+      matcher);
+
+  VELOX_ASSERT_THROW(
+      parseSql("SELECT t.a FROM (SELECT a FROM (VALUES 1) AS t(a))"),
+      "Cannot resolve column: t");
+
+  // A column whose unqualified name is ambiguous is reachable only through an
+  // alias inside the derived table, and so not reachable at all outside it.
+  testSelect(
+      "SELECT * FROM "
+      "(SELECT * FROM (VALUES 1) AS t1(a), (VALUES 2) AS t2(a))",
+      matchValues()
+          .project()
+          .join(matchValues().project().build())
+          .output({"a", "a"}));
+
+  VELOX_ASSERT_THROW(
+      parseSql(
+          "SELECT a FROM (SELECT * FROM (VALUES 1) AS t1(a), (VALUES 2) AS t2(a))"),
+      "Cannot resolve column: a");
+
+  VELOX_ASSERT_THROW(
+      parseSql(
+          "SELECT t.a FROM (VALUES 1) AS x(z), "
+          "LATERAL (SELECT a FROM (VALUES 2) AS t(a))"),
+      "Cannot resolve column: t");
+}
+
 // An UNNEST is applied to every row of the other side, which only a CROSS or
 // comma join expresses. Any other join type is rejected whatever its ON clause
 // says, matching Presto.

--- a/axiom/sql/presto/tests/SqlFunctionTest.cpp
+++ b/axiom/sql/presto/tests/SqlFunctionTest.cpp
@@ -68,6 +68,13 @@ TEST_F(SqlFunctionTest, inlines) {
       "SELECT tc.default.identity(n_nationkey + 123) FROM nation",
       matchScan("nation").project({"n_nationkey + 123::bigint"}).output());
 
+  // Capitalization does not change the resolved expression, so a SELECT
+  // expression still matches a grouping key that spells the name differently.
+  testSelect(
+      "SELECT TC.Default.Identity(n_nationkey), count(1) FROM nation "
+      "GROUP BY tc.default.identity(n_nationkey)",
+      matchScan("nation").aggregate().output());
+
   // f(a, b) := a + b
   metadata_->addFunction(
       {"default", "combine"},


### PR DESCRIPTION
Summary:
A correlated reference to a grouping key failed to plan when two grouping keys shared a column name. For example:

    SELECT (SELECT 1 WHERE u.x = 1) FROM t, u GROUP BY t.x, u.x

failed with:

    Cannot resolve column: u not in [x_1 -> x_1, x -> x]

Both keys are named `x`, and the aggregate's output dropped `t.x` and `u.x` along with the bare `x`. Only the bare name is ambiguous; each alias still names one column, so the correlated reference had nothing to resolve against.

A repeated column name now drops only unqualified access. A name that would denote two columns is marked ambiguous and stays unresolvable for the life of the mapping, so the order names are added cannot reinstate one. `GroupByPlanner` carries the aggregate's output as resolvable column references rather than bare names, since a column whose bare name is ambiguous is reachable only through its alias.

Differential Revision: D119265161
