### PR TITLE
feat(optimizer): Support EXPLAIN (TYPE OPTIMIZED) under v2 (#1876)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -174,6 +174,44 @@ would-I-say-this-aloud test to each):
   - Mixed types keep the two-vector form: `ROW({"a", "b"}, {BIGINT(),
     VARCHAR()})`.
 
+### Enums
+
+Every enum declared in a header gets name mapping, added with the enum itself.
+It is not the first caller's job to add it. Use `AXIOM_DECLARE_ENUM_NAME` /
+`AXIOM_DEFINE_ENUM_NAME` for a namespace-scope enum and the `_EMBEDDED_`
+variants for one nested in a class — the two are the same rule, and both
+macros are in `axiom/common/Enums.h`.
+
+The declaration goes in the header next to the enum, the definition in the
+`.cpp` next to a `Names()` function in an anonymous namespace mapping each
+enumerator to its name:
+
+```cpp
+// Schema.h
+enum class Kind { kUnspecified, kPartitioned, ... };
+
+AXIOM_DECLARE_EMBEDDED_ENUM_NAME(Kind);
+```
+
+```cpp
+// Schema.cpp
+namespace {
+const auto& distributionKindNames() {
+  static const folly::F14FastMap<Distribution::Kind, std::string_view> kNames =
+      {
+          {Distribution::Kind::kUnspecified, "UNSPECIFIED"},
+          {Distribution::Kind::kPartitioned, "PARTITIONED"},
+      };
+  return kNames;
+}
+} // namespace
+
+AXIOM_DEFINE_EMBEDDED_ENUM_NAME(Distribution, Kind, distributionKindNames);
+```
+
+A `DECLARE` without its `DEFINE` compiles and links until someone calls
+`toName`, so a missing definition is invisible until it is not.
+
 ### API Design
 
 - Keep the public API surface small.
@@ -319,8 +357,12 @@ undocumented if the name is self-explanatory.
 
 ### Non-trivial implementations in headers
 
-Keep method implementations in `.cpp` except for trivial one-liners. If a
-method body has more than one statement, it belongs in the `.cpp` file.
+Keep method implementations in `.cpp`. A body stays in the header only when it
+needs no types the header does not already have and is short enough that it
+will not churn — a getter, or a two-line check-and-set. Anything that pulls in
+an include, or that a reader has to scroll through, moves. Statement count is
+not the test: moving a two-line guard to the `.cpp` costs a declaration, a
+definition and a jump between files, and saves nothing.
 
 ```cpp
 // ❌ Wrong — multi-statement body in header.

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -1384,6 +1384,28 @@ std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
       options.tokenProvider);
 }
 
+template <typename Operation>
+auto SqlQueryRunner::withOptimizerV2(
+    const logical_plan::LogicalPlanNode& logicalPlan,
+    const std::shared_ptr<velox::core::QueryCtx>& queryCtx,
+    const std::shared_ptr<connector::SchemaResolver>& schemaResolver,
+    bool explain,
+    Operation&& operation) {
+  auto resolver = orDefaultSchemaResolver(schemaResolver);
+  auto session = makeOptimizerSession(
+      queryCtx->queryId(),
+      collectConnectorProperties(*sessionConfig_),
+      explain);
+  OptimizerContext optimizerContext(
+      optimizerPool_.get(), session->options().maxPlanObjects);
+  velox::exec::SimpleExpressionEvaluator evaluator(
+      queryCtx.get(), optimizerPool_.get());
+
+  optimizer::v2::Optimizer optimizer(
+      logicalPlan, *resolver, *session, evaluator, queryCtx);
+  return operation(optimizer);
+}
+
 std::string SqlQueryRunner::runExplainIo(
     const presto::SqlStatement& statement,
     const logical_plan::LogicalPlanNodePtr& logicalPlan,
@@ -1402,18 +1424,14 @@ std::string SqlQueryRunner::runExplainIo(
       QueryRuntimeStats::kOptimizeCpuNanos);
 
   if (useOptimizerV2_) {
-    auto resolver = orDefaultSchemaResolver(schemaResolver);
-    auto session = makeOptimizerSession(
-        queryCtx->queryId(),
-        collectConnectorProperties(*sessionConfig_),
-        /*explain=*/true);
-    OptimizerContext optimizerContext(
-        optimizerPool_.get(), session->options().maxPlanObjects);
-    velox::exec::SimpleExpressionEvaluator evaluator(
-        queryCtx.get(), optimizerPool_.get());
-    optimizer::v2::Optimizer optimizer(
-        *logicalPlan, *resolver, *session, evaluator, queryCtx);
-    return optimizer.explainIo(std::move(outputTable));
+    return withOptimizerV2(
+        *logicalPlan,
+        queryCtx,
+        schemaResolver,
+        /*explain=*/true,
+        [&](auto& optimizer) {
+          return optimizer.explainIo(std::move(outputTable));
+        });
   }
   std::string text;
   optimize(
@@ -1496,9 +1514,25 @@ std::string SqlQueryRunner::runExplain(
     }
 
     case presto::ExplainStatement::Type::kOptimized: {
-      VELOX_USER_CHECK(
-          !useOptimizerV2_,
-          "EXPLAIN TYPE OPTIMIZED is not supported with --v2");
+      if (useOptimizerV2_) {
+        auto queryCtx = newQuery(options);
+        PhaseTimer phaseTimer(
+            timing.optimize,
+            runtimeStats.get(),
+            QueryRuntimeStats::kOptimizeWallNanos,
+            QueryRuntimeStats::kOptimizeCpuNanos);
+        optimizer::MultiFragmentPlan::Options opts;
+        opts.maxRemotePartitions = options.numWorkers;
+        opts.maxLocalPartitions = options.numDrivers;
+        return withOptimizerV2(
+            *logicalPlan,
+            queryCtx,
+            schemaResolver,
+            explain,
+            [&](auto& optimizer) {
+              return optimizer.debugPlanTo(opts).root->toString();
+            });
+      }
       std::string text;
       auto queryCtx = newQuery(options);
       {
@@ -2090,34 +2124,29 @@ std::vector<velox::RowVectorPtr> SqlQueryRunner::runShowStatsForQuery(
   std::vector<velox::Variant> data;
 
   if (useOptimizerV2_) {
-    auto queryCtx = newQuery(options);
-    auto session = makeOptimizerSession(
-        queryCtx->queryId(),
-        collectConnectorProperties(*sessionConfig_),
-        /*explain=*/false);
-    OptimizerContext optimizerContext(
-        optimizerPool_.get(), session->options().maxPlanObjects);
-    velox::exec::SimpleExpressionEvaluator evaluator(
-        queryCtx.get(), optimizerPool_.get());
-    auto resolver = orDefaultSchemaResolver(nullptr);
+    // The stats reference optimizer-owned memory, so they are turned into rows
+    // inside the call.
+    data = withOptimizerV2(
+        *logicalPlan,
+        newQuery(options),
+        /*schemaResolver=*/nullptr,
+        /*explain=*/false,
+        [](auto& optimizer) {
+          const auto stats = optimizer.estimateQueryStats();
 
-    const auto stats =
-        optimizer::v2::Optimizer(
-            *logicalPlan, *resolver, *session, evaluator, queryCtx)
-            .estimateQueryStats();
-
-    presto::ShowStatsBuilder builder(roundCardinality(stats.cardinality));
-    for (const auto& column : stats.columns) {
-      builder.addColumn(
-          column.name,
-          *column.type,
-          castOpt<double>(column.nullFraction),
-          roundCardinality(column.distinctCount),
-          /*avgLength=*/std::nullopt,
-          column.min,
-          column.max);
-    }
-    data = builder.rows();
+          presto::ShowStatsBuilder builder(roundCardinality(stats.cardinality));
+          for (const auto& column : stats.columns) {
+            builder.addColumn(
+                column.name,
+                *column.type,
+                castOpt<double>(column.nullFraction),
+                roundCardinality(column.distinctCount),
+                /*avgLength=*/std::nullopt,
+                column.min,
+                column.max);
+          }
+          return builder.rows();
+        });
   } else {
     optimize(
         logicalPlan,

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -571,6 +571,18 @@ class SqlQueryRunner {
       facebook::axiom::connector::ConnectorProperties connectorProperties,
       bool explain);
 
+  // Runs 'operation' on a v2 Optimizer over 'logicalPlan'. The optimizer's
+  // arena, session and evaluator live for the duration of the call, so
+  // 'operation' must not let the optimizer's output escape it.
+  template <typename Operation>
+  auto withOptimizerV2(
+      const facebook::axiom::logical_plan::LogicalPlanNode& logicalPlan,
+      const std::shared_ptr<facebook::velox::core::QueryCtx>& queryCtx,
+      const std::shared_ptr<facebook::axiom::connector::SchemaResolver>&
+          schemaResolver,
+      bool explain,
+      Operation&& operation);
+
   std::string runExplain(
       const facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,
       presto::ExplainStatement::Type type,

--- a/axiom/cli/tests/ExplainTest.cpp
+++ b/axiom/cli/tests/ExplainTest.cpp
@@ -282,18 +282,14 @@ TEST_P(ExplainTest, explainCtas) {
         ::testing::HasSubstr("- TableWrite CREATE: -> ROW<rows:BIGINT>"));
   }
 
-  // TYPE OPTIMIZED is v1-only.
-  if (useV2_) {
-    VELOX_ASSERT_THROW(
-        run("EXPLAIN (TYPE OPTIMIZED) CREATE TABLE t AS SELECT 1 AS x"),
-        "EXPLAIN TYPE OPTIMIZED is not supported with --v2");
-  } else {
+  {
     auto result =
         run("EXPLAIN (TYPE OPTIMIZED) CREATE TABLE t AS SELECT 1 AS x");
     ASSERT_TRUE(result.message.has_value());
     EXPECT_THAT(
         result.message.value(),
-        ::testing::HasSubstr("TableWrite [1.00 rows] ->"));
+        ::testing::HasSubstr(
+            useV2_ ? "TableWrite" : "TableWrite [1.00 rows] ->"));
   }
 
   {
@@ -336,12 +332,12 @@ TEST_P(ExplainTest, explainPopulatesOptimizeTiming) {
   // EXPLAIN (TYPE LOGICAL) does not populate optimize timing.
   EXPECT_EQ(0, runWithTiming("EXPLAIN (TYPE LOGICAL) SELECT 1").optimize);
 
-  // TYPE GRAPH and TYPE OPTIMIZED are v1-only; the other EXPLAIN variants
-  // populate optimize timing under both optimizers.
+  // TYPE GRAPH is v1-only; every other EXPLAIN variant populates optimize
+  // timing under both optimizers.
   if (!useV2_) {
     EXPECT_GT(runWithTiming("EXPLAIN (TYPE GRAPH) SELECT 1").optimize, 0);
-    EXPECT_GT(runWithTiming("EXPLAIN (TYPE OPTIMIZED) SELECT 1").optimize, 0);
   }
+  EXPECT_GT(runWithTiming("EXPLAIN (TYPE OPTIMIZED) SELECT 1").optimize, 0);
   EXPECT_GT(runWithTiming("EXPLAIN SELECT 1").optimize, 0);
   EXPECT_GT(runWithTiming("EXPLAIN (TYPE IO) SELECT 1").optimize, 0);
 
@@ -382,7 +378,7 @@ TEST_P(ExplainTest, explainFormatGraphviz) {
         text.message.value(), ::testing::Not(::testing::HasSubstr("digraph")));
   }
 
-  // FORMAT GRAPHVIZ with unsupported TYPE fails (checked before the v2 gate).
+  // FORMAT GRAPHVIZ with an unsupported TYPE fails.
   VELOX_ASSERT_USER_THROW(
       run("EXPLAIN (TYPE OPTIMIZED, FORMAT GRAPHVIZ) SELECT 1 AS x"),
       "EXPLAIN FORMAT GRAPHVIZ is supported for TYPE LOGICAL and TYPE GRAPH only");

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -23,47 +23,17 @@
 #include "axiom/optimizer/v2/EmitPass.h"
 #include "axiom/optimizer/v2/EstimateLeafStatsPass.h"
 #include "axiom/optimizer/v2/EstimateProvider.h"
+#include "axiom/optimizer/v2/ExpandAggregatePass.h"
 #include "axiom/optimizer/v2/FoldMetadataAggregatePass.h"
 #include "axiom/optimizer/v2/LimitAndOrderPass.h"
-#include "axiom/optimizer/v2/PhysicalPlanAndEmit.h"
+#include "axiom/optimizer/v2/PlanPhysicalPass.h"
+#include "axiom/optimizer/v2/PrecomputeProjectionsPass.h"
 #include "axiom/optimizer/v2/PushdownAndPrunePass.h"
 #include "axiom/optimizer/v2/TranslatePass.h"
 
 namespace facebook::axiom::optimizer::v2 {
 
 namespace {
-
-// Bundles the outputs of the front-end passes shared by full optimization and
-// EXPLAIN (TYPE IO).
-struct FrontendResult {
-  TranslatePass::Result translated;
-  NodeCP pushed;
-};
-
-// Runs the front-end passes shared by `optimize` and `explainIo`. 'schema' and
-// 'builder' must outlive the returned IR.
-FrontendResult translateAndPushdown(
-    const logical_plan::LogicalPlanNode& plan,
-    Schema& schema,
-    velox::core::ExpressionEvaluator& evaluator,
-    Builder& builder,
-    const OptimizerSession& session,
-    const std::shared_ptr<velox::core::QueryCtx>& queryCtx,
-    PushdownAndPrunePass::ConnectorPushdown connectorPushdown) {
-  ConstantPlanRunner constantPlanRunner{queryCtx};
-  auto translated = TranslatePass::run(
-      plan, schema, evaluator, builder, session, constantPlanRunner);
-  NodeCP decorrelated = DecorrelatePass::run(translated.root, builder);
-  NodeCP limited = LimitAndOrderPass::run(decorrelated, builder);
-  NodeCP pushed = PushdownAndPrunePass::run(
-      limited,
-      translated.outputColumns,
-      builder,
-      evaluator,
-      session,
-      connectorPushdown);
-  return {std::move(translated), pushed};
-}
 
 // Collects each Scan's base table and the conjuncts that reach it. Reads them
 // off the `Filter` above the `Scan`, so the caller must have run the pushdown
@@ -134,50 +104,134 @@ int32_t chooseNumWorkers(
 
 } // namespace
 
-PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
-  VELOX_USER_CHECK_GE(
-      options.maxRemotePartitions, 1, "maxRemotePartitions must be at least 1");
-  VELOX_USER_CHECK_GE(
-      options.maxLocalPartitions, 1, "maxLocalPartitions must be at least 1");
+namespace {
+const auto& passNames() {
+  static const folly::F14FastMap<Optimizer::Pass, std::string_view> kNames = {
+      {Optimizer::Pass::kTranslate, "TRANSLATE"},
+      {Optimizer::Pass::kDecorrelate, "DECORRELATE"},
+      {Optimizer::Pass::kLimitAndOrder, "LIMIT_AND_ORDER"},
+      {Optimizer::Pass::kPushdownAndPrune, "PUSHDOWN_AND_PRUNE"},
+      {Optimizer::Pass::kFoldMetadataAggregate, "FOLD_METADATA_AGGREGATE"},
+      {Optimizer::Pass::kEstimateLeafStats, "ESTIMATE_LEAF_STATS"},
+      {Optimizer::Pass::kPlanPhysical, "PLAN_PHYSICAL"},
+      {Optimizer::Pass::kPrecomputeProjections, "PRECOMPUTE_PROJECTIONS"},
+      {Optimizer::Pass::kExpandAggregate, "EXPAND_AGGREGATE"},
+  };
+  return kNames;
+}
+} // namespace
 
-  // Schema is owned here so its `connector::TablePtr`s — and the
-  // `TableLayout`s the IR's `BaseTable` nodes hold raw pointers to —
-  // stay alive through translate, precompute, and emit.
-  Schema schema(schemaResolver_);
+AXIOM_DEFINE_EMBEDDED_ENUM_NAME(Optimizer, Pass, passNames);
 
-  Builder builder;
-  auto frontend = translateAndPushdown(
-      plan_,
-      schema,
-      evaluator_,
-      builder,
-      session_,
-      queryCtx_,
-      PushdownAndPrunePass::ConnectorPushdown::kOffer);
-  NodeCP folded =
-      FoldMetadataAggregatePass::run(frontend.pushed, builder, session_);
-  if (session_.options().useFilteredTableStats) {
-    EstimateLeafStatsPass::run(folded, session_);
+NodeCP Optimizer::planTo(
+    std::optional<Pass> pass,
+    PushdownAndPrunePass::ConnectorPushdown connectorPushdown,
+    const MultiFragmentPlan::Options* options) {
+  ConstantPlanRunner constantPlanRunner{queryCtx_};
+  auto translated = TranslatePass::run(
+      plan_, schema_, evaluator_, builder_, session_, constantPlanRunner);
+  outputColumns_ = translated.outputColumns;
+  outputNames_ = translated.outputNames;
+  if (pass == Pass::kTranslate) {
+    return translated.root;
   }
+
+  NodeCP node = DecorrelatePass::run(translated.root, builder_);
+  if (pass == Pass::kDecorrelate) {
+    return node;
+  }
+
+  node = LimitAndOrderPass::run(node, builder_);
+  if (pass == Pass::kLimitAndOrder) {
+    return node;
+  }
+
+  node = PushdownAndPrunePass::run(
+      node,
+      translated.outputColumns,
+      builder_,
+      evaluator_,
+      session_,
+      connectorPushdown);
+  if (pass == Pass::kPushdownAndPrune) {
+    return node;
+  }
+
+  node = FoldMetadataAggregatePass::run(node, builder_, session_);
+  if (pass == Pass::kFoldMetadataAggregate) {
+    return node;
+  }
+
+  if (session_.options().useFilteredTableStats) {
+    EstimateLeafStatsPass::run(node, session_);
+  }
+  if (pass == Pass::kEstimateLeafStats) {
+    return node;
+  }
+
+  VELOX_CHECK_NOT_NULL(options, "Physical planning needs plan options");
 
   // Decide the width before physical planning, which reads maxRemotePartitions
   // to shape exchanges and to cost broadcasts.
-  MultiFragmentPlan::Options planOptions = options;
-  planOptions.maxRemotePartitions =
-      chooseNumWorkers(folded, session_.options(), options.maxRemotePartitions);
+  planOptions_ = *options;
+  planOptions_.maxRemotePartitions =
+      chooseNumWorkers(node, session_.options(), options->maxRemotePartitions);
 
-  EmitPass::Result emitted = physicalPlanAndEmit(
-      folded,
-      frontend.translated.outputColumns,
-      frontend.translated.outputNames,
-      builder,
+  node = PlanPhysicalPass::run(
+      node,
+      builder_,
+      session_.options(),
+      planOptions_.maxRemotePartitions,
+      planOptions_.maxLocalPartitions);
+  if (pass == Pass::kPlanPhysical) {
+    return node;
+  }
+
+  node = PrecomputeProjectionsPass::run(node, builder_);
+  if (pass == Pass::kPrecomputeProjections) {
+    return node;
+  }
+
+  return ExpandAggregatePass::run(node, builder_);
+}
+
+Optimizer::DebugPlan Optimizer::debugPlanTo(
+    const MultiFragmentPlan::Options& options,
+    std::optional<Pass> pass) {
+  markUsed();
+  NodeCP root =
+      planTo(pass, PushdownAndPrunePass::ConnectorPushdown::kOffer, &options);
+
+  // Only the leaf-statistics pass leaves estimates a caller can read: the ones
+  // physical planning computes belong to a provider that dies with the pass.
+  if (pass != Pass::kEstimateLeafStats) {
+    return {root, nullptr};
+  }
+
+  debugEstimates_.emplace();
+  return {
+      root, [this](NodeCP node) { return debugEstimates_->estimate(node); }};
+}
+
+PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
+  markUsed();
+
+  NodeCP planned = planTo(
+      /*pass=*/std::nullopt,
+      PushdownAndPrunePass::ConnectorPushdown::kOffer,
+      &options);
+
+  EmitPass::Result emitted = EmitPass::run(
+      planned,
+      outputColumns_,
+      outputNames_,
       session_,
       evaluator_,
-      planOptions);
+      planOptions_);
 
   PlanAndStats result;
   result.plan = std::make_shared<MultiFragmentPlan>(
-      std::move(emitted.fragments), planOptions);
+      std::move(emitted.fragments), planOptions_);
   result.plan->checkConsistency(
       /*mayBeEmpty=*/plan_.is(logical_plan::NodeKind::kTableWrite));
   result.finishWrite = std::move(emitted.finishWrite);
@@ -201,52 +255,33 @@ PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
 
 std::string Optimizer::explainIo(
     std::optional<CatalogSchemaTableName> outputTable) {
-  // Schema is owned here so its `connector::TablePtr`s — and the raw pointers
-  // the IR's `BaseTable` nodes hold into them — stay alive for the duration.
-  Schema schema(schemaResolver_);
+  markUsed();
 
-  // Run only the passes that move predicates down to the scans; join ordering
-  // and Emit are not needed to report IO. The pushdown pass does not offer
-  // them to the connector: the report is what the query applies to each table,
-  // not how some connector would read it.
-  Builder builder;
-  auto frontend = translateAndPushdown(
-      plan_,
-      schema,
-      evaluator_,
-      builder,
-      session_,
-      queryCtx_,
-      PushdownAndPrunePass::ConnectorPushdown::kSkip);
+  // The filters are not offered to the connector: the report is what the query
+  // applies to each table, not how some connector would read it.
+  NodeCP pushed = planTo(
+      Pass::kPushdownAndPrune,
+      PushdownAndPrunePass::ConnectorPushdown::kSkip,
+      nullptr);
 
   std::vector<std::pair<BaseTableCP, ExprVector>> tableFilters;
-  collectScans(frontend.pushed, tableFilters);
+  collectScans(pushed, tableFilters);
   return optimizer::explainIo(tableFilters, std::move(outputTable));
 }
 
 QueryStats Optimizer::estimateQueryStats() {
-  // Schema is owned here so its tables — and the raw pointers the IR's
-  // BaseTable nodes hold into them — stay alive while the estimate is read.
-  Schema schema(schemaResolver_);
-  Builder builder;
+  markUsed();
 
-  auto frontend = translateAndPushdown(
-      plan_,
-      schema,
-      evaluator_,
-      builder,
-      session_,
-      queryCtx_,
-      PushdownAndPrunePass::ConnectorPushdown::kOffer);
-  if (session_.options().useFilteredTableStats) {
-    EstimateLeafStatsPass::run(frontend.pushed, session_);
-  }
+  NodeCP root = planTo(
+      Pass::kEstimateLeafStats,
+      PushdownAndPrunePass::ConnectorPushdown::kOffer,
+      nullptr);
 
   EstimateProvider estimateProvider;
-  const Estimate& estimate = estimateProvider.estimate(frontend.pushed);
+  const Estimate& estimate = estimateProvider.estimate(root);
 
-  const auto& columns = frontend.translated.outputColumns;
-  const auto& names = frontend.translated.outputNames;
+  const auto& columns = outputColumns_;
+  const auto& names = outputNames_;
   VELOX_CHECK_EQ(columns.size(), names.size());
 
   QueryStats result;

--- a/axiom/optimizer/v2/Optimize.h
+++ b/axiom/optimizer/v2/Optimize.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <functional>
 #include <optional>
 #include <string>
 #include <vector>
@@ -25,7 +26,11 @@
 #include "axiom/logical_plan/LogicalPlanNode.h"
 #include "axiom/optimizer/MultiFragmentPlan.h"
 #include "axiom/optimizer/OptimizerSession.h"
+#include "axiom/optimizer/Schema.h"
 #include "axiom/optimizer/ToVelox.h"
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/EstimateProvider.h"
+#include "axiom/optimizer/v2/PushdownAndPrunePass.h"
 #include "velox/core/Expressions.h"
 #include "velox/core/QueryCtx.h"
 #include "velox/type/Variant.h"
@@ -71,12 +76,13 @@ class Optimizer {
         schemaResolver_{schemaResolver},
         session_{session},
         evaluator_{evaluator},
-        queryCtx_{std::move(queryCtx)} {}
+        queryCtx_{std::move(queryCtx)},
+        schema_{schemaResolver_} {}
 
   /// Lowers the plan to a distributed Velox execution plan (a
   /// `MultiFragmentPlan` of one or more fragments).
   ///
-  /// Stages over a tree IR:
+  /// Passes over a tree IR:
   ///   - Translate — build the tree IR from the logical plan;
   ///   - Decorrelate — rewrite correlated subqueries as joins;
   ///   - LimitAndOrder — fold limits into ordering operators;
@@ -110,20 +116,105 @@ class Optimizer {
       std::optional<CatalogSchemaTableName> outputTable = std::nullopt);
 
   /// Estimates the result statistics of the plan (the estimate behind
-  /// SHOW STATS FOR (<query>)). Runs the shared front end (translate +
-  /// pushdown) and, when the `useFilteredTableStats` option is set,
-  /// EstimateLeafStatsPass, then reads the root estimate via EstimateProvider —
-  /// the v2 analogue of v1 reading the root DerivedTable after logical
-  /// optimization. The returned pointers are valid only for the enclosing
-  /// QueryGraphContext's lifetime.
+  /// SHOW STATS FOR (<query>)). Runs the pipeline through EstimateLeafStats —
+  /// join ordering and Emit are skipped — then reads the root estimate via
+  /// EstimateProvider, the v2 analogue of v1 reading the root DerivedTable
+  /// after logical optimization. The returned pointers are valid only for the
+  /// enclosing QueryGraphContext's lifetime.
   QueryStats estimateQueryStats();
 
+  /// The passes run over the tree IR, in order. `Emit` is absent because it
+  /// produces Velox nodes rather than IR.
+  enum class Pass {
+    kTranslate,
+    kDecorrelate,
+    kLimitAndOrder,
+    kPushdownAndPrune,
+    kFoldMetadataAggregate,
+
+    /// Annotates base tables with connector statistics rather than rewriting
+    /// the tree, so the root it returns is the one the pass before produced.
+    /// Skipped when `useFilteredTableStats` is unset.
+    kEstimateLeafStats,
+
+    kPlanPhysical,
+    kPrecomputeProjections,
+    kExpandAggregate,
+  };
+
+  AXIOM_DECLARE_EMBEDDED_ENUM_NAME(Pass);
+
+  /// Estimates for the nodes of a `DebugPlan`. Empty when the pass did not
+  /// produce them: populated for `kEstimateLeafStats` only, and for later
+  /// passes once the estimates that drive physical planning outlive the pass
+  /// that computes them.
+  using Estimates = std::function<Estimate(NodeCP)>;
+
+  /// The IR at a pass boundary, and what is known about it.
+  struct DebugPlan {
+    NodeCP root;
+    Estimates estimates;
+  };
+
+  /// Returns the IR as the pipeline leaves it: after `pass` when one is given,
+  /// after the last pass otherwise, so a caller wanting the fully optimized IR
+  /// does not name whichever pass currently comes last.
+  ///
+  /// The result is owned by this `Optimizer` and by the `QueryGraphContext` it
+  /// runs under, and is valid while both are alive. That includes `estimates`,
+  /// which reads through state this `Optimizer` holds.
+  ///
+  /// For debugging only, and not a stable API: the pass sequence is internal
+  /// and `Pass` changes with it. Production code calls `optimize`.
+  DebugPlan debugPlanTo(
+      const MultiFragmentPlan::Options& options,
+      std::optional<Pass> pass = std::nullopt);
+
  private:
+  // Runs the pipeline up to and including `pass`, or all of it when `pass` is
+  // unset, and returns the IR as the last pass run left it.
+  // `connectorPushdown` is what PushdownAndPrunePass does with the filters it
+  // lands on a scan. `options` may be null only for a `pass` earlier than
+  // `kPlanPhysical`, the first one that reads them.
+  NodeCP planTo(
+      std::optional<Pass> pass,
+      PushdownAndPrunePass::ConnectorPushdown connectorPushdown,
+      const MultiFragmentPlan::Options* options);
+
+  // One entry point per instance: the passes annotate shared IR objects and
+  // the front end runs once, so a second call would plan over what the first
+  // left behind.
+  void markUsed() {
+    VELOX_CHECK(!used_, "Optimizer is single use: construct one per query");
+    used_ = true;
+  }
+
   const logical_plan::LogicalPlanNode& plan_;
   const connector::SchemaResolver& schemaResolver_;
   const OptimizerSession& session_;
   velox::core::ExpressionEvaluator& evaluator_;
   const std::shared_ptr<velox::core::QueryCtx> queryCtx_;
+
+  // Own the schema and the node factory: the IR points into the schema's
+  // table layouts, and callers of `debugPlanTo` read the IR after the call.
+  Schema schema_;
+  Builder builder_;
+
+  bool used_{false};
+
+  // Estimates for `debugPlanTo`, computed over the IR it returns. Held here so
+  // the lookup it hands back stays valid for this Optimizer's lifetime.
+  std::optional<EstimateProvider> debugEstimates_;
+
+  // The query's output columns and the names to emit them under, as the
+  // translate pass resolved them.
+  ColumnVector outputColumns_;
+  std::vector<std::string> outputNames_;
+
+  // The options physical planning ran under, with the worker count the
+  // optimizer chose. `optimize` emits with these, so the plan and the fragment
+  // count it was made for cannot disagree.
+  MultiFragmentPlan::Options planOptions_;
 };
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PhysicalPlanAndEmit.h
+++ b/axiom/optimizer/v2/PhysicalPlanAndEmit.h
@@ -21,10 +21,10 @@
 
 namespace facebook::axiom::optimizer::v2 {
 
-/// Runs the physical-planning and emit passes over 'root' and returns the emit
-/// result: PlanPhysical -> PrecomputeProjections -> ExpandAggregate -> Emit.
-/// Shared by full optimization and the translate-time constant fold so the two
-/// cannot drift. 'outputColumns' / 'outputNames' pin the emitted output layout.
+/// Runs PlanPhysical -> PrecomputeProjections -> ExpandAggregate over 'root'
+/// and lowers the result to Velox nodes. Lets the translate-time constant fold
+/// make a runnable plan out of an IR subtree without depending on the passes
+/// themselves. 'outputColumns' / 'outputNames' pin the emitted output layout.
 EmitPass::Result physicalPlanAndEmit(
     NodeCP root,
     const ColumnVector& outputColumns,

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -1307,6 +1307,9 @@ NodeCP PlanPhysicalPass::run(
     const OptimizerOptions& options,
     int32_t numWorkers,
     int32_t numDrivers) {
+  VELOX_USER_CHECK_GE(numWorkers, 1, "numWorkers must be at least 1");
+  VELOX_USER_CHECK_GE(numDrivers, 1, "numDrivers must be at least 1");
+
   PhysicalPlanRewriter rewriter{builder, options, numWorkers, numDrivers};
   return rewriter.rewrite(root);
 }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/321


`EXPLAIN (TYPE OPTIMIZED)` used to fail under the v2 optimizer with:

    EXPLAIN TYPE OPTIMIZED is not supported with --v2

It now prints the optimizer IR, from the CLI and from the cluster alike, so a plan can be inspected wherever the query runs.

Behind it, the pass sequence lives in one place. `Optimizer::planTo` runs the pipeline and can stop after any pass, and every entry point goes through it, so an EXPLAIN cannot show a plan the query would not run. `debugPlanTo` exposes it for debugging only — the pass sequence is internal and `Pass` moves with it.

`SHOW STATS FOR (<query>)` changes with this. It now runs the metadata-aggregate fold, which the front end it used to share skipped, so an aggregate answerable from metadata reports the folded value rather than an estimate over an aggregate that never executes.

The printed plan carries no cardinalities yet. `debugPlanTo` returns estimates only when it stops after leaf-statistics collection, because the estimates that drive physical planning do not outlive the pass that computes them.

Reviewed By: singcha

Differential Revision: D119678163


