### PR TITLE
refactor(optimizer): Rename fragment parallelism fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,13 +278,13 @@ without executing it.
 
 ```
 SQL> explain  select count(*) from nation;
-Fragment 0: stage1 numWorkers=4:
+Fragment 0: stage1 numRemotePartitions=4:
 -- PartitionedOutput[2][SINGLE Presto] -> count:BIGINT
   -- Aggregation[1][PARTIAL count := count()] -> count:BIGINT
     -- TableScan[0][table: nation, scale factor: 0.01] ->
        Estimate: 25 rows, 0B peak memory
 
-Fragment 1:  numWorkers=1:
+Fragment 1:  numRemotePartitions=1:
 -- Aggregation[5][FINAL count := count("count")] -> count:BIGINT
   -- LocalPartition[4][GATHER] -> count:BIGINT
     -- Exchange[3][Presto] -> count:BIGINT
@@ -296,7 +296,7 @@ annotated with runtime statistics.
 
 ```
 SQL> explain analyze select count(*) from nation;
-Fragment 0: stage1 numWorkers=4:
+Fragment 0: stage1 numRemotePartitions=4:
 -- PartitionedOutput[2][SINGLE Presto] -> count:BIGINT
    Output: 16 rows (832B, 16 batches), Cpu time: 545.76us, Wall time: 643.00us, Blocked wall time: 0ns, Peak memory: 16.50KB, Memory allocations: 80, Threads: 16, CPU breakdown: B/I/O/F (56.46us/91.04us/369.00us/29.26us)
   -- Aggregation[1][PARTIAL count := count()] -> count:BIGINT
@@ -305,7 +305,7 @@ Fragment 0: stage1 numWorkers=4:
        Estimate: 25 rows, 0B peak memory
        Input: 25 rows (0B, 1 batches), Output: 25 rows (0B, 1 batches), Cpu time: 1.43s, Wall time: 1.43s, Blocked wall time: 7.20ms, Peak memory: 97.75KB, Memory allocations: 10, Threads: 16, Splits: 1, CPU breakdown: B/I/O/F (24.86us/0ns/1.43s/4.46us)
 
-Fragment 1:  numWorkers=1:
+Fragment 1:  numRemotePartitions=1:
 -- Aggregation[5][FINAL count := count("count")] -> count:BIGINT
    Output: 1 rows (32B, 1 batches), Cpu time: 72.03us, Wall time: 84.37us, Blocked wall time: 0ns, Peak memory: 64.50KB, Memory allocations: 5, Threads: 1, CPU breakdown: B/I/O/F (8.22us/53.59us/6.62us/3.60us)
   -- LocalPartition[4][GATHER] -> count:BIGINT

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -1857,8 +1857,8 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
     bool explain,
     std::shared_ptr<QueryRuntimeStats> runtimeStats) {
   optimizer::MultiFragmentPlan::Options opts;
-  opts.numWorkers = options.numWorkers;
-  opts.numDrivers = options.numDrivers;
+  opts.maxRemotePartitions = options.numWorkers;
+  opts.maxLocalPartitions = options.numDrivers;
   auto connectorProperties = collectConnectorProperties(*sessionConfig_);
   auto optimizerSession =
       makeOptimizerSession(queryCtx->queryId(), connectorProperties, explain);

--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -25,20 +25,23 @@ namespace facebook::axiom::connector {
 
 class PartitionType;
 
-/// Wraps a Velox ConnectorSplit with optional placement metadata. groupId is a
-/// hard within-query routing constraint for grouped execution: splits with the
-/// same groupId are routed to the same task. affinityId is a soft cross-query
-/// affinity hint: schedulers prefer to route splits with the same affinityId
-/// to the same task, but may choose another task for load balancing. When both
-/// are present, grouped-execution routing through groupId takes precedence
-/// over affinityId.
+/// Wraps a Velox ConnectorSplit with optional placement metadata.
+/// remotePartition is a hard within-query routing constraint for grouped
+/// execution: splits with the same remotePartition are routed to the same
+/// task. affinityId is a soft cross-query affinity hint: schedulers prefer to
+/// route splits with the same affinityId to the same task, but may choose
+/// another task for load balancing. When both are present, grouped-execution
+/// routing through remotePartition takes precedence over affinityId.
 struct Split {
   /// The underlying Velox connector split.
   std::shared_ptr<velox::connector::ConnectorSplit> connectorSplit;
 
-  /// Group ID for bucketed routing; splits sharing a groupId are routed to
-  /// the same task. Absent means any task may handle this split.
-  std::optional<int32_t> groupId{std::nullopt};
+  /// Remote partition for bucketed routing. This is a number in
+  /// [0, numRemotePartitions), where numRemotePartitions is the
+  /// ExecutableFragment's numRemotePartitions the split is read by. Splits
+  /// sharing a remotePartition are routed to the same task; the scheduler
+  /// must obey this decision. Absent means any task may handle this split.
+  std::optional<int32_t> remotePartition{std::nullopt};
 
   /// Stable connector-generated affinity ID for split affinity. Connectors
   /// that support split affinity must generate the same ID for repeated reads
@@ -123,8 +126,8 @@ class ConnectorSplitManager {
   /// enumeration metrics (e.g., file listing, Metastore RPCs).
   ///
   /// When 'partitionType' is non-null, the connector tags each emitted Split
-  /// with a groupId in [0, partitionType->numPartitions()). Pass 'nullptr'
-  /// for the non-bucketed case.
+  /// with a remotePartition in [0, partitionType->numPartitions()). Pass
+  /// 'nullptr' for the non-bucketed case.
   ///
   /// When 'samplePercentage' is set (TABLESAMPLE SYSTEM), the source emits each
   /// split with that probability, in the open interval (0, 100); the caller

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -68,8 +68,8 @@ class HivePartitionType : public connector::PartitionType {
 
   /// Returns a HivePartitionType whose partition count is
   /// min(numBuckets, maxPartitions). The native bucket count is preserved;
-  /// the partition count drives fragment width, and makeSpec maps native
-  /// buckets onto partitions via modulo.
+  /// the partition count drives the fragment's numRemotePartitions, and
+  /// makeSpec maps native buckets onto partitions via modulo.
   std::shared_ptr<PartitionType> scaleDown(
       int32_t maxPartitions) const override;
 

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -366,18 +366,20 @@ folly::coro::Task<SplitBatch> LocalHiveSplitSource::co_getSplits(
       if (!serdeParameters_.empty()) {
         builder.serdeParameters(serdeParameters_);
       }
-      std::optional<int32_t> groupId;
+      std::optional<int32_t> remotePartition;
       if (partitionType_ != nullptr) {
         VELOX_CHECK(
             info->bucketNumber.has_value(),
             "Bucketed scan requires bucketNumber on every file");
         const auto* hivePartitionType =
             partitionType_->asChecked<HivePartitionType>();
-        groupId =
+        remotePartition =
             hivePartitionType->mapBucketToPartition(info->bucketNumber.value());
       }
       batch.splits.push_back(
-          Split{.connectorSplit = builder.build(), .groupId = groupId});
+          Split{
+              .connectorSplit = builder.build(),
+              .remotePartition = remotePartition});
       ++splitWithinFile_;
     }
     if (splitWithinFile_ >= splitsPerFile) {

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -60,7 +60,7 @@ class LocalHiveSplitSource : public SplitSource {
   const std::string tableName_;
   std::vector<const FileInfo*> files_;
   const std::unordered_map<std::string, std::string> serdeParameters_;
-  // When non-null, used to assign a groupId to each split for bucketed
+  // When non-null, used to assign a remotePartition to each split for bucketed
   // execution.
   const std::shared_ptr<PartitionType> partitionType_;
   size_t fileIdx_{0};

--- a/axiom/connectors/tests/README.md
+++ b/axiom/connectors/tests/README.md
@@ -47,9 +47,9 @@ The Test connector is designed for three use cases:
   (`addTable(..., TestBucketSpec{...})`). Rows are routed to buckets via a
   generic hash partition function on append, and splits are emitted per
   bucket. When the split manager is asked for splits with a non-null
-  `PartitionType`, each emitted Split is tagged with a `groupId` derived
-  from its bucket, enabling end-to-end exercise of the bucketed-execution
-  scheduling contract.
+  `PartitionType`, each emitted Split is tagged with a `remotePartition`
+  derived from its bucket, enabling end-to-end exercise of the
+  bucketed-execution scheduling contract.
 
 **Not supported:**
 - Filter pushdown.

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -435,13 +435,15 @@ folly::coro::Task<SplitBatch> TestSplitSource::co_getSplits(
   for (auto i = nextOffset_; i < end; ++i) {
     auto split =
         std::make_shared<TestConnectorSplit>(connectorId_, dataIndices_[i]);
-    std::optional<int32_t> groupId;
+    std::optional<int32_t> remotePartition;
     if (partitionType_ != nullptr) {
       VELOX_CHECK_LT(i, dataBucketIds_.size());
-      groupId = dataBucketIds_[i] % partitionType_->numPartitions();
+      remotePartition = dataBucketIds_[i] % partitionType_->numPartitions();
     }
     batch.splits.push_back(
-        Split{.connectorSplit = std::move(split), .groupId = groupId});
+        Split{
+            .connectorSplit = std::move(split),
+            .remotePartition = remotePartition});
   }
   nextOffset_ = end;
   batch.noMoreSplits = (nextOffset_ >= dataIndices_.size());

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -266,7 +266,7 @@ class TestTable : public Table {
 
 /// SplitSource for TestTable. Emits one TestConnectorSplit per index in
 /// 'dataIndices'. When 'partitionType' is set, tags each Split with
-/// groupId = dataBucketIds[i] % partitionType->numPartitions().
+/// remotePartition = dataBucketIds[i] % partitionType->numPartitions().
 class TestSplitSource : public SplitSource {
  public:
   TestSplitSource(

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -633,7 +633,8 @@ CO_TEST_F(TestConnectorTest, bucketedTable) {
   EXPECT_EQ(partitions.size(), kNumBuckets);
 
   // Pass a non-null partitionType with numPartitions < numBuckets so the
-  // connector folds buckets into groups and tags each Split with groupId.
+  // connector folds buckets into groups and tags each Split with
+  // remotePartition.
   constexpr int32_t kNumGroups = 2;
   auto partitionType = std::make_shared<TestPartitionType>(
       kNumGroups, std::vector<TypePtr>{BIGINT()}, schema);
@@ -645,26 +646,26 @@ CO_TEST_F(TestConnectorTest, bucketedTable) {
       partitionType,
       /*samplePercentage=*/std::nullopt,
       noopStats);
-  std::vector<int32_t> observedGroupIds;
+  std::vector<int32_t> observedRemotePartitions;
   while (true) {
     auto batch = co_await source->co_getSplits(/*maxSplitCount=*/16);
     for (const auto& split : batch.splits) {
-      CO_ASSERT_TRUE(split.groupId.has_value());
-      EXPECT_GE(*split.groupId, 0);
-      EXPECT_LT(*split.groupId, kNumGroups);
+      CO_ASSERT_TRUE(split.remotePartition.has_value());
+      EXPECT_GE(*split.remotePartition, 0);
+      EXPECT_LT(*split.remotePartition, kNumGroups);
       auto testSplit = std::dynamic_pointer_cast<const TestConnectorSplit>(
           split.connectorSplit);
       CO_ASSERT_NE(testSplit, nullptr);
       const auto bucket = table->dataBucketIds()[testSplit->index()];
-      EXPECT_EQ(*split.groupId, bucket % kNumGroups);
-      observedGroupIds.push_back(*split.groupId);
+      EXPECT_EQ(*split.remotePartition, bucket % kNumGroups);
+      observedRemotePartitions.push_back(*split.remotePartition);
     }
     if (batch.noMoreSplits) {
       break;
     }
   }
   co_await source->co_close();
-  EXPECT_FALSE(observedGroupIds.empty());
+  EXPECT_FALSE(observedRemotePartitions.empty());
 }
 
 TEST_F(TestConnectorTest, bucketedTableNonExistentBucketColumn) {

--- a/axiom/graphviz/MultiFragmentPlanDotPrinter.cpp
+++ b/axiom/graphviz/MultiFragmentPlanDotPrinter.cpp
@@ -148,12 +148,12 @@ OutputDistribution outputDistribution(const velox::core::PlanNodePtr& root) {
 }
 
 std::string formatFragmentHeader(const ExecutableFragment& fragment) {
-  if (fragment.width.has_value()) {
+  if (fragment.numRemotePartitions.has_value()) {
     return fmt::format(
         "{} — {} × {}",
         fragment.taskPrefix,
         FragmentTypeName::toName(fragment.type),
-        fragment.width.value());
+        fragment.numRemotePartitions.value());
   }
   return fmt::format(
       "{} — {}", fragment.taskPrefix, FragmentTypeName::toName(fragment.type));

--- a/axiom/optimizer/MultiFragmentPlan.cpp
+++ b/axiom/optimizer/MultiFragmentPlan.cpp
@@ -406,8 +406,9 @@ std::string formatFragmentHeader(
       index,
       fragment.taskPrefix,
       FragmentTypeName::toName(fragment.type),
-      fragment.width.has_value()
-          ? fmt::format(" numWorkers={}", fragment.width.value())
+      fragment.numRemotePartitions.has_value()
+          ? fmt::format(
+                " numRemotePartitions={}", fragment.numRemotePartitions.value())
           : "",
       bucketedSuffix);
 }
@@ -491,27 +492,27 @@ std::string MultiFragmentPlan::toSummaryString(
 
 namespace {
 
-// Checks that each fragment's type is consistent with its width and that width
-// does not exceed numWorkers.
+// Checks that each fragment's type is consistent with its numRemotePartitions
+// and that numRemotePartitions does not exceed maxRemotePartitions.
 void checkFragmentTypes(
     const std::vector<ExecutableFragment>& fragments,
-    int32_t numWorkers) {
+    int32_t maxRemotePartitions) {
   for (const auto& fragment : fragments) {
-    const auto& width = fragment.width;
+    const auto& numRemotePartitions = fragment.numRemotePartitions;
     const auto& taskPrefix = fragment.taskPrefix;
 
     switch (fragment.type) {
       case FragmentType::kFixed:
         VELOX_CHECK(
-            width.has_value(),
-            "kFixed fragment must have width set: {}",
+            numRemotePartitions.has_value(),
+            "kFixed fragment must have numRemotePartitions set: {}",
             taskPrefix);
         break;
       case FragmentType::kSingle:
       case FragmentType::kCoordinator:
         VELOX_CHECK(
-            !width.has_value(),
-            "{} fragment must not have width set: {}",
+            !numRemotePartitions.has_value(),
+            "{} fragment must not have numRemotePartitions set: {}",
             FragmentTypeName::toName(fragment.type),
             taskPrefix);
         break;
@@ -519,13 +520,16 @@ void checkFragmentTypes(
         break;
     }
 
-    if (width.has_value()) {
+    if (numRemotePartitions.has_value()) {
       VELOX_CHECK_GT(
-          width.value(), 0, "Fragment width must be positive: {}", taskPrefix);
+          numRemotePartitions.value(),
+          0,
+          "Fragment numRemotePartitions must be positive: {}",
+          taskPrefix);
       VELOX_CHECK_LE(
-          width.value(),
-          numWorkers,
-          "Fragment width exceeds numWorkers: {}",
+          numRemotePartitions.value(),
+          maxRemotePartitions,
+          "Fragment numRemotePartitions exceeds maxRemotePartitions: {}",
           taskPrefix);
     }
   }
@@ -609,7 +613,7 @@ void checkProducerConsumerLinkage(
 
       VELOX_CHECK_EQ(
           partitionedOutput->numPartitions(),
-          consumer.width.value_or(1),
+          consumer.numRemotePartitions.value_or(1),
           "Partition count mismatch between producer {} and consumer {}",
           producer.taskPrefix,
           consumer.taskPrefix);
@@ -668,13 +672,16 @@ void checkGroupedNodes(const ExecutableFragment& fragment) {
 
 // Checks that the last fragment has a type compatible with local result
 // consumption.
-void checkLastFragment(const ExecutableFragment& last, int32_t numWorkers) {
+void checkLastFragment(
+    const ExecutableFragment& last,
+    int32_t maxRemotePartitions) {
   VELOX_CHECK(
       last.type == FragmentType::kSingle ||
           last.type == FragmentType::kCoordinator ||
-          (last.type == FragmentType::kSource && numWorkers == 1),
+          (last.type == FragmentType::kSource && maxRemotePartitions == 1),
       "Last fragment must be kSingle or kCoordinator "
-      "when remoteOutput is false (kSource allowed only with numWorkers == 1): {}",
+      "when remoteOutput is false (kSource allowed only with "
+      "maxRemotePartitions == 1): {}",
       last.taskPrefix);
 }
 
@@ -686,7 +693,7 @@ void MultiFragmentPlan::checkConsistency(bool mayBeEmpty) const {
     return;
   }
 
-  checkFragmentTypes(fragments_, options_.numWorkers);
+  checkFragmentTypes(fragments_, options_.maxRemotePartitions);
 
   checkProducerConsumerLinkage(fragments_);
 
@@ -695,7 +702,7 @@ void MultiFragmentPlan::checkConsistency(bool mayBeEmpty) const {
   }
 
   if (!options_.remoteOutput) {
-    checkLastFragment(fragments_.back(), options_.numWorkers);
+    checkLastFragment(fragments_.back(), options_.maxRemotePartitions);
   }
 }
 

--- a/axiom/optimizer/MultiFragmentPlan.h
+++ b/axiom/optimizer/MultiFragmentPlan.h
@@ -125,7 +125,7 @@ class FinishWrite {
 enum class FragmentType {
   /// Parallelism determined by the data source (number of splits).
   kSource,
-  /// Exactly `width` tasks.
+  /// Exactly `numRemotePartitions` tasks.
   kFixed,
   /// Exactly 1 task, any worker.
   kSingle,
@@ -149,9 +149,13 @@ struct ExecutableFragment {
   /// Scheduling type for this fragment.
   FragmentType type;
 
-  /// Number of tasks. Required for kFixed. std::nullopt for kSource (runtime
-  /// decides actual count), kSingle, and kCoordinator.
-  std::optional<int32_t> width;
+  /// Number of remote partitions, i.e. the number of tasks the scheduler
+  /// must run for this fragment. Required for kFixed. std::nullopt for
+  /// kSource (runtime decides actual count), kSingle, and kCoordinator.
+  /// Splits tagged with a remotePartition in [0, numRemotePartitions) are
+  /// routed to the task with that index; the scheduler must obey this
+  /// decision.
+  std::optional<int32_t> numRemotePartitions;
 
   velox::core::PlanFragment fragment;
 
@@ -161,11 +165,12 @@ struct ExecutableFragment {
 
   /// The leaf nodes of a fragment that runs one bucket group at a time. A scan
   /// read that way maps to the partitioning it is read by, already coarsened to
-  /// the worker count, and the connector tags each emitted Split with a groupId
-  /// the runtime routes by. An exchange feeding the same fragment maps to null:
-  /// its partitions line up with those groups by construction. All non-null
-  /// entries share numPartitions(), which is the fragment's width. Empty when
-  /// the fragment does not run grouped.
+  /// the worker count, and the connector tags each emitted Split with a
+  /// remotePartition the runtime routes by. An exchange feeding the same
+  /// fragment maps to null: its partitions line up with those groups by
+  /// construction. All non-null entries share numPartitions(), which is the
+  /// fragment's numRemotePartitions. Empty when the fragment does not run
+  /// grouped.
   folly::F14FastMap<
       velox::core::PlanNodeId,
       std::shared_ptr<connector::PartitionType>>
@@ -189,15 +194,15 @@ class MultiFragmentPlan {
     /// Query id used as a prefix for tasks ids.
     std::string queryId;
 
-    /// Maximum Number of independent Tasks for one stage of execution. If 1,
-    /// there are no exchanges. Starts as the workers available to the query.
+    /// Maximum number of remote partitions for one stage of execution. If 1,
+    /// there are no exchanges.
     /// The optimizer may lower it, so a plan carries the count it was planned
     /// for rather than the count available.
-    int32_t numWorkers{1};
+    int32_t maxRemotePartitions{1};
 
-    /// Number of threads in a fragment in a worker. If 1, there are no local
-    /// exchanges.
-    int32_t numDrivers{4};
+    /// Maximum number of local partitions, i.e. threads in a fragment in a
+    /// worker. If 1, there are no local exchanges.
+    int32_t maxLocalPartitions{4};
 
     /// Controls how query results are delivered from the final plan fragment.
     ///
@@ -218,7 +223,10 @@ class MultiFragmentPlan {
     /// Used by constant folding and join sampling which always run via
     /// LocalRunner regardless of the query's distributed options.
     static Options singleNode() {
-      return Options{.numWorkers = 1, .numDrivers = 1, .remoteOutput = false};
+      return Options{
+          .maxRemotePartitions = 1,
+          .maxLocalPartitions = 1,
+          .remoteOutput = false};
     }
   };
 
@@ -251,7 +259,8 @@ class MultiFragmentPlan {
       velox::core::PlanSummaryOptions options = {}) const;
 
   /// Validates structural consistency of the plan. Checks fragment types,
-  /// widths, producer-consumer linkage, and partition count alignment.
+  /// numRemotePartitions, producer-consumer linkage, and partition count
+  /// alignment.
   /// 'mayBeEmpty' allows a plan with no fragments, which is what a write the
   /// connector performs through metadata alone produces.
   void checkConsistency(bool mayBeEmpty) const;

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -81,8 +81,8 @@ Optimization::Optimization(
     : optimizerSession_{std::move(optimizerSession)},
       runnerSession_{std::move(runnerSession)},
       runnerOptions_(std::move(runnerOptions)),
-      isSingleWorker_(runnerOptions_.numWorkers == 1),
-      isSingleDriver_(runnerOptions_.numDrivers == 1),
+      isSingleWorker_(runnerOptions_.maxRemotePartitions == 1),
+      isSingleDriver_(runnerOptions_.maxLocalPartitions == 1),
       history_(history),
       veloxQueryCtx_(std::move(veloxQueryCtx)),
       aggregationPlanner_{
@@ -325,10 +325,12 @@ namespace {
 // Coarsens 'groupedLeaves' to the runner's task budget by calling scaleDown on
 // each non-null entry. GroupedLeaves is immutable once taken; this is the only
 // point that locks the per-leaf entries to runner-task partition counts.
-void scaleDownGroupedLeaves(GroupedLeaves& groupedLeaves, int32_t numWorkers) {
+void scaleDownGroupedLeaves(
+    GroupedLeaves& groupedLeaves,
+    int32_t maxRemotePartitions) {
   for (auto& [_, partitionType] : groupedLeaves) {
     if (partitionType != nullptr) {
-      partitionType = partitionType->scaleDown(numWorkers);
+      partitionType = partitionType->scaleDown(maxRemotePartitions);
     }
   }
 }
@@ -395,7 +397,7 @@ void commitGroupedLeavesForRepartition(
   collectFragmentLeaves(repartition->input().get(), producerLeaves);
   filterGroupedLeavesToProducerLeaves(groupedLeaves, producerLeaves);
   scaleDownGroupedLeaves(
-      groupedLeaves, state.optimization.runnerOptions().numWorkers);
+      groupedLeaves, state.optimization.runnerOptions().maxRemotePartitions);
   const auto& dist = repartition->distribution();
   if (dist.kind() == Distribution::Kind::kPartitioned &&
       !dist.partitionKeys().empty()) {
@@ -404,17 +406,17 @@ void commitGroupedLeavesForRepartition(
 }
 
 namespace {
-// Calls scaleDown(numWorkers) on 'partitionType' and returns the resulting
-// type, pushed onto 'owned' for lifetime management. Passes null through
-// unchanged.
+// Calls scaleDown(maxRemotePartitions) on 'partitionType' and returns the
+// resulting type, pushed onto 'owned' for lifetime management. Passes null
+// through unchanged.
 const connector::PartitionType* FOLLY_NULLABLE scaleDownPartitionType(
     const connector::PartitionType* partitionType,
-    int32_t numWorkers,
+    int32_t maxRemotePartitions,
     std::vector<std::shared_ptr<connector::PartitionType>>& owned) {
   if (partitionType == nullptr) {
     return nullptr;
   }
-  auto scaled = partitionType->scaleDown(numWorkers);
+  auto scaled = partitionType->scaleDown(maxRemotePartitions);
   const auto* raw = scaled.get();
   owned.push_back(std::move(scaled));
   return raw;
@@ -558,7 +560,8 @@ PlanP Optimization::bestPlan() {
     folly::F14FastSet<const RelationOp*> rootLeaves;
     collectFragmentLeaves(winner->op.get(), rootLeaves);
     filterGroupedLeavesToProducerLeaves(rootGroupedLeaves_, rootLeaves);
-    scaleDownGroupedLeaves(rootGroupedLeaves_, runnerOptions_.numWorkers);
+    scaleDownGroupedLeaves(
+        rootGroupedLeaves_, runnerOptions_.maxRemotePartitions);
   }
   return winner;
 }
@@ -1096,7 +1099,7 @@ uint32_t position(const V& exprs, Getter getter, const Expr& expr) {
 
 // True if single worker, i.e. do not plan remote exchanges
 bool isSingleWorker() {
-  return queryCtx()->optimization()->runnerOptions().numWorkers == 1;
+  return queryCtx()->optimization()->runnerOptions().maxRemotePartitions == 1;
 }
 
 CPSpan<Column> leadingColumns(const ExprVector& exprs) {
@@ -1264,7 +1267,7 @@ void alignJoinSides(
   Distribution distribution{
       scaleDownPartitionType(
           input->distribution().partitionType(),
-          state.optimization.runnerOptions().numWorkers,
+          state.optimization.runnerOptions().maxRemotePartitions,
           state.optimization.derivedPartitionTypes()),
       std::move(distColumns)};
   auto* repartition = make<Repartition>(
@@ -2420,7 +2423,7 @@ void Optimization::joinByHash(
         Distribution distribution{
             scaleDownPartitionType(
                 plan->distribution().partitionType(),
-                runnerOptions_.numWorkers,
+                runnerOptions_.maxRemotePartitions,
                 derivedPartitionTypes_),
             copartition};
         auto* repartition = make<Repartition>(
@@ -3771,7 +3774,7 @@ PlanP Optimization::makeUnionPlan(
     // wrap those.
     const auto* unionPartType = scaleDownPartitionType(
         effectiveDistribution->partitionType,
-        runnerOptions_.numWorkers,
+        runnerOptions_.maxRemotePartitions,
         derivedPartitionTypes_);
     for (auto i = 0; i < inputs.size(); ++i) {
       if (inputNeedsShuffle[i]) {

--- a/axiom/optimizer/Plan.cpp
+++ b/axiom/optimizer/Plan.cpp
@@ -25,7 +25,7 @@ namespace {
 
 // True if single worker, i.e. do not plan remote exchanges
 bool isSingleWorker() {
-  return queryCtx()->optimization()->runnerOptions().numWorkers == 1;
+  return queryCtx()->optimization()->runnerOptions().maxRemotePartitions == 1;
 }
 
 bool computeGreedyJoinOrder(

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -745,10 +745,10 @@ Repartition::Repartition(
   // and transfer costs scale with the number of workers. 'this->' disambiguates
   // the accessor from the constructor parameter 'distribution'.
   if (this->distribution().isBroadcast()) {
-    const auto numWorkers =
-        queryCtx()->optimization()->runnerOptions().numWorkers;
-    unitCost *= numWorkers;
-    rowBytes *= numWorkers;
+    const auto maxRemotePartitions =
+        queryCtx()->optimization()->runnerOptions().maxRemotePartitions;
+    unitCost *= maxRemotePartitions;
+    rowBytes *= maxRemotePartitions;
   }
 
   cost_.unitCost = unitCost;
@@ -1173,7 +1173,7 @@ void Aggregation::setCostWithGroups(
 
   if (step != velox::core::AggregationNode::Step::kPartial) {
     float localExchangeCost = 0;
-    if (runnerOptions.numDrivers > 1) {
+    if (runnerOptions.maxLocalPartitions > 1) {
       // If more than one driver per fragment, a non-partial group by needs a
       // local exchange. Estimated to be 1/3 of a remote shuffle.
       localExchangeCost = shuffleCost(input_->columns()) / 3;
@@ -1222,7 +1222,8 @@ void Aggregation::setCostWithGroups(
       numGroups / inputBeforePartial,
       partialCapacity / partialInputBetweenFlushes);
 
-  const auto width = runnerOptions.numWorkers * runnerOptions.numDrivers;
+  const auto width =
+      runnerOptions.maxRemotePartitions * runnerOptions.maxLocalPartitions;
   if ((inputBeforePartial > abandonPartialMinRows * width &&
        initialDistincts > abandonPartialMinRows * abandonPartialMinFraction) ||
       (inputBeforePartial > numGroups * 5 &&
@@ -2078,7 +2079,7 @@ MarkDistinct::MarkDistinct(
     // seen, and inserts a new entry if not. Estimated localExchangeCost to be
     // 1/3 of a remote shuffle, following the same cost modeling of Aggregation.
     float localExchangeCost = 0;
-    if (runnerOptions.numDrivers > 1) {
+    if (runnerOptions.maxLocalPartitions > 1) {
       localExchangeCost = shuffleCost(input_->columns()) / 3;
     }
     auto markDistinctCost = Costs::kHashColumnCost * keys_.size() +

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -58,7 +58,7 @@ ToVelox::ToVelox(
     const MultiFragmentPlan::Options& options)
     : optimizerSession_{std::move(optimizerSession)},
       options_{options},
-      isSingle_{options.numWorkers == 1},
+      isSingle_{options.maxRemotePartitions == 1},
       subscript_{FunctionRegistry::instance()->subscript()},
       elementAt_{FunctionRegistry::instance()->elementAt()} {
   VELOX_CHECK_NOT_NULL(optimizerSession_);
@@ -391,22 +391,22 @@ std::optional<FragmentType> fragmentTypeContribution(const RelationOp& op) {
 // to (but not including) any inner Repartition or leaf, merging contributions
 // per the compatibility rules in docs/UnionAllPlanning.md.
 //
-// For numWorkers == 1, all parallelism collapses to a single task; kSource,
-// kFixed N=1, and kSingle become equivalent. The compatibility rules (which
-// guard against multiplication of kSingle data across parallel tasks) don't
-// apply, so we skip the walk and use kSingle directly.
+// For maxRemotePartitions == 1, all parallelism collapses to a single task;
+// kSource, kFixed N=1, and kSingle become equivalent. The compatibility rules
+// (which guard against multiplication of kSingle data across parallel tasks)
+// don't apply, so we skip the walk and use kSingle directly.
 void decideFragmentType(
     const RelationOp& op,
     const MultiFragmentPlan::Options& options,
     ExecutableFragment& fragment) {
-  if (options.numWorkers == 1) {
+  if (options.maxRemotePartitions == 1) {
     fragment.type = FragmentType::kSingle;
     return;
   }
 
   fragment.type = fragmentTypeContribution(op).value_or(FragmentType::kSource);
   if (fragment.type == FragmentType::kFixed) {
-    fragment.width = options.numWorkers;
+    fragment.numRemotePartitions = options.maxRemotePartitions;
   }
 }
 
@@ -441,7 +441,7 @@ void ToVelox::applyGroupedLeaves(
   // A fragment is bucketed iff at least one groupedLeaves entry has a non-null
   // PartitionType. Non-bucketed fragments leave groupedNodes empty: a
   // fragment that consumes only hash-partitioned exchanges (all-null entries)
-  // doesn't participate in groupId routing.
+  // doesn't participate in remotePartition routing.
   bool anyNonNull = false;
   for (const auto& [_, pt] : groupedLeaves) {
     if (pt != nullptr) {
@@ -464,23 +464,23 @@ void ToVelox::applyGroupedLeaves(
         idIt->second,
         std::const_pointer_cast<connector::PartitionType>(partitionType));
   }
-  int32_t width = -1;
+  int32_t numRemotePartitions = -1;
   for (const auto& [_, pt] : fragment.groupedNodes) {
     if (pt == nullptr) {
       continue;
     }
-    if (width < 0) {
-      width = pt->numPartitions();
+    if (numRemotePartitions < 0) {
+      numRemotePartitions = pt->numPartitions();
     } else {
       VELOX_CHECK_EQ(
           pt->numPartitions(),
-          width,
+          numRemotePartitions,
           "fragment.groupedNodes has non-null PartitionTypes with disagreeing numPartitions");
     }
   }
-  if (width >= 0) {
+  if (numRemotePartitions >= 0) {
     fragment.type = FragmentType::kFixed;
-    fragment.width = width;
+    fragment.numRemotePartitions = numRemotePartitions;
   }
 }
 
@@ -506,7 +506,7 @@ PlanAndStats ToVelox::toVeloxPlan(
   // makeRepartition's consumer logic can treat it as carrying the root
   // fragment's GroupedLeaves (the gather was not present at planning time
   // and so has no entry in groupedLeaves_->perRepartition).
-  if (options_.numWorkers > 1 && !options_.remoteOutput) {
+  if (options_.maxRemotePartitions > 1 && !options_.remoteOutput) {
     plan = addGather(plan, &gatherRepartition_);
   }
 
@@ -1101,7 +1101,7 @@ velox::core::PlanNodePtr ToVelox::makeOrderBy(
   if (isSingle_ || op.input()->distribution().isGather()) {
     auto input = makeFragment(op.input(), fragment, stages);
 
-    if (options_.numDrivers == 1) {
+    if (options_.maxLocalPartitions == 1) {
       auto node = op.isNoLimit()
           ? std::make_shared<velox::core::OrderByNode>(
                 nextId(), keys, sortOrder, false, input)
@@ -1132,7 +1132,7 @@ velox::core::PlanNodePtr ToVelox::makeOrderBy(
   // At one driver the per-worker sort yields a single sorted run, so emit a
   // final sort and skip the LocalMerge; the MergeExchange combines the
   // per-worker runs.
-  const bool singleDriver = options_.numDrivers == 1;
+  const bool singleDriver = options_.maxLocalPartitions == 1;
 
   velox::core::PlanNodePtr node;
   if (op.isNoLimit()) {
@@ -1209,7 +1209,7 @@ velox::core::PlanNodePtr ToVelox::makeLimit(
   // partition keys), skip the distributed limit pattern.
   if (isSingle_ || op.input()->distribution().isGather()) {
     auto input = makeFragment(op.input(), fragment, stages);
-    if (options_.numDrivers == 1) {
+    if (options_.maxLocalPartitions == 1) {
       return addFinalLimit(nextId(), op.offset, op.limit, input);
     }
 
@@ -1226,7 +1226,7 @@ velox::core::PlanNodePtr ToVelox::makeLimit(
 
   auto node = addPartialLimit(nextId(), 0, op.offset + op.limit, input);
 
-  if (options_.numDrivers > 1) {
+  if (options_.maxLocalPartitions > 1) {
     node = addLocalGather(nextId(), node);
     node = addFinalLimit(nextId(), 0, op.offset + op.limit, node);
   }
@@ -1292,7 +1292,7 @@ velox::core::PartitionFunctionSpecPtr createPartitionFunctionSpec(
 
 // Adds a local gather (empty partition keys) or local repartition (non-empty
 // partition keys) to ensure all rows for a partition are processed by a single
-// driver when numDrivers > 1.
+// driver when maxLocalPartitions > 1.
 velox::core::PlanNodePtr addLocalPartition(
     const velox::core::PlanNodeId& id,
     const velox::core::PlanNodePtr& input,
@@ -1619,7 +1619,8 @@ velox::core::PlanNodePtr ToVelox::makeJoin(
   // probe side by join keys so each driver processes a non-overlapping subset
   // of keys and accesses independent counters. Skip if the probe is already
   // a counting join (its output is already partitioned by the same keys).
-  if (velox::core::isCountingJoin(join.joinType) && options_.numDrivers > 1) {
+  if (velox::core::isCountingJoin(join.joinType) &&
+      options_.maxLocalPartitions > 1) {
     auto* probeJoin =
         dynamic_cast<const velox::core::HashJoinNode*>(left.get());
     if (!probeJoin || !velox::core::isCountingJoin(probeJoin->joinType())) {
@@ -1738,7 +1739,7 @@ velox::core::PlanNodePtr ToVelox::makeAggregation(
     }
   }
 
-  if (op.preGroupedKeys.empty() && options_.numDrivers > 1 &&
+  if (op.preGroupedKeys.empty() && options_.maxLocalPartitions > 1 &&
       (op.step == velox::core::AggregationNode::Step::kFinal ||
        op.step == velox::core::AggregationNode::Step::kSingle)) {
     input = addLocalPartition(nextId(), input, keys);
@@ -1848,7 +1849,7 @@ velox::core::PlanNodePtr ToVelox::makeWindowInput(
   // through its sort/partition.
   auto input =
       maybeTrimColumns(makeFragment(op.input(), fragment, stages), op.input());
-  if (options_.numDrivers > 1) {
+  if (options_.maxLocalPartitions > 1) {
     input = addLocalPartition(nextId(), input, toFieldRefs(partitionKeys));
   }
   return input;
@@ -1976,8 +1977,8 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
         nextId(), outputType, exchangeSerdeKind_, sourcePlan);
   } else {
     VELOX_CHECK_NE(0, keys.size());
-    const auto numPartitions =
-        groupedLeavesWidth(*outerConsumerGroupedLeaves, options_.numWorkers);
+    const auto numPartitions = groupedLeavesWidth(
+        *outerConsumerGroupedLeaves, options_.maxRemotePartitions);
     if (numPartitions == 1) {
       source.fragment.planNode = velox::core::PartitionedOutputNode::single(
           nextId(), outputType, exchangeSerdeKind_, sourcePlan);
@@ -2206,7 +2207,7 @@ velox::core::PlanNodePtr ToVelox::makeWrite(
 
   auto* layout = table.layouts().front();
 
-  if (options_.numDrivers > 1) {
+  if (options_.maxLocalPartitions > 1) {
     const auto& partitionColumns = layout->partitionColumns();
     if (!partitionColumns.empty()) {
       std::vector<velox::column_index_t> channels;
@@ -2242,7 +2243,7 @@ velox::core::PlanNodePtr ToVelox::makeWrite(
 
   auto inputType = ROW(inputNames, inputTypes);
 
-  auto numDrivers = options_.numDrivers;
+  auto numDrivers = options_.maxLocalPartitions;
   if ((fragment.type == FragmentType::kSingle ||
        fragment.type == FragmentType::kCoordinator) &&
       numDrivers > 1 && isSingleThreadedPipeline(input)) {
@@ -2250,10 +2251,12 @@ velox::core::PlanNodePtr ToVelox::makeWrite(
   }
 
   VELOX_CHECK(
-      fragment.type != FragmentType::kFixed || fragment.width.has_value(),
-      "kFixed fragment must have width set");
-  auto numTasks = fragment.width.value_or(
-      fragment.type == FragmentType::kSource ? options_.numWorkers : 1);
+      fragment.type != FragmentType::kFixed ||
+          fragment.numRemotePartitions.has_value(),
+      "kFixed fragment must have numRemotePartitions set");
+  auto numTasks = fragment.numRemotePartitions.value_or(
+      fragment.type == FragmentType::kSource ? options_.maxRemotePartitions
+                                             : 1);
 
   WriteStatsBuilder statsBuilder(
       table, inputType, *handle, numDrivers, numTasks);
@@ -2364,7 +2367,7 @@ velox::core::PlanNodePtr ToVelox::makeMarkDistinct(
     ExecutableFragment& fragment,
     std::vector<ExecutableFragment>& stages) {
   auto input = makeFragment(op.input(), fragment, stages);
-  if (options_.numDrivers > 1) {
+  if (options_.maxLocalPartitions > 1) {
     // Add local partition unless keys are already co-located.
     bool needsLocalPartition = true;
     if (op.input()->relType() != RelType::kRepartition) {

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -410,15 +410,15 @@ class ToVelox {
   FinishWrite finishWrite_;
 
   // Pending final merge spec for multi-worker writes. Set by makeWrite
-  // when numWorkers > 1, consumed by toVeloxPlan to add a
+  // when maxRemotePartitions > 1, consumed by toVeloxPlan to add a
   // TableWriteMerge(kFinal) after the gather exchange.
   std::optional<velox::core::ColumnStatsSpec> finalMergeSpec_;
 
   // Translates 'groupedLeaves' (keyed by const RelationOp*) into entries in
   // 'fragment.groupedNodes' (keyed by Velox PlanNodeId) using
   // 'relationOpToNodeId_'. After translation, if any non-null PartitionType
-  // entry is present, sets fragment.type = kFixed and fragment.width =
-  // numPartitions().
+  // entry is present, sets fragment.type = kFixed and
+  // fragment.numRemotePartitions = numPartitions().
   void applyGroupedLeaves(
       ExecutableFragment& fragment,
       const GroupedLeaves& groupedLeaves);

--- a/axiom/optimizer/docs/DistributedExecution.md
+++ b/axiom/optimizer/docs/DistributedExecution.md
@@ -9,7 +9,7 @@ The optimizer's role is to decide where exchanges go, what partitioning each exc
 **Implementation status.** Sections 1 and 2 describe the fragment and exchange model that is in place today, with two exceptions called out where they appear:
 
 - **`kCoordinator` fragments and SystemConnector isolation** are not yet implemented. Section 1 (UNION ALL with single-task inputs) and Section 2 (`FragmentType::kCoordinator`) describe the intended behavior.
-- **Grouped execution** (Section 3) is partially implemented. The shuffle-avoidance path is in place: the `PartitionType` API, the `groupedNodes` field on `ExecutableFragment`, split-level `groupId` tagging, and `scaleDown` to a `kFixed` fragment whose tasks are routed by `groupId`. The full per-group-processing path — `GroupedSplitSource` (complete groups in order) and the `groupedExecution` flag that clears hash tables between groups — is not yet implemented.
+- **Grouped execution** (Section 3) is partially implemented. The shuffle-avoidance path is in place: the `PartitionType` API, the `groupedNodes` field on `ExecutableFragment`, split-level `remotePartition` tagging, and `scaleDown` to a `kFixed` fragment whose tasks are routed by `remotePartition`. The full per-group-processing path — `GroupedSplitSource` (complete groups in order) and the `groupedExecution` flag that clears hash tables between groups — is not yet implemented.
 
 ### 1. Fragment Structure and Scheduling Constraints
 
@@ -201,7 +201,7 @@ struct InputStage {
 /// Determines how the runtime decides the task count for a fragment.
 enum class FragmentType {
     kSource,       /// Task count driven by splits at runtime.
-    kFixed,        /// Exactly 'width' tasks.
+    kFixed,        /// Exactly 'numRemotePartitions' tasks.
     kSingle,       /// Exactly 1 task, any worker.
     kCoordinator,  /// Exactly 1 task, on coordinator.
 };
@@ -210,7 +210,7 @@ struct ExecutableFragment {
     std::string taskPrefix;
     FragmentType type;
     /// Required for kFixed, optional hint for kSource, nullopt otherwise.
-    std::optional<int32_t> width;
+    std::optional<int32_t> numRemotePartitions;
     velox::core::PlanFragment fragment;
     std::vector<InputStage> inputStages;
     /// See Section 3 for grouped execution fields.
@@ -221,26 +221,27 @@ struct ExecutableFragment {
 
 The runtime determines task count based on `FragmentType`:
 
-- **kFixed** — create exactly `width` tasks. The optimizer guarantees that
-  all hash-partitioned exchange inputs into this fragment use the same
-  `numPartitions` equal to `width`.
+- **kFixed** — create exactly `numRemotePartitions` tasks. The optimizer
+  guarantees that all hash-partitioned exchange inputs into this fragment use
+  the same `numPartitions` equal to `numRemotePartitions`.
 - **kSingle** — create exactly 1 task.
 - **kCoordinator** — create exactly 1 task, on the coordinator node.
-- **kSource** — runtime decides. The optimizer may set `width` as a
-  recommended task count. The runtime may use this as a starting point
+- **kSource** — runtime decides. The optimizer may set `numRemotePartitions`
+  as a recommended task count. The runtime may use this as a starting point
   but is not bound by it — it may adjust based on actual split count
   and available workers.
 
 > **Future work: cardinality-based width selection.** Today the
-> optimizer typically sets `width = numWorkers` for kFixed fragments
-> and leaves kSource width unset. This wastes resources on small
-> queries — a global aggregation over a few thousand rows should not
-> fan out to 100 workers. The optimizer should use cardinality
-> estimates to pick a smaller `width` when the data is small (kFixed:
-> set `width` and the matching upstream `numPartitions`; kSource: set
-> `width` as a hint to the runtime). Cardinality estimates at fragment
-> boundaries are already available — the optimizer just needs to
-> consult them when choosing `width`.
+> optimizer typically sets `numRemotePartitions = maxRemotePartitions` for
+> kFixed fragments and leaves kSource numRemotePartitions unset. This wastes
+> resources on small queries — a global aggregation over a few thousand rows
+> should not fan out to 100 workers. The optimizer should use cardinality
+> estimates to pick a smaller `numRemotePartitions` when the data is small
+> (kFixed: set `numRemotePartitions` and the matching upstream
+> `numPartitions`; kSource: set `numRemotePartitions` as a hint to the
+> runtime). Cardinality estimates at fragment boundaries are already
+> available — the optimizer just needs to consult them when choosing
+> `numRemotePartitions`.
 
 #### Data wiring
 
@@ -286,8 +287,8 @@ For fragments without scans (kSingle, kCoordinator), there are no
 connector splits. Data arrives through exchanges or is embedded in the
 plan (e.g., Values). kFixed fragments typically have no scans, but may have them in grouped execution (see Section 3) or when a scan leg is co-located in a kFixed UNION ALL fragment (see [UnionAllPlanning.md](UnionAllPlanning.md)).
 
-In single-node mode (`numWorkers == 1`), the entire plan runs in a single
-kSingle fragment with no exchanges.
+In single-node mode (`maxRemotePartitions == 1`), the entire plan runs in a
+single kSingle fragment with no exchanges.
 
 #### Examples
 
@@ -327,8 +328,8 @@ The FINAL aggregation lives in the same fragment as the UNION ALL because A6 (kS
 
 > **Status (2026-07-31): partially implemented.** The shuffle-avoidance
 > path is in place — the `PartitionType` API, the `groupedNodes` field on
-> `ExecutableFragment`, split-level `groupId` tagging, and `scaleDown` to a
-> `kFixed` fragment routed by `groupId` (see "Shuffle avoidance without
+> `ExecutableFragment`, split-level `remotePartition` tagging, and `scaleDown`
+> to a `kFixed` fragment routed by `remotePartition` (see "Shuffle avoidance without
 > per-group processing" below). The full per-group-processing path described
 > in this section — `GroupedSplitSource` / `co_getGroups` and the
 > `groupedExecution` flag that clears hash tables between groups — is not yet
@@ -473,13 +474,13 @@ For Hive, `copartition` returns a `HivePartitionType` with `min(bucketsA, bucket
 
 **Mixed inputs.** When joining a bucketed table with a non-bucketed table or intermediate query result, the optimizer hash-partitions the non-bucketed side using the same partition function as the bucketed side.
 
-The optimizer computes group count `g` from the bucketed side(s) via `copartition()`, then finds the exchange width `N` using `scaleDown(numWorkers)`. `N` is the largest value <= `numWorkers` that the connector considers valid given `g` (for Hive, the largest divisor of `g` that is <= `numWorkers`). The resulting `PartitionType` encapsulates both `g` and `N`, so its `makeSpec` produces the optimal partition function (e.g., Hive emits `bucket % N` directly rather than `bucket % g % N`).
+The optimizer computes group count `g` from the bucketed side(s) via `copartition()`, then finds the exchange width `N` using `scaleDown(maxRemotePartitions)`. `N` is the largest value <= `maxRemotePartitions` that the connector considers valid given `g` (for Hive, the largest divisor of `g` that is <= `maxRemotePartitions`). The resulting `PartitionType` encapsulates both `g` and `N`, so its `makeSpec` produces the optimal partition function (e.g., Hive emits `bucket % N` directly rather than `bucket % g % N`).
 
 A hash-partitioned exchange with N partitions is conceptually similar to a table bucketed into N buckets — partition `p` contains all rows whose key hashes to `p`. This is why `groupedNodes` can include both scan nodes and exchange nodes.
 
-`scaleDown` exists because of streaming shuffle's constraint: the consumer fragment must run exactly N tasks concurrently, so N can be at most `numWorkers`. With durable shuffle, the consumer can process groups dynamically and `scaleDown` is unnecessary — the producer can use the bucketed side's native group count `g` directly. See "Mixed inputs (scans + exchanges)" under Runtime contract below for how the streaming vs. durable choice changes fragment type.
+`scaleDown` exists because of streaming shuffle's constraint: the consumer fragment must run exactly N tasks concurrently, so N can be at most `maxRemotePartitions`. With durable shuffle, the consumer can process groups dynamically and `scaleDown` is unnecessary — the producer can use the bucketed side's native group count `g` directly. See "Mixed inputs (scans + exchanges)" under Runtime contract below for how the streaming vs. durable choice changes fragment type.
 
-The consumer fragment is `kFixed` with `width = N`. `groupedNodes` includes both the scan node(s) and the exchange node(s).
+The consumer fragment is `kFixed` with `numRemotePartitions = N`. `groupedNodes` includes both the scan node(s) and the exchange node(s).
 
 For Hive, `scaleDown(maxPartitions)` returns a `HivePartitionType` with the largest divisor of `numBuckets` that is <= `maxPartitions`; its `makeSpec` produces `nativeBucketFunction % N`.
 
@@ -631,11 +632,11 @@ When throughput matters more than latency, grouped execution is still the better
 `scaleDown()` flow as grouped execution to determine a shared
 `PartitionType`. For co-bucketed joins, `copartition()` finds the
 common partitioning across all bucketed inputs. Then
-`scaleDown(numWorkers)` reduces the group count to at most
-`numWorkers`, producing a `PartitionType` with
-`numPartitions() = N` where N <= numWorkers. The fragment is
-kFixed with `width = N` — the optimizer sets the task count so
-the runtime can co-schedule splits by `groupId` deterministically.
+`scaleDown(maxRemotePartitions)` reduces the group count to at most
+`maxRemotePartitions`, producing a `PartitionType` with
+`numPartitions() = N` where N <= maxRemotePartitions. The fragment is
+kFixed with `numRemotePartitions = N` — the optimizer sets the task count so
+the runtime can co-schedule splits by `remotePartition` deterministically.
 (kSource is only possible with `GroupedSplitSource`, which delivers
 complete groups in order — connectors like Hive that discover
 splits incrementally cannot support it, hence this fallback.)
@@ -645,9 +646,9 @@ The optimizer populates `groupedNodes` with the scaled
 and sets `groupedExecution = false`.
 
 **Split delivery.** Since `ConnectorSplit` is a Velox type and
-cannot carry `groupId` directly, Axiom defines its own
+cannot carry `remotePartition` directly, Axiom defines its own
 `axiom::connector::Split` that wraps a `ConnectorSplit` with an
-optional `groupId`. The runtime uses `groupId` to co-schedule
+optional `remotePartition`. The runtime uses `remotePartition` to co-schedule
 splits from the same group on the same task, then passes the inner
 `ConnectorSplit` to Velox for execution. Splits arrive
 incrementally as they are discovered — no ordering or completeness
@@ -658,11 +659,11 @@ data / numTasks rather than per-group data.
 ```cpp
 namespace axiom::connector {
 
-/// Wraps a Velox ConnectorSplit with an optional group ID for
+/// Wraps a Velox ConnectorSplit with an optional remote partition for
 /// bucketed execution routing.
 struct Split {
     std::shared_ptr<velox::connector::ConnectorSplit> connectorSplit;
-    std::optional<int32_t> groupId;
+    std::optional<int32_t> remotePartition;
 };
 
 struct SplitBatch {
@@ -671,7 +672,7 @@ struct SplitBatch {
 };
 
 /// Produces splits incrementally. When configured with a
-/// PartitionType, each Split carries a groupId computed by
+/// PartitionType, each Split carries a remotePartition computed by
 /// the connector.
 class SplitSource {
  public:
@@ -695,7 +696,7 @@ virtual std::shared_ptr<SplitSource> getSplitSource(
     const std::shared_ptr<PartitionType>& partitionType = nullptr) = 0;
 ```
 
-When `partitionType` is set, the connector sets `groupId` on each
+When `partitionType` is set, the connector sets `remotePartition` on each
 `Split` to a value in `0..partitionType->numPartitions()-1`,
 computed using the mapping encoded in the `PartitionType` (e.g.,
 for Hive, `bucketId % partitionType->numPartitions()`).
@@ -703,12 +704,12 @@ for Hive, `bucketId % partitionType->numPartitions()`).
 | | Grouped execution | Shuffle avoidance only |
 |---|---|---|
 | Fragment type | kSource | kFixed |
-| Split delivery | `GroupedSplitSource` (complete groups) | `SplitSource` (incremental, with `groupId`) |
+| Split delivery | `GroupedSplitSource` (complete groups) | `SplitSource` (incremental, with `remotePartition`) |
 | Per-group clearing | Yes | No |
 | Latency | May wait for group completion | Incremental, tasks start immediately |
 | Memory per task | Per-group data | Total data / numTasks |
 
-Shuffle avoidance uses the regular `SplitSource` with `groupId`
+Shuffle avoidance uses the regular `SplitSource` with `remotePartition`
 on each split — no per-group clearing. A future grouped-execution
 path may introduce a `GroupedSplitSource` and a corresponding
 capability bit on `ConnectorSplitManager`; the API surface is not
@@ -716,7 +717,7 @@ defined here.
 
 #### Examples
 
-These examples explain the design and validate it against diverse scenarios. All examples assume `numWorkers = 100`, Hive bucketing, and
+These examples explain the design and validate it against diverse scenarios. All examples assume `maxRemotePartitions = 100`, Hive bucketing, and
 `remoteOutput = true` — results remain distributed across workers.
 When `remoteOutput = false`, a kSingle output fragment is added to
 gather results to a single node. The output fragment is omitted

--- a/axiom/optimizer/docs/UnionAllPlanning.md
+++ b/axiom/optimizer/docs/UnionAllPlanning.md
@@ -89,9 +89,9 @@ Compatibility rules for co-locating legs in one fragment:
   violation: the single-row leg would be multiplied across the parallel
   tasks). The kSingle leg must be wrapped in `Repartition(arbitrary)`.
 - **kFixed N1 + kFixed N2** with N1 ≠ N2 → cannot co-locate (a fragment
-  has one width). One leg must be wrapped. Not produced by the optimizer
-  today — every parallel leg ends up at `numWorkers`; covered here for
-  completeness.
+  has one numRemotePartitions). One leg must be wrapped. Not produced by the
+  optimizer today — every parallel leg ends up at `maxRemotePartitions`;
+  covered here for completeness.
 
 Note: An `arbitrary` exchange consumer can adopt any width, so it never
 constrains the consumer fragment type — it conforms to whatever the

--- a/axiom/optimizer/tests/AggregationTest.cpp
+++ b/axiom/optimizer/tests/AggregationTest.cpp
@@ -221,7 +221,8 @@ TEST_F(AggregationTest, orderBy) {
     option.alwaysPlanPartialAggregation = (i == 0);
     auto plan = planVelox(
         logicalPlan,
-        MultiFragmentPlan::Options{.numWorkers = 4, .numDrivers = 4},
+        MultiFragmentPlan::Options{
+            .maxRemotePartitions = 4, .maxLocalPartitions = 4},
         option);
     AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
   }
@@ -282,7 +283,8 @@ TEST_F(AggregationTest, fanoutPrecisionRegression) {
   options.alwaysPlanPartialAggregation = true;
   auto plan = planVelox(
                   logicalPlan,
-                  MultiFragmentPlan::Options{.numWorkers = 4, .numDrivers = 4},
+                  MultiFragmentPlan::Options{
+                      .maxRemotePartitions = 4, .maxLocalPartitions = 4},
                   options)
                   .plan;
 
@@ -396,7 +398,8 @@ TEST_F(AggregationTest, bucketedAggregation) {
 
   {
     SCOPED_TRACE("multiple drivers: partial reduces before the local exchange");
-    auto plan = planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
+    auto plan = planVelox(
+        logicalPlan, {.maxRemotePartitions = 4, .maxLocalPartitions = 4});
     auto matcher = matchScan("t")
                        .partialAggregation({"k", "g"}, {"sum(v) as s"})
                        .localPartition({"k", "g"})
@@ -410,7 +413,8 @@ TEST_F(AggregationTest, bucketedAggregation) {
 
   {
     SCOPED_TRACE("single driver: no local exchange, single-step aggregation");
-    auto plan = planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 1});
+    auto plan = planVelox(
+        logicalPlan, {.maxRemotePartitions = 4, .maxLocalPartitions = 1});
     auto matcher = matchScan("t")
                        .multiThreaded(false)
                        .singleAggregation({"k", "g"}, {"sum(v)"})
@@ -585,7 +589,8 @@ TEST_F(AggregationTest, groupingSetsOrderByWithGlobalSet) {
   {
     auto plan = planVelox(
         logicalPlan,
-        MultiFragmentPlan::Options{.numWorkers = 4, .numDrivers = 4});
+        MultiFragmentPlan::Options{
+            .maxRemotePartitions = 4, .maxLocalPartitions = 4});
 
     auto matcher =
         matchScan("t")
@@ -668,7 +673,9 @@ TEST_F(AggregationTest, mask) {
           .finalAggregation({}, {"sum(sum)", "avg(avg)"})
           .build();
   AXIOM_ASSERT_DISTRIBUTED_PLAN(
-      planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4}).plan,
+      planVelox(
+          logicalPlan, {.maxRemotePartitions = 4, .maxLocalPartitions = 4})
+          .plan,
       distributedMatcher);
 }
 
@@ -875,7 +882,9 @@ TEST_F(AggregationTest, dropOrderByFromOrderInsensitiveAggregates) {
                                 .project()
                                 .build();
   AXIOM_ASSERT_DISTRIBUTED_PLAN(
-      planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4}).plan,
+      planVelox(
+          logicalPlan, {.maxRemotePartitions = 4, .maxLocalPartitions = 4})
+          .plan,
       distributedMatcher);
 }
 

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -582,8 +582,8 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
     }
 
     optimizer::MultiFragmentPlan::Options opts;
-    opts.numWorkers = FLAGS_num_workers;
-    opts.numDrivers = FLAGS_num_drivers;
+    opts.maxRemotePartitions = FLAGS_num_workers;
+    opts.maxLocalPartitions = FLAGS_num_drivers;
     auto allocator =
         std::make_unique<HashStringAllocator>(optimizerPool_.get());
     auto context = std::make_unique<optimizer::QueryGraphContext>(

--- a/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
@@ -73,7 +73,9 @@ class BucketedExecutionTest : public test::QueryTestBase,
 
   PlanAndStats planDistributed(const lp::LogicalPlanNodePtr& logicalPlan) {
     return planVelox(
-        logicalPlan, {.numWorkers = 4, .numDrivers = 4}, optimizerOptions_);
+        logicalPlan,
+        {.maxRemotePartitions = 4, .maxLocalPartitions = 4},
+        optimizerOptions_);
   }
 
   static void expectBucketedFragmentWithWidth(
@@ -87,8 +89,8 @@ class BucketedExecutionTest : public test::QueryTestBase,
         continue;
       }
       EXPECT_EQ(fragment.type, FragmentType::kFixed);
-      ASSERT_TRUE(fragment.width.has_value());
-      EXPECT_EQ(*fragment.width, expectedWidth);
+      ASSERT_TRUE(fragment.numRemotePartitions.has_value());
+      EXPECT_EQ(*fragment.numRemotePartitions, expectedWidth);
       int32_t bucketedScans = 0;
       int32_t hashExchanges = 0;
       for (const auto& [_, partitionType] : fragment.groupedNodes) {
@@ -1095,7 +1097,7 @@ TEST_P(BucketedExecutionTest, incompatibleBucketingOnOneWorker) {
           "SELECT * FROM w1_t JOIN w1_u "
           "ON w1_t.customer_id = w1_u.id",
           kTestConnectorId),
-      {.numWorkers = 1, .numDrivers = 4},
+      {.maxRemotePartitions = 1, .maxLocalPartitions = 4},
       optimizerOptions_);
 
   AXIOM_ASSERT_DISTRIBUTED_PLAN(

--- a/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
+++ b/axiom/optimizer/tests/DerivedTablePrinterTest.cpp
@@ -124,7 +124,7 @@ class DerivedTablePrinterTest : public ::testing::Test {
         history,
         veloxQueryCtx,
         evaluator,
-        {.numWorkers = 1, .numDrivers = 1}};
+        {.maxRemotePartitions = 1, .maxLocalPartitions = 1}};
 
     const auto dtString = DerivedTablePrinter::toText(*opt.rootDt());
 

--- a/axiom/optimizer/tests/DistinctAggregationTest.cpp
+++ b/axiom/optimizer/tests/DistinctAggregationTest.cpp
@@ -29,8 +29,8 @@ class DistinctAggregationTest : public test::QueryTestBase,
                                 public ::testing::WithParamInterface<bool> {
  public:
   DistinctAggregationTest() {
-    runnerOptions_.numWorkers = 4;
-    runnerOptions_.numDrivers = 4;
+    runnerOptions_.maxRemotePartitions = 4;
+    runnerOptions_.maxLocalPartitions = 4;
     optimizerOptions_.alwaysPlanPartialAggregation = true;
   }
 

--- a/axiom/optimizer/tests/FilteredTableStatsTest.cpp
+++ b/axiom/optimizer/tests/FilteredTableStatsTest.cpp
@@ -59,7 +59,7 @@ class FilteredTableStatsTest : public test::HiveQueriesTestBase,
 
     auto planAndStats = planVelox(
         logicalPlan,
-        {.numWorkers = 1, .numDrivers = 1},
+        {.maxRemotePartitions = 1, .maxLocalPartitions = 1},
         std::move(optimizerOptions));
 
     const auto& root = planAndStats.plan->fragments().back().fragment.planNode;

--- a/axiom/optimizer/tests/FixedPointTest.cpp
+++ b/axiom/optimizer/tests/FixedPointTest.cpp
@@ -123,7 +123,8 @@ TEST_F(FixedPointTest, multipleWorkersRejected) {
       kTestConnectorId);
 
   VELOX_ASSERT_THROW(
-      planVelox(logicalPlan, {.numWorkers = 2, .numDrivers = 1}),
+      planVelox(
+          logicalPlan, {.maxRemotePartitions = 2, .maxLocalPartitions = 1}),
       "Distributed FixedPoint execution is not yet implemented");
 }
 

--- a/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
@@ -87,7 +87,7 @@ class HiveBucketedExecutionTest : public test::HiveQueriesTestBase,
     VELOX_CHECK_GT(numWorkers, 1);
     return planVelox(
         logicalPlan,
-        {.numWorkers = numWorkers, .numDrivers = 4},
+        {.maxRemotePartitions = numWorkers, .maxLocalPartitions = 4},
         optimizerOptions_);
   }
 

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -151,8 +151,10 @@ velox::core::PlanNodePtr HiveQueriesTestBase::toSingleNodePlan(
     int32_t numDrivers) {
   auto logicalPlan = parseSelect(sql);
 
-  auto plan =
-      planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = numDrivers}).plan;
+  auto plan = planVelox(
+                  logicalPlan,
+                  {.maxRemotePartitions = 1, .maxLocalPartitions = numDrivers})
+                  .plan;
 
   EXPECT_EQ(1, plan->fragments().size());
   return plan->fragments().at(0).fragment.planNode;

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -532,8 +532,10 @@ TEST_P(JoinTest, broadcastSizeLimitGatesBroadcast) {
   // The 1000-row build (~16KB) is well under the default 100MB limit, so it is
   // broadcast rather than hash-partitioned.
   {
-    auto distributedPlan =
-        planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 1}, options);
+    auto distributedPlan = planVelox(
+        logicalPlan,
+        {.maxRemotePartitions = 4, .maxLocalPartitions = 1},
+        options);
     // V2 is worse: it adds a Project to reconstruct both equivalent join-key
     // names and emits `b_key` twice under different names.
     // TODO: Eliminate the V2 output-key reconstruction Project.
@@ -549,8 +551,10 @@ TEST_P(JoinTest, broadcastSizeLimitGatesBroadcast) {
   // so both sides are hash-partitioned on the join key.
   {
     options.broadcastSizeLimit = 1024;
-    auto distributedPlan =
-        planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 1}, options);
+    auto distributedPlan = planVelox(
+        logicalPlan,
+        {.maxRemotePartitions = 4, .maxLocalPartitions = 1},
+        options);
     // V2 is worse: it adds a Project to reconstruct both equivalent join-key
     // names after the partitioned join.
     auto matcher =

--- a/axiom/optimizer/tests/MultiFragmentPlanTest.cpp
+++ b/axiom/optimizer/tests/MultiFragmentPlanTest.cpp
@@ -65,12 +65,12 @@ class MultiFragmentPlanTest : public testing::Test {
   // Creates a single-fragment plan with the given type.
   MultiFragmentPlan makeSingleFragmentPlan(
       FragmentType type,
-      std::optional<int32_t> width = std::nullopt,
+      std::optional<int32_t> numRemotePartitions = std::nullopt,
       const MultiFragmentPlan::Options& options = defaultOptions()) {
     ExecutableFragment fragment;
     fragment.taskPrefix = "stage0";
     fragment.type = type;
-    fragment.width = width;
+    fragment.numRemotePartitions = numRemotePartitions;
     fragment.fragment = values();
     return MultiFragmentPlan({std::move(fragment)}, options);
   }
@@ -78,7 +78,7 @@ class MultiFragmentPlanTest : public testing::Test {
   static MultiFragmentPlan::Options defaultOptions() {
     return {
         .queryId = "test",
-        .numWorkers = 10,
+        .maxRemotePartitions = 10,
     };
   }
 
@@ -109,7 +109,7 @@ TEST_F(MultiFragmentPlanTest, validDistributedPlan) {
   ExecutableFragment consumer;
   consumer.taskPrefix = "stage1";
   consumer.type = FragmentType::kFixed;
-  consumer.width = 4;
+  consumer.numRemotePartitions = 4;
   consumer.fragment = exchange();
   consumer.inputStages.emplace_back(consumer.fragment.planNode->id(), "stage0");
 
@@ -129,33 +129,33 @@ TEST_F(MultiFragmentPlanTest, fixedWithoutWidth) {
   VELOX_ASSERT_THROW(
       makeSingleFragmentPlan(FragmentType::kFixed)
           .checkConsistency(/*mayBeEmpty=*/false),
-      "kFixed fragment must have width set");
+      "kFixed fragment must have numRemotePartitions set");
 }
 
 TEST_F(MultiFragmentPlanTest, singleWithWidth) {
   VELOX_ASSERT_THROW(
       makeSingleFragmentPlan(FragmentType::kSingle, 1)
           .checkConsistency(/*mayBeEmpty=*/false),
-      "fragment must not have width set");
+      "fragment must not have numRemotePartitions set");
 }
 
 TEST_F(MultiFragmentPlanTest, coordinatorWithWidth) {
   VELOX_ASSERT_THROW(
       makeSingleFragmentPlan(FragmentType::kCoordinator, 1)
           .checkConsistency(/*mayBeEmpty=*/false),
-      "fragment must not have width set");
+      "fragment must not have numRemotePartitions set");
 }
 
 TEST_F(MultiFragmentPlanTest, invalidWidth) {
   VELOX_ASSERT_THROW(
       makeSingleFragmentPlan(FragmentType::kFixed, 0)
           .checkConsistency(/*mayBeEmpty=*/false),
-      "Fragment width must be positive");
+      "Fragment numRemotePartitions must be positive");
 
   VELOX_ASSERT_THROW(
       makeSingleFragmentPlan(FragmentType::kFixed, 20)
           .checkConsistency(/*mayBeEmpty=*/false),
-      "Fragment width exceeds numWorkers");
+      "Fragment numRemotePartitions exceeds maxRemotePartitions");
 }
 
 TEST_F(MultiFragmentPlanTest, sourceWithWidthHint) {
@@ -205,13 +205,13 @@ TEST_F(MultiFragmentPlanTest, lastFragmentIsProducer) {
   ExecutableFragment producer;
   producer.taskPrefix = "stage1";
   producer.type = FragmentType::kFixed;
-  producer.width = 4;
+  producer.numRemotePartitions = 4;
   producer.fragment = partitionedOutput(4);
 
   ExecutableFragment consumer;
   consumer.taskPrefix = "stage0";
   consumer.type = FragmentType::kFixed;
-  consumer.width = 4;
+  consumer.numRemotePartitions = 4;
   consumer.fragment = exchange();
   consumer.inputStages.emplace_back(consumer.fragment.planNode->id(), "stage1");
 
@@ -240,7 +240,7 @@ TEST_F(MultiFragmentPlanTest, partitionCountMismatch) {
   ExecutableFragment consumer;
   consumer.taskPrefix = "stage1";
   consumer.type = FragmentType::kFixed;
-  consumer.width = 8;
+  consumer.numRemotePartitions = 8;
   consumer.fragment = exchange();
   consumer.inputStages.emplace_back(consumer.fragment.planNode->id(), "stage0");
 
@@ -281,7 +281,7 @@ TEST_F(MultiFragmentPlanTest, lastFragmentType) {
           .checkConsistency(/*mayBeEmpty=*/false),
       "Last fragment must be kSingle or kCoordinator");
 
-  // kSource is allowed as last fragment with numWorkers == 1.
+  // kSource is allowed as last fragment with maxRemotePartitions == 1.
   EXPECT_NO_THROW(makeSingleFragmentPlan(
                       FragmentType::kSource,
                       std::nullopt,
@@ -306,7 +306,7 @@ TEST_F(MultiFragmentPlanTest, orphanFragment) {
   ExecutableFragment output;
   output.taskPrefix = "stage1";
   output.type = FragmentType::kFixed;
-  output.width = 4;
+  output.numRemotePartitions = 4;
   output.fragment = values();
 
   auto plan =
@@ -328,7 +328,7 @@ TEST_F(MultiFragmentPlanTest, producerReferencedByMultipleConsumers) {
   ExecutableFragment consumerA;
   consumerA.taskPrefix = "stage1";
   consumerA.type = FragmentType::kFixed;
-  consumerA.width = 4;
+  consumerA.numRemotePartitions = 4;
   consumerA.fragment = exchange();
   consumerA.inputStages.emplace_back(
       consumerA.fragment.planNode->id(), "stage0");
@@ -336,7 +336,7 @@ TEST_F(MultiFragmentPlanTest, producerReferencedByMultipleConsumers) {
   ExecutableFragment consumerB;
   consumerB.taskPrefix = "stage2";
   consumerB.type = FragmentType::kFixed;
-  consumerB.width = 4;
+  consumerB.numRemotePartitions = 4;
   consumerB.fragment = exchange();
   consumerB.inputStages.emplace_back(
       consumerB.fragment.planNode->id(), "stage0");

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -2805,9 +2805,10 @@ PlanMatcherBuilder& PlanMatcherBuilder::fragment(FragmentDetails details) {
       matcher_,
       [details](const axiom::optimizer::ExecutableFragment& fragment) {
         if (details.width.has_value()) {
-          ASSERT_TRUE(fragment.width.has_value())
-              << "fragment width is not set";
-          EXPECT_EQ(*fragment.width, details.width.value()) << "fragment width";
+          ASSERT_TRUE(fragment.numRemotePartitions.has_value())
+              << "fragment numRemotePartitions is not set";
+          EXPECT_EQ(*fragment.numRemotePartitions, details.width.value())
+              << "fragment numRemotePartitions";
         }
         if (!details.bucketedScans.has_value() &&
             !details.bucketedExchanges.has_value()) {

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -857,8 +857,9 @@ class PlanMatcherBuilder {
       const std::vector<std::string>& keys,
       const std::vector<std::string>& markerAliases);
 
-  /// Sets whether this matcher describes a multi-threaded (numDrivers > 1)
-  /// plan. When enabled (the default for a new builder), the distributed*
+  /// Sets whether this matcher describes a multi-threaded
+  /// (maxLocalPartitions > 1) plan. When enabled (the default for a new
+  /// builder), the distributed*
   /// helpers (distributedAggregation, distributedSingleAggregation,
   /// distributedOrderBy, distributedMarkDistinct) expect the additional
   /// local-exchange nodes that intra-node parallelism inserts, e.g.

--- a/axiom/optimizer/tests/PrecomputeProjectionTest.cpp
+++ b/axiom/optimizer/tests/PrecomputeProjectionTest.cpp
@@ -86,7 +86,7 @@ class PrecomputeProjectionTest : public ::testing::Test {
         history,
         veloxQueryCtx,
         evaluator,
-        {.numWorkers = 1, .numDrivers = 1}};
+        {.maxRemotePartitions = 1, .maxLocalPartitions = 1}};
 
     testRoutine(opt.rootDt());
   }

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -142,8 +142,8 @@ runner::RunnerSessionPtr makeRunnerSession(const std::string& queryId) {
 
 TestResult QueryTestBase::runVelox(const core::PlanNodePtr& plan) {
   MultiFragmentPlan::Options options;
-  options.numWorkers = 1;
-  options.numDrivers = 1;
+  options.maxRemotePartitions = 1;
+  options.maxLocalPartitions = 1;
   options.queryId = fmt::format("q{}", ++gQueryCounter);
 
   ExecutableFragment fragment(fmt::format("{}.0", options.queryId));
@@ -263,7 +263,8 @@ void QueryTestBase::verifyOptimization(
       history,
       veloxQueryCtx,
       evaluator,
-      MultiFragmentPlan::Options{.numWorkers = 1, .numDrivers = 1});
+      MultiFragmentPlan::Options{
+          .maxRemotePartitions = 1, .maxLocalPartitions = 1});
 
   callback(optimization);
 }
@@ -314,8 +315,8 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
         fmt::format("{}.plans", planFilePathPrefix.value()));
 
     *planPath << "generated: " << formatCurrentTime() << " (snapshot)\n";
-    *planPath << "numWorkers: " << options.numWorkers << "\n";
-    *planPath << "numDrivers: " << options.numDrivers << "\n\n";
+    *planPath << "maxRemotePartitions: " << options.maxRemotePartitions << "\n";
+    *planPath << "maxLocalPartitions: " << options.maxLocalPartitions << "\n\n";
   }
 
   SCOPE_EXIT {
@@ -414,25 +415,31 @@ void QueryTestBase::checkSame(
   VELOX_CHECK_NOT_NULL(planNode);
 
   std::vector<MultiFragmentPlan::Options> testOptions = {
-      {.numWorkers = 1, .numDrivers = 1},
+      {.maxRemotePartitions = 1, .maxLocalPartitions = 1},
   };
 
-  if (options.numDrivers > 1) {
-    testOptions.push_back({.numWorkers = 1, .numDrivers = options.numDrivers});
+  if (options.maxLocalPartitions > 1) {
+    testOptions.push_back(
+        {.maxRemotePartitions = 1,
+         .maxLocalPartitions = options.maxLocalPartitions});
   }
 
-  if (options.numWorkers > 1) {
-    testOptions.push_back({.numWorkers = options.numWorkers, .numDrivers = 1});
+  if (options.maxRemotePartitions > 1) {
+    testOptions.push_back(
+        {.maxRemotePartitions = options.maxRemotePartitions,
+         .maxLocalPartitions = 1});
   }
 
-  if (options.numWorkers > 1 && options.numDrivers > 1) {
+  if (options.maxRemotePartitions > 1 && options.maxLocalPartitions > 1) {
     testOptions.push_back(options);
   }
 
   for (const auto& test : testOptions) {
     SCOPED_TRACE(
         fmt::format(
-            "workers: {}, drivers: {}", test.numWorkers, test.numDrivers));
+            "workers: {}, drivers: {}",
+            test.maxRemotePartitions,
+            test.maxLocalPartitions));
 
     auto plan = planVelox(planNode, test);
 
@@ -445,8 +452,10 @@ void QueryTestBase::checkSame(
 velox::core::PlanNodePtr QueryTestBase::toSingleNodePlan(
     const logical_plan::LogicalPlanNodePtr& logicalPlan,
     int32_t numDrivers) {
-  auto plan =
-      planVelox(logicalPlan, {.numWorkers = 1, .numDrivers = numDrivers}).plan;
+  auto plan = planVelox(
+                  logicalPlan,
+                  {.maxRemotePartitions = 1, .maxLocalPartitions = numDrivers})
+                  .plan;
 
   EXPECT_EQ(1, plan->fragments().size());
   return plan->fragments().at(0).fragment.planNode;

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -118,8 +118,8 @@ class QueryTestBase : public velox::exec::test::HiveConnectorTestBase {
       const logical_plan::LogicalPlanNodePtr& plan,
       const MultiFragmentPlan::Options& options =
           {
-              .numWorkers = 4,
-              .numDrivers = 4,
+              .maxRemotePartitions = 4,
+              .maxLocalPartitions = 4,
           },
       const std::optional<OptimizerOptions>& optimizerOptions = std::nullopt,
       const std::optional<std::string>& planFilePathPrefix = std::nullopt);
@@ -129,8 +129,8 @@ class QueryTestBase : public velox::exec::test::HiveConnectorTestBase {
       const connector::SchemaResolver& schemaResolver,
       const MultiFragmentPlan::Options& options =
           {
-              .numWorkers = 4,
-              .numDrivers = 4,
+              .maxRemotePartitions = 4,
+              .maxLocalPartitions = 4,
           },
       const std::optional<OptimizerOptions>& optimizerOptions = std::nullopt,
       const std::optional<std::string>& planFilePathPrefix = std::nullopt);
@@ -138,16 +138,16 @@ class QueryTestBase : public velox::exec::test::HiveConnectorTestBase {
   TestResult runVelox(
       const logical_plan::LogicalPlanNodePtr& plan,
       const MultiFragmentPlan::Options& options = {
-          .numWorkers = 4,
-          .numDrivers = 4,
+          .maxRemotePartitions = 4,
+          .maxLocalPartitions = 4,
       });
 
   TestResult runVelox(
       const logical_plan::LogicalPlanNodePtr& plan,
       const connector::SchemaResolver& schemaResolver,
       const MultiFragmentPlan::Options& options = {
-          .numWorkers = 4,
-          .numDrivers = 4,
+          .maxRemotePartitions = 4,
+          .maxLocalPartitions = 4,
       });
 
   TestResult runFragmentedPlan(optimizer::PlanAndStats& plan);
@@ -166,26 +166,26 @@ class QueryTestBase : public velox::exec::test::HiveConnectorTestBase {
   /// Runs 'referencePlan' single-threaded. Runs 'planNode' multiple times using
   /// different parallelism settings. Runs single-node-single-threaded,
   /// single-node-multi-threaded, multi-node-single-threaded, and
-  /// multi-node-multi-threaded. Uses options.numWorkers for multi-node runs and
-  /// options.numDrivers for multi-threaded runs. Doesn't run with higher
-  /// parallelism than specified in 'options'. E.g. if options = {.numWorkers =
-  /// 1, .numDrivers = 1}, then runs only once (single-node-single-threaded).
-  /// All runs are expected to produce the same result that matches result of
-  /// 'referencePlan'.
+  /// multi-node-multi-threaded. Uses options.maxRemotePartitions for multi-node
+  /// runs and options.maxLocalPartitions for multi-threaded runs. Doesn't run
+  /// with higher parallelism than specified in 'options'. E.g. if options =
+  /// {.maxRemotePartitions = 1, .maxLocalPartitions = 1}, then runs only once
+  /// (single-node-single-threaded). All runs are expected to produce the same
+  /// result that matches result of 'referencePlan'.
   void checkSame(
       const logical_plan::LogicalPlanNodePtr& planNode,
       const velox::core::PlanNodePtr& referencePlan,
       const MultiFragmentPlan::Options& options = {
-          .numWorkers = 4,
-          .numDrivers = 4,
+          .maxRemotePartitions = 4,
+          .maxLocalPartitions = 4,
       });
 
   void checkSame(
       const logical_plan::LogicalPlanNodePtr& planNode,
       const std::vector<velox::RowVectorPtr>& referenceResult,
       const MultiFragmentPlan::Options& options = {
-          .numWorkers = 4,
-          .numDrivers = 4,
+          .maxRemotePartitions = 4,
+          .maxLocalPartitions = 4,
       });
 
   velox::core::PlanNodePtr toSingleNodePlan(
@@ -197,7 +197,9 @@ class QueryTestBase : public velox::exec::test::HiveConnectorTestBase {
       const velox::core::PlanNodePtr& referencePlan,
       int32_t numDrivers = 1) {
     checkSame(
-        planNode, referencePlan, {.numWorkers = 1, .numDrivers = numDrivers});
+        planNode,
+        referencePlan,
+        {.maxRemotePartitions = 1, .maxLocalPartitions = numDrivers});
   }
 
   void checkSameSingleNode(
@@ -205,7 +207,9 @@ class QueryTestBase : public velox::exec::test::HiveConnectorTestBase {
       const std::vector<velox::RowVectorPtr>& referenceResult,
       int32_t numDrivers = 1) {
     checkSame(
-        planNode, referenceResult, {.numWorkers = 1, .numDrivers = numDrivers});
+        planNode,
+        referenceResult,
+        {.maxRemotePartitions = 1, .maxLocalPartitions = numDrivers});
   }
 
   velox::memory::MemoryPool& optimizerPool() const {
@@ -218,8 +222,8 @@ class QueryTestBase : public velox::exec::test::HiveConnectorTestBase {
       const logical_plan::LogicalPlanNodePtr& logicalPlan,
       const MultiFragmentPlan::Options& options =
           {
-              .numWorkers = 1,
-              .numDrivers = 1,
+              .maxRemotePartitions = 1,
+              .maxLocalPartitions = 1,
           },
       const std::optional<OptimizerOptions>& optimizerOptions = std::nullopt);
 

--- a/axiom/optimizer/tests/QueryWidthTest.cpp
+++ b/axiom/optimizer/tests/QueryWidthTest.cpp
@@ -44,7 +44,7 @@ class QueryWidthTest : public test::HiveQueriesTestBase {
   PlanAndStats plan(std::string_view sql, const OptimizerOptions& options) {
     return planVelox(
         parseSelect(sql),
-        {.numWorkers = kWorkersAvailable, .numDrivers = 2},
+        {.maxRemotePartitions = kWorkersAvailable, .maxLocalPartitions = 2},
         options);
   }
 
@@ -56,8 +56,8 @@ class QueryWidthTest : public test::HiveQueriesTestBase {
     return options;
   }
 
-  static int32_t numWorkers(const PlanAndStats& result) {
-    return result.plan->options().numWorkers;
+  static int32_t maxRemotePartitions(const PlanAndStats& result) {
+    return result.plan->options().maxRemotePartitions;
   }
 
   // Sums the raw-input estimates the optimizer recorded for the plan's scans,
@@ -86,19 +86,19 @@ TEST_F(QueryWidthTest, scan) {
     {
       const auto result = plan(sql, narrowingAt(kNationRows));
       EXPECT_EQ(scanRawInputRows(result), kNationRows);
-      EXPECT_EQ(numWorkers(result), 1);
+      EXPECT_EQ(maxRemotePartitions(result), 1);
     }
 
     {
       const auto result = plan(sql, narrowingAt(kNationRows - 1));
       EXPECT_EQ(scanRawInputRows(result), kNationRows);
-      EXPECT_EQ(numWorkers(result), kWorkersAvailable);
+      EXPECT_EQ(maxRemotePartitions(result), kWorkersAvailable);
     }
 
     {
       const auto result = plan(sql, narrowingAt(0));
       EXPECT_EQ(scanRawInputRows(result), kNationRows);
-      EXPECT_EQ(numWorkers(result), kWorkersAvailable);
+      EXPECT_EQ(maxRemotePartitions(result), kWorkersAvailable);
     }
   }
 }
@@ -113,13 +113,13 @@ TEST_F(QueryWidthTest, join) {
   {
     const auto result = plan(sql, narrowingAt(bothTables));
     EXPECT_EQ(scanRawInputRows(result), bothTables);
-    EXPECT_EQ(numWorkers(result), 1);
+    EXPECT_EQ(maxRemotePartitions(result), 1);
   }
 
   {
     const auto result = plan(sql, narrowingAt(bothTables - 1));
     EXPECT_EQ(scanRawInputRows(result), bothTables);
-    EXPECT_EQ(numWorkers(result), kWorkersAvailable);
+    EXPECT_EQ(maxRemotePartitions(result), kWorkersAvailable);
   }
 }
 
@@ -132,7 +132,7 @@ TEST_F(QueryWidthTest, noStats) {
 
   const auto result = plan("SELECT n_nationkey FROM nation", options);
   EXPECT_EQ(scanRawInputRows(result), std::nullopt);
-  EXPECT_EQ(numWorkers(result), kWorkersAvailable);
+  EXPECT_EQ(maxRemotePartitions(result), kWorkersAvailable);
 }
 
 // A narrowed query gets the configured number of workers, never more than the
@@ -143,12 +143,12 @@ TEST_F(QueryWidthTest, narrowWidth) {
   auto options = narrowingAt(kNationRows);
   {
     options.smallQueryNumWorkers = 2;
-    EXPECT_EQ(numWorkers(plan(sql, options)), 2);
+    EXPECT_EQ(maxRemotePartitions(plan(sql, options)), 2);
   }
 
   {
     options.smallQueryNumWorkers = kWorkersAvailable * 2;
-    EXPECT_EQ(numWorkers(plan(sql, options)), kWorkersAvailable);
+    EXPECT_EQ(maxRemotePartitions(plan(sql, options)), kWorkersAvailable);
   }
 }
 

--- a/axiom/optimizer/tests/RelationOpPrinterTest.cpp
+++ b/axiom/optimizer/tests/RelationOpPrinterTest.cpp
@@ -176,7 +176,7 @@ class RelationOpPrinterTest : public ::testing::Test {
         history,
         veloxQueryCtx,
         evaluator,
-        {.numWorkers = numWorkers, .numDrivers = numDrivers}};
+        {.maxRemotePartitions = numWorkers, .maxLocalPartitions = numDrivers}};
 
     auto* plan = opt.bestPlan();
     consume(*plan->op);

--- a/axiom/optimizer/tests/RemoteOutputTest.cpp
+++ b/axiom/optimizer/tests/RemoteOutputTest.cpp
@@ -42,7 +42,10 @@ TEST_P(RemoteOutputTest, scan) {
   // wraps output in a PartitionedOutputNode for remote consumption.
   {
     auto plan = planVelox(
-        logicalPlan, {.numWorkers = 2, .numDrivers = 2, .remoteOutput = true});
+        logicalPlan,
+        {.maxRemotePartitions = 2,
+         .maxLocalPartitions = 2,
+         .remoteOutput = true});
     auto matcher = matchScan("t").partitionedOutputSingle().build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
   }
@@ -51,7 +54,10 @@ TEST_P(RemoteOutputTest, scan) {
   // results onto a single node.
   {
     auto plan = planVelox(
-        logicalPlan, {.numWorkers = 2, .numDrivers = 2, .remoteOutput = false});
+        logicalPlan,
+        {.maxRemotePartitions = 2,
+         .maxLocalPartitions = 2,
+         .remoteOutput = false});
     auto matcher = matchScan("t").gather().build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
   }
@@ -60,7 +66,10 @@ TEST_P(RemoteOutputTest, scan) {
   // to enable remote consumption even though there is only one worker.
   {
     auto plan = planVelox(
-        logicalPlan, {.numWorkers = 1, .numDrivers = 2, .remoteOutput = true});
+        logicalPlan,
+        {.maxRemotePartitions = 1,
+         .maxLocalPartitions = 2,
+         .remoteOutput = true});
     auto matcher = matchScan("t").partitionedOutputSingle().build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
   }
@@ -69,7 +78,10 @@ TEST_P(RemoteOutputTest, scan) {
   // are consumed locally.
   {
     auto plan = planVelox(
-        logicalPlan, {.numWorkers = 1, .numDrivers = 2, .remoteOutput = false});
+        logicalPlan,
+        {.maxRemotePartitions = 1,
+         .maxLocalPartitions = 2,
+         .remoteOutput = false});
     auto matcher = matchScan("t").build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, matcher);
   }
@@ -84,7 +96,9 @@ TEST_P(RemoteOutputTest, globalAggregation) {
     SCOPED_TRACE(remoteOutput ? "remoteOutput=true" : "remoteOutput=false");
     auto plan = planVelox(
         logicalPlan,
-        {.numWorkers = 2, .numDrivers = 2, .remoteOutput = remoteOutput});
+        {.maxRemotePartitions = 2,
+         .maxLocalPartitions = 2,
+         .remoteOutput = remoteOutput});
 
     auto builder = matchScan("t").distributedAggregation({}, {"sum(b)"});
     builder.partitionedOutputSingleIf(remoteOutput);
@@ -103,7 +117,9 @@ TEST_P(RemoteOutputTest, groupByAggregation) {
     SCOPED_TRACE(remoteOutput ? "remoteOutput=true" : "remoteOutput=false");
     auto plan = planVelox(
         logicalPlan,
-        {.numWorkers = 2, .numDrivers = 2, .remoteOutput = remoteOutput});
+        {.maxRemotePartitions = 2,
+         .maxLocalPartitions = 2,
+         .remoteOutput = remoteOutput});
 
     auto builder = matchScan("t")
                        .distributedAggregation({"a"}, {"sum(b) as sum"})
@@ -128,7 +144,9 @@ TEST_P(RemoteOutputTest, repeatedOutputName) {
     SCOPED_TRACE(remoteOutput ? "remoteOutput=true" : "remoteOutput=false");
     auto plan = planVelox(
         logicalPlan,
-        {.numWorkers = 2, .numDrivers = 2, .remoteOutput = remoteOutput});
+        {.maxRemotePartitions = 2,
+         .maxLocalPartitions = 2,
+         .remoteOutput = remoteOutput});
 
     auto builder = matchScan("t");
     if (remoteOutput) {
@@ -158,7 +176,9 @@ TEST_P(RemoteOutputTest, sameColumnTwice) {
     SCOPED_TRACE(remoteOutput ? "remoteOutput=true" : "remoteOutput=false");
     auto plan = planVelox(
         logicalPlan,
-        {.numWorkers = 2, .numDrivers = 2, .remoteOutput = remoteOutput});
+        {.maxRemotePartitions = 2,
+         .maxLocalPartitions = 2,
+         .remoteOutput = remoteOutput});
 
     auto builder = matchScan("t");
     if (remoteOutput) {
@@ -192,7 +212,9 @@ TEST_P(RemoteOutputTest, tableWrite) {
     SCOPED_TRACE(remoteOutput ? "remoteOutput=true" : "remoteOutput=false");
     auto plan = planVelox(
         logicalPlan,
-        {.numWorkers = 2, .numDrivers = 2, .remoteOutput = remoteOutput});
+        {.maxRemotePartitions = 2,
+         .maxLocalPartitions = 2,
+         .remoteOutput = remoteOutput});
 
     auto builder = matchScan("t").tableWrite().localGather().tableWriteMerge();
     // v2 always runs the final TableWriteMerge on a separate coordinator

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -123,8 +123,8 @@ std::shared_ptr<runner::LocalRunner> makeLocalRunnerImpl(
       connector::ConnectorMetadataRegistry::global()};
 
   MultiFragmentPlan::Options options;
-  options.numWorkers = numWorkers;
-  options.numDrivers = numDrivers;
+  options.maxRemotePartitions = numWorkers;
+  options.maxLocalPartitions = numDrivers;
   options.queryId = queryId;
 
   OptimizerOptions optimizerOptions;

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -2639,7 +2639,8 @@ TEST_P(SubqueryTest, constantFoldingWithoutExecutor) {
   auto logicalPlan =
       parseSelect("SELECT * FROM nation WHERE n_regionkey > (SELECT 1)");
 
-  auto plan = planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
+  auto plan = planVelox(
+      logicalPlan, {.maxRemotePartitions = 4, .maxLocalPartitions = 4});
   EXPECT_EQ(3, plan.plan->fragments().size());
 }
 

--- a/axiom/optimizer/tests/TableSampleTest.cpp
+++ b/axiom/optimizer/tests/TableSampleTest.cpp
@@ -64,8 +64,9 @@ TEST_P(TableSampleTest, system) {
 
   // Returns the single fragment's plan node and its sampled-scan map.
   auto planSampled = [&](const std::string& sample) {
-    auto result =
-        planVelox(parseSampledScan(sample), {.numWorkers = 1, .numDrivers = 1});
+    auto result = planVelox(
+        parseSampledScan(sample),
+        {.maxRemotePartitions = 1, .maxLocalPartitions = 1});
     EXPECT_EQ(result.plan->fragments().size(), 1);
     const auto& fragment = result.plan->fragments().at(0);
     return std::make_pair(fragment.fragment.planNode, fragment.sampledScans);
@@ -100,7 +101,7 @@ TEST_P(TableSampleTest, system) {
           parseSelect(
               "SELECT * FROM (VALUES (1)) AS v (x) TABLESAMPLE SYSTEM (50)",
               kTestConnectorId),
-          {.numWorkers = 1, .numDrivers = 1}),
+          {.maxRemotePartitions = 1, .maxLocalPartitions = 1}),
       "TABLESAMPLE SYSTEM is only supported directly over a table");
 }
 
@@ -109,7 +110,8 @@ TEST_P(TableSampleTest, explainShowsSampleRate) {
 
   auto explain = [&](const std::string& sample) {
     return planVelox(
-               parseSampledScan(sample), {.numWorkers = 1, .numDrivers = 1})
+               parseSampledScan(sample),
+               {.maxRemotePartitions = 1, .maxLocalPartitions = 1})
         .plan->toString();
   };
 

--- a/axiom/optimizer/tests/TestConnectorQueryTest.cpp
+++ b/axiom/optimizer/tests/TestConnectorQueryTest.cpp
@@ -71,7 +71,9 @@ class TestConnectorQueryTest : public QueryTestBase,
     return std::make_shared<MultiFragmentPlan>(fragments, options_);
   }
 
-  const MultiFragmentPlan::Options options_{.numWorkers = 1, .numDrivers = 16};
+  const MultiFragmentPlan::Options options_{
+      .maxRemotePartitions = 1,
+      .maxLocalPartitions = 16};
 };
 
 TEST_P(TestConnectorQueryTest, selectFiltered) {

--- a/axiom/optimizer/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/tests/TpchPlanTest.cpp
@@ -75,8 +75,8 @@ class TpchPlanTest : public test::QueryTestBase {
     return planVelox(
                parseTpch(options.query),
                {
-                   .numWorkers = options.numWorkers,
-                   .numDrivers = options.numDrivers,
+                   .maxRemotePartitions = options.numWorkers,
+                   .maxLocalPartitions = options.numDrivers,
                })
         .plan;
   }
@@ -753,7 +753,8 @@ TEST_F(TpchPlanTest, q22) {
 // Use to re-generate the plans stored in the tpch/plans directory.
 TEST_F(TpchPlanTest, DISABLED_makePlans) {
   const auto path = test::getTestFilePath("tpch/plans");
-  const MultiFragmentPlan::Options options{.numWorkers = 1, .numDrivers = 1};
+  const MultiFragmentPlan::Options options{
+      .maxRemotePartitions = 1, .maxLocalPartitions = 1};
   for (int32_t query = 1; query <= 22; ++query) {
     LOG(ERROR) << "q" << query;
     planVelox(

--- a/axiom/optimizer/tests/TpchResultTest.cpp
+++ b/axiom/optimizer/tests/TpchResultTest.cpp
@@ -51,8 +51,8 @@ class TpchResultTest : public test::HiveQueriesTestBase,
   // multi-driver ({1,1}, {1,4}, {2,1}, {2,4}) — exercising the local exchanges
   // that numDrivers > 1 inserts.
   static inline const MultiFragmentPlan::Options kMaxParallelism{
-      .numWorkers = 2,
-      .numDrivers = 4,
+      .maxRemotePartitions = 2,
+      .maxLocalPartitions = 4,
   };
 
   void checkTpchQuery(int32_t query) {

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -1051,7 +1051,8 @@ TEST_P(UnnestTest, inSubqueryOverUnnest) {
   AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
 
   // Two single-row inputs stay on one task, so distributing changes nothing.
-  auto distributed = planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
+  auto distributed = planVelox(
+      logicalPlan, {.maxRemotePartitions = 4, .maxLocalPartitions = 4});
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributed.plan, matcher);
 }
 
@@ -1092,8 +1093,8 @@ TEST_P(UnnestTest, unnestPlacedAboveJoin) {
     SCOPED_TRACE("cost-based enumeration");
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), makeMatcher(false));
 
-    auto distributed =
-        planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
+    auto distributed = planVelox(
+        logicalPlan, {.maxRemotePartitions = 4, .maxLocalPartitions = 4});
     AXIOM_ASSERT_DISTRIBUTED_PLAN(distributed.plan, makeMatcher(true));
   }
 
@@ -1102,8 +1103,8 @@ TEST_P(UnnestTest, unnestPlacedAboveJoin) {
     optimizerOptions_.dphypEnumerationBudget = 1;
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), makeMatcher(false));
 
-    auto distributed =
-        planVelox(logicalPlan, {.numWorkers = 4, .numDrivers = 4});
+    auto distributed = planVelox(
+        logicalPlan, {.maxRemotePartitions = 4, .maxLocalPartitions = 4});
     AXIOM_ASSERT_DISTRIBUTED_PLAN(distributed.plan, makeMatcher(true));
   }
 }

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -164,8 +164,8 @@ class WriteTest : public test::HiveQueriesTestBase,
       const std::function<void(const MultiFragmentPlan& plan)>& verifyPlan =
           nullptr,
       const MultiFragmentPlan::Options& options = {
-          .numWorkers = 4,
-          .numDrivers = 4,
+          .maxRemotePartitions = 4,
+          .maxLocalPartitions = 4,
       }) {
     SCOPED_TRACE(sql);
 
@@ -825,7 +825,7 @@ TEST_P(WriteTest, ctasValuesNoMerge) {
         auto matcher = matchValues().project().tableWrite().build();
         AXIOM_ASSERT_PLAN(nodeAt(plan, 0), matcher);
       },
-      {.numWorkers = 4, .numDrivers = 4});
+      {.maxRemotePartitions = 4, .maxLocalPartitions = 4});
 }
 
 TEST_P(WriteTest, ctasBucketedSql) {
@@ -894,7 +894,7 @@ TEST_P(WriteTest, ctasBucketedSingleNode) {
                            .build();
         AXIOM_ASSERT_PLAN(nodeAt(plan, 0), matcher);
       },
-      {.numWorkers = 1, .numDrivers = 3});
+      {.maxRemotePartitions = 1, .maxLocalPartitions = 3});
 
   verifyPartitionedLayout(getLayout("test"), "key", 128);
 }
@@ -919,7 +919,7 @@ TEST_P(WriteTest, ctasBucketedSingleThreaded) {
                            .build();
         AXIOM_ASSERT_PLAN(nodeAt(plan, 0), matcher);
       },
-      {.numWorkers = 1, .numDrivers = 1});
+      {.maxRemotePartitions = 1, .maxLocalPartitions = 1});
 
   verifyPartitionedLayout(getLayout("test"), "key", 64);
 }

--- a/axiom/optimizer/tests/tpch/plans/q1.plans
+++ b/axiom/optimizer/tests/tpch/plans/q1.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:30 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q10.plans
+++ b/axiom/optimizer/tests/tpch/plans/q10.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q11.plans
+++ b/axiom/optimizer/tests/tpch/plans/q11.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q12.plans
+++ b/axiom/optimizer/tests/tpch/plans/q12.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q13.plans
+++ b/axiom/optimizer/tests/tpch/plans/q13.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q14.plans
+++ b/axiom/optimizer/tests/tpch/plans/q14.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q15.plans
+++ b/axiom/optimizer/tests/tpch/plans/q15.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q16.plans
+++ b/axiom/optimizer/tests/tpch/plans/q16.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q17.plans
+++ b/axiom/optimizer/tests/tpch/plans/q17.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q18.plans
+++ b/axiom/optimizer/tests/tpch/plans/q18.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q19.plans
+++ b/axiom/optimizer/tests/tpch/plans/q19.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q2.plans
+++ b/axiom/optimizer/tests/tpch/plans/q2.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:30 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q20.plans
+++ b/axiom/optimizer/tests/tpch/plans/q20.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q21.plans
+++ b/axiom/optimizer/tests/tpch/plans/q21.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q22.plans
+++ b/axiom/optimizer/tests/tpch/plans/q22.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q3.plans
+++ b/axiom/optimizer/tests/tpch/plans/q3.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:31 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q4.plans
+++ b/axiom/optimizer/tests/tpch/plans/q4.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:31 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q5.plans
+++ b/axiom/optimizer/tests/tpch/plans/q5.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:31 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q6.plans
+++ b/axiom/optimizer/tests/tpch/plans/q6.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:32 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q7.plans
+++ b/axiom/optimizer/tests/tpch/plans/q7.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:32 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q8.plans
+++ b/axiom/optimizer/tests/tpch/plans/q8.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:32 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q9.plans
+++ b/axiom/optimizer/tests/tpch/plans/q9.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:32 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/tests/tpch/plans/q9_alt.plans
+++ b/axiom/optimizer/tests/tpch/plans/q9_alt.plans
@@ -1,6 +1,6 @@
 generated: 2026-06-14 18:29:33 (snapshot; regenerate with TpchPlanTest.makePlans)
-numWorkers: 1
-numDrivers: 1
+maxRemotePartitions: 1
+maxLocalPartitions: 1
 
 Query Graph:
 

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -342,7 +342,7 @@ class Emitter {
   velox::core::PlanNodePtr addLocalPartitionForCountingJoin(
       velox::core::PlanNodePtr probe,
       const std::vector<velox::core::FieldAccessTypedExprPtr>& keys) {
-    if (options_.numDrivers <= 1) {
+    if (options_.maxLocalPartitions <= 1) {
       return probe;
     }
 
@@ -541,8 +541,8 @@ class Emitter {
   const OptimizerSession& session_;
   velox::core::ExpressionEvaluator& evaluator_;
   ExprEmitter exprEmitter_;
-  // A copy, not a reference: emitting a fixed point lowers `numDrivers` for the
-  // recursive subtree and restores it afterwards.
+  // A copy, not a reference: emitting a fixed point lowers
+  // `maxLocalPartitions` for the recursive subtree and restores it afterwards.
   MultiFragmentPlan::Options options_;
   int32_t nextNodeId_{0};
 
@@ -958,7 +958,7 @@ ExprVector Emitter::preGroupedKeysForEmission(
     const ExprVector& groupingKeys) const {
   // Multi-driver MarkDistinct emission inserts an unmodeled local repartition
   // on its distinct keys, invalidating inherited grouping and order.
-  if (options_.numDrivers > 1 && input->is(NodeType::kMarkDistinct)) {
+  if (options_.maxLocalPartitions > 1 && input->is(NodeType::kMarkDistinct)) {
     return {};
   }
   return computePreGroupedKeys(input->physicalProperties().local, groupingKeys);
@@ -1030,11 +1030,11 @@ velox::core::PlanNodePtr Emitter::emitSingleAggregation(
       preGroupedKeysForEmission(aggregate.input(), aggregate.groupingKeys()),
       "Pre-grouped key");
 
-  // At numDrivers > 1 a group's rows must all reach one driver. Skip the local
-  // exchange when the input is pre-grouped on the keys: a local grouping
-  // guarantees driver-confinement by contract (see `LocalProperty` in
+  // At maxLocalPartitions > 1 a group's rows must all reach one driver. Skip
+  // the local exchange when the input is pre-grouped on the keys: a local
+  // grouping guarantees driver-confinement by contract (see `LocalProperty` in
   // PhysicalProperties.h), so the aggregation streams correctly per driver.
-  if (options_.numDrivers > 1 && preGroupedKeys.empty()) {
+  if (options_.maxLocalPartitions > 1 && preGroupedKeys.empty()) {
     input = addLocalPartition(std::move(input), groupingKeys);
   }
 
@@ -1085,11 +1085,11 @@ velox::core::PlanNodePtr Emitter::emitFinalAggregation(
   auto groupingKeys =
       toFieldAccessList(aggregate.groupingKeys(), "Grouping key");
 
-  // At numDrivers > 1 the Final's input rows are spread across drivers (read
-  // round-robin from a remote exchange, or straight from the Partial in a
-  // local-only split), so a local exchange co-partitions each group onto one
+  // At maxLocalPartitions > 1 the Final's input rows are spread across drivers
+  // (read round-robin from a remote exchange, or straight from the Partial in
+  // a local-only split), so a local exchange co-partitions each group onto one
   // driver before the merge.
-  if (options_.numDrivers > 1) {
+  if (options_.maxLocalPartitions > 1) {
     input = addLocalPartition(std::move(input), groupingKeys);
   }
 
@@ -1164,10 +1164,10 @@ velox::core::PlanNodePtr Emitter::emitMarkDistinct(
   std::vector<velox::core::FieldAccessTypedExprPtr> distinctKeys =
       toFieldAccessList(markDistinct.distinctKeys(), "MarkDistinct key");
 
-  // At numDrivers > 1 every row of a distinct-key tuple must reach one driver,
-  // else each driver marks the tuple as first-seen and the distinct count
-  // over-counts. Co-partition the input on the distinct keys.
-  if (options_.numDrivers > 1) {
+  // At maxLocalPartitions > 1 every row of a distinct-key tuple must reach one
+  // driver, else each driver marks the tuple as first-seen and the distinct
+  // count over-counts. Co-partition the input on the distinct keys.
+  if (options_.maxLocalPartitions > 1) {
     input = addLocalPartition(std::move(input), distinctKeys);
   }
 
@@ -1288,7 +1288,7 @@ velox::core::PlanNodePtr Emitter::emitSort(const Sort& sort) {
   // With multiple drivers each driver sorts its rows (a partial sort) and a
   // LocalMerge combines the per-driver runs into one sorted stream. With a
   // single driver a plain final sort suffices.
-  const bool multiDriver = options_.numDrivers > 1;
+  const bool multiDriver = options_.maxLocalPartitions > 1;
   auto ordered = std::make_shared<velox::core::OrderByNode>(
       nextId(),
       sortingKeys,
@@ -1315,14 +1315,15 @@ velox::core::PlanNodePtr Emitter::emitTopN(const TopN& topN) {
       topNCount,
       std::numeric_limits<int32_t>::max(),
       "TopN offset + count exceeds the Velox TopNNode count limit");
-  // At numDrivers > 1 each driver keeps its own top rows (a partial top-n).
-  // Those outputs are already sorted, so an order-preserving merge combines
-  // them and a Limit takes the window — cheaper than sorting them again.
+  // At maxLocalPartitions > 1 each driver keeps its own top rows (a partial
+  // top-n). Those outputs are already sorted, so an order-preserving merge
+  // combines them and a Limit takes the window — cheaper than sorting them
+  // again.
   //
   // TODO: skip the split when the input already feeds one driver. Knowing that
   // takes the emitted plan's local exchanges; the distribution properties here
   // describe tasks, not drivers.
-  if (options_.numDrivers > 1) {
+  if (options_.maxLocalPartitions > 1) {
     velox::core::PlanNodePtr partial = std::make_shared<velox::core::TopNNode>(
         nextId(),
         sortingKeys,
@@ -1362,12 +1363,12 @@ velox::core::PlanNodePtr Emitter::emitTopN(const TopN& topN) {
 
 velox::core::PlanNodePtr Emitter::emitLimit(const Limit& limit) {
   velox::core::PlanNodePtr input = emit(limit.input());
-  // At numDrivers > 1 each driver keeps its own top offset+count rows (a
-  // partial limit); a gather to one driver then applies the final offset/count
-  // so the limit is enforced across the task, not per driver. Velox runs an
-  // exact limit single-threaded either way, so the split is worth it only when
-  // it keeps work below the limit parallel — above a gather exchange the limit
-  // is the whole pipeline.
+  // At maxLocalPartitions > 1 each driver keeps its own top offset+count rows
+  // (a partial limit); a gather to one driver then applies the final
+  // offset/count so the limit is enforced across the task, not per driver.
+  // Velox runs an exact limit single-threaded either way, so the split is
+  // worth it only when it keeps work below the limit parallel — above a gather
+  // exchange the limit is the whole pipeline.
   const bool readsGatherExchange = limit.input()->is(NodeType::kExchange) &&
       limit.input()->physicalProperties().globalPartition.is(
           PartitionKind::kGather);
@@ -1375,7 +1376,8 @@ velox::core::PlanNodePtr Emitter::emitLimit(const Limit& limit) {
   // there is no count, so it would filter nothing.
   const bool partialReduces =
       limit.offsetPlusCount() != std::numeric_limits<int64_t>::max();
-  if (options_.numDrivers > 1 && !readsGatherExchange && partialReduces) {
+  if (options_.maxLocalPartitions > 1 && !readsGatherExchange &&
+      partialReduces) {
     input = std::make_shared<velox::core::LimitNode>(
         nextId(),
         /*offset=*/0,
@@ -1468,10 +1470,10 @@ velox::core::PlanNodePtr Emitter::emitWindow(const Window& window) {
   auto partitionKeys =
       toFieldAccessList(window.partitionKeys(), "Window partition key");
 
-  // At numDrivers > 1 each partition must be complete in one driver:
+  // At maxLocalPartitions > 1 each partition must be complete in one driver:
   // repartition on the PARTITION BY keys, or gather when the window spans the
   // whole input.
-  if (options_.numDrivers > 1) {
+  if (options_.maxLocalPartitions > 1) {
     input = addLocalPartition(std::move(input), partitionKeys);
   }
 
@@ -1531,9 +1533,9 @@ velox::core::PlanNodePtr Emitter::emitRowNumber(const RowNumber& node) {
   velox::core::PlanNodePtr input = emit(node.input());
   auto partitionKeys =
       toFieldAccessList(node.partitionKeys(), "RowNumber partition key");
-  // At numDrivers > 1 each partition must be complete in one driver:
+  // At maxLocalPartitions > 1 each partition must be complete in one driver:
   // repartition on the partition keys, or gather when there are none.
-  if (options_.numDrivers > 1) {
+  if (options_.maxLocalPartitions > 1) {
     input = addLocalPartition(std::move(input), partitionKeys);
   }
   std::optional<std::string> rowNumberColumnName;
@@ -1552,9 +1554,9 @@ velox::core::PlanNodePtr Emitter::emitTopNRowNumber(const TopNRowNumber& node) {
   velox::core::PlanNodePtr input = emit(node.input());
   auto partitionKeys =
       toFieldAccessList(node.partitionKeys(), "TopNRowNumber partition key");
-  // At numDrivers > 1 each partition must be complete in one driver:
+  // At maxLocalPartitions > 1 each partition must be complete in one driver:
   // repartition on the partition keys, or gather when there are none.
-  if (options_.numDrivers > 1) {
+  if (options_.maxLocalPartitions > 1) {
     input = addLocalPartition(std::move(input), partitionKeys);
   }
   auto [sortingKeys, sortingOrders] = toSortingKeys(
@@ -1632,9 +1634,10 @@ velox::core::PlanNodePtr Emitter::emitUnionAll(const UnionAll& unionNode) {
 velox::core::PlanNodePtr Emitter::emitEnforceSingleRow(
     const EnforceSingleRow& node) {
   velox::core::PlanNodePtr input = emit(node.input());
-  // Asserting at most one row is a global check; at numDrivers > 1 gather to
-  // one driver first so the count is across the whole task, not per driver.
-  if (options_.numDrivers > 1) {
+  // Asserting at most one row is a global check; at maxLocalPartitions > 1
+  // gather to one driver first so the count is across the whole task, not per
+  // driver.
+  if (options_.maxLocalPartitions > 1) {
     input =
         velox::core::LocalPartitionNode::gather(nextId(), {std::move(input)});
   }
@@ -1658,10 +1661,10 @@ velox::core::PlanNodePtr Emitter::emitEnforceDistinct(
   auto preGroupedKeys = toFieldAccessList(
       preGroupedKeysForEmission(node.input(), node.distinctKeys()),
       "EnforceDistinct pre-grouped key");
-  // At numDrivers > 1 each distinct-key group must be complete in one driver.
-  // Skip when the input is pre-grouped on the keys: a local grouping guarantees
-  // driver-confinement by contract (see `LocalProperty`).
-  if (options_.numDrivers > 1 && preGroupedKeys.empty()) {
+  // At maxLocalPartitions > 1 each distinct-key group must be complete in one
+  // driver. Skip when the input is pre-grouped on the keys: a local grouping
+  // guarantees driver-confinement by contract (see `LocalProperty`).
+  if (options_.maxLocalPartitions > 1 && preGroupedKeys.empty()) {
     input = addLocalPartition(std::move(input), distinctKeys);
   }
   return std::make_shared<velox::core::EnforceDistinctNode>(
@@ -1740,22 +1743,23 @@ std::optional<FragmentType> fragmentTypeContribution(NodeCP node) {
   }
 }
 
-// Sets 'fragment.type' (and 'width' for kFixed) from an already-computed root
-// 'contribution'. At numWorkers == 1 all parallelism collapses to one task. A
-// nullopt contribution (no split source below -- no scan, only exchanges and/or
-// values) is single-task regardless of output partitioning: kSource requires
-// connector splits to drive its task count, so the fallback is kSingle.
+// Sets 'fragment.type' (and 'numRemotePartitions' for kFixed) from an
+// already-computed root 'contribution'. At maxRemotePartitions == 1 all
+// parallelism collapses to one task. A nullopt contribution (no split source
+// below -- no scan, only exchanges and/or values) is single-task regardless of
+// output partitioning: kSource requires connector splits to drive its task
+// count, so the fallback is kSingle.
 void decideFragmentType(
     std::optional<FragmentType> contribution,
-    int32_t numWorkers,
+    int32_t maxRemotePartitions,
     ExecutableFragment& fragment) {
-  if (numWorkers == 1) {
+  if (maxRemotePartitions == 1) {
     fragment.type = FragmentType::kSingle;
     return;
   }
   fragment.type = contribution.value_or(FragmentType::kSingle);
   if (fragment.type == FragmentType::kFixed) {
-    fragment.width = numWorkers;
+    fragment.numRemotePartitions = maxRemotePartitions;
   }
 }
 
@@ -1763,11 +1767,11 @@ void decideFragmentType(
 // to, not across, inner exchanges -- and sets the fragment type from it.
 void decideFragmentType(
     NodeCP node,
-    int32_t numWorkers,
+    int32_t maxRemotePartitions,
     ExecutableFragment& fragment) {
   decideFragmentType(
-      numWorkers == 1 ? std::nullopt : fragmentTypeContribution(node),
-      numWorkers,
+      maxRemotePartitions == 1 ? std::nullopt : fragmentTypeContribution(node),
+      maxRemotePartitions,
       fragment);
 }
 
@@ -1775,7 +1779,7 @@ void Emitter::finalizeGroupedLeaves(ExecutableFragment& fragment) {
   // Fold the grouped scans' partitionings into the one every task reads by.
   // Planning already coarsened each to the worker count and only groups scans
   // it checked copartition, so the fold must succeed and its count is the
-  // fragment's width.
+  // fragment's numRemotePartitions.
   const connector::PartitionType* folded = nullptr;
   for (const auto& leaf : groupedLeaves_) {
     if (leaf.partitionType == nullptr) {
@@ -1807,7 +1811,7 @@ void Emitter::finalizeGroupedLeaves(ExecutableFragment& fragment) {
             : nullptr);
   }
   fragment.type = FragmentType::kFixed;
-  fragment.width = folded->numPartitions();
+  fragment.numRemotePartitions = folded->numPartitions();
 }
 
 velox::core::PlanNodePtr Emitter::emitChildFragment(
@@ -1828,7 +1832,7 @@ void Emitter::emitGatheredOutput(
       layoutAboveGather && rootProject != nullptr ? rootProject->input() : root;
 
   ExecutableFragment source = newFragment();
-  decideFragmentType(belowRoot, options_.numWorkers, source);
+  decideFragmentType(belowRoot, options_.maxRemotePartitions, source);
   velox::core::PlanNodePtr sourcePlan = layoutAboveGather
       ? emitChildFragment(belowRoot, source)
       : emitInFragment(
@@ -1877,9 +1881,9 @@ velox::core::PlanNodePtr Emitter::makeExchangeProducer(
       // A partitionType aligns this shuffle to a bucketed side: use the
       // connector's partition function so rows land in the same groups as that
       // side. Planning coarsened it to the worker count, so its partition count
-      // is the consumer fragment's width. Otherwise standard Velox hash over
-      // numWorkers partitions.
-      int32_t numPartitions = options_.numWorkers;
+      // is the consumer fragment's numRemotePartitions. Otherwise standard
+      // Velox hash over maxRemotePartitions partitions.
+      int32_t numPartitions = options_.maxRemotePartitions;
       velox::core::PartitionFunctionSpecPtr spec;
       if (partitioning.partitionType != nullptr) {
         numPartitions = partitioning.partitionType->numPartitions();
@@ -1935,7 +1939,7 @@ velox::core::PlanNodePtr Emitter::emitExchange(const Exchange& exchange) {
 
   // Producer fragment: the exchange's input, capped with a PartitionedOutput.
   ExecutableFragment source = newFragment();
-  decideFragmentType(exchange.input(), options_.numWorkers, source);
+  decideFragmentType(exchange.input(), options_.maxRemotePartitions, source);
   velox::core::PlanNodePtr sourcePlan =
       emitChildFragment(exchange.input(), source);
   const auto outputType = sourcePlan->outputType();
@@ -2018,7 +2022,7 @@ velox::core::PlanNodePtr Emitter::emitTableWrite(const TableWrite& tableWrite) {
 
   // Parallelize writers only when the input is already distributed; gathering
   // an already-single-task input would add a redundant exchange.
-  const bool distributed = options_.numWorkers > 1 &&
+  const bool distributed = options_.maxRemotePartitions > 1 &&
       fragmentTypeContribution(tableWrite.input()) != FragmentType::kSingle;
 
   ExecutableFragment* rootFragment = currentFragment_;
@@ -2026,7 +2030,8 @@ velox::core::PlanNodePtr Emitter::emitTableWrite(const TableWrite& tableWrite) {
   std::vector<PendingGroupedLeaf> rootGroupedLeaves;
   if (distributed) {
     writerFragment = newFragment();
-    decideFragmentType(tableWrite.input(), options_.numWorkers, writerFragment);
+    decideFragmentType(
+        tableWrite.input(), options_.maxRemotePartitions, writerFragment);
     rootGroupedLeaves = std::move(groupedLeaves_);
     groupedLeaves_.clear();
     currentFragment_ = &writerFragment;
@@ -2045,7 +2050,7 @@ velox::core::PlanNodePtr Emitter::emitTableWrite(const TableWrite& tableWrite) {
         tableWrite.input()->physicalProperties().globalPartition.partitionType;
     if (exchangeType != nullptr) {
       writerFragment.type = FragmentType::kFixed;
-      writerFragment.width = exchangeType->numPartitions();
+      writerFragment.numRemotePartitions = exchangeType->numPartitions();
     }
   }
 
@@ -2065,9 +2070,9 @@ velox::core::PlanNodePtr Emitter::emitTableWrite(const TableWrite& tableWrite) {
   // target's partition (bucket) columns so each partition's rows go to a single
   // writer driver. The remote bucket exchange added in physical planning has
   // already confined each partition to one worker; this is the within-worker
-  // split (only meaningful at numDrivers > 1).
+  // split (only meaningful at maxLocalPartitions > 1).
   const auto& partitionColumns = layout->partitionColumns();
-  if (options_.numDrivers > 1 && !partitionColumns.empty()) {
+  if (options_.maxLocalPartitions > 1 && !partitionColumns.empty()) {
     input = std::make_shared<velox::core::LocalPartitionNode>(
         nextId(),
         velox::core::LocalPartitionNode::Type::kRepartition,
@@ -2087,13 +2092,15 @@ velox::core::PlanNodePtr Emitter::emitTableWrite(const TableWrite& tableWrite) {
   // source) has one writer producing all rows, so the per-driver stats need no
   // merge. Reporting one driver keeps the plan a bare TableWrite.
   const int32_t writerNumDrivers =
-      !distributed && isSingleThreadedPipeline(input) ? 1 : options_.numDrivers;
+      !distributed && isSingleThreadedPipeline(input)
+      ? 1
+      : options_.maxLocalPartitions;
   WriteStatsBuilder statsBuilder(
       table,
       inputType,
       *handle,
       writerNumDrivers,
-      distributed ? options_.numWorkers : 1);
+      distributed ? options_.maxRemotePartitions : 1);
   std::optional<velox::core::ColumnStatsSpec> writeStatsSpec;
   if (statsBuilder.hasStats()) {
     writeStatsSpec = statsBuilder.writeSpec();
@@ -2174,7 +2181,7 @@ velox::core::PlanNodePtr Emitter::emitTableWrite(const TableWrite& tableWrite) {
 }
 
 velox::core::PlanNodePtr Emitter::emitFixedPoint(const FixedPoint& fixedPoint) {
-  if (options_.numWorkers > 1) {
+  if (options_.maxRemotePartitions > 1) {
     VELOX_NYI("Distributed FixedPoint execution is not yet implemented");
   }
 
@@ -2184,10 +2191,10 @@ velox::core::PlanNodePtr Emitter::emitFixedPoint(const FixedPoint& fixedPoint) {
       fixedPoint.recursiveNumDrivers().value_or(0),
       1,
       "FixedPoint must be physically planned for one recursive driver before emission");
-  const int32_t previousNumDrivers =
-      std::exchange(options_.numDrivers, *fixedPoint.recursiveNumDrivers());
+  const int32_t previousMaxLocalPartitions = std::exchange(
+      options_.maxLocalPartitions, *fixedPoint.recursiveNumDrivers());
   SCOPE_EXIT {
-    options_.numDrivers = previousNumDrivers;
+    options_.maxLocalPartitions = previousMaxLocalPartitions;
   };
   auto stepPlan = emit(fixedPoint.step());
 
@@ -2289,10 +2296,10 @@ std::vector<ExecutableFragment> Emitter::emitFragments(
     // The root's fragment-type contribution drives both the output-gather
     // decision and the root fragment's type; compute it once and reuse it.
     std::optional<FragmentType> rootType;
-    if (options_.numWorkers > 1) {
+    if (options_.maxRemotePartitions > 1) {
       rootType = fragmentTypeContribution(root);
     }
-    const bool gatherForOutput = options_.numWorkers > 1 &&
+    const bool gatherForOutput = options_.maxRemotePartitions > 1 &&
         rootType != FragmentType::kSingle &&
         rootType != FragmentType::kCoordinator;
 
@@ -2301,9 +2308,9 @@ std::vector<ExecutableFragment> Emitter::emitFragments(
       // a PartitionedOutput for remote consumption, with no gather consumer
       // fragment. The fragment type follows the root's contents (kFixed for a
       // multi-worker source, kCoordinator for a coordinator-only scan, kSingle
-      // at numWorkers == 1 or when there is no split source below).
+      // at maxRemotePartitions == 1 or when there is no split source below).
       currentFragment_ = &top;
-      decideFragmentType(rootType, options_.numWorkers, top);
+      decideFragmentType(rootType, options_.maxRemotePartitions, top);
       outputProjection = emitRoot(root, outputColumns, outputNames);
       top.fragment.planNode =
           makeSingleOutput(outputProjection->outputType(), outputProjection);
@@ -2311,7 +2318,7 @@ std::vector<ExecutableFragment> Emitter::emitFragments(
       emitGatheredOutput(root, outputColumns, outputNames, top);
     } else {
       currentFragment_ = &top;
-      decideFragmentType(rootType, options_.numWorkers, top);
+      decideFragmentType(rootType, options_.maxRemotePartitions, top);
       top.fragment.planNode = emitRoot(root, outputColumns, outputNames);
     }
   }

--- a/axiom/optimizer/v2/EmitPass.h
+++ b/axiom/optimizer/v2/EmitPass.h
@@ -43,9 +43,9 @@ class EmitPass {
   /// user-visible layout described by 'outputColumns' and 'outputNames'
   /// (aligned 1:1). Each `ir.Exchange` becomes a fragment boundary (a producer
   /// fragment ending in `PartitionedOutput`, a consumer `Exchange`). For
-  /// `options.numWorkers > 1` a final gather collects the distributed output
-  /// into a single root fragment; for `numWorkers == 1` the result is one
-  /// fragment. 'session' supplies the connector
+  /// `options.maxRemotePartitions > 1` a final gather collects the distributed
+  /// output into a single root fragment; for `maxRemotePartitions == 1` the
+  /// result is one fragment. 'session' supplies the connector
   /// session for table writes; 'evaluator' folds filter constants. A `Scan`
   /// carries the connector handle it is read with. Throws VELOX_NYI for
   /// unsupported node or expression types.

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -135,8 +135,10 @@ int32_t chooseNumWorkers(
 } // namespace
 
 PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
-  VELOX_USER_CHECK_GE(options.numWorkers, 1, "numWorkers must be at least 1");
-  VELOX_USER_CHECK_GE(options.numDrivers, 1, "numDrivers must be at least 1");
+  VELOX_USER_CHECK_GE(
+      options.maxRemotePartitions, 1, "maxRemotePartitions must be at least 1");
+  VELOX_USER_CHECK_GE(
+      options.maxLocalPartitions, 1, "maxLocalPartitions must be at least 1");
 
   // Schema is owned here so its `connector::TablePtr`s — and the
   // `TableLayout`s the IR's `BaseTable` nodes hold raw pointers to —
@@ -158,11 +160,11 @@ PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
     EstimateLeafStatsPass::run(folded, session_);
   }
 
-  // Decide the width before physical planning, which reads numWorkers to shape
-  // exchanges and to cost broadcasts.
+  // Decide the width before physical planning, which reads maxRemotePartitions
+  // to shape exchanges and to cost broadcasts.
   MultiFragmentPlan::Options planOptions = options;
-  planOptions.numWorkers =
-      chooseNumWorkers(folded, session_.options(), options.numWorkers);
+  planOptions.maxRemotePartitions =
+      chooseNumWorkers(folded, session_.options(), options.maxRemotePartitions);
 
   EmitPass::Result emitted = physicalPlanAndEmit(
       folded,

--- a/axiom/optimizer/v2/Optimize.h
+++ b/axiom/optimizer/v2/Optimize.h
@@ -90,9 +90,10 @@ class Optimizer {
   ///   - ExpandAggregate — lower distinct aggregates to `MarkDistinct`;
   ///   - Emit — lower to Velox `PlanNode`s.
   ///
-  /// `options.numWorkers` / `options.numDrivers` (each >= 1) are the target
-  /// task and per-task driver counts; at `numWorkers > 1` the plan is
-  /// distributed across fragments with remote exchanges.
+  /// `options.maxRemotePartitions` / `options.maxLocalPartitions` (each >= 1)
+  /// are the target task and per-task driver counts; at
+  /// `maxRemotePartitions > 1` the plan is distributed across fragments with
+  /// remote exchanges.
   ///
   /// Output column names are guaranteed to match the query only when the plan
   /// is rooted in an `OutputNode`, whose field names pin the result names. For

--- a/axiom/optimizer/v2/PhysicalPlanAndEmit.cpp
+++ b/axiom/optimizer/v2/PhysicalPlanAndEmit.cpp
@@ -31,7 +31,11 @@ EmitPass::Result physicalPlanAndEmit(
     velox::core::ExpressionEvaluator& evaluator,
     const MultiFragmentPlan::Options& options) {
   NodeCP physicalPlanned = PlanPhysicalPass::run(
-      root, builder, session.options(), options.numWorkers, options.numDrivers);
+      root,
+      builder,
+      session.options(),
+      options.maxRemotePartitions,
+      options.maxLocalPartitions);
   NodeCP precomputed = PrecomputeProjectionsPass::run(physicalPlanned, builder);
   // Distinct aggregates lower to MarkDistinct here, after physical planning
   // (grouping sets were already lowered to GroupId in translate).

--- a/axiom/optimizer/v2/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/v2/tests/TpchPlanTest.cpp
@@ -69,8 +69,8 @@ class TpchPlanTest : public optimizer::test::QueryTestBase {
                    optimizer::test::readTpchSql(options.query),
                    kTestConnectorId),
                {
-                   .numWorkers = options.numWorkers,
-                   .numDrivers = options.numDrivers,
+                   .maxRemotePartitions = options.numWorkers,
+                   .maxLocalPartitions = options.numDrivers,
                })
         .plan;
   }
@@ -374,8 +374,10 @@ TEST_F(TpchPlanTest, q09Alt) {
 
   auto logicalPlan =
       parseSelect(optimizer::test::readTpchSql("q9_alt"), kTestConnectorId);
-  ASSERT_NO_THROW(planVelox(logicalPlan, {.numWorkers = 2, .numDrivers = 1}));
-  ASSERT_NO_THROW(planVelox(logicalPlan, {.numWorkers = 2, .numDrivers = 4}));
+  ASSERT_NO_THROW(planVelox(
+      logicalPlan, {.maxRemotePartitions = 2, .maxLocalPartitions = 1}));
+  ASSERT_NO_THROW(planVelox(
+      logicalPlan, {.maxRemotePartitions = 2, .maxLocalPartitions = 4}));
 }
 
 TEST_F(TpchPlanTest, q10) {

--- a/axiom/pyspark/Optimizer.cpp
+++ b/axiom/pyspark/Optimizer.cpp
@@ -132,8 +132,8 @@ facebook::axiom::optimizer::PlanAndStats optimize(
   auto history = std::make_unique<facebook::axiom::optimizer::VeloxHistory>();
 
   facebook::axiom::optimizer::MultiFragmentPlan::Options runnerOpts{
-      .numWorkers = 1,
-      .numDrivers = 1,
+      .maxRemotePartitions = 1,
+      .maxLocalPartitions = 1,
   };
 
   auto queryCtx = velox::core::QueryCtx::create();

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -170,19 +170,21 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
       for (auto& split : batch.splits) {
         size_t targetTask;
         if (grouped) {
-          // Grouped execution routes each split to the task owning its group.
-          // The connector tags grouped splits with a groupId in
-          // [0, tasks.size()); same-group splits must share a task.
+          // Grouped execution routes each split to the task owning its
+          // remote partition. The connector tags grouped splits with a
+          // remotePartition in [0, tasks.size()); same-partition splits must
+          // share a task.
           VELOX_CHECK(
-              split.groupId.has_value(),
-              "Grouped scan produced a split without a groupId: {}",
+              split.remotePartition.has_value(),
+              "Grouped scan produced a split without a remotePartition: {}",
               scanId);
-          VELOX_CHECK_LT(static_cast<size_t>(*split.groupId), tasks.size());
-          targetTask = static_cast<size_t>(*split.groupId);
+          VELOX_CHECK_LT(
+              static_cast<size_t>(*split.remotePartition), tasks.size());
+          targetTask = static_cast<size_t>(*split.remotePartition);
         } else {
-          // Not grouped: round-robin. Any groupId a connector stamped is
-          // ignored here rather than used as a task index that could be out of
-          // range.
+          // Not grouped: round-robin. Any remotePartition a connector stamped
+          // is ignored here rather than used as a task index that could be out
+          // of range.
           targetTask = taskIdx;
           taskIdx = (taskIdx + 1) % tasks.size();
         }
@@ -492,12 +494,12 @@ void LocalRunner::start() {
     VELOX_CHECK_EQ(state_, State::kInitialized);
   }
 
-  params_.maxDrivers = plan_->options().numDrivers;
+  params_.maxDrivers = plan_->options().maxLocalPartitions;
   params_.planNode = fragments_.back().fragment.planNode;
   params_.serialExecution = !params_.queryCtx->isExecutorSupplied();
 
   VELOX_CHECK_LE(
-      fragments_.back().width.value_or(1),
+      fragments_.back().numRemotePartitions.value_or(1),
       1,
       "Last fragment must be single-task");
 
@@ -755,9 +757,9 @@ void LocalRunner::makeStages(
       stages_.emplace_back();
     }
 
-    auto numTasks = fragment.width.value_or(
+    auto numTasks = fragment.numRemotePartitions.value_or(
         fragment.type == optimizer::FragmentType::kSource
-            ? plan_->options().numWorkers
+            ? plan_->options().maxRemotePartitions
             : 1);
     for (auto i = 0; i < numTasks; ++i) {
       auto taskId = fmt::format(
@@ -784,7 +786,7 @@ void LocalRunner::makeStages(
         std::lock_guard<std::mutex> lock(mutex_);
         stages_.back().push_back(task);
       }
-      task->start(plan_->options().numDrivers);
+      task->start(plan_->options().maxLocalPartitions);
     }
   }
 

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -40,7 +40,7 @@ class SplitSourceFactory {
   /// Returns a splitSource for one TableScan across all Tasks of
   /// the fragment. The source will be invoked to produce splits for
   /// each individual worker running the scan. When 'partitionType' is
-  /// non-null, emitted Splits are tagged with a groupId. When
+  /// non-null, emitted Splits are tagged with a remotePartition. When
   /// 'samplePercentage' is set (TABLESAMPLE SYSTEM), the source emits each
   /// split with that probability.
   virtual std::shared_ptr<connector::SplitSource> splitSourceForScan(

--- a/axiom/runner/tests/DistributedPlanBuilder.cpp
+++ b/axiom/runner/tests/DistributedPlanBuilder.cpp
@@ -26,7 +26,7 @@ DistributedPlanBuilder::DistributedPlanBuilder(
       options_(options),
       root_(this) {
   root_->stack_.push_back(this);
-  newFragment(options_.numWorkers);
+  newFragment(options_.maxRemotePartitions);
 }
 
 DistributedPlanBuilder::DistributedPlanBuilder(DistributedPlanBuilder& root)
@@ -34,7 +34,7 @@ DistributedPlanBuilder::DistributedPlanBuilder(DistributedPlanBuilder& root)
       options_(root.options_),
       root_(&root) {
   root_->stack_.push_back(this);
-  newFragment(options_.numWorkers);
+  newFragment(options_.maxRemotePartitions);
 }
 
 DistributedPlanBuilder::~DistributedPlanBuilder() {
@@ -50,7 +50,8 @@ optimizer::MultiFragmentPlanPtr DistributedPlanBuilder::build() {
   return std::make_shared<optimizer::MultiFragmentPlan>(fragments(), options_);
 }
 
-void DistributedPlanBuilder::newFragment(std::optional<int32_t> width) {
+void DistributedPlanBuilder::newFragment(
+    std::optional<int32_t> numRemotePartitions) {
   if (current_) {
     current_->fragment = velox::core::PlanFragment(std::move(planNode_));
     fragments_.push_back(std::move(*current_));
@@ -58,14 +59,14 @@ void DistributedPlanBuilder::newFragment(std::optional<int32_t> width) {
 
   auto taskPrefix =
       fmt::format("{}.{}", options_.queryId, root_->fragmentCounter_++);
-  if (width.has_value() && width.value() > 1) {
+  if (numRemotePartitions.has_value() && numRemotePartitions.value() > 1) {
     current_ = std::make_unique<optimizer::ExecutableFragment>(
         optimizer::ExecutableFragment{
             .taskPrefix = std::move(taskPrefix),
             .type = optimizer::FragmentType::kFixed,
-            .width = width,
+            .numRemotePartitions = numRemotePartitions,
         });
-  } else if (width.has_value()) {
+  } else if (numRemotePartitions.has_value()) {
     current_ = std::make_unique<optimizer::ExecutableFragment>(
         optimizer::ExecutableFragment{
             .taskPrefix = std::move(taskPrefix),
@@ -147,16 +148,16 @@ velox::core::PlanNodePtr DistributedPlanBuilder::shufflePartitionedResult(
   root_->stack_.pop_back(); // Remove self.
 
   auto* consumer = root_->stack_.back();
-  if (consumer->current_->width.has_value()) {
+  if (consumer->current_->numRemotePartitions.has_value()) {
     VELOX_CHECK_EQ(
         numPartitions,
-        consumer->current_->width.value(),
-        "The consumer width should match the producer fanout");
+        consumer->current_->numRemotePartitions.value(),
+        "The consumer numRemotePartitions should match the producer fanout");
   } else {
     consumer->current_->type = numPartitions > 1
         ? optimizer::FragmentType::kFixed
         : optimizer::FragmentType::kSingle;
-    consumer->current_->width = numPartitions > 1
+    consumer->current_->numRemotePartitions = numPartitions > 1
         ? std::optional<int32_t>{numPartitions}
         : std::nullopt;
   }
@@ -180,7 +181,7 @@ velox::core::PlanNodePtr DistributedPlanBuilder::shuffleBroadcastResult() {
   auto* consumer = root_->stack_.back();
 
   VELOX_CHECK(
-      consumer->current_->width.has_value() ||
+      consumer->current_->numRemotePartitions.has_value() ||
       consumer->current_->type == optimizer::FragmentType::kSingle ||
       consumer->current_->type == optimizer::FragmentType::kCoordinator);
 

--- a/axiom/runner/tests/DistributedPlanBuilder.h
+++ b/axiom/runner/tests/DistributedPlanBuilder.h
@@ -59,7 +59,7 @@ class DistributedPlanBuilder : public velox::exec::test::PlanBuilder {
   optimizer::MultiFragmentPlanPtr build();
 
  private:
-  void newFragment(std::optional<int32_t> width = std::nullopt);
+  void newFragment(std::optional<int32_t> numRemotePartitions = std::nullopt);
 
   void appendFragments(std::vector<optimizer::ExecutableFragment> fragments);
 

--- a/axiom/runner/tests/LocalRunnerTest.cpp
+++ b/axiom/runner/tests/LocalRunnerTest.cpp
@@ -95,7 +95,9 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
   // scan results.
   optimizer::MultiFragmentPlanPtr makeScanPlan(int32_t numWorkers) {
     optimizer::MultiFragmentPlan::Options options = {
-        .queryId = makeQueryId(), .numWorkers = numWorkers, .numDrivers = 2};
+        .queryId = makeQueryId(),
+        .maxRemotePartitions = numWorkers,
+        .maxLocalPartitions = 2};
 
     test::DistributedPlanBuilder builder(options, idGenerator_, pool_.get());
     builder.tableScan("t", rowType_);
@@ -109,7 +111,9 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
       std::string_view project = "c0",
       bool broadcastBuild = false) {
     optimizer::MultiFragmentPlan::Options options = {
-        .queryId = makeQueryId(), .numWorkers = 4, .numDrivers = 2};
+        .queryId = makeQueryId(),
+        .maxRemotePartitions = 4,
+        .maxLocalPartitions = 2};
     const int32_t width = 3;
 
     test::DistributedPlanBuilder rootBuilder(
@@ -423,7 +427,7 @@ TEST_F(LocalRunnerTest, broadcast) {
 
 TEST_F(LocalRunnerTest, lastStageWithMultipleInputs) {
   optimizer::MultiFragmentPlan::Options options = {
-      .queryId = "test.", .numWorkers = 1, .numDrivers = 1};
+      .queryId = "test.", .maxRemotePartitions = 1, .maxLocalPartitions = 1};
 
   test::DistributedPlanBuilder rootBuilder(options, idGenerator_, pool_.get());
   auto probe = test::DistributedPlanBuilder(rootBuilder)

--- a/axiom/runner/tests/PrestoQueryReplayRunner.cpp
+++ b/axiom/runner/tests/PrestoQueryReplayRunner.cpp
@@ -180,7 +180,7 @@ std::vector<optimizer::ExecutableFragment> createExecutableFragments(
           optimizer::ExecutableFragment{
               .taskPrefix = taskPrefix,
               .type = optimizer::FragmentType::kFixed,
-              .width = planFragmentInfo.numWorkers,
+              .numRemotePartitions = planFragmentInfo.numWorkers,
               .fragment = velox::core::PlanFragment{planFragmentInfo.plan},
               .inputStages = std::move(inputStages),
           });

--- a/axiom/runner/tests/ProgressReporterTest.cpp
+++ b/axiom/runner/tests/ProgressReporterTest.cpp
@@ -103,7 +103,9 @@ class ProgressReporterTest : public test::LocalRunnerTestBase {
 
   optimizer::MultiFragmentPlanPtr makeScanPlan() {
     optimizer::MultiFragmentPlan::Options options = {
-        .queryId = "progress-q", .numWorkers = 1, .numDrivers = 1};
+        .queryId = "progress-q",
+        .maxRemotePartitions = 1,
+        .maxLocalPartitions = 1};
     test::DistributedPlanBuilder builder(options, idGenerator_, pool_.get());
     builder.tableScan("t", rowType_);
     return builder.build();


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/318

Renames the plan API fields that describe parallelism so the names state what the values mean instead of what runs them. `Options::numWorkers` becomes `maxRemotePartitions` and `Options::numDrivers` becomes `maxLocalPartitions`, since both are caps the optimizer can lower rather than machine counts. EXPLAIN output now prints `Fragment 0: stage1 numRemotePartitions=4` instead of `numWorkers=4`.

`ExecutableFragment::width` becomes `numRemotePartitions`. `Split::groupId` becomes `remotePartition`, which spells the routing contract on the field itself: a value in `[0, numRemotePartitions)` that the scheduler must obey.

Pure rename with no behavior change, applied to the plan API and every consumer. Comments and consistency-check messages follow the new names, as do the TPC-H plan snapshots and planning docs.

Sibling surfaces that share the old words but are separate APIs keep their names. That includes `SqlQueryRunner::RunOptions` and the v2 physical-pass parameters, as well as the test matcher DSL.

Reviewed By: mbasmanova

Differential Revision: D118349838
