### PR TITLE
fix(parser): Rewrite lambda bodies over an aggregate

### DIFF
--- a/axiom/optimizer/tests/sql/aggregation.sql
+++ b/axiom/optimizer/tests/sql/aggregation.sql
@@ -137,3 +137,18 @@ SELECT a, array_agg(b ORDER BY b) FILTER (WHERE b < 100) FROM t GROUP BY a
 ----
 -- sum and count do not depend on input order, so the ORDER BY has no effect.
 SELECT sum(b ORDER BY a), count(c ORDER BY b) FROM t
+----
+-- A lambda body reads a grouping key it captures.
+-- duckdb: SELECT a, [a + 10, a + 20] FROM t GROUP BY a
+SELECT a AS g, transform(ARRAY[10, 20], x -> (x + a)) FROM t GROUP BY 1
+----
+-- A lambda argument with the same name as a grouping key shadows it inside
+-- the body, so the body reads the argument.
+-- duckdb: SELECT a, [11, 12] FROM t GROUP BY a
+SELECT a AS g, transform(ARRAY[1, 2], a -> (a + 10)) FROM t GROUP BY 1
+----
+-- An argument binds a bare name, so it does not shadow a struct field that
+-- happens to use that name.
+-- duckdb: SELECT 1, [2, 3]
+SELECT s.f AS g, transform(ARRAY[1, 2], f -> (f + s.f))
+FROM (VALUES (row(1 AS f))) AS v(s) GROUP BY 1

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -15,7 +15,9 @@
  */
 
 #include "axiom/sql/presto/GroupByPlanner.h"
+#include <algorithm>
 #include <set>
+#include <span>
 #include "axiom/sql/presto/ColumnsExpansion.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/SortProjection.h"
@@ -98,18 +100,102 @@ lp::ExprApi rewriteWindowExpr(
       item.name());
 }
 
+// Returns true if any of 'names' occurs free in 'expr', that is as a column
+// reference not bound by a lambda within 'expr'. A name is read where it is a
+// column reference, so 's.f' reads 's', not 'f'.
+bool readsAnyOf(const core::IExpr& expr, std::span<const std::string> names) {
+  if (names.empty()) {
+    return false;
+  }
+
+  if (expr.is(core::IExpr::Kind::kFieldAccess)) {
+    const auto* field = expr.as<core::FieldAccessExpr>();
+    if (field->isRootColumn()) {
+      return std::ranges::find(names, field->name()) != names.end();
+    }
+    // A qualified reference reads its root, which the walk below reaches.
+  }
+
+  if (expr.is(core::IExpr::Kind::kLambda)) {
+    // The lambda binds its own arguments, so an occurrence of one inside its
+    // body is that argument, not the name being looked for.
+    const auto* lambda = expr.as<core::LambdaExpr>();
+    std::vector<std::string> notBound;
+    for (const auto& name : names) {
+      if (std::ranges::find(lambda->arguments(), name) ==
+          lambda->arguments().end()) {
+        notBound.push_back(name);
+      }
+    }
+    return readsAnyOf(*lambda->body(), notBound);
+  }
+
+  return std::ranges::any_of(expr.inputs(), [&](const auto& input) {
+    return readsAnyOf(*input, names);
+  });
+}
+
 // Given an expression, and pairs of search-and-replace sub-expressions,
 // produces a new expression with sub-expressions replaced. Uses keyReplacements
 // for grouping keys and aggregateReplacements for aggregates. If
 // 'onUnreplacedLeaf' is provided, invokes the callback for any
 // FieldAccessExpr that is not in the replacement map and whose children were
 // not replaced either. Used to detect invalid column references in HAVING.
+//
+// Descends into lambda bodies. A lambda's arguments bind inside its body, so a
+// replacement whose expression reads one of them stands for something else
+// there: it is not substituted, and a leaf reading one is not reported.
 core::ExprPtr replaceInputs(
     const core::ExprPtr& expr,
     const ExprMap<core::ExprPtr>& keyReplacements,
     const AggregateExprMap& aggregateReplacements,
     const std::function<void(const core::FieldAccessExpr&)>& onUnreplacedLeaf =
-        nullptr) {
+        nullptr);
+
+// Rewrites the body of 'lambda' under the capture rule described on
+// 'replaceInputs'.
+core::ExprPtr replaceLambdaBodyInputs(
+    const core::LambdaExpr& lambda,
+    const ExprMap<core::ExprPtr>& keyReplacements,
+    const AggregateExprMap& aggregateReplacements,
+    const std::function<void(const core::FieldAccessExpr&)>& onUnreplacedLeaf) {
+  const auto& arguments = lambda.arguments();
+
+  ExprMap<core::ExprPtr> bodyKeyReplacements;
+  for (const auto& [key, replacement] : keyReplacements) {
+    if (!readsAnyOf(*key, arguments)) {
+      bodyKeyReplacements.emplace(key, replacement);
+    }
+  }
+
+  AggregateExprMap bodyAggregateReplacements;
+  for (const auto& [aggregate, replacement] : aggregateReplacements) {
+    if (!readsAnyOf(*aggregate, arguments)) {
+      bodyAggregateReplacements.emplace(aggregate, replacement);
+    }
+  }
+
+  std::function<void(const core::FieldAccessExpr&)> onUnreplacedBodyLeaf;
+  if (onUnreplacedLeaf) {
+    onUnreplacedBodyLeaf = [&](const core::FieldAccessExpr& field) {
+      if (!readsAnyOf(field, arguments)) {
+        onUnreplacedLeaf(field);
+      }
+    };
+  }
+
+  return replaceInputs(
+      lambda.body(),
+      bodyKeyReplacements,
+      bodyAggregateReplacements,
+      onUnreplacedBodyLeaf);
+}
+
+core::ExprPtr replaceInputs(
+    const core::ExprPtr& expr,
+    const ExprMap<core::ExprPtr>& keyReplacements,
+    const AggregateExprMap& aggregateReplacements,
+    const std::function<void(const core::FieldAccessExpr&)>& onUnreplacedLeaf) {
   // First try grouping keys.
   auto keyIt = keyReplacements.find(expr);
   if (keyIt != keyReplacements.end()) {
@@ -120,6 +206,18 @@ core::ExprPtr replaceInputs(
   auto aggIt = aggregateReplacements.find(expr);
   if (aggIt != aggregateReplacements.end()) {
     return aggIt->second;
+  }
+
+  // A lambda's body is not one of its inputs.
+  if (expr->is(core::IExpr::Kind::kLambda)) {
+    const auto* lambda = expr->as<core::LambdaExpr>();
+    auto newBody = replaceLambdaBodyInputs(
+        *lambda, keyReplacements, aggregateReplacements, onUnreplacedLeaf);
+    if (newBody.get() == lambda->body().get()) {
+      return expr;
+    }
+    return std::make_shared<core::LambdaExpr>(
+        lambda->arguments(), std::move(newBody));
   }
 
   std::vector<core::ExprPtr> newInputs;

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -980,6 +980,64 @@ TEST_F(AggregationParserTest, scalarSubqueryRepeatedInSelectAndGroupBy) {
       matcher);
 }
 
+// A lambda argument binds the names it reads, so a grouping key that reads one
+// stands for something else inside the body and is not substituted for it.
+TEST_F(AggregationParserTest, groupingKeyInLambdaBody) {
+  // The body reads the grouping key, which is substituted.
+  testSelect(
+      "SELECT n_regionkey AS r, "
+      "transform(ARRAY[1, 2], x -> n_regionkey) AS t "
+      "FROM nation GROUP BY 1",
+      matchScan("nation")
+          .aggregate({"n_regionkey"}, {})
+          .project({"r", "transform(array_constructor(1, 2), x -> r)"})
+          .output({"r", "t"}));
+
+  // The argument shadows the key's name.
+  testSelect(
+      "SELECT n_regionkey AS r, "
+      "transform(ARRAY[1, 2], n_regionkey -> (n_regionkey + 1)) AS t "
+      "FROM nation GROUP BY 1",
+      matchScan("nation")
+          .aggregate({"n_regionkey"}, {})
+          .project(
+              {"r",
+               "transform(array_constructor(1, 2), n_regionkey -> n_regionkey + 1)"})
+          .output({"r", "t"}));
+
+  // The argument appears inside a compound key.
+  testSelect(
+      "SELECT n_regionkey + 1 AS r, "
+      "transform(ARRAY[1, 2], n_regionkey -> (n_regionkey + 1)) AS t "
+      "FROM nation GROUP BY 1",
+      matchScan("nation")
+          .aggregate({"n_regionkey + 1::bigint"}, {})
+          .project(
+              {"r",
+               "transform(array_constructor(1, 2), n_regionkey -> n_regionkey + 1)"})
+          .output({"r", "t"}));
+
+  // A name bound inside the key is not the argument that shares its spelling,
+  // so the key still stands for the same value in the body.
+  testSelect(
+      "SELECT transform(ARRAY[1, 2], x -> n_regionkey) AS r, "
+      "transform(ARRAY[1, 2], x -> transform(ARRAY[1, 2], x -> n_regionkey)) AS t "
+      "FROM nation GROUP BY 1",
+      matchScan("nation")
+          .aggregate(
+              {"transform(array_constructor(1, 2), x -> n_regionkey)"}, {})
+          .project({"r", "transform(array_constructor(1, 2), x -> r)"})
+          .output({"r", "t"}));
+
+  // An aggregate inside a lambda is not the one the query computes per group.
+  VELOX_ASSERT_THROW(
+      parseSql(
+          "SELECT sum(n_regionkey), "
+          "transform(ARRAY[1, 2], n_regionkey -> sum(n_regionkey)) "
+          "FROM nation GROUP BY n_regionkey"),
+      "Scalar function doesn't exist: sum");
+}
+
 TEST_F(AggregationParserTest, correlatedSubqueryWithGroupBy) {
   connector_->addTable("t", ROW("x", INTEGER()));
   connector_->addTable("u", ROW("x", INTEGER()));


### PR DESCRIPTION
Summary:
A lambda whose body reads a grouping key failed to plan. For example:

    SELECT a AS g, transform(ARRAY[1, 2], x -> a) FROM t GROUP BY 1

failed with:

    Cannot resolve column: a not in [g -> g]

Planning a clause above an aggregate rewrites references to grouping keys into references to the aggregate's output columns. A lambda holds its body outside its inputs, so that rewrite walked past it and the body went on naming a column the aggregate does not produce.

The rewrite now descends into a lambda body. A lambda's arguments bind inside it, so a replacement whose expression reads one of them stands for something else there and is not substituted; the same holds for grouping keys and for aggregates, and a leaf reading an argument is not reported as a column the clause failed to resolve. Reading is free occurrence: a name a lambda inside the replacement binds is not read, so a key that is itself a lambda still stands for the same value in the body.

Reviewed By: xiaoxmeng

Differential Revision: D119270091


