### PR TITLE
fix(parser): Scope a CTE to the ones declared before it (#1853)

### DIFF
--- a/axiom/sql/presto/CteScope.h
+++ b/axiom/sql/presto/CteScope.h
@@ -78,6 +78,14 @@ class CteScope {
 
     /// Never null. Shared by every reference to this CTE.
     std::shared_ptr<const DefiningScope> definingScope;
+
+    /// The WITH list this CTE belongs to, in declaration order, shared by
+    /// every entry in that list, and this CTE's position in it. Never null.
+    /// A body sees only the names before its own position, so the ones after
+    /// are hidden while it is translated and a reference to one of them means
+    /// the base table.
+    std::shared_ptr<const std::vector<std::string>> siblings;
+    size_t index{0};
   };
 
   /// Hides a name's in-scope binding for the guard's lifetime, so the

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -693,6 +693,15 @@ class RelationPlanner : public AstVisitor {
     if (auto hidden = ctes_.hide(name)) {
       const auto& entry = hidden.entry();
       VELOX_CHECK_NOT_NULL(entry.definingScope);
+      VELOX_CHECK_NOT_NULL(entry.siblings);
+
+      // The body sees only the CTEs declared before this one.
+      std::vector<CteScope::Hidden> laterSiblings;
+      laterSiblings.reserve(entry.siblings->size() - entry.index - 1);
+      for (auto i = entry.index + 1; i < entry.siblings->size(); ++i) {
+        laterSiblings.push_back(ctes_.hide((*entry.siblings)[i]));
+      }
+
       const auto& definingScope = *entry.definingScope;
       auto relationsGuard = scopedRelations(&definingScope);
       // The body resolves in the scope where the WITH is written. The relation
@@ -1623,24 +1632,34 @@ class RelationPlanner : public AstVisitor {
       // Names must be unique within a single WITH list. A nested WITH may
       // still reuse an enclosing name -- that is shadowing, handled below.
       std::unordered_set<std::string> namesInList;
+      std::vector<std::string> names;
+      names.reserve(with->queries().size());
       for (const auto& withQuery : with->queries()) {
-        const auto cteName = canonicalizeIdentifier(*withQuery->name());
+        auto cteName = canonicalizeIdentifier(*withQuery->name());
         AXIOM_PRESTO_SEMANTIC_CHECK(
             namesInList.insert(cteName).second,
             withQuery->location(),
             cteName,
             "WITH query name specified more than once: {}",
             cteName);
+        names.push_back(std::move(cteName));
+      }
+
+      auto siblings =
+          std::make_shared<const std::vector<std::string>>(std::move(names));
+      for (size_t i = 0; i < siblings->size(); ++i) {
+        const auto& withQuery = with->queries().at(i);
         // A CTE in a WITH RECURSIVE block is only recursive if its body
         // actually references its own name. Otherwise it's a standard union.
         bool selfReferential = false;
         if (with->isRecursive()) {
           selfReferential = presto::RecursiveCteValidator::referencesCte(
-              *withQuery->query(), cteName);
+              *withQuery->query(), (*siblings)[i]);
         }
         ctes_.bind(
-            cteName,
-            CteScope::Entry{withQuery, selfReferential, definingScope});
+            (*siblings)[i],
+            CteScope::Entry{
+                withQuery, selfReferential, definingScope, siblings, i});
       }
     }
 

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -633,6 +633,13 @@ TEST_F(PrestoParserTest, withMultipleCtes) {
       "     b AS (SELECT * FROM a) "
       "SELECT * FROM b",
       matchScan().project().output({"n_nationkey", "n_name"}));
+
+  // An earlier CTE does not see a later one, so 'nation' is the base table.
+  testSelect(
+      "WITH a AS (SELECT n_name FROM nation), "
+      "     nation AS (SELECT 1 AS k) "
+      "SELECT * FROM a",
+      matchScan().project().output({"n_name"}));
 }
 
 TEST_F(PrestoParserTest, withColumnAliases) {


### PR DESCRIPTION
Summary:

A CTE that reads a table named by a later CTE in the same WITH list failed to plan. For example:

    WITH a AS (SELECT s.n_name FROM nation s), nation AS (SELECT 1 AS k) SELECT * FROM a

failed with:

    Cannot resolve column: s not in [s.k -> k, k -> k]

The reference to `nation` inside `a` bound to the CTE declared after it. A non-recursive WITH scopes each CTE to the ones before it, so `nation` there is the base table.

Every CTE in a WITH list is bound before any body is translated, and translating a body hid only that CTE's own binding. An entry now records the names declared after it, and those are hidden while its body is translated. Hiding removes one binding rather than the name, so a name a later sibling reuses from an enclosing WITH reappears instead of falling through to a base table.

Reviewed By: xiaoxmeng

Differential Revision: D119271122


