### PR TITLE
feat(parser): Support single-parameter `DECIMAL` types

### DIFF
--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -894,14 +894,14 @@ TypePtr tryResolveBuiltinType(const TypeSignaturePtr& type) {
         parameters.emplace_back(parseType(param), fieldName);
       }
     } else if (baseName == "DECIMAL") {
-      AXIOM_PRESTO_SEMANTIC_CHECK_EQ(
-          numParams,
-          static_cast<size_t>(2),
+      AXIOM_PRESTO_SEMANTIC_CHECK(
+          numParams == 1 || numParams == 2,
           type->location(),
           baseName,
-          "DECIMAL expects 2 parameters");
+          "DECIMAL expects 1 or 2 parameters");
       parameters.emplace_back(parseInt(type->parameters().at(0)));
-      parameters.emplace_back(parseInt(type->parameters().at(1)));
+      parameters.emplace_back(
+          numParams == 1 ? 0 : parseInt(type->parameters().at(1)));
     } else if (baseName == "TDIGEST" || baseName == "QDIGEST") {
       AXIOM_PRESTO_SEMANTIC_CHECK_EQ(
           numParams,

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -119,6 +119,7 @@ TEST_F(ExpressionParserTest, types) {
   test("'3' as bIgInT", BIGINT());
   test("'2020-01-01' as date", DATE());
   test("null as timestamp", TIMESTAMP());
+  test("1 as decimal(3)", DECIMAL(3, 0));
   test("null as decimal(3, 2)", DECIMAL(3, 2));
   test("null as decimal(33, 10)", DECIMAL(33, 10));
   // DECIMAL without parameters defaults to DECIMAL(38, 0), matching Presto.


### PR DESCRIPTION
Summary: Treat `DECIMAL(p)` as shorthand for `DECIMAL(p, 0)`, matching Presto. Add `CAST` and `TRY_CAST` test coverage.

Differential Revision: D119430131


