### PR TITLE
fix(builder): Match INSERT column list case-insensitively

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -1831,14 +1831,20 @@ PlanBuilder& PlanBuilder::tableWrite(
       // Check input types.
       const auto& schema = table->type();
 
+      // A connector reports canonical column names, so only the user-written
+      // name is reduced by the dialect's identifier rule. A matched column is
+      // recorded under the name the connector uses for it.
       for (auto i = 0; i < columnNames.size(); i++) {
-        const auto& name = columnNames[i];
-        const auto index = schema->getChildIdxIfExists(name);
+        auto& name = columnNames[i];
+        const auto index = schema->getChildIdxIfExists(
+            identifierCanonicalizer_ ? identifierCanonicalizer_(name) : name);
         VELOX_USER_CHECK(
             index.has_value(),
             "Column not found: '{}' in table {}",
             name,
             schemaTableName.toString());
+
+        name = schema->nameOf(index.value());
 
         const auto& inputType = columnExpressions[i]->type();
         const auto& schemaType = schema->childAt(index.value());

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -155,12 +155,11 @@ class PlanBuilder {
     /// override this with their dialect's coercer.
     const velox::TypeCoercer* coercer{nullptr};
 
-    /// Optional transform applied to user-facing column names introduced by
-    /// 'tableScan' before they are stored in the name lookup map. SQL
-    /// dialects with case-insensitive identifiers set this to a lowercasing
-    /// function so that case-insensitive references in the query body
-    /// resolve against connector-supplied column names. Defaults to
-    /// identity, leaving names as-is.
+    /// Optional transform applied to user-facing column names before they
+    /// are matched against the names a connector supplies. SQL dialects with
+    /// case-insensitive identifiers set this to a lowercasing function so
+    /// that a reference written in any case resolves. Defaults to identity,
+    /// leaving names as-is.
     std::function<std::string(const std::string&)> identifierCanonicalizer;
 
     explicit Context(

--- a/axiom/sql/presto/tests/DdlParserTest.cpp
+++ b/axiom/sql/presto/tests/DdlParserTest.cpp
@@ -48,6 +48,11 @@ TEST_F(DdlParserTest, insertIntoTable) {
     testInsert(
         "INSERT INTO nation(n_nationkey, n_regionkey, n_name) SELECT 100, 2, 'n-100'",
         matcher);
+
+    // The column list names target columns case-insensitively, quoted or not.
+    testInsert(
+        "INSERT INTO nation(N_NationKey, \"n_REGIONKEY\", n_NAME) SELECT 100, 2, 'n-100'",
+        matcher);
   }
 
   // Wrong types.
@@ -55,10 +60,14 @@ TEST_F(DdlParserTest, insertIntoTable) {
       parseSql("INSERT INTO nation SELECT 100, 'n-100', 2, 3"),
       "Wrong column type: INTEGER vs. VARCHAR, column 'n_comment' in table \"default\".\"nation\"");
 
-  // Non-existent target column.
+  // Non-existent target column. The error names it as the user wrote it.
   VELOX_ASSERT_THROW(
       parseSql("INSERT INTO nation(no_such_col) SELECT 1"),
       "Column not found: 'no_such_col' in table \"default\".\"nation\"");
+
+  VELOX_ASSERT_THROW(
+      parseSql("INSERT INTO nation(NoSuchCol) SELECT 1"),
+      "Column not found: 'NoSuchCol' in table \"default\".\"nation\"");
 }
 
 TEST_F(DdlParserTest, deleteFromTable) {


### PR DESCRIPTION
Summary:
An INSERT whose column list spells a target column in any capitalization other than the connector's failed to plan. For example:

    INSERT INTO t (userId) SELECT 1

fails with `Column not found: 'userId' in table "s"."t"` when the connector reports the column as `userid`. Presto matches identifiers case-insensitively, so the same column resolves in a SELECT against the same table.

`PlanBuilder` already takes the dialect's identifier rule as `identifierCanonicalizer` and applies it in `tableScan`. `tableWrite` now applies it too: the user-written name is reduced before it is looked up in the target table, and the matched column is recorded under the name the connector uses. A name that matches nothing is still reported the way the user spelled it.

Differential Revision: D119328892
