### PR TITLE
feat(explain): Annotate the optimized plan with estimates (#1880)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -53,6 +53,7 @@
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/RelationOpPrinter.h"
 #include "axiom/optimizer/VeloxHistory.h"
+#include "axiom/optimizer/v2/NodePrinter.h"
 #include "axiom/optimizer/v2/Optimize.h"
 #include "axiom/runner/ProgressReporter.h"
 #include "axiom/sql/presto/PrestoParser.h"
@@ -1565,7 +1566,9 @@ std::string SqlQueryRunner::runExplain(
             schemaResolver,
             explain,
             [&](auto& optimizer) {
-              return optimizer.debugPlanTo(opts, lastPass).root->toString();
+              const auto plan = optimizer.debugPlanTo(opts, lastPass);
+              return optimizer::v2::NodePrinter::toText(
+                  plan.root, {.estimates = plan.estimates});
             });
       }
       VELOX_USER_CHECK(

--- a/axiom/cli/tests/ExplainTest.cpp
+++ b/axiom/cli/tests/ExplainTest.cpp
@@ -341,6 +341,14 @@ TEST_P(ExplainTest, explainLastPass) {
   auto afterEveryPass = run("EXPLAIN (TYPE OPTIMIZED) " + query);
   ASSERT_TRUE(afterEveryPass.message.has_value());
 
+  // Estimates appear once leaf statistics have been read, and not before. The
+  // values are checked by hand rather than pinned here.
+  EXPECT_THAT(
+      afterEveryPass.message.value(), ::testing::HasSubstr("Estimate:"));
+  EXPECT_THAT(
+      afterTranslate.message.value(),
+      ::testing::Not(::testing::HasSubstr("Estimate:")));
+
   // Pushdown gives the scan its connector handle, so the pre-pushdown IR has
   // none.
   EXPECT_THAT(

--- a/axiom/optimizer/tests/JoinTest.cpp
+++ b/axiom/optimizer/tests/JoinTest.cpp
@@ -34,14 +34,18 @@ class JoinTest : public test::QueryTestBase,
     return lp::PlanBuilder::Context{kTestConnectorId, kDefaultSchema};
   }
 
-  // Adds an all-BIGINT table whose columns each have `numRows` distinct values.
+  // Adds an all-BIGINT table whose columns each have `numRows` distinct values,
+  // except those named in `numDistinct`.
   void addTableWithStats(
       const std::string& name,
       const std::vector<std::string>& columns,
-      int64_t numRows) {
+      int64_t numRows,
+      const std::unordered_map<std::string, int64_t>& numDistinct = {}) {
     std::unordered_map<std::string, connector::ColumnStatistics> stats;
     for (const auto& column : columns) {
-      stats[column] = {.numDistinct = numRows};
+      const auto it = numDistinct.find(column);
+      stats[column] = {
+          .numDistinct = it != numDistinct.end() ? it->second : numRows};
     }
     testConnector_->addTable(name, ROW(columns, BIGINT()))
         ->setStats(numRows, stats);
@@ -240,6 +244,84 @@ TEST_P(JoinTest, pushdownFilterThroughJoin) {
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
   }
+}
+
+// A filter between two joins does not stop them being reordered.
+TEST_P(JoinTest, filterBetweenJoins) {
+  // 'events' joins 'tags' ten to one, so the outer join alone produces ten
+  // thousand rows, while 'picks' reduces 'events' to three.
+  addTableWithStats("events", {"x", "k"}, 1'000, {{"k", 100}});
+  addTableWithStats("tags", {"bk", "b"}, 1'000, {{"bk", 100}});
+  addTableWithStats("picks", {"tx"}, 3);
+
+  // The predicate admits a null 'b', so it does not turn the outer join inner
+  // and cannot move into either input.
+  {
+    auto query =
+        "SELECT count(*) FROM events LEFT JOIN tags ON events.k = tags.bk "
+        "JOIN picks ON events.x = picks.tx "
+        "WHERE tags.b IS NULL OR tags.b > 5";
+    SCOPED_TRACE(query);
+
+    auto matcher = matchScan("tags")
+                       .hashJoinRight(
+                           matchScan("events").hashJoinInner(
+                               matchScan("picks"), {.keys = {{"x = tx"}}}),
+                           {.keys = {{"bk = k"}}})
+                       .filter("b IS NULL OR b > 5")
+                       .singleAggregation({}, {"count(*)"})
+                       .build();
+
+    AXIOM_ASSERT_PLAN_V2(toSingleNodePlan(query), matcher);
+  }
+
+  // Under a full outer join the predicate reads a side the join null-extends,
+  // so it stays above the join while 'picks' moves across it. 'picks' joins on
+  // the left to keep the full outer join from collapsing to an inner one.
+  {
+    auto query =
+        "SELECT count(*) FROM events FULL OUTER JOIN tags ON events.k = tags.bk "
+        "LEFT JOIN picks ON events.x = picks.tx "
+        "WHERE tags.b IS NULL OR tags.b > 5";
+    SCOPED_TRACE(query);
+
+    auto matcher =
+        matchScan("picks")
+            .hashJoinRight(
+                matchScan("events")
+                    .hashJoin(matchScan("tags"), core::JoinType::kFull)
+                    .filter("b IS NULL OR b > 5"),
+                {.keys = {{"tx = x"}}})
+            .singleAggregation({}, {"count(*)"})
+            .build();
+
+    AXIOM_ASSERT_PLAN_V2(toSingleNodePlan(query), matcher);
+  }
+}
+
+// A non-deterministic predicate between two joins stays where it was written.
+TEST_P(JoinTest, nonDeterministicFilterBetweenJoins) {
+  addTableWithStats("events", {"x", "k"}, 1'000, {{"k", 100}});
+  addTableWithStats("tags", {"bk", "b"}, 1'000, {{"bk", 100}});
+  addTableWithStats("picks", {"tx"}, 3);
+
+  // The semi join cannot duplicate rows, which is what lets the predicate
+  // settle between the two joins.
+  auto query =
+      "SELECT count(*) FROM events JOIN tags ON events.k = tags.bk "
+      "WHERE tags.b > 10000 * rand() "
+      "AND events.x IN (SELECT tx FROM picks)";
+  SCOPED_TRACE(query);
+
+  auto matcher =
+      matchScan("events")
+          .hashJoinInner(matchScan("tags"), {.keys = {{"k = bk"}}})
+          .filter("b::double > 10000.0 * rand()")
+          .hashJoin(matchScan("picks"), core::JoinType::kLeftSemiFilter)
+          .singleAggregation({}, {"count(*)"})
+          .build();
+
+  AXIOM_ASSERT_PLAN_V2(toSingleNodePlan(query), matcher);
 }
 
 TEST_P(JoinTest, hyperEdge) {

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -16,6 +16,34 @@ SELECT t1.a FROM t t1 LEFT JOIN t t2 ON t1.a = t2.a AND 1 = 2 WHERE t2.b IS NULL
 -- count 0
 SELECT t1.a FROM t t1 LEFT JOIN t t2 ON t1.a = t2.a AND 1 = 2 WHERE t2.b > 5
 ----
+-- A filter between two joins, kept out of both inputs by the outer join's
+-- null padding, still lets the joins be reordered. Only a = 3 finds a match
+-- above 140, so the surviving rows are the null-padded ones: pushing the
+-- predicate into 'r' would keep a = 3 as well.
+-- ordered
+SELECT o.a, o.b
+FROM t o
+LEFT JOIN t r ON o.a = r.a AND r.b > 140
+JOIN t s ON o.b = s.b
+WHERE r.b IS NULL OR r.b > 200
+ORDER BY o.a, o.b
+
+----
+-- The same shape over a full outer join. The predicate admits nulls on the
+-- right side, so the rows the join pads there are kept.
+SELECT count(*), count(o.a), count(r.b)
+FROM t o
+FULL OUTER JOIN t r ON o.a = r.a AND r.b > 140
+LEFT JOIN t s ON o.b = s.b
+WHERE r.b IS NULL OR r.b > 200
+----
+-- The same predicate on the left side, which a full outer join pads as well.
+SELECT count(*), count(o.a), count(r.b)
+FROM t o
+FULL OUTER JOIN t r ON o.a = r.a AND r.b > 140
+LEFT JOIN t s ON o.b = s.b
+WHERE o.b IS NULL OR o.b > 200
+----
 -- JOIN with UNION ALL subquery.
 SELECT t1.a, t1.b
 FROM t t1 JOIN (SELECT a FROM t WHERE a = 1 UNION ALL SELECT a FROM t WHERE a = 2) t2 ON t1.a = t2.a

--- a/axiom/optimizer/v2/HypergraphBuilder.cpp
+++ b/axiom/optimizer/v2/HypergraphBuilder.cpp
@@ -136,6 +136,17 @@ SubtreeRelations populateJoinInputs(
     return subtree;
   }
 
+  if (node->is(NodeType::kFilter)) {
+    // A Filter the cluster descended through contributes no relation of its
+    // own; its predicates became graph conjuncts.
+    return populateJoinInputs(
+        node->as<Filter>()->input(),
+        leafIds,
+        unnestIds,
+        inputs,
+        unnestSubtrees);
+  }
+
   const auto* join = node->as<Join>();
   const SubtreeRelations left = populateJoinInputs(
       join->left(), leafIds, unnestIds, inputs, unnestSubtrees);
@@ -235,6 +246,17 @@ RelationSet tesExpansion(
         input, parentType, parentSes, leftSide, leafIds, inputs);
   }
 
+  if (node->is(NodeType::kFilter)) {
+    // A Filter contributes no join to reshape over; its predicates are graph
+    // conjuncts, eligible by their own relation sets.
+    return tesExpansion(
+        node->as<Filter>()->input(),
+        parentType,
+        parentSes,
+        leftSide,
+        leafIds,
+        inputs);
+  }
   const auto* childJoin = node->as<Join>();
   const auto& childInputs = inputs.at(childJoin);
 
@@ -731,6 +753,31 @@ JoinHypergraph HypergraphBuilder::build(
   }
 
   addTransitiveInnerEdges(graph, columnToLeaf);
+
+  // A predicate that reads a side an outer join null-extends takes that edge's
+  // eligibility, so it cannot fire before the padding exists. Edges are
+  // normalized to left form, so no edge carries kRight.
+  for (ExprCP predicate : cluster.filterPredicates) {
+    RelationSet relations = expressionRelations(predicate, columnToLeaf);
+    for (const auto& edge : graph.edges()) {
+      RelationSet extended;
+      switch (edge.joinType()) {
+        case velox::core::JoinType::kLeft:
+          extended = edge.rightEligibility();
+          break;
+        case velox::core::JoinType::kFull:
+          extended = edge.leftEligibility();
+          extended.unionSet(edge.rightEligibility());
+          break;
+        default:
+          continue;
+      }
+      if (relations.hasIntersection(extended)) {
+        relations.unionSet(edge.totalEligibility());
+      }
+    }
+    graph.addFilterConjunct({predicate, relations});
+  }
 
   return graph;
 }

--- a/axiom/optimizer/v2/JoinCluster.h
+++ b/axiom/optimizer/v2/JoinCluster.h
@@ -42,6 +42,10 @@ struct JoinCluster {
   std::vector<NodeCP> leaves;
   std::vector<JoinCP> joins;
   std::vector<UnnestCP> unnests;
+
+  /// Predicates of the `Filter` nodes the cluster spans. Each becomes a graph
+  /// conjunct, applied wherever the relations it reads are covered.
+  ExprVector filterPredicates;
 };
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -1560,6 +1560,31 @@ Join::Join(Key key)
   }
 }
 
+Join::PreservedSides Join::preservedSides(velox::core::JoinType joinType) {
+  using JoinType = velox::core::JoinType;
+  switch (joinType) {
+    case JoinType::kInner:
+      return {.left = true, .right = true};
+    case JoinType::kLeft:
+    case JoinType::kLeftSemiFilter:
+    case JoinType::kCountingLeftSemiFilter:
+    case JoinType::kLeftSemiProject:
+    case JoinType::kAnti:
+    case JoinType::kCountingAnti:
+      return {.left = true};
+    case JoinType::kRight:
+    case JoinType::kRightSemiFilter:
+    case JoinType::kRightSemiProject:
+    case JoinType::kRightAnti:
+      return {.right = true};
+    case JoinType::kFull:
+      return {};
+    case JoinType::kNumJoinTypes:
+      break;
+  }
+  VELOX_UNREACHABLE();
+}
+
 ColumnCP Join::markColumn() const {
   VELOX_CHECK(
       projectsMark(joinType_),

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -1265,6 +1265,19 @@ class Join : public Node {
     return joinType_ == velox::core::JoinType::kLeftSemiProject;
   }
 
+  /// Which of a join's inputs pass their rows through unchanged.
+  struct PreservedSides {
+    bool left{false};
+    bool right{false};
+  };
+
+  /// Returns which inputs a join of `joinType` passes through unchanged. Such
+  /// a row reaches the output as itself or not at all: the join may drop it --
+  /// a semi join keeps only matching rows, an anti join only non-matching ones
+  /// -- but it never nulls the row's columns and never invents a row the input
+  /// did not have.
+  static PreservedSides preservedSides(velox::core::JoinType joinType);
+
   /// Returns the BOOLEAN mark this semi-project join adds to the preserved
   /// side's columns, which is its last output column. Only semi-project joins
   /// project one.

--- a/axiom/optimizer/v2/NodePrinter.cpp
+++ b/axiom/optimizer/v2/NodePrinter.cpp
@@ -60,6 +60,7 @@ class Printer : public NodeVisitor {
   struct Context : public NodeVisitorContext {
     std::stringstream out;
     size_t indent{0};
+    const NodePrinter::Options* options{nullptr};
   };
 
   // Bumps `ctx.indent` by 2 on construction, restores on destruction.
@@ -396,6 +397,14 @@ class Printer : public NodeVisitor {
       ctx.out << extra;
     }
     ctx.out << " -> " << formatColumns(node.outputColumns()) << '\n';
+
+    if (ctx.options->estimates) {
+      const auto estimate = ctx.options->estimates(&node);
+      if (estimate.cardinality.has_value()) {
+        ctx.out << spaces(ctx.indent + 2)
+                << "Estimate: " << *estimate.cardinality << " rows\n";
+      }
+    }
   }
 
   void visitInputs(const Node& node, Context& ctx) const {
@@ -406,8 +415,9 @@ class Printer : public NodeVisitor {
 
 } // namespace
 
-std::string NodePrinter::toText(NodeCP root) {
+std::string NodePrinter::toText(NodeCP root, const Options& options) {
   Printer::Context ctx;
+  ctx.options = &options;
   root->accept(Printer{}, ctx);
   return ctx.out.str();
 }

--- a/axiom/optimizer/v2/NodePrinter.h
+++ b/axiom/optimizer/v2/NodePrinter.h
@@ -15,7 +15,9 @@
  */
 #pragma once
 
+#include <functional>
 #include <string>
+#include "axiom/optimizer/v2/EstimateProvider.h"
 #include "axiom/optimizer/v2/Node.h"
 
 namespace facebook::axiom::optimizer::v2 {
@@ -23,9 +25,15 @@ namespace facebook::axiom::optimizer::v2 {
 /// Renders an IR tree as indented text.
 class NodePrinter {
  public:
+  struct Options {
+    /// Supplies the estimate to print under each node. Unset prints none, and
+    /// a node whose cardinality is unknown prints none either way.
+    std::function<Estimate(NodeCP)> estimates;
+  };
+
   /// Returns 'root' as indented text. Columns are shown by their `name()`
   /// (the unique synthetic), not `outputName()`, so identity is visible.
-  static std::string toText(NodeCP root);
+  static std::string toText(NodeCP root, const Options& options = {});
 };
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -202,9 +202,9 @@ Optimizer::DebugPlan Optimizer::debugPlanTo(
   NodeCP root =
       planTo(pass, PushdownAndPrunePass::ConnectorPushdown::kOffer, &options);
 
-  // Only the leaf-statistics pass leaves estimates a caller can read: the ones
-  // physical planning computes belong to a provider that dies with the pass.
-  if (pass != Pass::kEstimateLeafStats) {
+  // Before leaf statistics are read the numbers are not the ones planning goes
+  // on, so no estimate is offered at all.
+  if (pass.has_value() && *pass < Pass::kEstimateLeafStats) {
     return {root, nullptr};
   }
 

--- a/axiom/optimizer/v2/Optimize.h
+++ b/axiom/optimizer/v2/Optimize.h
@@ -144,10 +144,15 @@ class Optimizer {
 
   AXIOM_DECLARE_EMBEDDED_ENUM_NAME(Pass);
 
-  /// Estimates for the nodes of a `DebugPlan`. Empty when the pass did not
-  /// produce them: populated for `kEstimateLeafStats` only, and for later
-  /// passes once the estimates that drive physical planning outlive the pass
-  /// that computes them.
+  /// Cardinality and column constraints for the nodes of a `DebugPlan`,
+  /// computed the way physical planning computes them — the same
+  /// `EstimateProvider` over the same base statistics, so a leaf reproduces
+  /// exactly and a join subtree is estimated as planning would estimate it.
+  ///
+  /// Empty for a pass before `kEstimateLeafStats`, where the base statistics
+  /// have not been read yet. That is a position in the pipeline, not a
+  /// statement that the pass ran: it is skipped when `useFilteredTableStats`
+  /// is unset, and the estimates then fall back to the table's own statistics.
   using Estimates = std::function<Estimate(NodeCP)>;
 
   /// The IR at a pass boundary, and what is known about it.

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -24,6 +24,7 @@
 #include <folly/container/F14Map.h>
 
 #include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/optimizer/v2/AppendAll.h"
 #include "axiom/optimizer/v2/CostModel.h"
 #include "axiom/optimizer/v2/DPhyp.h"
 #include "axiom/optimizer/v2/EstimateProvider.h"
@@ -74,17 +75,58 @@ bool isClusterable(const Join* join) {
       kind == JoinType::kLeftSemiProject;
 }
 
+// True when a Filter over `node` stands between joins the cluster enumerates
+// together. The emitter applies a conjunct at a join, never at a leaf, so a
+// predicate taken from a Filter over a single leaf would move up to the first
+// join above, away from the scan pushdown placed it on.
+bool separatesJoins(
+    NodeCP node,
+    bool dissolveCrossJoins,
+    const folly::F14FastSet<const Join*>& opaqueJoins) {
+  if (node->is(NodeType::kFilter)) {
+    return separatesJoins(
+        node->as<Filter>()->input(), dissolveCrossJoins, opaqueJoins);
+  }
+  if (node->is(NodeType::kUnnest)) {
+    return separatesJoins(
+        node->as<Unnest>()->input(), dissolveCrossJoins, opaqueJoins);
+  }
+  if (!node->is(NodeType::kJoin)) {
+    return false;
+  }
+  const auto* join = node->as<Join>();
+  if (isClusterable(join) && !opaqueJoins.contains(join)) {
+    return true;
+  }
+  // A dissolved cross join puts its children in the cluster, so a Filter over
+  // one still stands between whatever they contribute.
+  return dissolveCrossJoins && join->isInner() && join->leftKeys().empty() &&
+      join->filter().empty();
+}
+
 void collectCluster(
     NodeCP node,
     JoinCluster& cluster,
     bool dissolveCrossJoins,
-    const folly::F14FastSet<const Join*>& opaqueJoins = {}) {
+    const folly::F14FastSet<const Join*>& opaqueJoins,
+    bool preserved) {
   if (node->is(NodeType::kJoin)) {
     const auto* join = node->as<Join>();
     if (isClusterable(join) && !opaqueJoins.contains(join)) {
       cluster.joins.push_back(join);
-      collectCluster(join->left(), cluster, dissolveCrossJoins, opaqueJoins);
-      collectCluster(join->right(), cluster, dissolveCrossJoins, opaqueJoins);
+      const auto sides = Join::preservedSides(join->joinType());
+      collectCluster(
+          join->left(),
+          cluster,
+          dissolveCrossJoins,
+          opaqueJoins,
+          preserved && sides.left);
+      collectCluster(
+          join->right(),
+          cluster,
+          dissolveCrossJoins,
+          opaqueJoins,
+          preserved && sides.right);
       return;
     }
     // A bare keyless inner join (no keys, no filter) is a comma-join cross
@@ -95,11 +137,35 @@ void collectCluster(
     // join; leave it an opaque leaf so its semantics are preserved.
     if (dissolveCrossJoins && join->isInner() && join->leftKeys().empty() &&
         join->filter().empty()) {
-      collectCluster(join->left(), cluster, dissolveCrossJoins, opaqueJoins);
-      collectCluster(join->right(), cluster, dissolveCrossJoins, opaqueJoins);
+      collectCluster(
+          join->left(), cluster, dissolveCrossJoins, opaqueJoins, preserved);
+      collectCluster(
+          join->right(), cluster, dissolveCrossJoins, opaqueJoins, preserved);
       return;
     }
   }
+
+  if (node->is(NodeType::kFilter)) {
+    const auto* filter = node->as<Filter>();
+    // A Filter emits its input's columns, so descending through it leaves the
+    // relations unchanged. Three things keep it a leaf: a non-deterministic
+    // predicate must run where it was written; a Filter inside an input the
+    // join above does not preserve decides which rows that join sees, so it
+    // cannot move above the join; a Filter separating no joins is already
+    // where pushdown put it.
+    const bool deterministic = std::none_of(
+        filter->predicates().begin(),
+        filter->predicates().end(),
+        [](ExprCP predicate) { return predicate->containsNonDeterministic(); });
+    if (deterministic && preserved &&
+        separatesJoins(filter->input(), dissolveCrossJoins, opaqueJoins)) {
+      appendAll(cluster.filterPredicates, filter->predicates());
+      collectCluster(
+          filter->input(), cluster, dissolveCrossJoins, opaqueJoins, preserved);
+      return;
+    }
+  }
+
   if (node->is(NodeType::kUnnest)) {
     const auto* unnest = node->as<Unnest>();
     // An Unnest of a constant, as in UNNEST(ARRAY[1, 2]), reads a subtree that
@@ -107,7 +173,8 @@ void collectCluster(
     // relation of the cluster; the Unnest emits it as its own input.
     NodeCP input = unnest->input();
     if (!input->outputColumns().empty()) {
-      collectCluster(input, cluster, dissolveCrossJoins, opaqueJoins);
+      collectCluster(
+          input, cluster, dissolveCrossJoins, opaqueJoins, preserved);
     }
     // Preserve JoinCluster's post-order invariant.
     cluster.unnests.push_back(unnest);
@@ -132,6 +199,11 @@ folly::F14FastSet<const Join*> markProducersReadInCluster(
     add(join->leftKeys());
     add(join->rightKeys());
     add(join->filter());
+  }
+  // A predicate the cluster took from a Filter resolves against the same
+  // relations, so a mark it reads also keeps its producer opaque.
+  for (ExprCP predicate : cluster.filterPredicates) {
+    predicateColumns.unionSet(predicate->columns());
   }
 
   folly::F14FastSet<const Join*> opaqueJoins;
@@ -409,7 +481,12 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
 
     JoinCluster cluster;
     cluster.root = node;
-    collectCluster(node, cluster, /*dissolveCrossJoins=*/true);
+    collectCluster(
+        node,
+        cluster,
+        /*dissolveCrossJoins=*/true,
+        /*opaqueJoins=*/{},
+        /*preserved=*/true);
     if (cluster.joins.empty()) {
       return rewriteUnclusteredJoin(node, context);
     }
@@ -419,7 +496,12 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
     if (!opaqueJoins.empty()) {
       cluster = JoinCluster{};
       cluster.root = node;
-      collectCluster(node, cluster, /*dissolveCrossJoins=*/true, opaqueJoins);
+      collectCluster(
+          node,
+          cluster,
+          /*dissolveCrossJoins=*/true,
+          opaqueJoins,
+          /*preserved=*/true);
     }
 
     // A RelationSet holds `kMaxRelations` relations, so a larger cluster has
@@ -452,7 +534,12 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
     if (hasEndpointStrandedRelation(graph)) {
       cluster = JoinCluster{};
       cluster.root = node;
-      collectCluster(node, cluster, /*dissolveCrossJoins=*/false, opaqueJoins);
+      collectCluster(
+          node,
+          cluster,
+          /*dissolveCrossJoins=*/false,
+          opaqueJoins,
+          /*preserved=*/true);
       graph = buildGraph();
     }
 

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -230,28 +230,7 @@ std::optional<MarkFusion> fuseMarkFilter(
 // conjunct is an extra restriction on the join output; this differs from a
 // conjunct in the join's own match condition (see joinFilterTarget).
 bool canPushLeft(velox::core::JoinType joinType, bool leftOnly) {
-  if (!leftOnly) {
-    return false;
-  }
-  switch (joinType) {
-    case velox::core::JoinType::kInner:
-    case velox::core::JoinType::kLeft:
-    case velox::core::JoinType::kLeftSemiFilter:
-    case velox::core::JoinType::kCountingLeftSemiFilter:
-    case velox::core::JoinType::kLeftSemiProject:
-    case velox::core::JoinType::kAnti:
-    case velox::core::JoinType::kCountingAnti:
-      return true;
-    case velox::core::JoinType::kRight:
-    case velox::core::JoinType::kFull:
-    case velox::core::JoinType::kRightSemiFilter:
-    case velox::core::JoinType::kRightSemiProject:
-    case velox::core::JoinType::kRightAnti:
-      return false;
-    case velox::core::JoinType::kNumJoinTypes:
-      break;
-  }
-  VELOX_UNREACHABLE();
+  return leftOnly && Join::preservedSides(joinType).left;
 }
 
 // Returns the cross-side `Column == Column` equi-pairs reachable on
@@ -417,28 +396,7 @@ void blockNondeterministic(ExprVector& pushable, ExprVector& blocked) {
 
 // Mirror of canPushLeft for the right input (from-above conjuncts).
 bool canPushRight(velox::core::JoinType joinType, bool rightOnly) {
-  if (!rightOnly) {
-    return false;
-  }
-  switch (joinType) {
-    case velox::core::JoinType::kInner:
-    case velox::core::JoinType::kRight:
-    case velox::core::JoinType::kRightSemiFilter:
-    case velox::core::JoinType::kRightSemiProject:
-    case velox::core::JoinType::kRightAnti:
-      return true;
-    case velox::core::JoinType::kLeft:
-    case velox::core::JoinType::kFull:
-    case velox::core::JoinType::kLeftSemiFilter:
-    case velox::core::JoinType::kCountingLeftSemiFilter:
-    case velox::core::JoinType::kLeftSemiProject:
-    case velox::core::JoinType::kAnti:
-    case velox::core::JoinType::kCountingAnti:
-      return false;
-    case velox::core::JoinType::kNumJoinTypes:
-      break;
-  }
-  VELOX_UNREACHABLE();
+  return rightOnly && Join::preservedSides(joinType).right;
 }
 
 // Where a conjunct from a join's own match condition (its filter) that


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/325


`EXPLAIN (TYPE OPTIMIZED)` showed the shape the optimizer chose but none of the numbers behind it, so a suspicious join order gave no way to tell whether the estimates or the costing was at fault. Each node now carries the cardinality the optimizer works from:

    - Filter -> a:BIGINT
      Estimate: 49 rows
      predicate: lt(a, 50)
      - Scan["default"."t"] -> a:BIGINT
        Estimate: 1000 rows

The numbers come from an `EstimateProvider` built over the tree being printed — the same class, reading the same base statistics off `BaseTable` and `Column`, that physical planning seeds its join-cluster leaves from. A relation set's cardinality does not depend on the order it is joined in, which is what lets DPhyp key its memo by the set, so estimating a finished tree reproduces what planning went on rather than approximating it.

Nothing is reported for a pass before `EstimateLeafStats`, where the base statistics have not been read. The per-column constraints the estimator also tracks — ndv, ranges, null fractions — stay unprinted.

Reviewed By: amitkdutta

Differential Revision: D119698402


