### PR TITLE
fix(logical_plan): Reconcile row field names in sets (#1864)

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -113,7 +113,7 @@ ExprPtr makeCoercedRef(
     const std::string& name,
     const velox::TypePtr& targetType) {
   auto ref = makeInputRef(columnType, name);
-  if (targetType != nullptr && !columnType->equivalent(*targetType)) {
+  if (targetType != nullptr && *columnType != *targetType) {
     return applyCoercion(ref, targetType);
   }
   return ref;
@@ -1483,7 +1483,7 @@ std::vector<velox::TypePtr> PlanBuilder::computeCommonTypes(
     auto leftColumnType = leftType->findChild(column.leftId);
     auto rightColumnType = rightType->findChild(column.rightId);
 
-    if (leftColumnType->equivalent(*rightColumnType)) {
+    if (*leftColumnType == *rightColumnType) {
       commonTypes.push_back(nullptr);
       continue;
     }
@@ -1549,7 +1549,7 @@ void PlanBuilder::addJoinUsingProjection(
           joinType == JoinType::kRight ? rightColumnType : leftColumnType;
       exprs.push_back(makeCoercedRef(sourceType, sourceId, commonTypes[i]));
       const bool coerced =
-          commonTypes[i] != nullptr && !sourceType->equivalent(*commonTypes[i]);
+          commonTypes[i] != nullptr && *sourceType != *commonTypes[i];
       outputNames.push_back(coerced ? newName(column.name) : sourceId);
     }
 
@@ -1704,7 +1704,7 @@ void PlanBuilder::coerceSetInputs(std::vector<LogicalPlanNodePtr>& nodes) {
       const auto& currentType = targetTypes[j];
       const auto& nextType = rowType->childAt(j);
 
-      if (currentType->equivalent(*nextType)) {
+      if (*currentType == *nextType) {
         continue;
       }
 
@@ -1731,12 +1731,12 @@ void PlanBuilder::coerceSetInputs(std::vector<LogicalPlanNodePtr>& nodes) {
     for (uint32_t i = 0; i < inputRowType->size(); ++i) {
       const auto& inputType = inputRowType->childAt(i);
       const auto& targetType = targetTypes[i];
-      if (inputType->equivalent(*targetType)) {
+      if (*inputType == *targetType) {
         exprs.push_back(makeInputRef(inputType, inputRowType->nameOf(i)));
       } else {
         needsCast = true;
-        exprs.push_back(
-            makeCoercedRef(inputType, inputRowType->nameOf(i), targetType));
+        exprs.push_back(applyCoercion(
+            makeInputRef(inputType, inputRowType->nameOf(i)), targetType));
         outputNames[i] = newName(inputRowType->nameOf(i));
       }
     }

--- a/axiom/logical_plan/tests/PlanBuilderTest.cpp
+++ b/axiom/logical_plan/tests/PlanBuilderTest.cpp
@@ -540,6 +540,23 @@ TEST_F(PlanBuilderTest, joinUsingTypeCoercion) {
     ASSERT_TRUE(matcher->match(plan)) << plan->toString();
   }
 
+  // Nested ROW field names are reconciled in join keys and USING outputs.
+  for (const auto joinType : {JoinType::kInner, JoinType::kFull}) {
+    PlanBuilder::Context context;
+    auto [left, right] = makeBuilders(
+        context,
+        ROW("c0", ROW("x", INTEGER())),
+        ROW("c0", ROW("X", INTEGER())));
+
+    auto plan = left.joinUsing(right, {"c0"}, joinType).build();
+
+    VELOX_EXPECT_EQ_TYPES(plan->outputType(), ROW("c0", ROW("", INTEGER())));
+
+    auto matcher =
+        startMatcher().join(startMatcher().build()).project().project().build();
+    ASSERT_TRUE(matcher->match(plan)) << plan->toString();
+  }
+
   // Multiple USING columns with mixed match/mismatch.
   {
     PlanBuilder::Context context;

--- a/axiom/optimizer/tests/sql/set.sql
+++ b/axiom/optimizer/tests/sql/set.sql
@@ -197,6 +197,12 @@ SELECT a FROM t WHERE b > 50
 UNION ALL
 SELECT a FROM t WHERE b > 100
 ----
+-- UNION ALL reconciles nested row field names that differ in capitalization.
+-- duckdb: VALUES (ROW(1)), (ROW(2))
+SELECT ROW(1 AS x)
+UNION ALL
+SELECT ROW(2 AS "X")
+----
 -- A leg that selects one column under two names.
 SELECT a AS x, a AS y FROM t WHERE a = 1 AND b = 10
 EXCEPT


### PR DESCRIPTION
Summary:

Planning failed with `Output schemas of all inputs to a Set operation must match` for:

    SELECT CAST(ROW(1) AS ROW(x INTEGER))
    UNION ALL
    SELECT CAST(ROW(2) AS ROW("X" INTEGER))

Compute a common type unless the input types are exactly equal. This drops conflicting row field names and casts affected inputs to the resulting schema.

Reviewed By: amitkdutta

Differential Revision: D119445174


