### PR TITLE
feat(v2): Lift a subquery out of a lambda body (#1869)

### DIFF
--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -2777,6 +2777,25 @@ TEST_P(JoinTest, neverMatchingCondition) {
   }
 }
 
+// A cluster with more relations than a RelationSet can hold has no hypergraph
+// to enumerate over, and keeps the query's own join order.
+TEST_P(JoinTest, clusterLargerThanRelationSet) {
+  if (!useV2_) {
+    GTEST_SKIP();
+  }
+
+  constexpr int32_t kTables = 66;
+  std::string query = "SELECT d0.a FROM d0";
+  for (int32_t i = 0; i < kTables; ++i) {
+    testConnector_->addTable(fmt::format("d{}", i), ROW({"a"}, BIGINT()));
+    if (i > 0) {
+      query += fmt::format(" LEFT JOIN d{0} ON d0.a = d{0}.a", i);
+    }
+  }
+
+  EXPECT_NO_THROW(toSingleNodePlan(parseSelect(query, kTestConnectorId)));
+}
+
 AXIOM_INSTANTIATE_V1_V2(JoinTest);
 
 } // namespace

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -2754,6 +2754,29 @@ TEST_P(JoinTest, constantInput) {
   }
 }
 
+// A join condition no row satisfies needs no join: an inner join produces
+// nothing, and an outer join produces its preserved side alone.
+TEST_P(JoinTest, neverMatchingCondition) {
+  if (!useV2_) {
+    GTEST_SKIP();
+  }
+
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  testConnector_->addTable("u", ROW({"x", "y"}, BIGINT()));
+
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT t.a, u.y FROM t LEFT JOIN u ON t.a = u.x AND 1 = 2");
+    AXIOM_ASSERT_PLAN_V2(plan, matchScan("t").project({"a", "null"}).build());
+  }
+
+  {
+    auto plan =
+        toSingleNodePlan("SELECT t.a FROM t JOIN u ON t.a = u.x AND 1 = 2");
+    AXIOM_ASSERT_PLAN_V2(plan, matchValues().build());
+  }
+}
+
 AXIOM_INSTANTIATE_V1_V2(JoinTest);
 
 } // namespace

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -1,5 +1,21 @@
 -- setup_file: common_setup.sql
 
+-- A join condition no row satisfies keeps every left row and reads NULL for
+-- the right side.
+SELECT t1.a, t2.b FROM t t1 LEFT JOIN t t2 ON t1.a = t2.a AND 1 = 2
+----
+-- The same condition on an inner join yields nothing.
+-- count 0
+SELECT t1.a FROM t t1 JOIN t t2 ON t1.a = t2.a AND 1 = 2
+----
+-- A WHERE reading the side that never matches sees the NULLs the outer join
+-- pads with: an IS NULL keeps every row.
+SELECT t1.a FROM t t1 LEFT JOIN t t2 ON t1.a = t2.a AND 1 = 2 WHERE t2.b IS NULL
+----
+-- A comparison against those NULLs keeps none.
+-- count 0
+SELECT t1.a FROM t t1 LEFT JOIN t t2 ON t1.a = t2.a AND 1 = 2 WHERE t2.b > 5
+----
 -- JOIN with UNION ALL subquery.
 SELECT t1.a, t1.b
 FROM t t1 JOIN (SELECT a FROM t WHERE a = 1 UNION ALL SELECT a FROM t WHERE a = 2) t2 ON t1.a = t2.a

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -1500,3 +1500,21 @@ ORDER BY (SELECT v.a)
 SELECT (SELECT 1 WHERE v.a = 2)
 FROM v
 GROUP BY a
+----
+-- A subquery in a lambda body reads a value the row already has: it is
+-- evaluated once for the row, and every element of the array sees it. The
+-- smallest 'v.a' is 2, so one element of each array survives. DuckDB rejects
+-- a subquery in a lambda, so the expected rows are stated here.
+-- duckdb: VALUES (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)
+-- error_v1: Unexpected expression: Subquery
+SELECT u.a, cardinality(filter(ARRAY[1, 2, 3], x -> x > (SELECT min(a) FROM v)))
+FROM u
+----
+-- The same where the subquery is correlated to the row: the array survives
+-- whole for the rows whose value 'v' holds, and empties for the rest.
+-- duckdb: VALUES (1, 0), (2, 3), (3, 0), (4, 3), (5, 0)
+-- error_v1: Unexpected expression: Subquery
+SELECT
+  u.a,
+  cardinality(filter(ARRAY[1, 2, 3], x -> EXISTS (SELECT 1 FROM v WHERE v.a = u.a)))
+FROM u

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -814,6 +814,17 @@ SELECT (SELECT t2.b FROM t t2 WHERE t2.a = t.a) FROM t
 -- error: Expected single row of input. Received 5 rows.
 SELECT (SELECT a FROM u) FROM t
 ----
+-- A disjunct that is always true decides the WHERE on its own, so the EXISTS
+-- beside it settles nothing and every row is counted.
+WITH ids AS (SELECT * FROM (VALUES (1), (2)) AS _(id))
+SELECT count(*) FROM ids
+WHERE 1 = 1 OR EXISTS (SELECT 1 FROM u WHERE u.a = ids.id)
+----
+-- The same, counting distinct values instead of rows.
+WITH ids AS (SELECT * FROM (VALUES (1), (2)) AS _(id))
+SELECT count(DISTINCT ids.id) FROM ids
+WHERE 1 = 1 OR EXISTS (SELECT 1 FROM u WHERE u.a = ids.id)
+----
 -- Correlated EXISTS over a scalar-aggregate body. EXISTS is true iff
 -- the per-outer aggregate produces a row — for count(*) without
 -- HAVING, that's iff u has any matching row.

--- a/axiom/optimizer/tests/sql/unnest.sql
+++ b/axiom/optimizer/tests/sql/unnest.sql
@@ -5,6 +5,9 @@ SELECT * FROM (VALUES
   (8, ARRAY[30, 10], ARRAY[5], ARRAY[ARRAY[4]]),
   (9, ARRAY[40], ARRAY[6, 7, 8], ARRAY[ARRAY[5, 6]])
 ) AS _(x, ys, zs, nested)
+----
+CREATE TABLE elements AS
+SELECT * FROM (VALUES (10), (40)) AS _(v)
 -- end_setup
 
 -- One row per element of the unnested array; 'x' is replicated.
@@ -82,6 +85,24 @@ JOIN (SELECT s FROM UNNEST(ARRAY[7, 8]) AS u(s)) ON a.x = s
 SELECT a.x, s
 FROM arrays a
 LEFT JOIN (SELECT s FROM UNNEST(ARRAY[7, 8]) AS u(s)) ON a.x = s
+----
+-- An 'x' with no array of its own reads no elements, so it matches none and
+-- keeps a NULL. Every other 'x' whose array holds a listed element reads its
+-- own value back.
+WITH keyed AS (
+  SELECT a.x FROM arrays a, arrays b WHERE a.x = b.x
+),
+joined AS (
+  SELECT keyed.x, s.ys
+  FROM keyed LEFT JOIN (SELECT * FROM arrays WHERE x < 9) s ON s.x = keyed.x
+),
+matched AS (
+  SELECT joined.x FROM joined
+  CROSS JOIN UNNEST(joined.ys) AS _(y)
+  INNER JOIN elements ON elements.v = y
+)
+SELECT joined.x, matched.x AS m
+FROM joined LEFT JOIN matched ON joined.x = matched.x
 ----
 -- A join on both a replicated column and an unnested one, projecting a column
 -- from each side.

--- a/axiom/optimizer/v2/HypergraphBuilder.cpp
+++ b/axiom/optimizer/v2/HypergraphBuilder.cpp
@@ -99,18 +99,25 @@ struct SubtreeRelations {
   RelationSet allRelations;
 };
 
-// Returns the leaf relations and all hypergraph relations below `node`, and
-// records the normalized operands of every Join reached during the walk.
+// Returns the leaf relations and all hypergraph relations below `node`,
+// records the normalized operands of every Join reached during the walk in
+// `inputs`, and records in `unnestSubtrees` what each Unnest's input subtree
+// contributes. That set excludes the Unnest's own relation id, so testing a
+// join's relations against it asks whether the join lies below the Unnest.
+// Every Unnest of the cluster gets an entry, an Unnest of a constant an empty
+// one: the cluster holds no part of its input.
 SubtreeRelations populateJoinInputs(
     NodeCP node,
     const folly::F14FastMap<NodeCP, int8_t>& leafIds,
     const folly::F14FastMap<UnnestCP, int8_t>& unnestIds,
-    folly::F14FastMap<JoinCP, JoinInputs>& inputs) {
+    folly::F14FastMap<JoinCP, JoinInputs>& inputs,
+    folly::F14FastMap<int8_t, RelationSet>& unnestSubtrees) {
   const auto it = leafIds.find(node);
   if (it != leafIds.end()) {
     const RelationSet relation = RelationSet::singleton(it->second);
     return {relation, relation};
   }
+
   if (node->is(NodeType::kUnnest)) {
     const auto* unnest = node->as<Unnest>();
     NodeCP input = unnest->input();
@@ -118,19 +125,23 @@ SubtreeRelations populateJoinInputs(
     // The cluster does not contain the input of an Unnest of a constant, so
     // the Unnest's own relation is all its subtree contributes.
     if (input->outputColumns().empty()) {
+      unnestSubtrees[unnestId] = RelationSet{};
       const RelationSet relation = RelationSet::singleton(unnestId);
       return {relation, relation};
     }
     SubtreeRelations subtree =
-        populateJoinInputs(input, leafIds, unnestIds, inputs);
+        populateJoinInputs(input, leafIds, unnestIds, inputs, unnestSubtrees);
+    unnestSubtrees[unnestId] = subtree.allRelations;
     subtree.allRelations.add(unnestId);
     return subtree;
   }
+
   const auto* join = node->as<Join>();
-  const SubtreeRelations left =
-      populateJoinInputs(join->left(), leafIds, unnestIds, inputs);
-  const SubtreeRelations right =
-      populateJoinInputs(join->right(), leafIds, unnestIds, inputs);
+  const SubtreeRelations left = populateJoinInputs(
+      join->left(), leafIds, unnestIds, inputs, unnestSubtrees);
+  const SubtreeRelations right = populateJoinInputs(
+      join->right(), leafIds, unnestIds, inputs, unnestSubtrees);
+
   // Normalize right-form joins to their left form by swapping operands.
   // kRight, kRightSemiFilter and kRightSemiProject each map to the
   // matching left-form type; the rest of the pipeline never sees a
@@ -411,56 +422,36 @@ void addTransitiveInnerEdges(
   }
 }
 
-} // namespace
+// The TES of an edge: its SES plus what each side's shape forbids reordering
+// past. 'left' and 'right' are the join's operands in normalized order.
+RelationSet expandTes(
+    const RelationSet& ses,
+    NodeCP left,
+    NodeCP right,
+    velox::core::JoinType joinType,
+    const folly::F14FastMap<NodeCP, int8_t>& leafIds,
+    const folly::F14FastMap<JoinCP, JoinInputs>& joinInputs) {
+  RelationSet tes{ses};
+  tes.unionSet(tesExpansion(
+      left, joinType, ses, /*leftSide=*/true, leafIds, joinInputs));
+  tes.unionSet(tesExpansion(
+      right, joinType, ses, /*leftSide=*/false, leafIds, joinInputs));
+  return tes;
+}
 
-JoinHypergraph HypergraphBuilder::build(
+// Admits an Unnest relation per Unnest in 'cluster', in post-order so an input
+// Unnest receives a lower id than one depending on it, and extends
+// 'columnToLeaf' so each Unnest's produced columns resolve to its relation id.
+folly::F14FastMap<UnnestCP, int8_t> addUnnestRelations(
     const JoinCluster& cluster,
-    const std::vector<NodeCP>& rewrittenLeaves,
-    EstimateProvider& estimateProvider) {
-  VELOX_CHECK_LE(
-      cluster.leaves.size(),
-      RelationSet::kMaxRelations,
-      "Cluster has more leaves than RelationSet can represent");
-  VELOX_CHECK_EQ(
-      cluster.leaves.size(),
-      rewrittenLeaves.size(),
-      "rewrittenLeaves must align 1:1 with cluster.leaves");
-
-  JoinHypergraph graph;
-  folly::F14FastMap<ColumnCP, int8_t> columnToLeaf;
-  folly::F14FastMap<NodeCP, int8_t> leafIds;
-  for (size_t i = 0; i < cluster.leaves.size(); ++i) {
-    NodeCP original = cluster.leaves[i];
-    NodeCP rewritten = rewrittenLeaves[i];
-    PlanObjectSet columns;
-    for (const auto* column : rewritten->outputColumns()) {
-      columns.add(column);
-    }
-    const int8_t id = graph.addRelation(
-        rewritten,
-        estimateProvider.estimate(rewritten).cardinality,
-        std::move(columns));
-    VELOX_CHECK(leafIds.emplace(original, id).second, "Duplicate cluster leaf");
-    if (rewritten != original) {
-      VELOX_CHECK(
-          leafIds.emplace(rewritten, id).second,
-          "Duplicate rewritten cluster leaf");
-    }
-    for (const auto* column : rewritten->outputColumns()) {
-      columnToLeaf.emplace(column, id);
-    }
-  }
-
-  // Admit Unnest relations in post-order so input Unnests receive lower ids
-  // than the Unnests that depend on them. Extend the column-resolution map so
-  // each Unnest's produced columns resolve to its relation id.
+    EstimateProvider& estimateProvider,
+    JoinHypergraph& graph,
+    folly::F14FastMap<ColumnCP, int8_t>& columnToLeaf) {
   folly::F14FastMap<UnnestCP, int8_t> unnestIds;
   for (UnnestCP unnest : cluster.unnests) {
     PlanObjectSet producedColumns;
     for (const auto& columnsForExpr : unnest->unnestColumns()) {
-      for (const auto* column : columnsForExpr) {
-        producedColumns.add(column);
-      }
+      producedColumns.unionObjects(columnsForExpr);
     }
     if (unnest->ordinalityColumn() != nullptr) {
       producedColumns.add(unnest->ordinalityColumn());
@@ -480,11 +471,18 @@ JoinHypergraph HypergraphBuilder::build(
       columnToLeaf.emplace(unnest->ordinalityColumn(), id);
     }
   }
+  return unnestIds;
+}
 
-  // Builds each Unnest edge and records the relation ids referenced by the
-  // Unnest input's output columns. These data dependencies determine whether
-  // an outer join must precede or follow the Unnest; they are distinct from the
-  // complete structural subtree membership recorded in `joinInputs` below.
+// Adds an edge per Unnest, from the relations its input's columns read to the
+// Unnest itself, and returns those input relations by Unnest id: the Unnest's
+// data dependencies, which decide whether an outer join must precede or
+// follow it.
+folly::F14FastMap<int8_t, RelationSet> addUnnestEdges(
+    const JoinCluster& cluster,
+    const folly::F14FastMap<UnnestCP, int8_t>& unnestIds,
+    const folly::F14FastMap<ColumnCP, int8_t>& columnToLeaf,
+    JoinHypergraph& graph) {
   folly::F14FastMap<int8_t, RelationSet> unnestInputRelations;
   for (UnnestCP unnest : cluster.unnests) {
     const int8_t id = unnestIds.at(unnest);
@@ -509,9 +507,103 @@ JoinHypergraph HypergraphBuilder::build(
 
     graph.addEdge(JoinEdge::unnest(inputRelations, RelationSet::singleton(id)));
   }
+  return unnestInputRelations;
+}
+
+// Adds to 'tes' the Unnests this outer join must not be reordered past.
+//
+// An Unnest reading an array from the join's null-padded side has to run
+// before the join: after it, the padded row carries a NULL array, which
+// unnests to no rows and drops the row the outer join preserved. Adding the
+// Unnest's relation id to the TES is what pins that order for DPhyp.
+//
+// A join contained in the Unnest's input subtree is one the query unnests the
+// result of, so its own order is join-then-unnest and the barrier, which
+// demands the reverse, does not apply to it. Containment is structural: a
+// projection can drop the columns of a relation the join reads, which is why
+// the Unnest's data dependencies do not answer this.
+void addUnnestBarriers(
+    const JoinInputs& inputs,
+    const folly::F14FastMap<int8_t, RelationSet>& unnestInputRelations,
+    const folly::F14FastMap<int8_t, RelationSet>& unnestSubtrees,
+    RelationSet& tes) {
+  RelationSet nullPaddedSide;
+  if (inputs.joinType == velox::core::JoinType::kLeft) {
+    nullPaddedSide = inputs.rightLeaves;
+  } else if (inputs.joinType == velox::core::JoinType::kFull) {
+    nullPaddedSide = inputs.leftLeaves;
+    nullPaddedSide.unionSet(inputs.rightLeaves);
+  } else {
+    return;
+  }
+
+  RelationSet joinRelations{inputs.leftRelations};
+  joinRelations.unionSet(inputs.rightRelations);
+
+  for (const auto& [unnestId, inputRelations] : unnestInputRelations) {
+    if (joinRelations.isSubset(unnestSubtrees.at(unnestId))) {
+      continue;
+    }
+    if (!nullPaddedSide.hasIntersection(inputRelations)) {
+      continue;
+    }
+    VELOX_CHECK(
+        inputs.leftRelations.contains(unnestId) ||
+            inputs.rightRelations.contains(unnestId),
+        "Unnest must belong to one normalized join side: {}",
+        unnestId);
+    tes.add(unnestId);
+  }
+}
+
+} // namespace
+
+JoinHypergraph HypergraphBuilder::build(
+    const JoinCluster& cluster,
+    const std::vector<NodeCP>& rewrittenLeaves,
+    EstimateProvider& estimateProvider) {
+  VELOX_CHECK_LE(
+      cluster.leaves.size(),
+      RelationSet::kMaxRelations,
+      "Cluster has more leaves than RelationSet can represent");
+  VELOX_CHECK_EQ(
+      cluster.leaves.size(),
+      rewrittenLeaves.size(),
+      "rewrittenLeaves must align 1:1 with cluster.leaves");
+
+  JoinHypergraph graph;
+  folly::F14FastMap<ColumnCP, int8_t> columnToLeaf;
+  folly::F14FastMap<NodeCP, int8_t> leafIds;
+  for (size_t i = 0; i < cluster.leaves.size(); ++i) {
+    NodeCP original = cluster.leaves[i];
+    NodeCP rewritten = rewrittenLeaves[i];
+    PlanObjectSet columns =
+        PlanObjectSet::fromObjects(rewritten->outputColumns());
+    const int8_t id = graph.addRelation(
+        rewritten,
+        estimateProvider.estimate(rewritten).cardinality,
+        std::move(columns));
+    VELOX_CHECK(leafIds.emplace(original, id).second, "Duplicate cluster leaf");
+    if (rewritten != original) {
+      VELOX_CHECK(
+          leafIds.emplace(rewritten, id).second,
+          "Duplicate rewritten cluster leaf");
+    }
+    for (const auto* column : rewritten->outputColumns()) {
+      columnToLeaf.emplace(column, id);
+    }
+  }
+
+  folly::F14FastMap<UnnestCP, int8_t> unnestIds =
+      addUnnestRelations(cluster, estimateProvider, graph, columnToLeaf);
+
+  folly::F14FastMap<int8_t, RelationSet> unnestInputRelations =
+      addUnnestEdges(cluster, unnestIds, columnToLeaf, graph);
 
   folly::F14FastMap<JoinCP, JoinInputs> joinInputs;
-  populateJoinInputs(cluster.root, leafIds, unnestIds, joinInputs);
+  folly::F14FastMap<int8_t, RelationSet> unnestSubtrees;
+  populateJoinInputs(
+      cluster.root, leafIds, unnestIds, joinInputs, unnestSubtrees);
 
   for (JoinCP join : cluster.joins) {
     const auto& inputs = joinInputs.at(join);
@@ -545,21 +637,13 @@ JoinHypergraph HypergraphBuilder::build(
             keyRelationsOrOperand(rightKeys, columnToLeaf, inputs.rightLeaves)};
         RelationSet ses{leftSet};
         ses.unionSet(rightSet);
-        RelationSet tes{ses};
-        tes.unionSet(tesExpansion(
-            join->left(),
-            join->joinType(),
+        const RelationSet tes = expandTes(
             ses,
-            /*leftSide=*/true,
-            leafIds,
-            joinInputs));
-        tes.unionSet(tesExpansion(
+            join->left(),
             join->right(),
             join->joinType(),
-            ses,
-            /*leftSide=*/false,
             leafIds,
-            joinInputs));
+            joinInputs);
         auto [leftTes, rightTes] =
             splitTes(tes, inputs.leftRelations, inputs.rightRelations);
 
@@ -603,60 +687,21 @@ JoinHypergraph HypergraphBuilder::build(
       for (ExprCP conjunct : join->filter()) {
         ses.unionSet(expressionRelations(conjunct, columnToLeaf));
       }
-      RelationSet tes{ses};
-      tes.unionSet(tesExpansion(
-          normalizedLeftChild,
-          inputs.joinType,
+      RelationSet tes = expandTes(
           ses,
-          /*leftSide=*/true,
-          leafIds,
-          joinInputs));
-      tes.unionSet(tesExpansion(
+          normalizedLeftChild,
           normalizedRightChild,
           inputs.joinType,
-          ses,
-          /*leftSide=*/false,
           leafIds,
-          joinInputs));
+          joinInputs);
+
+      addUnnestBarriers(inputs, unnestInputRelations, unnestSubtrees, tes);
 
       // `populateJoinInputs` already applies the same right-form operand swap
-      // as the normalized child selection above.
-      const RelationSet& normalizedLeftRelations = inputs.leftRelations;
-      const RelationSet& normalizedRightRelations = inputs.rightRelations;
-
-      // Outer-join barrier: if an Unnest's input subtree contributes a relation
-      // on this outer join's null-padded side, the unnest edge must fire before
-      // the outer join. Otherwise null-padding flows into UNNEST and rows drop.
-      // Expand TES to include the Unnest relation id so DPhyp pins the order.
-      RelationSet joinRelations{inputs.leftLeaves};
-      joinRelations.unionSet(inputs.rightLeaves);
-      for (const auto& [unnestId, inputRelations] : unnestInputRelations) {
-        // An outer join inside the Unnest's input subtree is already ordered
-        // before the Unnest by the unnest edge. The barrier would demand the
-        // reverse order, which no plan can satisfy when this join is the only
-        // edge co-locating the input relations.
-        if (joinRelations.isSubset(inputRelations)) {
-          continue;
-        }
-        RelationSet nullPaddedSide;
-        if (inputs.joinType == velox::core::JoinType::kLeft) {
-          nullPaddedSide = inputs.rightLeaves;
-        } else if (inputs.joinType == velox::core::JoinType::kFull) {
-          nullPaddedSide = inputs.leftLeaves;
-          nullPaddedSide.unionSet(inputs.rightLeaves);
-        }
-        if (nullPaddedSide.hasIntersection(inputRelations)) {
-          VELOX_CHECK(
-              normalizedLeftRelations.contains(unnestId) ||
-                  normalizedRightRelations.contains(unnestId),
-              "Unnest must belong to one normalized join side: {}",
-              static_cast<int32_t>(unnestId));
-          tes.add(unnestId);
-        }
-      }
-
+      // as the normalized child selection above, so these are in normalized
+      // order.
       auto [leftTes, rightTes] =
-          splitTes(tes, normalizedLeftRelations, normalizedRightRelations);
+          splitTes(tes, inputs.leftRelations, inputs.rightRelations);
 
       // kLeftSemiProject preserves the left side and appends a mark; the
       // Join (and its Apply origin) build outputColumns as

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -422,6 +422,15 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
       collectCluster(node, cluster, /*dissolveCrossJoins=*/true, opaqueJoins);
     }
 
+    // A RelationSet holds `kMaxRelations` relations, so a larger cluster has
+    // no hypergraph to enumerate over. Keep this join in query order, as an
+    // exhausted enumeration budget does, and let the recursion re-examine
+    // what is below it: joins come off the top until the rest fits, and that
+    // part is enumerated under the usual budget.
+    if (cluster.leaves.size() > RelationSet::kMaxRelations) {
+      return rewriteUnclusteredJoin(node, context);
+    }
+
     std::vector<NodeCP> rewrittenLeaves;
     auto buildGraph = [&]() {
       rewrittenLeaves.clear();

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -906,12 +906,32 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     return maybeWrapFilter(newAggregate, std::move(blocked));
   }
 
+  // True if nothing reads 'mark': neither a consumer above nor a conjunct
+  // still looking for a home here.
+  static bool markIsDead(ColumnCP mark, const PushdownContext& context) {
+    if (context.requiredAbove.contains(mark)) {
+      return false;
+    }
+    return std::none_of(
+        context.pending.begin(), context.pending.end(), [&](ExprCP conjunct) {
+          return conjunct->columns().contains(mark);
+        });
+  }
+
   // Join: demote outer to inner when possible, then route each pending
   // conjunct to one of: left input, right input, join filter, or
   // stay-above. The join's own filter conjuncts are redistributed by the same
   // rules. Neither moves a nondeterministic conjunct into an input, which
   // would evaluate it once for rows the join then multiplies.
   NodeCP rewriteJoin(const Join* node, PushdownContext& context) override {
+    // A kLeftSemiProject keeps every left row and adds a mark, so with the
+    // mark read by nobody the join has no effect and its left input stands in
+    // its place.
+    if (velox::core::isLeftSemiProjectJoin(node->joinType()) &&
+        markIsDead(node->markColumn(), context)) {
+      return rewrite(node->left(), context);
+    }
+
     PlanObjectSet leftColumns =
         PlanObjectSet::fromObjects(node->left()->outputColumns());
     PlanObjectSet rightColumns =

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -906,6 +906,81 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     return maybeWrapFilter(newAggregate, std::move(blocked));
   }
 
+  // True if a conjunct of 'conjuncts' is statically false, so no row passes.
+  bool neverMatches(const ExprVector& conjuncts) {
+    ExprVector kept;
+    for (ExprCP conjunct : conjuncts) {
+      kept.clear();
+      if (simplifier_.simplifyFilter(conjunct, kept)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // A join condition no row satisfies decides the join's answer without a
+  // join: an inner join produces nothing, and an outer join produces its
+  // preserved side with the other side's columns NULL.
+  //
+  // Only a written ON clause reaches here as a false condition. A subquery
+  // whose body is empty is a different shape, still joined against.
+  NodeCP simplifyNeverMatchingJoin(const Join* node, PushdownContext& context) {
+    if (!neverMatches(node->filter())) {
+      return nullptr;
+    }
+
+    NodeCP preserved{nullptr};
+    switch (node->joinType()) {
+      case velox::core::JoinType::kInner:
+        return makeEmptyValues(node);
+      case velox::core::JoinType::kLeft:
+        preserved = node->left();
+        break;
+      case velox::core::JoinType::kRight:
+        preserved = node->right();
+        break;
+      default:
+        // kFull preserves both sides, which is a union rather than one node.
+        // A written ON clause reaches the semi and anti kinds as the body of
+        // a subquery rather than as a join condition, so a false one does not
+        // arrive here.
+        return nullptr;
+    }
+
+    // The preserved side is asked only for the columns it passes through;
+    // the rest of the join's output is NULL.
+    const PlanObjectSet preservedColumns =
+        PlanObjectSet::fromObjects(preserved->outputColumns());
+    ExprVector expressions;
+    expressions.reserve(node->outputColumns().size());
+    PlanObjectSet kept;
+    for (ColumnCP column : node->outputColumns()) {
+      if (preservedColumns.contains(column)) {
+        expressions.push_back(column);
+        kept.add(column);
+      } else {
+        expressions.push_back(builder().makeNull(column->value().type));
+      }
+    }
+
+    PushdownContext preservedContext;
+    preservedContext.required = std::move(kept);
+    preservedContext.requiredAbove = preservedContext.required;
+    preservedContext.nonNullColumns = context.nonNullColumns;
+
+    // The conjuncts waiting above the join read its output columns, some of
+    // them from the side that is gone. They stay above the Project, which is
+    // where the join's output now comes from.
+    ExprVector above = std::move(context.pending);
+    context.pending.clear();
+
+    NodeCP project = builder().make<Project>(
+        {rewrite(preserved, preservedContext),
+         std::move(expressions),
+         node->outputColumns()});
+    return maybeWrapFilter(project, std::move(above));
+  }
+
   // True if nothing reads 'mark': neither a consumer above nor a conjunct
   // still looking for a home here.
   static bool markIsDead(ColumnCP mark, const PushdownContext& context) {
@@ -924,6 +999,10 @@ class Pushdown : public NodeRewriter<PushdownContext> {
   // rules. Neither moves a nondeterministic conjunct into an input, which
   // would evaluate it once for rows the join then multiplies.
   NodeCP rewriteJoin(const Join* node, PushdownContext& context) override {
+    if (NodeCP simplified = simplifyNeverMatchingJoin(node, context)) {
+      return simplified;
+    }
+
     // A kLeftSemiProject keeps every left row and adds a mark, so with the
     // mark read by nobody the join has no effect and its left input stands in
     // its place.

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -675,7 +675,10 @@ class Translator {
   ExprCP
   translateDereference(ExprVector args, Name callName, const Value& value);
 
-  ExprCP translateLambda(const lp::LambdaExpr& expr, const Scope& scope);
+  ExprCP translateLambda(
+      const lp::LambdaExpr& expr,
+      const Scope& scope,
+      LiftTarget* liftTarget);
 
   // Joins 'body' into 'target's pending lifts with the body's own top-level
   // filter as the join condition, and replaces them with the result under an
@@ -2907,7 +2910,7 @@ ExprCP Translator::translateExpr(
       return translateSpecialForm(
           *expr.as<lp::SpecialFormExpr>(), scope, liftTarget);
     case lp::ExprKind::kLambda:
-      return translateLambda(*expr.as<lp::LambdaExpr>(), scope);
+      return translateLambda(*expr.as<lp::LambdaExpr>(), scope, liftTarget);
     case lp::ExprKind::kSubquery: {
       // Bare subquery in scalar position. `liftSubquery` decides the
       // lowered shape: uncorrelated → cross-join + EnforceSingleRow
@@ -3175,7 +3178,8 @@ ExprCP Translator::translateDereference(
 
 ExprCP Translator::translateLambda(
     const lp::LambdaExpr& expr,
-    const Scope& scope) {
+    const Scope& scope,
+    LiftTarget* liftTarget) {
   const auto& signature = expr.signature();
 
   // TODO: mint canonical `Column*` per `(arg position, arg type)` so
@@ -3193,10 +3197,11 @@ ExprCP Translator::translateLambda(
     bodyScope[signature->nameOf(i)] = column;
   }
 
-  // Lambdas appear inside higher-order functions; subqueries inside a
-  // lambda body would need lifting above the surrounding higher-order
-  // call's relational input — uncommon and not threaded today.
-  ExprCP body = translateExpr(*expr.body(), bodyScope, /*liftTarget=*/nullptr);
+  // A subquery in the body lifts onto the same target as the higher-order
+  // call itself: it is evaluated once per row, and the body reads the result
+  // as a capture. The arguments are not in scope inside such a subquery, so
+  // it cannot correlate to a value that varies per element.
+  ExprCP body = translateExpr(*expr.body(), bodyScope, liftTarget);
   return make<Lambda>(std::move(args), toType(expr.type()), body);
 }
 


### PR DESCRIPTION
Summary:

A subquery inside a lambda body failed to plan under the v2 optimizer, correlated or not:

    SELECT filter(ARRAY[1, 2, 3], x -> x > (SELECT min(a) FROM v)) FROM u

    Subquery encountered in an expression position with no relational
    input above which to lift Apply

Translating a subquery lifts an Apply above the relational input the expression sits over, and the expression then reads a column. Every expression position threads that input through, except a lambda body, which passed none — the surrounding higher-order call's input was never handed down.

It is the same input, though: the higher-order call is evaluated per row, so a subquery in its lambda is too, and the body reads the lifted column as a capture. Threading the target through is all this takes. An uncorrelated subquery attaches by cross join and a correlated one joins on its correlation, both already handled by the lift.

What a lambda body cannot have is a subquery correlated to the lambda's own argument, which would have to run once per element of the collection. Those are refused while building the logical plan, where an argument is not in scope inside the subquery.

Differential Revision: D119523595


