### PR TITLE
fix(v2): Drop rows a WHERE above a LEFT JOIN rejects (#1856)

### DIFF
--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -971,6 +971,12 @@ SELECT t.k,
              (SELECT x FROM v WHERE v.k = t.k) r)
 FROM (VALUES (1), (2)) AS t(k)
 ----
+-- A WHERE above a LEFT JOIN removes rows the join padded, so an outer whose
+-- rows it all rejects reads NULL rather than the padded left value.
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
+SELECT u.a, (SELECT x.a FROM (SELECT a FROM u u2 WHERE u2.a = u.a) x LEFT JOIN v v3 ON v3.a = x.a WHERE v3.a < 0)
+FROM u
+----
 -- Duplicate outer rows with the same correlation value stay
 -- independent: each produces its own result row.
 -- error_v1: Nested correlation across subquery boundaries is not supported yet

--- a/axiom/optimizer/v2/DecorrelatePass.cpp
+++ b/axiom/optimizer/v2/DecorrelatePass.cpp
@@ -709,58 +709,59 @@ class Decorrelator : public NodeRewriter<> {
 
     NodeCP leftSide = joinBody->left();
     NodeCP rightSide = joinBody->right();
-    ExprVector applyBFilter;
-    if (joinBody->isLeft()) {
-      applyBFilter = std::move(joinPredicate);
-    }
-    appendAll(applyBFilter, accumulatedFilter);
 
     if (joinBody->isInner()) {
       return joinPeelLeftInner(
-          node, input, leftSide, rightSide, std::move(applyBFilter));
+          node, input, leftSide, rightSide, std::move(accumulatedFilter));
     }
 
-    // Body is kLeft. Chain: applyA over A, then applyB over B with
-    // applyA's output as input. joinPredicate becomes applyB.filter
-    // (the LEFT JOIN's ON condition); kLeft pad on no match preserves
-    // the body LEFT JOIN's semantics.
-
-    ColumnCP applyAIncludeMarker = makeIncludeColumn();
-    NodeCP applyA = makeLeftLeg(
+    return joinPeelLeftOuter(
+        node,
         input,
         leftSide,
+        rightSide,
+        std::move(joinPredicate),
+        std::move(accumulatedFilter));
+  }
+
+  // Outer kLeft over a body kLeft Join. A row the join predicate rejects is
+  // still a body row, the left side preserved with NULL right columns, so
+  // only the predicate rides on applyB. A row the accumulated filter rejects
+  // is not a body row, so the filter decides which rows the per-rn
+  // pad-collapse keeps, and an outer left with none keeps one pad.
+  NodeCP joinPeelLeftOuter(
+      ApplyCP node,
+      NodeCP input,
+      NodeCP leftSide,
+      NodeCP rightSide,
+      ExprVector joinPredicate,
+      ExprVector accumulatedFilter) {
+    ColumnCP rowId = makeIdColumn();
+    NodeCP taggedInput = tagOuterRows(input, rowId);
+
+    // The accumulated filter can cut a multi-row body down to one, so the
+    // scalar bound is checked once after the collapse, not per leg.
+    ColumnCP markA = makeIncludeColumn();
+    NodeCP applyA = makeLeftLeg(
+        taggedInput,
+        leftSide,
         /*filter=*/ExprVector{},
-        node->enforceSingleRow(),
-        applyAIncludeMarker);
+        /*enforceSingleRow=*/false,
+        markA);
 
     NodeCP applyB = makeLeftLeg(
         applyA,
         rightSide,
-        std::move(applyBFilter),
-        node->enforceSingleRow(),
+        std::move(joinPredicate),
+        /*enforceSingleRow=*/false,
         makeIncludeColumn());
 
-    NodeCP decorrelatedChain = rewrite(applyB);
+    NodeCP chain = rewrite(applyB);
 
-    // Final Project: shape to outer Apply's outputColumns. Body is
-    // kLeft, so the inner LEFT JOIN's right-side pad rows are legitimate
-    // body output (left preserved with NULL right cols) and stay
-    // included; applyA's marker alone gates inclusion.
-    ExprCP includeMarker = applyAIncludeMarker;
-    ExprVector finalExprs;
-    finalExprs.reserve(node->outputColumns().size());
-    for (ColumnCP outputColumn : node->outputColumns()) {
-      if (outputColumn == node->includeMarker()) {
-        finalExprs.push_back(includeMarker);
-      } else {
-        finalExprs.push_back(outputColumn);
-      }
-    }
-    return builder().make<Project>({
-        decorrelatedChain,
-        std::move(finalExprs),
-        node->outputColumns(),
-    });
+    ExprCP matched = accumulatedFilter.empty()
+        ? markA
+        : exprFactory_.makeAnd(markA, exprFactory_.andAll(accumulatedFilter));
+    return collapsePadRows(node, input, chain, rowId, matched);
   }
 
   // Outer kLeft over a body kLeftSemiProject: the body emits A's rows plus a
@@ -851,10 +852,10 @@ class Decorrelator : public NodeRewriter<> {
     }
 
     // A body row counts when A matched and the mark filter accepts it.
-    ExprCP matchedExpr = applyAIncludeMarker;
-    for (ExprCP conjunct : markFilter) {
-      matchedExpr = exprFactory_.makeAnd(matchedExpr, conjunct);
-    }
+    ExprCP matchedExpr = markFilter.empty()
+        ? applyAIncludeMarker
+        : exprFactory_.makeAnd(
+              applyAIncludeMarker, exprFactory_.andAll(markFilter));
     return collapsePadRows(node, input, chain, rowId, matchedExpr);
   }
 


### PR DESCRIPTION
Summary:

A correlated scalar subquery whose body filters a LEFT JOIN returned a value where the answer is NULL. For example:

    SELECT u.a,
           (SELECT x.a
            FROM (SELECT a FROM u u2 WHERE u2.a = u.a) x
            LEFT JOIN v v3 ON v3.a = x.a
            WHERE v3.a < 0)
    FROM u

reads `1, 2, 3, 4, 5` under the v2 optimizer. No row survives `v3.a < 0`, so every outer must read NULL.

Peeling the Join turns it into two legs, and the second leg pads when its filter rejects a row. The join's own predicate belongs there, because a LEFT JOIN keeps the left row with NULL right columns when nothing matches. A filter written above the join does not: it removes the row. Both were going to the same place, so rejected rows came back as pads and the first leg's marker kept them. Only the join predicate rides on the second leg now, and the filter decides which rows the per-outer collapse keeps, with one padded row for an outer left with none. The scalar row count is checked after that collapse rather than per leg, since the filter can cut a multi-row body down to one.

Reviewed By: amitkdutta

Differential Revision: D119352977


