### PR TITLE
feat(v2): Decorrelate a scalar subquery over an inner join (#1855)

### DIFF
--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -971,6 +971,24 @@ SELECT t.k,
              (SELECT x FROM v WHERE v.k = t.k) r)
 FROM (VALUES (1), (2)) AS t(k)
 ----
+-- A correlated scalar subquery over a join that carries the correlation in
+-- its ON clause. Every outer has a matching pair.
+SELECT u.a, (SELECT v2.a FROM v v2 JOIN v v3 ON v3.a = v2.a AND v2.a = u.a * 2)
+FROM u
+----
+-- The same shape where some outers have no matching pair, which reads NULL.
+SELECT u.a, (SELECT v2.a FROM v v2 JOIN v v3 ON v3.a = v2.a AND v2.a = u.a * 4)
+FROM u
+----
+-- Both the ON predicate and a WHERE above the join decide which pairs
+-- contribute.
+SELECT u.a, (SELECT v2.a FROM v v2 JOIN v v3 ON v3.a = v2.a AND v2.a = u.a * 2 WHERE v3.a < 8)
+FROM u
+----
+-- An ON predicate reading only one side still selects the pairs.
+SELECT u.a, (SELECT v2.a FROM v v2 JOIN v v3 ON v3.a = v2.a AND v3.a < 8 AND v2.a = u.a * 2)
+FROM u
+----
 -- A WHERE above a LEFT JOIN removes rows the join padded, so an outer whose
 -- rows it all rejects reads NULL rather than the padded left value.
 -- error_v1: Nested correlation across subquery boundaries is not supported yet

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -971,6 +971,12 @@ SELECT t.k,
              (SELECT x FROM v WHERE v.k = t.k) r)
 FROM (VALUES (1), (2)) AS t(k)
 ----
+-- A WHERE above a LEFT JOIN removes rows the join padded, so an outer whose
+-- rows it all rejects reads NULL rather than the padded left value.
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
+SELECT u.a, (SELECT x.a FROM (SELECT a FROM u u2 WHERE u2.a = u.a) x LEFT JOIN v v3 ON v3.a = x.a WHERE v3.a < 0)
+FROM u
+----
 -- Duplicate outer rows with the same correlation value stay
 -- independent: each produces its own result row.
 -- error_v1: Nested correlation across subquery boundaries is not supported yet

--- a/axiom/optimizer/v2/DecorrelatePass.cpp
+++ b/axiom/optimizer/v2/DecorrelatePass.cpp
@@ -709,58 +709,59 @@ class Decorrelator : public NodeRewriter<> {
 
     NodeCP leftSide = joinBody->left();
     NodeCP rightSide = joinBody->right();
-    ExprVector applyBFilter;
-    if (joinBody->isLeft()) {
-      applyBFilter = std::move(joinPredicate);
-    }
-    appendAll(applyBFilter, accumulatedFilter);
 
     if (joinBody->isInner()) {
       return joinPeelLeftInner(
-          node, input, leftSide, rightSide, std::move(applyBFilter));
+          node, input, leftSide, rightSide, std::move(accumulatedFilter));
     }
 
-    // Body is kLeft. Chain: applyA over A, then applyB over B with
-    // applyA's output as input. joinPredicate becomes applyB.filter
-    // (the LEFT JOIN's ON condition); kLeft pad on no match preserves
-    // the body LEFT JOIN's semantics.
-
-    ColumnCP applyAIncludeMarker = makeIncludeColumn();
-    NodeCP applyA = makeLeftLeg(
+    return joinPeelLeftOuter(
+        node,
         input,
         leftSide,
+        rightSide,
+        std::move(joinPredicate),
+        std::move(accumulatedFilter));
+  }
+
+  // Outer kLeft over a body kLeft Join. A row the join predicate rejects is
+  // still a body row, the left side preserved with NULL right columns, so
+  // only the predicate rides on applyB. A row the accumulated filter rejects
+  // is not a body row, so the filter decides which rows the per-rn
+  // pad-collapse keeps, and an outer left with none keeps one pad.
+  NodeCP joinPeelLeftOuter(
+      ApplyCP node,
+      NodeCP input,
+      NodeCP leftSide,
+      NodeCP rightSide,
+      ExprVector joinPredicate,
+      ExprVector accumulatedFilter) {
+    ColumnCP rowId = makeIdColumn();
+    NodeCP taggedInput = tagOuterRows(input, rowId);
+
+    // The accumulated filter can cut a multi-row body down to one, so the
+    // scalar bound is checked once after the collapse, not per leg.
+    ColumnCP markA = makeIncludeColumn();
+    NodeCP applyA = makeLeftLeg(
+        taggedInput,
+        leftSide,
         /*filter=*/ExprVector{},
-        node->enforceSingleRow(),
-        applyAIncludeMarker);
+        /*enforceSingleRow=*/false,
+        markA);
 
     NodeCP applyB = makeLeftLeg(
         applyA,
         rightSide,
-        std::move(applyBFilter),
-        node->enforceSingleRow(),
+        std::move(joinPredicate),
+        /*enforceSingleRow=*/false,
         makeIncludeColumn());
 
-    NodeCP decorrelatedChain = rewrite(applyB);
+    NodeCP chain = rewrite(applyB);
 
-    // Final Project: shape to outer Apply's outputColumns. Body is
-    // kLeft, so the inner LEFT JOIN's right-side pad rows are legitimate
-    // body output (left preserved with NULL right cols) and stay
-    // included; applyA's marker alone gates inclusion.
-    ExprCP includeMarker = applyAIncludeMarker;
-    ExprVector finalExprs;
-    finalExprs.reserve(node->outputColumns().size());
-    for (ColumnCP outputColumn : node->outputColumns()) {
-      if (outputColumn == node->includeMarker()) {
-        finalExprs.push_back(includeMarker);
-      } else {
-        finalExprs.push_back(outputColumn);
-      }
-    }
-    return builder().make<Project>({
-        decorrelatedChain,
-        std::move(finalExprs),
-        node->outputColumns(),
-    });
+    ExprCP matched = accumulatedFilter.empty()
+        ? markA
+        : exprFactory_.makeAnd(markA, exprFactory_.andAll(accumulatedFilter));
+    return collapsePadRows(node, input, chain, rowId, matched);
   }
 
   // Outer kLeft over a body kLeftSemiProject: the body emits A's rows plus a
@@ -851,10 +852,10 @@ class Decorrelator : public NodeRewriter<> {
     }
 
     // A body row counts when A matched and the mark filter accepts it.
-    ExprCP matchedExpr = applyAIncludeMarker;
-    for (ExprCP conjunct : markFilter) {
-      matchedExpr = exprFactory_.makeAnd(matchedExpr, conjunct);
-    }
+    ExprCP matchedExpr = markFilter.empty()
+        ? applyAIncludeMarker
+        : exprFactory_.makeAnd(
+              applyAIncludeMarker, exprFactory_.andAll(markFilter));
     return collapsePadRows(node, input, chain, rowId, matchedExpr);
   }
 

--- a/axiom/optimizer/v2/DecorrelatePass.cpp
+++ b/axiom/optimizer/v2/DecorrelatePass.cpp
@@ -680,10 +680,9 @@ class Decorrelator : public NodeRewriter<> {
     return conjuncts;
   }
 
-  // Outer Apply is kLeft (scalar). Supports a kLeftSemiProject body, a kLeft
-  // body with predicate, and a kInner cross-join body with none. kInner with
-  // a predicate (requires per-rn pad-collapse over matches) and the remaining
-  // kinds NYI loud.
+  // Outer Apply is kLeft (scalar). Supports a kLeftSemiProject body and a
+  // kLeft or kInner body, with or without a predicate. The remaining kinds
+  // NYI loud.
   NodeCP joinPeelLeft(
       ApplyCP node,
       NodeCP input,
@@ -701,18 +700,18 @@ class Decorrelator : public NodeRewriter<> {
           "yet implemented: {}",
           joinBody->joinTypeName());
     }
-    if (joinBody->isInner() && !joinPredicate.empty()) {
-      VELOX_NYI(
-          "Decorrelate joinPeel: outer kLeft over kInner Join with "
-          "predicate not yet implemented (needs per-rn pad-collapse)");
-    }
 
     NodeCP leftSide = joinBody->left();
     NodeCP rightSide = joinBody->right();
 
     if (joinBody->isInner()) {
+      // A row the join predicate rejects is not a body row, and neither is
+      // one the accumulated filter rejects, so both ride on applyB and the
+      // collapse drops what they reject.
+      ExprVector applyBFilter = std::move(joinPredicate);
+      appendAll(applyBFilter, accumulatedFilter);
       return joinPeelLeftInner(
-          node, input, leftSide, rightSide, std::move(accumulatedFilter));
+          node, input, leftSide, rightSide, std::move(applyBFilter));
     }
 
     return joinPeelLeftOuter(
@@ -859,12 +858,12 @@ class Decorrelator : public NodeRewriter<> {
     return collapsePadRows(node, input, chain, rowId, matchedExpr);
   }
 
-  // Outer kLeft over a body kInner cross-join. The leg cascade uses
-  // kLeft legs so outers and left rows survive, but that over-produces
-  // pad rows when one side is empty and the other has >1 rows, which
-  // would duplicate the outer. Restore `outer LEFT JOIN (A x B)`
-  // semantics with a per-rn pad-collapse: keep every real (a, b) row
-  // and, for an outer with no match, keep exactly one pad row. See
+  // Outer kLeft over a body kInner Join. The leg cascade uses kLeft legs
+  // so outers and left rows survive, but that over-produces pad rows: from
+  // an empty side, and from a row applyB's filter rejects. Restore
+  // `outer LEFT JOIN (A JOIN B)` semantics with a per-rn pad-collapse:
+  // keep every real (a, b) row and, for an outer with no match, keep
+  // exactly one pad row. See
   // Decorrelate-join-rules.md §"INNER pad-row drop".
   NodeCP joinPeelLeftInner(
       ApplyCP node,

--- a/axiom/optimizer/v2/docs/Decorrelate-join-rules.md
+++ b/axiom/optimizer/v2/docs/Decorrelate-join-rules.md
@@ -220,13 +220,11 @@ match-less outer while keeping every real row:
    real rows survive; a match-less outer keeps its first row (a pad)
    and drops the rest.
 
-This covers the cross-join case (empty Join-node `predicate`): a side
-being empty is exactly the 0-match case, and the collapse reduces the
-duplicate pads to one. A cross-side predicate written as a WHERE above
-the cross join rides in `applyB.filter`, so `anyMatch` correctly
-handles the resulting mixed matches; only a predicate on the Join node
-itself (explicit `JOIN ... ON`) is currently NYI (see §"Cases
-covered").
+A side being empty is exactly the 0-match case, and the collapse
+reduces the duplicate pads to one. A predicate rides in
+`applyB.filter`, whether written on the Join node itself
+(`JOIN ... ON`) or as a WHERE above it, so `anyMatch` correctly
+handles the resulting mixed matches.
 
 ### ESR interaction
 
@@ -249,14 +247,14 @@ Combinations across (outerKind, joinKind):
 | outerKind | joinKind | Status |
 |---|---|---|
 | kLeft (ESR=true) | kInner cross-join | **in scope** (per-rn pad-collapse + `EnforceDistinct(rn)`) |
-| kLeft (ESR=true) | kInner with predicate | designed (per-rn pad-collapse + `EnforceDistinct(rn)`); **NYI loud** in code |
+| kLeft (ESR=true) | kInner with predicate | **in scope** (per-rn pad-collapse + `EnforceDistinct(rn)`) |
 | kLeft (ESR=true) | kLeft | **in scope** |
 | kLeft (ESR=true) | kRight | **in scope** (via swap) |
 | kLeft (ESR=true) | kFull | NYI loud |
 | kLeft (ESR=true) | kLeftSemiProject | **in scope** |
 | kLeft (ESR=true) | kLeftSemiFilter / kAnti | NYI loud |
 | kLeft (ESR=false) | kInner cross-join | **in scope** (per-rn pad-collapse; see §"INNER pad-row drop") |
-| kLeft (ESR=false) | kInner with predicate | designed (per-rn pad-collapse; see §"INNER pad-row drop"); **NYI loud** in code |
+| kLeft (ESR=false) | kInner with predicate | **in scope** (per-rn pad-collapse; see §"INNER pad-row drop") |
 | kLeft (ESR=false) | kLeft / kRight | **in scope** |
 | kLeft (ESR=false) | kFull | NYI loud |
 | kLeft (ESR=false) | kLeftSemiProject | **in scope** |


### PR DESCRIPTION
Summary:

A correlated scalar subquery whose join carries a predicate failed to plan under the v2 optimizer. For example:

    SELECT u.a, (SELECT v2.a FROM v v2 JOIN v v3 ON v3.a = v2.a AND v2.a = u.a * 2) FROM u

failed with:

    Decorrelate joinPeel: outer kLeft over kInner Join with predicate not yet implemented

Drop the predicate from the join and the same query plans.

Peeling a Join replaces it, so the predicate it carried has to be re-hosted on the second leg's filter. That was done only for a `kLeft` body; an inner body reached the same code with the predicate dropped, which is what the refusal was protecting against. Both kinds now re-host it. What separates them stays where it already was, in the pad-collapse: an inner body keeps a row when both legs matched, a `kLeft` body when the first leg did. The per-rn pad-collapse the old message asked for was never missing — `joinPeelLeftInner` has always called it.

Reviewed By: amitkdutta

Differential Revision: D119349897


