### PR TITLE
feat(connector): Add group ID to connector splits

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -352,6 +352,12 @@ class PartitionType {
   /// Number of partitions.
   virtual int32_t numPartitions() const = 0;
 
+  /// Number of split groups. Splits produced under this partitioning carry
+  /// groupIds in [0, numGroups()). May exceed numPartitions(): after
+  /// scaleDown folds several buckets into one partition, each task processes
+  /// multiple groups.
+  virtual int32_t numGroups() const = 0;
+
   virtual std::string toString() const = 0;
 
   template <typename T>

--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -30,8 +30,10 @@ class PartitionType;
 /// execution: splits with the same remotePartition are routed to the same
 /// task. affinityId is a soft cross-query affinity hint: schedulers prefer to
 /// route splits with the same affinityId to the same task, but may choose
-/// another task for load balancing. When both are present, grouped-execution
-/// routing through remotePartition takes precedence over affinityId.
+/// another task for load balancing. groupId carries the raw bucket id of a
+/// split from a bucketed table, independent of grouped execution. When both
+/// are present, grouped-execution routing through remotePartition takes
+/// precedence over affinityId.
 struct Split {
   /// The underlying Velox connector split.
   std::shared_ptr<velox::connector::ConnectorSplit> connectorSplit;
@@ -49,6 +51,13 @@ struct Split {
   /// affinityId; such collisions only cause them to share a preferred task. If
   /// unset, no affinityId-based placement hint is available for this split.
   std::optional<int64_t> affinityId{std::nullopt};
+
+  /// Bucket id of this split when the underlying table is bucketed. Unlike
+  /// remotePartition, this is populated whenever the connector knows the
+  /// bucket, even when no PartitionType was passed for grouped execution.
+  /// Under grouped execution it is normalized to the bucket count selected
+  /// by the supplied partitionType. Absent for non-bucketed tables.
+  std::optional<int32_t> groupId{std::nullopt};
 };
 
 /// A batch of splits returned by SplitSource::co_getSplits.

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -82,6 +82,13 @@ class HivePartitionType : public connector::PartitionType {
     return numPartitions_;
   }
 
+  /// Number of split groups: the bucket count. Split groupIds lie in
+  /// [0, numBuckets()), independent of the (possibly smaller) partition
+  /// count.
+  int32_t numGroups() const override {
+    return numBuckets_;
+  }
+
   /// Native bucket count of the underlying Hive table layout.
   int32_t numBuckets() const {
     return numBuckets_;

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -366,20 +366,27 @@ folly::coro::Task<SplitBatch> LocalHiveSplitSource::co_getSplits(
       if (!serdeParameters_.empty()) {
         builder.serdeParameters(serdeParameters_);
       }
+      // groupId carries the bucket number whenever the file knows it,
+      // independent of grouped execution. Under grouped execution it is
+      // normalized to the bucket count selected by the supplied
+      // partitionType.
       std::optional<int32_t> remotePartition;
+      std::optional<int32_t> groupId = info->bucketNumber;
       if (partitionType_ != nullptr) {
         VELOX_CHECK(
             info->bucketNumber.has_value(),
             "Bucketed scan requires bucketNumber on every file");
         const auto* hivePartitionType =
             partitionType_->asChecked<HivePartitionType>();
+        groupId = info->bucketNumber.value() % hivePartitionType->numGroups();
         remotePartition =
             hivePartitionType->mapBucketToPartition(info->bucketNumber.value());
       }
       batch.splits.push_back(
           Split{
               .connectorSplit = builder.build(),
-              .remotePartition = remotePartition});
+              .remotePartition = remotePartition,
+              .groupId = groupId});
       ++splitWithinFile_;
     }
     if (splitWithinFile_ >= splitsPerFile) {

--- a/axiom/connectors/hive/tests/HivePartitionTypeTest.cpp
+++ b/axiom/connectors/hive/tests/HivePartitionTypeTest.cpp
@@ -82,6 +82,15 @@ TEST(HivePartitionTypeTest, scaleDownPrimePartitionCount) {
   EXPECT_EQ(scaled->numPartitions(), 7);
 }
 
+TEST(HivePartitionTypeTest, numGroupsEqualsNumBuckets) {
+  EXPECT_EQ(makePartitionType(8).numGroups(), 8);
+
+  const auto scaled = makePartitionType(256).scaleDown(100);
+  ASSERT_NE(scaled, nullptr);
+  EXPECT_EQ(scaled->numPartitions(), 100);
+  EXPECT_EQ(scaled->numGroups(), 256);
+}
+
 TEST(HivePartitionTypeTest, scaleDownRejectsNonPositiveMax) {
   const auto partitionType = makePartitionType(8);
 

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -436,14 +436,17 @@ folly::coro::Task<SplitBatch> TestSplitSource::co_getSplits(
     auto split =
         std::make_shared<TestConnectorSplit>(connectorId_, dataIndices_[i]);
     std::optional<int32_t> remotePartition;
+    std::optional<int32_t> groupId;
     if (partitionType_ != nullptr) {
       VELOX_CHECK_LT(i, dataBucketIds_.size());
+      groupId = dataBucketIds_[i] % partitionType_->numGroups();
       remotePartition = dataBucketIds_[i] % partitionType_->numPartitions();
     }
     batch.splits.push_back(
         Split{
             .connectorSplit = std::move(split),
-            .remotePartition = remotePartition});
+            .remotePartition = remotePartition,
+            .groupId = groupId});
   }
   nextOffset_ = end;
   batch.noMoreSplits = (nextOffset_ >= dataIndices_.size());

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -68,6 +68,12 @@ class TestPartitionType : public PartitionType {
     return numPartitions_;
   }
 
+  /// Number of split groups. Test partitioning does not fold buckets, so
+  /// groups and partitions coincide.
+  int32_t numGroups() const override {
+    return numPartitions_;
+  }
+
   std::string toString() const override;
 
  private:
@@ -266,7 +272,8 @@ class TestTable : public Table {
 
 /// SplitSource for TestTable. Emits one TestConnectorSplit per index in
 /// 'dataIndices'. When 'partitionType' is set, tags each Split with
-/// remotePartition = dataBucketIds[i] % partitionType->numPartitions().
+/// remotePartition = dataBucketIds[i] % partitionType->numPartitions() and
+/// groupId = dataBucketIds[i].
 class TestSplitSource : public SplitSource {
  public:
   TestSplitSource(

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -658,6 +658,8 @@ CO_TEST_F(TestConnectorTest, bucketedTable) {
       CO_ASSERT_NE(testSplit, nullptr);
       const auto bucket = table->dataBucketIds()[testSplit->index()];
       EXPECT_EQ(*split.remotePartition, bucket % kNumGroups);
+      CO_ASSERT_TRUE(split.groupId.has_value());
+      EXPECT_EQ(*split.groupId, bucket % kNumGroups);
       observedRemotePartitions.push_back(*split.remotePartition);
     }
     if (batch.noMoreSplits) {


### PR DESCRIPTION
Summary:
Bucketed scans need the raw bucket id next to the grouped-execution routing partition: after scale-down folds several buckets into one partition, the partition alone no longer identifies the bucket, so a consumer that stages one group at a time cannot tell which splits belong together. Splits now carry an optional `groupId` holding the bucket id, and partitioning exposes `numGroups()` with the group count for producers to normalize against.
Adds `groupId` to `Split` and a `numGroups()` override to the partition-type hierarchy. `HiveConnectorMetadata` reports the native bucket count and tags each Hive split with its file bucket number, normalized to the selected bucket count when a partition type is supplied, and the test connector mirrors the same tagging.

Differential Revision: D119602479


