### PR TITLE
fix(optimizer): Preserve right join partitioning (#1870)

### DIFF
--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -553,6 +553,115 @@ TEST_P(JoinTest, nestedOuterJoins) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
+TEST_P(JoinTest, rightJoinPreservesBuildPartitioning) {
+  addTableWithStats("t", {"a"}, 1'000'000);
+  addTableWithStats("u", {"b"}, 1'000);
+  addTableWithStats("v", {"c"}, 1'000'000, {{"c", 1}});
+  optimizerOptions_.broadcastSizeLimit = 1;
+
+  const auto logicalPlan = parseSelect(
+      "SELECT u.b "
+      "FROM t RIGHT JOIN u ON t.a = u.b "
+      "JOIN v ON u.b = v.c",
+      kTestConnectorId);
+  const auto distributedPlan =
+      planVelox(logicalPlan, {.maxRemotePartitions = 2});
+
+  auto matcher =
+      matchScan("v")
+          .shuffle({"c"})
+          .hashJoinInner(
+              matchScan("t").shuffle({"a"}).hashJoin(
+                  matchScan("u").shuffle({"b"}), core::JoinType::kRight),
+              {.keys = {{"c = b"}}})
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN_V2(distributedPlan.plan, matcher);
+}
+
+TEST_P(JoinTest, rightSemiFilterPreservesBuildPartitioning) {
+  addTableWithStats("t", {"a"}, 1'000'000);
+  addTableWithStats("u", {"b"}, 1'000);
+  addTableWithStats("v", {"c"}, 1'000'000, {{"c", 1}});
+  optimizerOptions_.broadcastSizeLimit = 1;
+
+  const auto logicalPlan = parseSelect(
+      "SELECT s.b "
+      "FROM (SELECT u.b FROM u WHERE u.b IN (SELECT a FROM t)) s "
+      "JOIN v ON s.b = v.c",
+      kTestConnectorId);
+  const auto distributedPlan =
+      planVelox(logicalPlan, {.maxRemotePartitions = 2});
+
+  auto matcher = matchScan("v")
+                     .shuffle({"c"})
+                     .hashJoinInner(
+                         matchScan("t").shuffle({"a"}).hashJoin(
+                             matchScan("u").shuffle({"b"}),
+                             core::JoinType::kRightSemiFilter),
+                         {.keys = {{"c = b"}}})
+                     .gather()
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN_V2(distributedPlan.plan, matcher);
+}
+
+TEST_P(JoinTest, rightSemiProjectPreservesBuildPartitioning) {
+  addTableWithStats("t", {"a"}, 1'000'000);
+  addTableWithStats("u", {"b"}, 1'000);
+  addTableWithStats("v", {"c"}, 1'000'000, {{"c", 1}});
+  optimizerOptions_.broadcastSizeLimit = 1;
+
+  const auto logicalPlan = parseSelect(
+      "SELECT s.b, s.matched "
+      "FROM ("
+      "  SELECT u.b, EXISTS (SELECT 1 FROM t WHERE t.a = u.b) AS matched "
+      "  FROM u"
+      ") s "
+      "JOIN v ON s.b = v.c",
+      kTestConnectorId);
+  const auto distributedPlan =
+      planVelox(logicalPlan, {.maxRemotePartitions = 2});
+
+  auto matcher = matchScan("v")
+                     .shuffle({"c"})
+                     .hashJoinInner(
+                         matchScan("t").shuffle({"a"}).hashJoin(
+                             matchScan("u").shuffle({"b"}),
+                             core::JoinType::kRightSemiProject,
+                             {.nullAware = false}),
+                         {.keys = {{"c = b"}}})
+                     .project()
+                     .gather()
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN_V2(distributedPlan.plan, matcher);
+}
+
+TEST_P(JoinTest, countingAntiPreservesProbePartitioning) {
+  // Keep every candidate build above the default broadcast limit.
+  addTableWithStats("t", {"a"}, 100'000'000);
+  addTableWithStats("u", {"b"}, 100'000'000);
+  addTableWithStats("v", {"c"}, 100'000'000, {{"c", 1}});
+
+  const auto logicalPlan = parseSelect(
+      "SELECT s.a "
+      "FROM (SELECT a FROM t EXCEPT ALL SELECT b FROM u) s "
+      "JOIN v ON s.a = v.c",
+      kTestConnectorId);
+  const auto distributedPlan =
+      planVelox(logicalPlan, {.maxRemotePartitions = 2});
+
+  auto matcher =
+      matchScan("t")
+          .shuffle({"a"})
+          .localPartition({"a"})
+          .hashJoin(
+              matchScan("u").shuffle({"b"}), core::JoinType::kCountingAnti)
+          .hashJoinInner(matchScan("v").shuffle({"c"}), {.keys = {{"a = c"}}})
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN_V2(distributedPlan.plan, matcher);
+}
+
 TEST_P(JoinTest, joinWithComputedKeys) {
   auto sql =
       "SELECT count(1) FROM nation n RIGHT JOIN region ON coalesce(n_regionkey, 1) = r_regionkey";

--- a/axiom/optimizer/v2/DPhyp.cpp
+++ b/axiom/optimizer/v2/DPhyp.cpp
@@ -27,6 +27,7 @@
 #include "axiom/optimizer/EstimateMath.h"
 #include "axiom/optimizer/QueryGraph.h"
 #include "axiom/optimizer/v2/CostModel.h"
+#include "axiom/optimizer/v2/Node.h"
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::axiom::optimizer::v2 {
@@ -971,6 +972,33 @@ class Enumerator {
     return result;
   }
 
+  Partitioning joinOutputPartitioning(
+      velox::core::JoinType joinType,
+      bool reversedAnti,
+      const ExprVector& leftKeys,
+      const ExprVector& rightKeys,
+      const RelationSet& combined,
+      const connector::PartitionType* partitionType = nullptr) {
+    const ExprVector* outputKeys;
+    if (reversedAnti) {
+      outputKeys = &rightKeys;
+    } else {
+      const auto preservedSides = Join::preservedSides(joinType);
+      if (preservedSides.left) {
+        outputKeys = &leftKeys;
+      } else if (preservedSides.right) {
+        outputKeys = &rightKeys;
+      } else {
+        return {};
+      }
+    }
+
+    auto output =
+        Partitioning::globalHash(keysInCoverSchema(*outputKeys, combined));
+    output.partitionType = partitionType;
+    return output;
+  }
+
   // Builds, costs, and (if costable) inserts one join candidate with the given
   // output partitioning. The children are already distribution-enforced.
   void addJoinCandidate(
@@ -1008,7 +1036,7 @@ class Enumerator {
   // Adds join candidates that avoid shuffling the bucketed side(s): both sides
   // co-located when both are bucketed, or the unbucketed side repartitioned to
   // the bucketed side's connector partitioning. The output is partitioned on
-  // the probe (left) keys with the preserved bucket type.
+  // the preserved side's keys with the preserved bucket type.
   void addCoBucketedCandidate(
       MemoOpCP left,
       MemoOpCP right,
@@ -1029,9 +1057,6 @@ class Enumerator {
     const auto add = [&](MemoOpCP leftChild,
                          MemoOpCP rightChild,
                          const connector::PartitionType* outputType) {
-      Partitioning outputPartitioning =
-          Partitioning::globalHash(keysInCoverSchema(leftKeys, combined));
-      outputPartitioning.partitionType = outputType;
       addJoinCandidate(
           leftChild,
           rightChild,
@@ -1041,7 +1066,13 @@ class Enumerator {
           reversedAnti,
           keyEdges,
           filterEdges,
-          std::move(outputPartitioning));
+          joinOutputPartitioning(
+              joinType,
+              reversedAnti,
+              leftKeys,
+              rightKeys,
+              combined,
+              outputType));
     };
 
     if (leftBucketed != nullptr && rightBucketed != nullptr) {
@@ -1125,7 +1156,8 @@ class Enumerator {
     const auto [leftKeys, rightKeys] = orientedKeys(left, edgeIndex, keyEdges);
     if (!leftKeys.empty()) {
       // Partition strategy: co-partition both inputs on the join keys; the
-      // output is partitioned on the keys for same-key reuse above. A
+      // output is partitioned on the preserved side's keys for same-key reuse
+      // above. A
       // null-aware anti/semi join (NOT IN / IN) needs the existence side's
       // null keys on every probe partition; the existence side is the edge's
       // right operand, which may be either physical child depending on
@@ -1149,7 +1181,8 @@ class Enumerator {
             reversedAnti,
             keyEdges,
             filterEdges,
-            Partitioning::globalHash(keysInCoverSchema(leftKeys, combined)));
+            joinOutputPartitioning(
+                joinType, reversedAnti, leftKeys, rightKeys, combined));
       }
 
       // Skipped for null-aware anti/semi: a connector-bucketed existence side

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -270,8 +270,9 @@ void appendProbeUniqueGroupings(
   }
 }
 
-// The probe (left) side's local properties survive an inner / left join within
-// a driver; build-emitting and cross joins drop them.
+// Local properties follow the physical probe (left) stream. Inner and left
+// joins emit each probe row's matches contiguously; hash-table construction
+// does not preserve the build input's order or grouping.
 // TODO: order through a spillable join is not guaranteed once spilling is
 // enabled; revisit when spilling is modeled.
 LocalPropertyVector joinLocal(
@@ -386,14 +387,9 @@ ExprCP survivingEquiKey(ExprCP key, const PlanObjectSet& outputColumns) {
   return nullptr;
 }
 
-// Output global partitioning of a join. A join keeps the probe's (left's)
-// partitioning when every output row is a probe row carrying its probe column
-// values unchanged, which holds for inner, left, the left semi and anti
-// joins, and the counting semijoin. Right and full joins emit build rows, so
-// they drop it.
-//
-// If every probe key is still an output column, the output is partitioned
-// exactly as the probe was. Otherwise only an inner join recovers a dropped
+// Re-expresses a preserved input's partitioning on the join output. If every
+// partition key is still an output column, the output is partitioned exactly
+// as that input was. Otherwise only an inner join recovers a dropped
 // key: it keeps a key whose columns all survive (a join projects columns
 // unchanged, so a surviving column is identity-projected, and an expression
 // over surviving columns still partitions the output), else substitutes an
@@ -403,55 +399,43 @@ ExprCP survivingEquiKey(ExprCP key, const PlanObjectSet& outputColumns) {
 //
 // A non-hash distribution (gather / broadcast / arbitrary) carries no keys and
 // is inherited by kind, minus any merge order (see `Partitioning::dropOrder`).
-Partitioning joinGlobalPartition(
-    velox::core::JoinType joinType,
-    NodeCP left,
-    NodeCP right,
+Partitioning preservedJoinGlobalPartition(
+    NodeCP preservedInput,
+    NodeCP otherInput,
+    bool allowEquivalentKeySubstitution,
     const ColumnVector& outputColumns) {
-  switch (joinType) {
-    case velox::core::JoinType::kInner:
-    case velox::core::JoinType::kLeft:
-    case velox::core::JoinType::kLeftSemiFilter:
-    case velox::core::JoinType::kLeftSemiProject:
-    case velox::core::JoinType::kAnti:
-    case velox::core::JoinType::kCountingLeftSemiFilter:
-      break;
-    default:
-      return {};
-  }
-
-  Partitioning probe = left->physicalProperties().globalPartition;
-  if (probe.kind != PartitionKind::kPartitioned) {
-    return probe.dropOrder();
+  Partitioning preserved = preservedInput->physicalProperties().globalPartition;
+  if (preserved.kind != PartitionKind::kPartitioned) {
+    return preserved.dropOrder();
   }
 
   // Both sides connector-bucketed: the join runs on the partitioning the two
-  // agree on, which can be coarser than the probe's. Reporting the probe's
-  // would let a consumer align a shuffle to more partitions than the join's
-  // fragment has tasks.
-  const auto* buildType =
-      right->physicalProperties().globalPartition.partitionType;
-  if (probe.partitionType != nullptr && buildType != nullptr) {
+  // agree on, which can be coarser than the preserved input's. Reporting the
+  // original partitioning would let a consumer align a shuffle to more
+  // partitions than the join's fragment has tasks.
+  const auto* otherType =
+      otherInput->physicalProperties().globalPartition.partitionType;
+  if (preserved.partitionType != nullptr && otherType != nullptr) {
     const auto* folded =
-        queryCtx()->copartitionedType(probe.partitionType, buildType);
+        queryCtx()->copartitionedType(preserved.partitionType, otherType);
     if (folded == nullptr) {
       return {};
     }
-    probe.partitionType = folded;
+    preserved.partitionType = folded;
   }
 
   const auto outputSet = PlanObjectSet::fromObjects(outputColumns);
-  if (outputSet.containsAll(probe.keys)) {
-    return probe;
+  if (outputSet.containsAll(preserved.keys)) {
+    return preserved;
   }
 
-  if (joinType != velox::core::JoinType::kInner) {
+  if (!allowEquivalentKeySubstitution) {
     return {};
   }
 
   ExprVector keys;
-  keys.reserve(probe.keys.size());
-  for (ExprCP key : probe.keys) {
+  keys.reserve(preserved.keys.size());
+  for (ExprCP key : preserved.keys) {
     if (outputSet.containsColumns(key)) {
       keys.push_back(key);
       continue;
@@ -463,9 +447,30 @@ Partitioning joinGlobalPartition(
     keys.push_back(equiKey);
   }
 
-  Partitioning result = probe;
+  Partitioning result = preserved;
   result.keys = std::move(keys);
   return result;
+}
+
+// Derives a join's global partitioning from a preserved input. Left-preserving
+// joins use the left input, and right-preserving joins use the right input. An
+// inner join uses the left (probe) input; an equivalent output column may
+// replace an omitted left-side partition key.
+Partitioning joinGlobalPartition(
+    velox::core::JoinType joinType,
+    NodeCP left,
+    NodeCP right,
+    const ColumnVector& outputColumns) {
+  const auto preservedSides = Join::preservedSides(joinType);
+  if (preservedSides.left) {
+    return preservedJoinGlobalPartition(
+        left, right, joinType == velox::core::JoinType::kInner, outputColumns);
+  }
+  if (preservedSides.right) {
+    return preservedJoinGlobalPartition(
+        right, left, /*allowEquivalentKeySubstitution=*/false, outputColumns);
+  }
+  return {};
 }
 
 // The input's partitioning re-expressed on the aggregate's output. An aggregate


### PR DESCRIPTION
Summary:

Before this change, a `RIGHT JOIN` always discarded its output partitioning because join property derivation only considered the left input. That was wrong when the right input was partitioned on a key that remained in the output. For example:

    SELECT j.k
    FROM (SELECT r.k FROM l RIGHT JOIN r ON l.k = r.k) j
    JOIN t ON j.k = t.k

The final join could have reused the partitioning on `r.k`. Instead, the optimizer treated it as unknown and inserted an unnecessary remote exchange.

For one-sided joins, the fix takes partitioning from the input whose rows survive. Right-preserving joins now use the right input; the existing left-input behavior is unchanged.

Differential Revision: D119545232


