### PR TITLE
fix(parser): Preserve names across `CROSS JOIN UNNEST` (#1862)

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -1141,25 +1141,42 @@ PlanBuilder& PlanBuilder::unnest(
   static const std::string kKeyHint = "k";
   static const std::string kValueHint = "v";
 
+  std::vector<ExprPtr> exprs;
+  exprs.reserve(unnestExprs.size());
+  size_t numRelationAliases{0};
+  for (const auto& unnestExpr : unnestExprs) {
+    auto expr = resolveScalarTypes(unnestExpr.expr());
+    switch (expr->type()->kind()) {
+      case velox::TypeKind::ARRAY:
+      case velox::TypeKind::MAP:
+        if (unnestExpr.unnestedAliases().empty()) {
+          numRelationAliases += expr->type()->size();
+        }
+        break;
+      default:
+        VELOX_USER_FAIL(
+            "Unsupported type to unnest: {}", expr->type()->toString());
+    }
+    exprs.push_back(std::move(expr));
+  }
+
   // Create new mappings for unnested columns, then merge with existing.
   NameMappings unnestMapping;
   NameTracker tracker(allowAmbiguousOutputNames_, unnestMapping);
 
-  if (unnestAliases.empty()) {
-    for (const auto& unnestExpr : unnestExprs) {
-      tracker.track(unnestExpr.unnestedAliases());
-    }
-  } else {
-    tracker.track(unnestAliases);
+  for (const auto& unnestExpr : unnestExprs) {
+    tracker.track(unnestExpr.unnestedAliases());
+  }
+  for (size_t i = 0; i < numRelationAliases && i < unnestAliases.size(); ++i) {
+    tracker.track(unnestAliases[i]);
   }
 
   if (ordinality.has_value() && ordinality->alias().has_value()) {
     tracker.track(*ordinality->alias());
   }
 
-  size_t index = 0;
+  size_t unnestAliasIndex = 0;
 
-  std::vector<ExprPtr> exprs;
   std::vector<std::vector<std::string>> outputNames;
 
   // A column the query did not name. The relation alias still names it, so
@@ -1183,12 +1200,19 @@ PlanBuilder& PlanBuilder::unnest(
       outputNames.back().emplace_back(newName(name));
       tracker.add(name, outputNames.back().back(), alias);
     }
-    ++index;
   };
 
-  for (const auto& unnestExpr : unnestExprs) {
-    auto expr = resolveScalarTypes(unnestExpr.expr());
-    exprs.push_back(expr);
+  const auto addRelationAliasOrUnnamed = [&](const std::string& hint) {
+    if (unnestAliasIndex < unnestAliases.size()) {
+      addUnnestOutput(unnestAliases[unnestAliasIndex++], hint);
+    } else {
+      addUnnamedUnnestOutput(hint);
+    }
+  };
+
+  for (size_t i = 0; i < unnestExprs.size(); ++i) {
+    const auto& unnestExpr = unnestExprs[i];
+    const auto& expr = exprs[i];
     outputNames.emplace_back();
 
     // Per-expression aliases (unnestedAliases) take priority over per-relation
@@ -1201,11 +1225,8 @@ PlanBuilder& PlanBuilder::unnest(
         if (!aliases.empty()) {
           VELOX_USER_CHECK_EQ(aliases.size(), 1);
           addUnnestOutput(aliases[0], kElementHint);
-        } else if (!unnestAliases.empty()) {
-          VELOX_USER_CHECK_LT(index, unnestAliases.size());
-          addUnnestOutput(unnestAliases[index], kElementHint);
         } else {
-          addUnnamedUnnestOutput(kElementHint);
+          addRelationAliasOrUnnamed(kElementHint);
         }
         break;
 
@@ -1214,19 +1235,14 @@ PlanBuilder& PlanBuilder::unnest(
           VELOX_USER_CHECK_EQ(aliases.size(), 2);
           addUnnestOutput(aliases[0], kKeyHint);
           addUnnestOutput(aliases[1], kValueHint);
-        } else if (!unnestAliases.empty()) {
-          VELOX_USER_CHECK_LT(index, unnestAliases.size());
-          addUnnestOutput(unnestAliases[index], kKeyHint);
-          addUnnestOutput(unnestAliases[index], kValueHint);
         } else {
-          addUnnamedUnnestOutput(kKeyHint);
-          addUnnamedUnnestOutput(kValueHint);
+          addRelationAliasOrUnnamed(kKeyHint);
+          addRelationAliasOrUnnamed(kValueHint);
         }
         break;
 
       default:
-        VELOX_USER_FAIL(
-            "Unsupported type to unnest: {}", expr->type()->toString());
+        VELOX_UNREACHABLE();
     }
   }
 

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -483,9 +483,9 @@ class PlanBuilder {
   /// @param ordinality If set, adds an ordinality column. Must be created
   /// using the Ordinality() factory function.
   /// @param alias Optional alias for the relation produced by unnest.
-  /// @param columnAliases An optional list of aliases for columns produced by
-  /// unnest. The list can be empty or must have a non-empty alias for each
-  /// column.
+  /// @param unnestAliases Aliases to apply in order to columns produced by
+  /// expressions that do not have per-expression aliases. Missing aliases use
+  /// generated names and excess aliases are ignored.
   PlanBuilder& unnest(
       const std::vector<ExprApi>& unnestExprs,
       const std::optional<ExprApi>& ordinality,

--- a/axiom/logical_plan/tests/PlanBuilderTest.cpp
+++ b/axiom/logical_plan/tests/PlanBuilderTest.cpp
@@ -310,6 +310,37 @@ TEST_F(PlanBuilderTest, unnestOrdinality) {
       {"a", "elem", "ord"});
 }
 
+TEST_F(PlanBuilderTest, mixedUnnestAliases) {
+  auto plan =
+      PlanBuilder()
+          .values(
+              ROW({"a", "m"}, {ARRAY(BIGINT()), MAP(BIGINT(), BIGINT())}),
+              ValuesNode::Variants{})
+          .unnest(
+              {Col("a").unnestAs("element"), Col("m")},
+              std::nullopt,
+              "u",
+              {"key", "value"})
+          .build();
+
+  EXPECT_THAT(
+      plan->outputType()->names(),
+      testing::ElementsAre("a", "m", "element", "key", "value"));
+}
+
+TEST_F(PlanBuilderTest, unusedUnnestAlias) {
+  PlanBuilder::Context context;
+  auto plan =
+      PlanBuilder(context, /*allowAmbiguousOutputNames=*/true)
+          .values(ROW("a", ARRAY(BIGINT())), ValuesNode::Variants{})
+          .unnest(
+              {Col("a").unnestAs("element")}, std::nullopt, "u", {"element"})
+          .project({Col("element")})
+          .build();
+
+  EXPECT_THAT(plan->outputType()->names(), testing::ElementsAre("element"));
+}
+
 TEST_F(PlanBuilderTest, setOperationTypeCoercion) {
   auto startMatcher = [] { return test::LogicalPlanMatcherBuilder().values(); };
 

--- a/axiom/sql/presto/DisplayNames.cpp
+++ b/axiom/sql/presto/DisplayNames.cpp
@@ -85,6 +85,13 @@ void DisplayNames::captureLastNames(const std::vector<SelectItemPtr>& items) {
 void DisplayNames::accumulate(
     const lp::PlanBuilder& builder,
     const std::optional<std::string>& relationAlias) {
+  accumulateFrom(builder, relationAlias, 0);
+}
+
+void DisplayNames::accumulateFrom(
+    const lp::PlanBuilder& builder,
+    const std::optional<std::string>& relationAlias,
+    size_t firstColumn) {
   if (lastNames.empty()) {
     return;
   }
@@ -92,7 +99,7 @@ void DisplayNames::accumulate(
   std::vector<std::optional<std::string>> names =
       builder.outputNames(/*includeHiddenColumns=*/false);
   VELOX_CHECK_EQ(names.size(), lastNames.size());
-  for (size_t i = 0; i < names.size(); ++i) {
+  for (size_t i = firstColumn; i < names.size(); ++i) {
     const auto& name = names[i];
     const auto& display = lastNames[i];
     if (!display.has_value() || !name.has_value()) {

--- a/axiom/sql/presto/DisplayNames.h
+++ b/axiom/sql/presto/DisplayNames.h
@@ -93,6 +93,13 @@ struct DisplayNames {
   void accumulate(
       const lp::PlanBuilder& builder,
       const std::optional<std::string>& relationAlias);
+
+  /// Captures display names for 'builder' columns starting at 'firstColumn'.
+  /// Used when a relation appends columns to an existing input.
+  void accumulateFrom(
+      const lp::PlanBuilder& builder,
+      const std::optional<std::string>& relationAlias,
+      size_t firstColumn);
 };
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -478,9 +478,39 @@ class RelationPlanner : public AstVisitor {
     return std::nullopt;
   }
 
+  void updateUnnestDisplayNames(
+      const AliasedRelation& aliasedRelation,
+      const std::string& relationAlias,
+      std::span<const std::shared_ptr<Identifier>> columnAliases,
+      size_t numInputColumns) {
+    const auto& planNode = builder_->planNode();
+    VELOX_CHECK(
+        planNode->is(lp::NodeKind::kUnnest),
+        "Expected UnnestNode after PlanBuilder::unnest");
+    const auto* unnestNode = planNode->as<lp::UnnestNode>();
+    const auto numOutputColumns = unnestNode->outputType()->size() -
+        unnestNode->onlyInput()->outputType()->size();
+    AXIOM_PRESTO_SEMANTIC_CHECK_EQ(
+        columnAliases.size(),
+        numOutputColumns,
+        aliasedRelation.location(),
+        aliasedRelation.alias()->value(),
+        "Column alias list size does not match the number of output columns");
+
+    VELOX_CHECK_EQ(
+        displayNames_.lastNames.size(), numInputColumns + numOutputColumns);
+    for (size_t i = 0; i < numOutputColumns; ++i) {
+      displayNames_.lastNames[numInputColumns + i] = columnAliases[i]->value();
+    }
+    displayNames_.accumulateFrom(*builder_, relationAlias, numInputColumns);
+  }
+
   void addCrossJoinUnnest(
       const Unnest& unnest,
       const AliasedRelation* aliasedRelation) {
+    const auto numInputColumns =
+        builder_->outputNames(/*includeHiddenColumns=*/false).size();
+
     std::vector<lp::ExprApi> inputs;
     for (const auto& expr : unnest.expressions()) {
       inputs.push_back(toExpr(expr));
@@ -493,26 +523,35 @@ class RelationPlanner : public AstVisitor {
       return lp::Ordinality();
     };
 
-    if (aliasedRelation) {
-      std::vector<std::string> columnNames;
-      columnNames.reserve(aliasedRelation->columnNames().size());
-      for (const auto& name : aliasedRelation->columnNames()) {
-        columnNames.emplace_back(canonicalizeIdentifier(*name));
+    std::optional<std::string> relationAlias;
+    std::span<const std::shared_ptr<Identifier>> columnAliases;
+    if (aliasedRelation != nullptr) {
+      relationAlias = canonicalizeIdentifier(*aliasedRelation->alias());
+      columnAliases = aliasedRelation->columnNames();
+    }
+
+    if (relationAlias.has_value()) {
+      std::vector<std::string> canonicalColumnNames;
+      canonicalColumnNames.reserve(columnAliases.size());
+      for (const auto& name : columnAliases) {
+        canonicalColumnNames.emplace_back(canonicalizeIdentifier(*name));
       }
 
       auto ordinality = toOrdinality();
-      if (ordinality.has_value() && !columnNames.empty()) {
-        ordinality = ordinality->as(columnNames.back());
-        columnNames.pop_back();
+      if (ordinality.has_value() && !canonicalColumnNames.empty()) {
+        ordinality = ordinality->as(canonicalColumnNames.back());
+        canonicalColumnNames.pop_back();
       }
 
-      builder_->unnest(
-          inputs,
-          ordinality,
-          canonicalizeIdentifier(*aliasedRelation->alias()),
-          columnNames);
+      builder_->unnest(inputs, ordinality, relationAlias, canonicalColumnNames);
     } else {
       builder_->unnest(inputs, toOrdinality());
+    }
+
+    displayNames_.captureLastNames(*builder_);
+    if (!columnAliases.empty()) {
+      updateUnnestDisplayNames(
+          *aliasedRelation, *relationAlias, columnAliases, numInputColumns);
     }
   }
 

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -88,6 +88,47 @@ TEST_F(PrestoParserTest, unnest) {
           matchValues().unnest().output()),
       "Column alias list size does not match");
 
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect(
+          "SELECT * FROM (SELECT ARRAY[1] AS a) "
+          "CROSS JOIN UNNEST(a) AS u(x, y)"),
+      "Column alias list size does not match");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect(
+          "SELECT * FROM (SELECT MAP(ARRAY[1], ARRAY[2]) AS m) "
+          "CROSS JOIN UNNEST(m) AS u(k)"),
+      "Column alias list size does not match");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect(
+          "SELECT * FROM (SELECT ARRAY[1] AS a) "
+          "CROSS JOIN UNNEST(a) WITH ORDINALITY AS u(x)"),
+      "Column alias list size does not match");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect(
+          "SELECT * FROM (SELECT MAP(ARRAY[1], ARRAY[2]) AS m, "
+          "ARRAY[ROW(1, 2)] AS a) "
+          "CROSS JOIN UNNEST(m, a) AS u(k)"),
+      "Column alias list size does not match");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect(
+          "SELECT * FROM (SELECT ARRAY[ROW(1, 2)] AS a) "
+          "CROSS JOIN UNNEST(a) WITH ORDINALITY AS u(x)"),
+      "Column alias list size does not match");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect(
+          "SELECT * FROM (SELECT ARRAY[ROW(1, 2)] AS a) "
+          "CROSS JOIN UNNEST(a) AS u(x, y)"),
+      "Column alias list size does not match");
+  testSelect(
+      "SELECT * FROM (SELECT ARRAY[ROW(1, 2)] AS a) "
+      "CROSS JOIN UNNEST(a) AS u(x)",
+      matchValues().project().unnest().output({"a", "x"}));
+
   testSelect(
       "SELECT * FROM unnest(array[1, 2, 3], array[4, 5]) with ordinality as t(x, y, ord)",
       matchValues().unnest().project().output({"x", "y", "ord"}));
@@ -1852,6 +1893,34 @@ TEST_F(PrestoParserTest, outputNamesPreserveAliasCaseAcrossJoin) {
           "SELECT * FROM ((SELECT 1 AS X) CROSS JOIN (SELECT 2 AS Y)) a"),
       testing::ElementsAre("X", "Y"));
 
+  // A wrapped CROSS JOIN preserves the case of its input and UNNEST output.
+  EXPECT_THAT(
+      outputNames(
+          "SELECT * FROM ((SELECT ARRAY[1] AS A) CROSS JOIN UNNEST(a) AS u(X)) t"),
+      testing::ElementsAre("A", "X"));
+  EXPECT_THAT(
+      outputNames(
+          "SELECT * FROM ((SELECT MAP(ARRAY[1], ARRAY[2]) AS M) "
+          "CROSS JOIN UNNEST(m) AS u(K, V)) t"),
+      testing::ElementsAre("M", "K", "V"));
+  EXPECT_THAT(
+      outputNames(
+          "SELECT * FROM ((SELECT ARRAY[1] AS A) "
+          "CROSS JOIN UNNEST(a) WITH ORDINALITY AS u(X, N)) t"),
+      testing::ElementsAre("A", "X", "N"));
+
+  // Qualified and chained joins preserve each UNNEST column alias's case.
+  EXPECT_THAT(
+      outputNames(
+          "SELECT u.* FROM (SELECT ARRAY[1] AS A) CROSS JOIN UNNEST(a) AS u(X)"),
+      testing::ElementsAre("X"));
+  EXPECT_THAT(
+      outputNames(
+          "SELECT * FROM ((SELECT ARRAY[1] AS A, ARRAY[2] AS B) "
+          "CROSS JOIN UNNEST(a) AS u(X) "
+          "CROSS JOIN UNNEST(b) AS v(Y)) t"),
+      testing::ElementsAre("A", "B", "X", "Y"));
+
   // Alias-qualified star expansion.
   EXPECT_THAT(
       outputNames(
@@ -1879,7 +1948,9 @@ TEST_F(PrestoParserTest, outputNamesPreserveAliasCaseAcrossJoin) {
   // Nested JOIN inside the right leg.
   EXPECT_THAT(
       outputNames(
-          "SELECT * FROM ((SELECT 1 AS X) CROSS JOIN ((SELECT 2 AS Y) CROSS JOIN (SELECT 3 AS Z))) a"),
+          "SELECT * FROM ((SELECT 1 AS X) "
+          "CROSS JOIN ((SELECT 2 AS Y) "
+          "CROSS JOIN (SELECT 3 AS Z))) a"),
       testing::ElementsAre("X", "Y", "Z"));
 }
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/316


Wrapping `CROSS JOIN UNNEST` in a relation alias failed during logical planning with `names.size() == lastNames.size()`. Rebuild the combined display names after UNNEST and preserve explicit alias capitalization across relation wrappers and chained joins.

Validate UNNEST alias counts before consuming them so malformed aliases fail cleanly.

Reviewed By: amitkdutta

Differential Revision: D119441501


