### PR TITLE
fix(parser): Preserve empty aggregate aliases

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -1014,17 +1014,25 @@ void PlanBuilder::resolveAggregates(
 
     auto expr = resolveAggregateTypes(aggregate.expr());
 
-    if (aggregate.name().has_value()) {
-      const auto& alias = aggregate.name().value();
-      outputNames.push_back(newName(alias));
-      tracker.add(alias, outputNames.back());
+    const auto& alias = aggregate.name();
+    if (alias.has_value() && !alias->empty()) {
+      outputNames.push_back(newName(*alias));
+      tracker.add(*alias, outputNames.back());
     } else {
+      if (alias.has_value()) {
+        VELOX_USER_CHECK(
+            allowAmbiguousOutputNames_, "Empty column alias is not allowed");
+      }
+
       // Derive the output name from the parse-time call name, canonicalized so
       // it reflects the source function rather than any internal name the
       // resolved expr may carry.
       const auto* call = aggregate.expr()->as<velox::core::CallExpr>();
       VELOX_CHECK_NOT_NULL(call, "Aggregate expression must be a call");
       outputNames.push_back(newName(velox::exec::sanitizeName(call->name())));
+      if (alias.has_value()) {
+        mappings.addUserName(outputNames.back(), "");
+      }
     }
 
     exprs.emplace_back(std::move(expr));

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -894,14 +894,14 @@ TypePtr tryResolveBuiltinType(const TypeSignaturePtr& type) {
         parameters.emplace_back(parseType(param), fieldName);
       }
     } else if (baseName == "DECIMAL") {
-      AXIOM_PRESTO_SEMANTIC_CHECK_EQ(
-          numParams,
-          static_cast<size_t>(2),
+      AXIOM_PRESTO_SEMANTIC_CHECK(
+          numParams == 1 || numParams == 2,
           type->location(),
           baseName,
-          "DECIMAL expects 2 parameters");
+          "DECIMAL expects 1 or 2 parameters");
       parameters.emplace_back(parseInt(type->parameters().at(0)));
-      parameters.emplace_back(parseInt(type->parameters().at(1)));
+      parameters.emplace_back(
+          numParams == 1 ? 0 : parseInt(type->parameters().at(1)));
     } else if (baseName == "TDIGEST" || baseName == "QDIGEST") {
       AXIOM_PRESTO_SEMANTIC_CHECK_EQ(
           numParams,

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -119,6 +119,7 @@ TEST_F(ExpressionParserTest, types) {
   test("'3' as bIgInT", BIGINT());
   test("'2020-01-01' as date", DATE());
   test("null as timestamp", TIMESTAMP());
+  test("1 as decimal(3)", DECIMAL(3, 0));
   test("null as decimal(3, 2)", DECIMAL(3, 2));
   test("null as decimal(33, 10)", DECIMAL(33, 10));
   // DECIMAL without parameters defaults to DECIMAL(38, 0), matching Presto.

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1623,6 +1623,9 @@ TEST_F(PrestoParserTest, outputNames) {
   // Direct SELECT with empty and duplicate aliases.
   test(R"(SELECT 1 as "", 2 as "", 3 as x, 4 as x)", {"", "", "x", "x"});
 
+  // Empty aliases are preserved on aggregate output columns.
+  test(R"(SELECT count(1) AS "")", {""});
+
   // SELECT * from subquery preserves empty and duplicate names.
   test(
       R"(SELECT * FROM (SELECT 1 as "", 2 as "", 3 as x, 4 as x))",


### PR DESCRIPTION
Summary: Queries such as `SELECT count(1) AS ""` failed during planning with `Hint cannot be empty`. Preserve the empty display name while allocating a non-empty internal name for the aggregate.

Differential Revision: D119430875
