### PR TITLE
feat(optimizer): Plan and lower an index lookup join (#1872)

### DIFF
--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -200,6 +200,18 @@ TestTable::TestTable(
         allColumns(),
         std::move(partitionColumns),
         std::move(partitionType));
+  } else if (auto lookupIt =
+                 options.find(std::string{TestConnectorMetadata::kLookupKeys});
+             lookupIt != options.end()) {
+    std::vector<const Column*> lookupKeys;
+    for (const auto& columnName : lookupIt->second.array<std::string>()) {
+      const auto* column = findColumn(columnName);
+      VELOX_USER_CHECK_NOT_NULL(
+          column, "Lookup key names no column: {}", columnName);
+      lookupKeys.push_back(column);
+    }
+    exportedLayout_ = std::make_unique<TestTableLayout>(
+        tableName, this, connector_, allColumns(), std::move(lookupKeys));
   } else {
     exportedLayout_ = std::make_unique<TestTableLayout>(
         tableName, this, connector_, allColumns());
@@ -788,7 +800,7 @@ velox::connector::ConnectorTableHandlePtr TestTableLayout::createTableHandle(
     std::vector<velox::core::TypedExprPtr> filters,
     std::vector<int32_t>& rejectedFilterIndices,
     velox::RowTypePtr /* dataColumns */,
-    std::optional<LookupKeys> /*lookupKeys*/) const {
+    std::optional<LookupKeys> lookupKeys) const {
   auto* testConnector = dynamic_cast<TestConnector*>(connector());
   VELOX_CHECK_NOT_NULL(testConnector);
   if (const auto& inspector = testConnector->onCreateTableHandle()) {
@@ -796,7 +808,32 @@ velox::connector::ConnectorTableHandlePtr TestTableLayout::createTableHandle(
   }
   rejectedFilterIndices.resize(filters.size());
   std::iota(rejectedFilterIndices.begin(), rejectedFilterIndices.end(), 0);
-  return std::make_shared<TestTableHandle>(*this, std::move(columnHandles));
+  return std::make_shared<TestTableHandle>(
+      *this, std::move(columnHandles), lookupKeys.has_value());
+}
+
+std::shared_ptr<TestTable> TestConnectorMetadata::addLookupTable(
+    const std::string& name,
+    const velox::RowTypePtr& schema,
+    const std::vector<std::string>& lookupKeyNames) {
+  std::vector<velox::Variant> keys;
+  keys.reserve(lookupKeyNames.size());
+  for (const auto& keyName : lookupKeyNames) {
+    keys.emplace_back(keyName);
+  }
+
+  SchemaTableName tableName{std::string(kDefaultSchema), name};
+  schemas_.insert(tableName.schema);
+  auto table = std::make_shared<TestTable>(
+      tableName,
+      schema,
+      velox::ROW({}),
+      connector_,
+      folly::F14FastMap<std::string, velox::Variant>{
+          {std::string(kLookupKeys), velox::Variant::array(std::move(keys))}});
+  auto [it, ok] = tables_.emplace(std::move(tableName), std::move(table));
+  VELOX_CHECK(ok, "Table already exists: {}", it->first.toString());
+  return it->second;
 }
 
 std::shared_ptr<TestTable> TestConnectorMetadata::addTable(
@@ -840,7 +877,8 @@ TablePtr TestConnectorMetadata::createTable(
 
   for (const auto& [key, value] : options) {
     VELOX_USER_CHECK(
-        key == kHidden || key == kExplainIo || key == kCollectStatistics,
+        key == kHidden || key == kExplainIo || key == kCollectStatistics ||
+            key == kLookupKeys,
         "TestConnector does not support CREATE TABLE property: {}",
         key);
   }

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -110,6 +110,26 @@ class TestTableLayout : public TableLayout {
             /*lookupKeys=*/{},
             /*supportsScan=*/true) {}
 
+  /// Models a table that can only be read by key: 'lookupKeys' are the key
+  /// columns and a full scan is refused. Lets a test drive the optimizer's
+  /// index-lookup path, which no scannable layout reaches.
+  TestTableLayout(
+      const std::string& label,
+      Table* table,
+      velox::connector::Connector* connector,
+      std::vector<const Column*> columns,
+      std::vector<const Column*> lookupKeys)
+      : TableLayout(
+            label,
+            table,
+            connector,
+            std::move(columns),
+            /*partitionColumns=*/{},
+            /*orderColumns=*/{},
+            /*sortOrder=*/{},
+            std::move(lookupKeys),
+            /*supportsScan=*/false) {}
+
   TestTableLayout(
       const std::string& label,
       Table* table,
@@ -407,12 +427,19 @@ class TestTableHandle : public velox::connector::ConnectorTableHandle {
 
   TestTableHandle(
       const TableLayout& layout,
-      std::vector<velox::connector::ColumnHandlePtr> columnHandles)
+      std::vector<velox::connector::ColumnHandlePtr> columnHandles,
+      bool lookup = false)
       : TestTableHandle(
             layout.connector()->connectorId(),
             layout.table().name(),
             getTableSize(layout),
-            std::move(columnHandles)) {}
+            std::move(columnHandles)) {
+    lookup_ = lookup;
+  }
+
+  bool supportsIndexLookup() const override {
+    return lookup_;
+  }
 
   static int64_t getTableSize(const TableLayout& layout) {
     auto& table = dynamic_cast<const TestTable&>(layout.table());
@@ -438,6 +465,9 @@ class TestTableHandle : public velox::connector::ConnectorTableHandle {
   const std::vector<velox::connector::ColumnHandlePtr>& columnHandles() const {
     return columnHandles_;
   }
+
+  // True when the handle was built for an index lookup rather than a scan.
+  bool lookup_{false};
 
   folly::dynamic serialize() const override {
     folly::dynamic obj = folly::dynamic::object;
@@ -528,6 +558,10 @@ class TestConnectorMetadata : public ConnectorMetadata {
   /// Example: WITH (explain_io = ARRAY['ds']).
   static constexpr std::string_view kExplainIo = "explain_io";
 
+  /// CREATE TABLE property naming the key columns of a lookup-only table,
+  /// which cannot be scanned. Example: WITH (lookup_keys = ARRAY['id']).
+  static constexpr std::string_view kLookupKeys = "lookup_keys";
+
   /// CREATE TABLE property. When false, the table reports no row count and no
   /// column statistics regardless of the data it holds, modeling a table the
   /// metastore has no statistics for. Defaults to true.
@@ -576,6 +610,13 @@ class TestConnectorMetadata : public ConnectorMetadata {
       const velox::RowTypePtr& hiddenColumns,
       std::optional<TestBucketSpec> bucketSpec = std::nullopt,
       folly::F14FastMap<std::string, std::string> columnComments = {});
+
+  /// Registers a table that can only be read by key: 'lookupKeyNames' are its
+  /// key columns and a full scan is refused.
+  std::shared_ptr<TestTable> addLookupTable(
+      const std::string& name,
+      const velox::RowTypePtr& schema,
+      const std::vector<std::string>& lookupKeyNames);
 
   /// Appends data to the table with the specified name.
   void appendData(

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1166,6 +1166,11 @@ RelationOpPtr repartitionForIndex(
 
   ExprVector keyExprs;
   const auto& partitionKeys = distribution.partitionKeys();
+  if (partitionKeys.empty()) {
+    // An unpartitioned index is reachable from every worker, so the probe
+    // needs no shuffle to line up with it.
+    return plan;
+  }
   for (auto key : partitionKeys) {
     // partition is in schema columns, lookupKeys is in BaseTable columns. Use
     // the schema column of lookup key for matching.
@@ -2046,14 +2051,34 @@ void Optimization::joinByIndex(
       fanout = minOf(fanout, 1.0f);
     }
 
-    auto lookupKeys = left.keys;
-    // The number of keys is the prefix that matches index order.
-    lookupKeys.resize(info.lookupKeys.size());
+    // Pair each index key with the probe expression the join equates it to.
+    // 'info.lookupKeys' is in index order and 'left.keys' in join order, so
+    // matching by position would silently swap the probe values whenever the
+    // two orders disagree.
+    ExprVector lookupKeys;
+    lookupKeys.reserve(info.lookupKeys.size());
+    for (auto* lookupColumn : info.lookupKeys) {
+      const auto nth = std::ranges::find(keyColumns, lookupColumn);
+      VELOX_CHECK(
+          nth != keyColumns.end(),
+          "Index lookup key is not one of the join keys: {}",
+          lookupColumn->name());
+      lookupKeys.push_back(left.keys[nth - keyColumns.begin()]);
+    }
     state.placeColumns(availableColumns(rightTable, index));
 
     auto c = state.downstreamColumns();
     c.intersect(state.columns());
     c.unionColumns(rightTable->filter);
+
+    // The lookup key columns must survive column pruning: they name the
+    // right-hand side of the equalities the lookup is driven by.
+    ColumnVector lookupColumns;
+    lookupColumns.reserve(info.lookupKeys.size());
+    for (auto* lookupColumn : info.lookupKeys) {
+      c.add(lookupColumn);
+      lookupColumns.push_back(lookupColumn);
+    }
 
     auto* scan = make<TableScan>(
         newPartition,
@@ -2063,6 +2088,7 @@ void Optimization::joinByIndex(
         fanout,
         c.toObjects<Column>(),
         lookupKeys,
+        std::move(lookupColumns),
         joinType,
         candidate.join->filter());
 
@@ -2292,11 +2318,33 @@ void tryOptimizeSemiProject(
 }
 } // namespace
 
+namespace {
+
+// True if any table in 'candidate' can only be reached by index lookup. A hash
+// join has to scan its build side standalone, which such a table forbids.
+bool isLookupOnly(const JoinCandidate& candidate) {
+  for (auto* table : candidate.tables) {
+    if (!table->is(PlanType::kTableNode)) {
+      continue;
+    }
+    const auto* layout = table->as<BaseTable>()->layout();
+    if (layout != nullptr && !layout->supportsScan()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
+
 void Optimization::joinByHash(
     const RelationOpPtr& plan,
     const JoinCandidate& candidate,
     PlanState& state,
     std::vector<NextJoin>& toTry) {
+  if (isLookupOnly(candidate)) {
+    return;
+  }
   checkTables(candidate);
 
   auto [build, probe] = candidate.joinSides();
@@ -2546,6 +2594,9 @@ void Optimization::joinByHashRight(
     const JoinCandidate& candidate,
     PlanState& state,
     std::vector<NextJoin>& toTry) {
+  if (isLookupOnly(candidate)) {
+    return;
+  }
   checkTables(candidate);
 
   VELOX_CHECK_NULL(candidate.join->rowNumberColumn());

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1197,10 +1197,16 @@ struct BaseTable : public TableObject {
 
   PathSet columnSubfields(int32_t id) const;
 
-  /// Returns possible indices for driving table scan of 'table'.
+  /// Returns possible indices for driving table scan of 'table'. Empty when
+  /// every layout is lookup-only, which leaves index lookup as the sole way
+  /// to reach the table.
   std::vector<ColumnGroupCP> chooseLeafIndex() const {
     VELOX_DCHECK(!schemaTable->columnGroups.empty());
-    return {schemaTable->columnGroups[0]};
+    auto* group = schemaTable->columnGroups[0];
+    if (!group->layout->supportsScan()) {
+      return {};
+    }
+    return {group};
   }
 
   /// The connector table layout backing this scan. A BaseTable always has

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -129,6 +129,7 @@ TableScan::TableScan(
           /*fanout=*/table->filteredCardinality,
           columns,
           /*lookupKeys=*/{},
+          /*lookupColumns=*/{},
           velox::core::JoinType::kInner,
           /*joinFilter=*/{}) {}
 
@@ -140,6 +141,7 @@ TableScan::TableScan(
     std::optional<float> fanout,
     ColumnVector columns,
     ExprVector lookupKeys,
+    ColumnVector lookupColumns,
     velox::core::JoinType joinType,
     ExprVector joinFilter)
     : RelationOp(
@@ -150,6 +152,7 @@ TableScan::TableScan(
       baseTable(table),
       index(index),
       keys(std::move(lookupKeys)),
+      lookupColumns(std::move(lookupColumns)),
       joinType(joinType),
       joinFilter(std::move(joinFilter)) {
   cost_.inputCardinality = inputCardinality();

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -382,6 +382,7 @@ struct TableScan : public RelationOp {
       std::optional<float> fanout,
       ColumnVector columns,
       ExprVector lookupKeys,
+      ColumnVector lookupColumns,
       velox::core::JoinType joinType,
       ExprVector joinFilter);
 
@@ -408,8 +409,12 @@ struct TableScan : public RelationOp {
   /// access.
   ColumnGroupCP const index;
 
-  /// Lookup keys, empty if full table scan.
+  /// Lookup keys, empty if full table scan. These are probe-side expressions.
   const ExprVector keys;
+
+  /// Columns of 'index' the 'keys' are matched against, 1:1 with 'keys'.
+  /// Empty if full table scan.
+  const ColumnVector lookupColumns;
 
   /// If this is a lookup, 'joinType' can be inner, left or anti.
   const velox::core::JoinType joinType;

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -373,6 +373,21 @@ IndexInfo SchemaTable::indexInfo(
     }
   }
 
+  // A layout may advertise lookup keys without being sorted on them, in which
+  // case the loop above found nothing. Match the declared keys in order and
+  // stop at the first one the query does not constrain, since a lookup can
+  // only use a leading prefix of the key.
+  if (info.lookupKeys.empty()) {
+    for (const auto* lookupKey : index->layout->lookupKeys()) {
+      auto part = findColumnByName(columnsSpan, toName(lookupKey->name()));
+      if (!part) {
+        break;
+      }
+      covered.add(part);
+      info.lookupKeys.push_back(part);
+    }
+  }
+
   for (auto column : columnsSpan) {
     if (covered.contains(column)) {
       continue;

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -141,7 +141,9 @@ RelationOpPtr addGather(
 
 } // namespace
 
-void ToVelox::filterUpdated(BaseTableCP table) {
+void ToVelox::filterUpdated(
+    BaseTableCP table,
+    std::optional<connector::LookupKeys> lookupKeys) {
   PlanObjectSet columnSet;
   columnSet.unionColumns(table->columnFilters);
 
@@ -200,7 +202,9 @@ void ToVelox::filterUpdated(BaseTableCP table) {
       std::move(columns),
       *evaluator,
       std::move(filterConjuncts),
-      rejectedFilterIndices);
+      rejectedFilterIndices,
+      /*dataColumns=*/nullptr,
+      std::move(lookupKeys));
 
   // Each rejected index selects a conjunct to evaluate post-scan (as TypedExpr)
   // and to post-apply selectivity for (as ExprCP).
@@ -1463,17 +1467,79 @@ velox::core::TypedExprPtr toAndWithAliases(
 
 } // namespace
 
+velox::core::PlanNodePtr ToVelox::makeIndexLookupJoin(
+    const TableScan& scan,
+    const velox::core::TableScanNodePtr& lookupSource,
+    ExecutableFragment& fragment,
+    std::vector<ExecutableFragment>& stages) {
+  VELOX_CHECK_EQ(
+      scan.keys.size(),
+      scan.lookupColumns.size(),
+      "Index lookup needs one index column per probe key");
+  VELOX_CHECK(
+      velox::core::IndexLookupJoinNode::isSupported(scan.joinType),
+      "Join type not available by index lookup: {}",
+      velox::core::JoinTypeName::toName(scan.joinType));
+
+  auto probe = makeFragment(scan.input(), fragment, stages);
+
+  ExprVector lookupExprs;
+  lookupExprs.reserve(scan.lookupColumns.size());
+  for (auto* column : scan.lookupColumns) {
+    lookupExprs.push_back(column);
+  }
+
+  // The probe's columns come first so a column named on both sides resolves to
+  // the probe, matching the ordering the optimizer placed them in.
+  std::vector<std::string> names = probe->outputType()->names();
+  std::vector<velox::TypePtr> types = probe->outputType()->children();
+  const auto& lookupType = lookupSource->outputType();
+  for (auto i = 0; i < lookupType->size(); ++i) {
+    if (probe->outputType()->containsChild(lookupType->nameOf(i))) {
+      continue;
+    }
+    names.push_back(lookupType->nameOf(i));
+    types.push_back(lookupType->childAt(i));
+  }
+
+  auto joinNode = std::make_shared<velox::core::IndexLookupJoinNode>(
+      nextId(),
+      scan.joinType,
+      toFieldRefs(scan.keys),
+      toFieldRefs(lookupExprs),
+      /*joinConditions=*/std::vector<velox::core::IndexLookupConditionPtr>{},
+      toAnd(scan.joinFilter),
+      /*hasMarker=*/false,
+      /*splitOutput=*/std::nullopt,
+      std::move(probe),
+      lookupSource,
+      ROW(std::move(names), std::move(types)));
+
+  makePredictionAndHistory(joinNode->id(), &scan);
+  return joinNode;
+}
+
 velox::core::PlanNodePtr ToVelox::makeScan(
     const TableScan& scan,
     ExecutableFragment& fragment,
-    std::vector<ExecutableFragment>& /*stages*/) {
+    std::vector<ExecutableFragment>& stages) {
   columnAlteredTypes_.clear();
 
   const bool isSubfieldPushdown = hasSubfieldPushdown(scan);
 
   auto* data = leafData(scan.baseTable->id());
-  if (!data) {
-    filterUpdated(scan.baseTable);
+  if (!data || !scan.keys.empty()) {
+    // A lookup needs a handle the connector built knowing the lookup keys, so
+    // rebuild rather than reuse the cached scan handle.
+    std::optional<connector::LookupKeys> lookupKeys;
+    if (!scan.keys.empty()) {
+      lookupKeys.emplace();
+      lookupKeys->equalityColumns.reserve(scan.lookupColumns.size());
+      for (auto* column : scan.lookupColumns) {
+        lookupKeys->equalityColumns.emplace_back(column->name());
+      }
+    }
+    filterUpdated(scan.baseTable, std::move(lookupKeys));
     data = leafData(scan.baseTable->id());
     VELOX_CHECK_NOT_NULL(data, "No table for scan {}", scan.toString());
   }
@@ -1482,6 +1548,14 @@ velox::core::PlanNodePtr ToVelox::makeScan(
 
   // Add columns used by rejected filters to scan columns.
   ColumnVector allColumns = scan.columns();
+  if (!scan.keys.empty()) {
+    // For a lookup, 'columns' is the join's output: probe columns alongside
+    // the index's. Only the latter are read from the connector; the former
+    // arrive from the probe side.
+    std::erase_if(allColumns, [&](ColumnCP column) {
+      return column->relation() != scan.baseTable;
+    });
+  }
   velox::core::TypedExprPtr filter;
   if (!rejectedFilters.empty()) {
     filter = toAndWithAliases(
@@ -1515,14 +1589,21 @@ velox::core::PlanNodePtr ToVelox::makeScan(
   }
 
   auto scanId = nextId();
-  velox::core::PlanNodePtr result =
-      std::make_shared<velox::core::TableScanNode>(
-          scanId, outputType, tableHandle, assignments);
+  auto scanNode = std::make_shared<velox::core::TableScanNode>(
+      scanId, outputType, tableHandle, assignments);
+  velox::core::PlanNodePtr result = scanNode;
 
   relationOpToNodeId_.insert_or_assign(&scan, scanId);
 
   if (scan.baseTable->sampledPercentage.has_value()) {
     fragment.sampledScans.emplace(scanId, *scan.baseTable->sampledPercentage);
+  }
+
+  if (!scan.keys.empty()) {
+    // Index lookup: the scan is the lookup side of a join whose probe side is
+    // the scan's input. The rejected filters and subfield projections below
+    // apply to the joined rows, so build the join first and let them wrap it.
+    result = makeIndexLookupJoin(scan, scanNode, fragment, stages);
   }
 
   if (filter != nullptr) {

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -98,7 +98,11 @@ class ToVelox {
 
   /// Builds the connector table handle for 'baseTable' from its current
   /// filters and column handles. Populates leafData for the base table.
-  void filterUpdated(BaseTableCP baseTable);
+  /// 'lookupKeys' is set when the handle drives an index lookup rather than a
+  /// scan; the connector then returns a lookup-capable handle.
+  void filterUpdated(
+      BaseTableCP baseTable,
+      std::optional<connector::LookupKeys> lookupKeys = std::nullopt);
 
   /// Returns the leaf data for 'id' populated by filterUpdated, or nullptr
   /// if filterUpdated has not been called for this id.
@@ -218,6 +222,14 @@ class ToVelox {
 
   velox::core::PlanNodePtr makeScan(
       const TableScan& scan,
+      ExecutableFragment& fragment,
+      std::vector<ExecutableFragment>& stages);
+
+  // Joins 'scan's probe-side input to 'lookupSource' by index lookup. Only
+  // called for a TableScan carrying lookup keys.
+  velox::core::PlanNodePtr makeIndexLookupJoin(
+      const TableScan& scan,
+      const velox::core::TableScanNodePtr& lookupSource,
       ExecutableFragment& fragment,
       std::vector<ExecutableFragment>& stages);
 

--- a/axiom/optimizer/tests/IndexLookupJoinTest.cpp
+++ b/axiom/optimizer/tests/IndexLookupJoinTest.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+namespace facebook::axiom::optimizer::test {
+namespace {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+// Counts the plan nodes of type T anywhere under 'plan'.
+template <typename T>
+int32_t countNodes(const core::PlanNodePtr& plan) {
+  int32_t count = std::dynamic_pointer_cast<const T>(plan) != nullptr ? 1 : 0;
+  for (const auto& source : plan->sources()) {
+    count += countNodes<T>(source);
+  }
+  return count;
+}
+
+template <typename T>
+int32_t countNodes(const optimizer::PlanAndStats& plan) {
+  int32_t count = 0;
+  for (const auto& fragment : plan.plan->fragments()) {
+    count += countNodes<T>(fragment.fragment.planNode);
+  }
+  return count;
+}
+
+// A table that can only be read by key is reachable only through an index
+// lookup. These tests cover the planning and lowering of that shape, which no
+// scannable layout exercises.
+class IndexLookupJoinTest : public QueryTestBase {
+ protected:
+  void SetUp() override {
+    QueryTestBase::SetUp();
+    testConnector_->addTable("probe", ROW({"a", "b"}, BIGINT()));
+    testConnector_->metadata()->addLookupTable(
+        "lookup", ROW({"id", "v"}, BIGINT()), {"id"});
+  }
+
+  // Plans `probe join lookup on probe.a = lookup.id`.
+  optimizer::PlanAndStats planJoin() {
+    lp::PlanBuilder::Context context(kTestConnectorId, kDefaultSchema);
+    auto logicalPlan = lp::PlanBuilder(context)
+                           .tableScan("probe")
+                           .join(
+                               lp::PlanBuilder(context).tableScan("lookup"),
+                               "a = id",
+                               lp::JoinType::kInner)
+                           .build();
+    return planVelox(logicalPlan);
+  }
+};
+
+// The lookup side is joined by key rather than scanned and hash-joined. Before
+// index lookup was lowered, ToVelox dropped the probe input and emitted a plain
+// TableScanNode for the lookup side.
+TEST_F(IndexLookupJoinTest, lowersToIndexLookupJoin) {
+  auto plan = planJoin();
+  EXPECT_EQ(countNodes<core::IndexLookupJoinNode>(plan), 1);
+}
+
+// joinByHash has to decline a build side it cannot scan. Without that, the
+// optimizer plans a build that yields no plan and the failure surfaces far
+// away, as an empty plan set inside the memo.
+TEST_F(IndexLookupJoinTest, doesNotHashJoinALookupOnlyBuildSide) {
+  auto plan = planJoin();
+  EXPECT_EQ(countNodes<core::HashJoinNode>(plan), 0);
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer::test

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -708,6 +708,18 @@ void gatherScans(
     scans.push_back(scan);
     return;
   }
+  if (auto lookupJoin =
+          std::dynamic_pointer_cast<const velox::core::IndexLookupJoinNode>(
+              plan)) {
+    // The lookup side is not a driver source: the join operator reads it
+    // through an IndexSource. Only a lookup source that asks for splits gets
+    // them, and then the operator, not a TableScan, consumes them.
+    gatherScans(lookupJoin->sources()[0], scans);
+    if (lookupJoin->lookupSource()->tableHandle()->needsIndexSplit()) {
+      scans.push_back(lookupJoin->lookupSource());
+    }
+    return;
+  }
   for (const auto& source : plan->sources()) {
     gatherScans(source, scans);
   }


### PR DESCRIPTION
Summary:

A connector whose table can only be read by key had no way to be joined. `TableLayout::lookupKeys()` and `supportsScan()` were part of the connector API but nothing read them, so a layout declaring lookup keys was still planned as a full scan and lowered to a plain `TableScanNode`. A layout declaring `supportsScan=false` had no plan at all, and the failure surfaced far from the cause:

    Line: axiom/optimizer/Plan.h:417, Expression: !plans.plans.empty()

`Optimization::joinByIndex` already built the right relation for this shape. It never fired, because `SchemaTable::indexInfo` derived lookup keys only from the layout's sort order, and `ToVelox::makeScan` dropped the scan's probe-side input and emitted a plain scan regardless.

Lookup keys now come from `lookupKeys()` when the layout is not sorted on them, and a scan carrying lookup keys lowers to `IndexLookupJoinNode` with the probe as its left input. `TableScan` gains the index columns the probe keys pair with, since the pairing cannot be recovered from the key list alone. Three paths had to learn that a lookup-only table is unreachable by scan:

  - `chooseLeafIndex` no longer offers it as a driving scan.
  - `joinByHash` and `joinByHashRight` skip a candidate whose build side cannot be scanned, rather than planning a build that yields nothing.
  - `gatherScans` stops feeding splits to the lookup side, which is read through an `IndexSource` and is not a driver source. Velox rejected them with `Splits can be associated only with leaf plan nodes which require splits`.

`joinByIndex` also paired the index keys with the probe keys by position, taking `left.keys` and truncating it. The two lists are ordered independently — one by the index, one by the join — so whenever they disagreed the probe values were silently swapped between keys. It now matches each index key to the join key naming the same column. This is only reachable with two or more lookup keys, which nothing could produce before.

Also fixes `repartitionForIndex` emitting a hash shuffle with an empty key list for an index with no partitioning, which tripped `makeRepartition`. An unpartitioned index is reachable from every worker and needs no shuffle.

Deferred: probe keys must be column references; a computed key fails in `toFieldRef`. Only equality lookups are planned, so the `IN` and `BETWEEN` lookup conditions Velox supports are not yet reachable.

Reviewed By: mbasmanova

Differential Revision: D119534051


