### PR TITLE
fix(v2): Let a join inside an Unnest's input keep its order

### DIFF
--- a/axiom/optimizer/tests/sql/unnest.sql
+++ b/axiom/optimizer/tests/sql/unnest.sql
@@ -5,6 +5,9 @@ SELECT * FROM (VALUES
   (8, ARRAY[30, 10], ARRAY[5], ARRAY[ARRAY[4]]),
   (9, ARRAY[40], ARRAY[6, 7, 8], ARRAY[ARRAY[5, 6]])
 ) AS _(x, ys, zs, nested)
+----
+CREATE TABLE elements AS
+SELECT * FROM (VALUES (10), (40)) AS _(v)
 -- end_setup
 
 -- One row per element of the unnested array; 'x' is replicated.
@@ -82,6 +85,24 @@ JOIN (SELECT s FROM UNNEST(ARRAY[7, 8]) AS u(s)) ON a.x = s
 SELECT a.x, s
 FROM arrays a
 LEFT JOIN (SELECT s FROM UNNEST(ARRAY[7, 8]) AS u(s)) ON a.x = s
+----
+-- An 'x' with no array of its own reads no elements, so it matches none and
+-- keeps a NULL. Every other 'x' whose array holds a listed element reads its
+-- own value back.
+WITH keyed AS (
+  SELECT a.x FROM arrays a, arrays b WHERE a.x = b.x
+),
+joined AS (
+  SELECT keyed.x, s.ys
+  FROM keyed LEFT JOIN (SELECT * FROM arrays WHERE x < 9) s ON s.x = keyed.x
+),
+matched AS (
+  SELECT joined.x FROM joined
+  CROSS JOIN UNNEST(joined.ys) AS _(y)
+  INNER JOIN elements ON elements.v = y
+)
+SELECT joined.x, matched.x AS m
+FROM joined LEFT JOIN matched ON joined.x = matched.x
 ----
 -- A join on both a replicated column and an unnested one, projecting a column
 -- from each side.

--- a/axiom/optimizer/v2/HypergraphBuilder.cpp
+++ b/axiom/optimizer/v2/HypergraphBuilder.cpp
@@ -105,12 +105,14 @@ SubtreeRelations populateJoinInputs(
     NodeCP node,
     const folly::F14FastMap<NodeCP, int8_t>& leafIds,
     const folly::F14FastMap<UnnestCP, int8_t>& unnestIds,
-    folly::F14FastMap<JoinCP, JoinInputs>& inputs) {
+    folly::F14FastMap<JoinCP, JoinInputs>& inputs,
+    folly::F14FastMap<int8_t, RelationSet>& unnestSubtrees) {
   const auto it = leafIds.find(node);
   if (it != leafIds.end()) {
     const RelationSet relation = RelationSet::singleton(it->second);
     return {relation, relation};
   }
+
   if (node->is(NodeType::kUnnest)) {
     const auto* unnest = node->as<Unnest>();
     NodeCP input = unnest->input();
@@ -122,15 +124,18 @@ SubtreeRelations populateJoinInputs(
       return {relation, relation};
     }
     SubtreeRelations subtree =
-        populateJoinInputs(input, leafIds, unnestIds, inputs);
+        populateJoinInputs(input, leafIds, unnestIds, inputs, unnestSubtrees);
+    unnestSubtrees[unnestId] = subtree.allRelations;
     subtree.allRelations.add(unnestId);
     return subtree;
   }
+
   const auto* join = node->as<Join>();
-  const SubtreeRelations left =
-      populateJoinInputs(join->left(), leafIds, unnestIds, inputs);
-  const SubtreeRelations right =
-      populateJoinInputs(join->right(), leafIds, unnestIds, inputs);
+  const SubtreeRelations left = populateJoinInputs(
+      join->left(), leafIds, unnestIds, inputs, unnestSubtrees);
+  const SubtreeRelations right = populateJoinInputs(
+      join->right(), leafIds, unnestIds, inputs, unnestSubtrees);
+
   // Normalize right-form joins to their left form by swapping operands.
   // kRight, kRightSemiFilter and kRightSemiProject each map to the
   // matching left-form type; the rest of the pipeline never sees a
@@ -413,54 +418,36 @@ void addTransitiveInnerEdges(
 
 } // namespace
 
-JoinHypergraph HypergraphBuilder::build(
+// The TES of an edge: its SES plus what each side's shape forbids reordering
+// past. 'left' and 'right' are the join's operands in normalized order.
+RelationSet expandTes(
+    const RelationSet& ses,
+    NodeCP left,
+    NodeCP right,
+    velox::core::JoinType joinType,
+    const folly::F14FastMap<NodeCP, int8_t>& leafIds,
+    const folly::F14FastMap<JoinCP, JoinInputs>& joinInputs) {
+  RelationSet tes{ses};
+  tes.unionSet(tesExpansion(
+      left, joinType, ses, /*leftSide=*/true, leafIds, joinInputs));
+  tes.unionSet(tesExpansion(
+      right, joinType, ses, /*leftSide=*/false, leafIds, joinInputs));
+  return tes;
+}
+
+// Admits an Unnest relation per Unnest in 'cluster', in post-order so an input
+// Unnest receives a lower id than one depending on it, and extends
+// 'columnToLeaf' so each Unnest's produced columns resolve to its relation id.
+folly::F14FastMap<UnnestCP, int8_t> addUnnestRelations(
     const JoinCluster& cluster,
-    const std::vector<NodeCP>& rewrittenLeaves,
-    EstimateProvider& estimateProvider) {
-  VELOX_CHECK_LE(
-      cluster.leaves.size(),
-      RelationSet::kMaxRelations,
-      "Cluster has more leaves than RelationSet can represent");
-  VELOX_CHECK_EQ(
-      cluster.leaves.size(),
-      rewrittenLeaves.size(),
-      "rewrittenLeaves must align 1:1 with cluster.leaves");
-
-  JoinHypergraph graph;
-  folly::F14FastMap<ColumnCP, int8_t> columnToLeaf;
-  folly::F14FastMap<NodeCP, int8_t> leafIds;
-  for (size_t i = 0; i < cluster.leaves.size(); ++i) {
-    NodeCP original = cluster.leaves[i];
-    NodeCP rewritten = rewrittenLeaves[i];
-    PlanObjectSet columns;
-    for (const auto* column : rewritten->outputColumns()) {
-      columns.add(column);
-    }
-    const int8_t id = graph.addRelation(
-        rewritten,
-        estimateProvider.estimate(rewritten).cardinality,
-        std::move(columns));
-    VELOX_CHECK(leafIds.emplace(original, id).second, "Duplicate cluster leaf");
-    if (rewritten != original) {
-      VELOX_CHECK(
-          leafIds.emplace(rewritten, id).second,
-          "Duplicate rewritten cluster leaf");
-    }
-    for (const auto* column : rewritten->outputColumns()) {
-      columnToLeaf.emplace(column, id);
-    }
-  }
-
-  // Admit Unnest relations in post-order so input Unnests receive lower ids
-  // than the Unnests that depend on them. Extend the column-resolution map so
-  // each Unnest's produced columns resolve to its relation id.
+    EstimateProvider& estimateProvider,
+    JoinHypergraph& graph,
+    folly::F14FastMap<ColumnCP, int8_t>& columnToLeaf) {
   folly::F14FastMap<UnnestCP, int8_t> unnestIds;
   for (UnnestCP unnest : cluster.unnests) {
     PlanObjectSet producedColumns;
     for (const auto& columnsForExpr : unnest->unnestColumns()) {
-      for (const auto* column : columnsForExpr) {
-        producedColumns.add(column);
-      }
+      producedColumns.unionObjects(columnsForExpr);
     }
     if (unnest->ordinalityColumn() != nullptr) {
       producedColumns.add(unnest->ordinalityColumn());
@@ -480,11 +467,19 @@ JoinHypergraph HypergraphBuilder::build(
       columnToLeaf.emplace(unnest->ordinalityColumn(), id);
     }
   }
+  return unnestIds;
+}
 
-  // Builds each Unnest edge and records the relation ids referenced by the
-  // Unnest input's output columns. These data dependencies determine whether
-  // an outer join must precede or follow the Unnest; they are distinct from the
-  // complete structural subtree membership recorded in `joinInputs` below.
+// Adds an edge per Unnest, from the relations its input's columns read to the
+// Unnest itself, and returns those input relations by Unnest id. They are the
+// Unnest's data dependencies, which decide whether an outer join must precede
+// or follow it; structural subtree membership is recorded separately, by
+// 'populateJoinInputs'.
+folly::F14FastMap<int8_t, RelationSet> addUnnestEdges(
+    const JoinCluster& cluster,
+    const folly::F14FastMap<UnnestCP, int8_t>& unnestIds,
+    const folly::F14FastMap<ColumnCP, int8_t>& columnToLeaf,
+    JoinHypergraph& graph) {
   folly::F14FastMap<int8_t, RelationSet> unnestInputRelations;
   for (UnnestCP unnest : cluster.unnests) {
     const int8_t id = unnestIds.at(unnest);
@@ -509,9 +504,103 @@ JoinHypergraph HypergraphBuilder::build(
 
     graph.addEdge(JoinEdge::unnest(inputRelations, RelationSet::singleton(id)));
   }
+  return unnestInputRelations;
+}
+
+// Adds to 'tes' the Unnests this outer join must not be reordered past.
+//
+// An Unnest reading an array from the join's null-padded side has to run
+// before the join: after it, the padded row carries a NULL array, which
+// unnests to no rows and drops the row the outer join preserved. Adding the
+// Unnest's relation id to the TES is what pins that order for DPhyp.
+//
+// A join inside the Unnest's input subtree is the opposite case: the query
+// unnests what that join produced, and the Unnest's own edge already orders
+// the two, so no barrier applies. Structural containment decides this, not
+// the Unnest input's columns — a projection can drop the columns of a
+// relation the join reads while the join still sits inside the subtree.
+void addUnnestBarriers(
+    const JoinInputs& inputs,
+    const folly::F14FastMap<int8_t, RelationSet>& unnestInputRelations,
+    const folly::F14FastMap<int8_t, RelationSet>& unnestSubtrees,
+    RelationSet& tes) {
+  RelationSet nullPaddedSide;
+  if (inputs.joinType == velox::core::JoinType::kLeft) {
+    nullPaddedSide = inputs.rightLeaves;
+  } else if (inputs.joinType == velox::core::JoinType::kFull) {
+    nullPaddedSide = inputs.leftLeaves;
+    nullPaddedSide.unionSet(inputs.rightLeaves);
+  } else {
+    return;
+  }
+
+  RelationSet joinRelations{inputs.leftLeaves};
+  joinRelations.unionSet(inputs.rightLeaves);
+
+  for (const auto& [unnestId, inputRelations] : unnestInputRelations) {
+    const auto subtreeIt = unnestSubtrees.find(unnestId);
+    if (subtreeIt != unnestSubtrees.end() &&
+        joinRelations.isSubset(subtreeIt->second)) {
+      continue;
+    }
+    if (!nullPaddedSide.hasIntersection(inputRelations)) {
+      continue;
+    }
+    VELOX_CHECK(
+        inputs.leftRelations.contains(unnestId) ||
+            inputs.rightRelations.contains(unnestId),
+        "Unnest must belong to one normalized join side: {}",
+        unnestId);
+    tes.add(unnestId);
+  }
+}
+
+JoinHypergraph HypergraphBuilder::build(
+    const JoinCluster& cluster,
+    const std::vector<NodeCP>& rewrittenLeaves,
+    EstimateProvider& estimateProvider) {
+  VELOX_CHECK_LE(
+      cluster.leaves.size(),
+      RelationSet::kMaxRelations,
+      "Cluster has more leaves than RelationSet can represent");
+  VELOX_CHECK_EQ(
+      cluster.leaves.size(),
+      rewrittenLeaves.size(),
+      "rewrittenLeaves must align 1:1 with cluster.leaves");
+
+  JoinHypergraph graph;
+  folly::F14FastMap<ColumnCP, int8_t> columnToLeaf;
+  folly::F14FastMap<NodeCP, int8_t> leafIds;
+  for (size_t i = 0; i < cluster.leaves.size(); ++i) {
+    NodeCP original = cluster.leaves[i];
+    NodeCP rewritten = rewrittenLeaves[i];
+    PlanObjectSet columns =
+        PlanObjectSet::fromObjects(rewritten->outputColumns());
+    const int8_t id = graph.addRelation(
+        rewritten,
+        estimateProvider.estimate(rewritten).cardinality,
+        std::move(columns));
+    VELOX_CHECK(leafIds.emplace(original, id).second, "Duplicate cluster leaf");
+    if (rewritten != original) {
+      VELOX_CHECK(
+          leafIds.emplace(rewritten, id).second,
+          "Duplicate rewritten cluster leaf");
+    }
+    for (const auto* column : rewritten->outputColumns()) {
+      columnToLeaf.emplace(column, id);
+    }
+  }
+
+  folly::F14FastMap<UnnestCP, int8_t> unnestIds =
+      addUnnestRelations(cluster, estimateProvider, graph, columnToLeaf);
+
+  folly::F14FastMap<int8_t, RelationSet> unnestInputRelations =
+      addUnnestEdges(cluster, unnestIds, columnToLeaf, graph);
 
   folly::F14FastMap<JoinCP, JoinInputs> joinInputs;
-  populateJoinInputs(cluster.root, leafIds, unnestIds, joinInputs);
+  folly::F14FastMap<int8_t, RelationSet> unnestSubtrees;
+  populateJoinInputs(
+      cluster.root, leafIds, unnestIds, joinInputs, unnestSubtrees);
 
   for (JoinCP join : cluster.joins) {
     const auto& inputs = joinInputs.at(join);
@@ -545,21 +634,13 @@ JoinHypergraph HypergraphBuilder::build(
             keyRelationsOrOperand(rightKeys, columnToLeaf, inputs.rightLeaves)};
         RelationSet ses{leftSet};
         ses.unionSet(rightSet);
-        RelationSet tes{ses};
-        tes.unionSet(tesExpansion(
-            join->left(),
-            join->joinType(),
+        const RelationSet tes = expandTes(
             ses,
-            /*leftSide=*/true,
-            leafIds,
-            joinInputs));
-        tes.unionSet(tesExpansion(
+            join->left(),
             join->right(),
             join->joinType(),
-            ses,
-            /*leftSide=*/false,
             leafIds,
-            joinInputs));
+            joinInputs);
         auto [leftTes, rightTes] =
             splitTes(tes, inputs.leftRelations, inputs.rightRelations);
 
@@ -603,60 +684,21 @@ JoinHypergraph HypergraphBuilder::build(
       for (ExprCP conjunct : join->filter()) {
         ses.unionSet(expressionRelations(conjunct, columnToLeaf));
       }
-      RelationSet tes{ses};
-      tes.unionSet(tesExpansion(
-          normalizedLeftChild,
-          inputs.joinType,
+      RelationSet tes = expandTes(
           ses,
-          /*leftSide=*/true,
-          leafIds,
-          joinInputs));
-      tes.unionSet(tesExpansion(
+          normalizedLeftChild,
           normalizedRightChild,
           inputs.joinType,
-          ses,
-          /*leftSide=*/false,
           leafIds,
-          joinInputs));
+          joinInputs);
+
+      addUnnestBarriers(inputs, unnestInputRelations, unnestSubtrees, tes);
 
       // `populateJoinInputs` already applies the same right-form operand swap
-      // as the normalized child selection above.
-      const RelationSet& normalizedLeftRelations = inputs.leftRelations;
-      const RelationSet& normalizedRightRelations = inputs.rightRelations;
-
-      // Outer-join barrier: if an Unnest's input subtree contributes a relation
-      // on this outer join's null-padded side, the unnest edge must fire before
-      // the outer join. Otherwise null-padding flows into UNNEST and rows drop.
-      // Expand TES to include the Unnest relation id so DPhyp pins the order.
-      RelationSet joinRelations{inputs.leftLeaves};
-      joinRelations.unionSet(inputs.rightLeaves);
-      for (const auto& [unnestId, inputRelations] : unnestInputRelations) {
-        // An outer join inside the Unnest's input subtree is already ordered
-        // before the Unnest by the unnest edge. The barrier would demand the
-        // reverse order, which no plan can satisfy when this join is the only
-        // edge co-locating the input relations.
-        if (joinRelations.isSubset(inputRelations)) {
-          continue;
-        }
-        RelationSet nullPaddedSide;
-        if (inputs.joinType == velox::core::JoinType::kLeft) {
-          nullPaddedSide = inputs.rightLeaves;
-        } else if (inputs.joinType == velox::core::JoinType::kFull) {
-          nullPaddedSide = inputs.leftLeaves;
-          nullPaddedSide.unionSet(inputs.rightLeaves);
-        }
-        if (nullPaddedSide.hasIntersection(inputRelations)) {
-          VELOX_CHECK(
-              normalizedLeftRelations.contains(unnestId) ||
-                  normalizedRightRelations.contains(unnestId),
-              "Unnest must belong to one normalized join side: {}",
-              static_cast<int32_t>(unnestId));
-          tes.add(unnestId);
-        }
-      }
-
+      // as the normalized child selection above, so these are in normalized
+      // order.
       auto [leftTes, rightTes] =
-          splitTes(tes, normalizedLeftRelations, normalizedRightRelations);
+          splitTes(tes, inputs.leftRelations, inputs.rightRelations);
 
       // kLeftSemiProject preserves the left side and appends a mark; the
       // Join (and its Apply origin) build outputColumns as


### PR DESCRIPTION
Summary:
A query that unnests an array produced by a LEFT JOIN failed to plan under the v2 optimizer:

    Unnest must belong to one normalized join side: 15

The join order search treats an Unnest reading an array from a join's null-padded side as a barrier: that Unnest has to run before the join, since afterwards the padded row carries a NULL array, which unnests to no rows and drops the row the outer join preserved. The barrier is expressed by adding the Unnest to the join's TES, which requires the Unnest to sit on one side of that join.

A join *inside* the Unnest's input is the opposite case — the query unnests what that join produced, and the Unnest's own edge already orders the two, so no barrier applies. That case was recognized by comparing the join's relations against the relations the Unnest input's columns read. A projection between the two breaks that comparison: a relation whose columns are all dropped is absent from the Unnest input, so the join looks like it is outside, and the barrier demands an order the query cannot have. The check then fails because the Unnest is above the join rather than on either side of it.

Structural containment answers the question the comparison was approximating, so the walk that records each join's operands now also records each Unnest's input subtree, and the guard uses that.

Differential Revision: D119497403
