### PR TITLE
refactor(optimizer): Break up cluster collection and build

### DIFF
--- a/axiom/optimizer/v2/HypergraphBuilder.cpp
+++ b/axiom/optimizer/v2/HypergraphBuilder.cpp
@@ -578,24 +578,153 @@ void addUnnestBarriers(
   }
 }
 
-} // namespace
+// The graph under construction and the maps edge construction resolves
+// against: which leaf a column comes from, which relation a node is, and what
+// each join's inputs contribute.
+struct EdgeBuilder {
+  JoinHypergraph& graph;
+  const folly::F14FastMap<ColumnCP, int8_t>& columnToLeaf;
+  const folly::F14FastMap<NodeCP, int8_t>& leafIds;
+  const folly::F14FastMap<JoinCP, JoinInputs>& joinInputs;
+  const folly::F14FastMap<int8_t, RelationSet>& unnestInputRelations;
+  const folly::F14FastMap<int8_t, RelationSet>& unnestSubtrees;
 
-JoinHypergraph HypergraphBuilder::build(
+  // Adds the edges of an inner join, and its filter as graph conjuncts.
+  void addInner(JoinCP join, const JoinInputs& inputs) {
+    // Group keys by endpoint relation-pair and emit one edge per group.
+    // Keys sharing an endpoint (a composite key) stay on one edge so
+    // their combined selectivity is preserved; keys with different
+    // endpoints become separate edges, so two relations are not forced
+    // co-located by a single hyperedge.
+    std::map<std::pair<uint64_t, uint64_t>, std::vector<size_t>> keysByEndpoint;
+    for (size_t i = 0; i < join->leftKeys().size(); ++i) {
+      const RelationSet leftKeyRelations{
+          expressionRelations(join->leftKeys()[i], columnToLeaf)};
+      const RelationSet rightKeyRelations{
+          expressionRelations(join->rightKeys()[i], columnToLeaf)};
+      keysByEndpoint[{leftKeyRelations.bits(), rightKeyRelations.bits()}]
+          .push_back(i);
+    }
+
+    for (const auto& [endpoint, keyIndices] : keysByEndpoint) {
+      ExprVector leftKeys;
+      ExprVector rightKeys;
+      for (size_t i : keyIndices) {
+        leftKeys.push_back(join->leftKeys()[i]);
+        rightKeys.push_back(join->rightKeys()[i]);
+      }
+      const RelationSet leftSet{
+          keyRelationsOrOperand(leftKeys, columnToLeaf, inputs.leftLeaves)};
+      const RelationSet rightSet{
+          keyRelationsOrOperand(rightKeys, columnToLeaf, inputs.rightLeaves)};
+      RelationSet ses{leftSet};
+      ses.unionSet(rightSet);
+      const RelationSet tes = expandTes(
+          ses,
+          join->left(),
+          join->right(),
+          join->joinType(),
+          leafIds,
+          joinInputs);
+      auto [leftTes, rightTes] =
+          splitTes(tes, inputs.leftRelations, inputs.rightRelations);
+
+      graph.addEdge(
+          JoinEdge{
+              leftSet,
+              rightSet,
+              leftTes,
+              rightTes,
+              leftKeys,
+              rightKeys,
+              ExprVector{},
+              join->joinType(),
+              /*nullAware=*/false,
+              /*nullAsValue=*/false});
+    }
+
+    for (ExprCP conjunct : join->filter()) {
+      graph.addFilterConjunct(
+          {conjunct, expressionRelations(conjunct, columnToLeaf)});
+    }
+  }
+
+  // Adds the single edge of a non-inner join, normalized to left form.
+  void addOuter(JoinCP join, const JoinInputs& inputs) {
+    // Swap keys when the IR join is a right-form join so the edge's
+    // leftKeys reference the normalized left input.
+    const bool flip = join->joinType() == velox::core::JoinType::kRight ||
+        join->joinType() == velox::core::JoinType::kRightSemiFilter ||
+        join->joinType() == velox::core::JoinType::kRightSemiProject;
+    const ExprVector& edgeLeftKeys =
+        flip ? join->rightKeys() : join->leftKeys();
+    const ExprVector& edgeRightKeys =
+        flip ? join->leftKeys() : join->rightKeys();
+    NodeCP normalizedLeftChild = flip ? join->right() : join->left();
+    NodeCP normalizedRightChild = flip ? join->left() : join->right();
+
+    const RelationSet leftSet{
+        keyRelationsOrOperand(edgeLeftKeys, columnToLeaf, inputs.leftLeaves)};
+    const RelationSet rightSet{
+        keyRelationsOrOperand(edgeRightKeys, columnToLeaf, inputs.rightLeaves)};
+    RelationSet ses{leftSet};
+    ses.unionSet(rightSet);
+    for (ExprCP conjunct : join->filter()) {
+      ses.unionSet(expressionRelations(conjunct, columnToLeaf));
+    }
+    RelationSet tes = expandTes(
+        ses,
+        normalizedLeftChild,
+        normalizedRightChild,
+        inputs.joinType,
+        leafIds,
+        joinInputs);
+
+    addUnnestBarriers(inputs, unnestInputRelations, unnestSubtrees, tes);
+
+    // `populateJoinInputs` already applies the same right-form operand swap
+    // as the normalized child selection above, so these are in normalized
+    // order.
+    auto [leftTes, rightTes] =
+        splitTes(tes, inputs.leftRelations, inputs.rightRelations);
+
+    // kLeftSemiProject preserves the left side and appends a mark; the
+    // Join (and its Apply origin) build outputColumns as
+    // `left.outputColumns ++ mark`, so the mark is the last output
+    // column. Emit reads it back via JoinEdge::markColumn to thread the
+    // mark through reordering. The filtering forms (kLeftSemiFilter /
+    // kAnti) carry no mark.
+    ColumnCP markColumn =
+        inputs.joinType == velox::core::JoinType::kLeftSemiProject
+        ? join->markColumn()
+        : nullptr;
+
+    graph.addEdge(
+        JoinEdge{
+            leftSet,
+            rightSet,
+            leftTes,
+            rightTes,
+            edgeLeftKeys,
+            edgeRightKeys,
+            join->filter(),
+            inputs.joinType,
+            join->nullAware(),
+            join->nullAsValue(),
+            markColumn});
+  }
+};
+
+// Adds one relation per cluster leaf, keyed so that both the original and the
+// rewritten pointer resolve to it, and records which leaf each column comes
+// from.
+void addLeafRelations(
     const JoinCluster& cluster,
     const std::vector<NodeCP>& rewrittenLeaves,
-    EstimateProvider& estimateProvider) {
-  VELOX_CHECK_LE(
-      cluster.leaves.size(),
-      RelationSet::kMaxRelations,
-      "Cluster has more leaves than RelationSet can represent");
-  VELOX_CHECK_EQ(
-      cluster.leaves.size(),
-      rewrittenLeaves.size(),
-      "rewrittenLeaves must align 1:1 with cluster.leaves");
-
-  JoinHypergraph graph;
-  folly::F14FastMap<ColumnCP, int8_t> columnToLeaf;
-  folly::F14FastMap<NodeCP, int8_t> leafIds;
+    EstimateProvider& estimateProvider,
+    JoinHypergraph& graph,
+    folly::F14FastMap<ColumnCP, int8_t>& columnToLeaf,
+    folly::F14FastMap<NodeCP, int8_t>& leafIds) {
   for (size_t i = 0; i < cluster.leaves.size(); ++i) {
     NodeCP original = cluster.leaves[i];
     NodeCP rewritten = rewrittenLeaves[i];
@@ -615,149 +744,17 @@ JoinHypergraph HypergraphBuilder::build(
       columnToLeaf.emplace(column, id);
     }
   }
+}
 
-  folly::F14FastMap<UnnestCP, int8_t> unnestIds =
-      addUnnestRelations(cluster, estimateProvider, graph, columnToLeaf);
-
-  folly::F14FastMap<int8_t, RelationSet> unnestInputRelations =
-      addUnnestEdges(cluster, unnestIds, columnToLeaf, graph);
-
-  folly::F14FastMap<JoinCP, JoinInputs> joinInputs;
-  folly::F14FastMap<int8_t, RelationSet> unnestSubtrees;
-  populateJoinInputs(
-      cluster.root, leafIds, unnestIds, joinInputs, unnestSubtrees);
-
-  for (JoinCP join : cluster.joins) {
-    const auto& inputs = joinInputs.at(join);
-    if (join->isInner()) {
-      // Group keys by endpoint relation-pair and emit one edge per group.
-      // Keys sharing an endpoint (a composite key) stay on one edge so
-      // their combined selectivity is preserved; keys with different
-      // endpoints become separate edges, so two relations are not forced
-      // co-located by a single hyperedge.
-      std::map<std::pair<uint64_t, uint64_t>, std::vector<size_t>>
-          keysByEndpoint;
-      for (size_t i = 0; i < join->leftKeys().size(); ++i) {
-        const RelationSet leftKeyRelations{
-            expressionRelations(join->leftKeys()[i], columnToLeaf)};
-        const RelationSet rightKeyRelations{
-            expressionRelations(join->rightKeys()[i], columnToLeaf)};
-        keysByEndpoint[{leftKeyRelations.bits(), rightKeyRelations.bits()}]
-            .push_back(i);
-      }
-
-      for (const auto& [endpoint, keyIndices] : keysByEndpoint) {
-        ExprVector leftKeys;
-        ExprVector rightKeys;
-        for (size_t i : keyIndices) {
-          leftKeys.push_back(join->leftKeys()[i]);
-          rightKeys.push_back(join->rightKeys()[i]);
-        }
-        const RelationSet leftSet{
-            keyRelationsOrOperand(leftKeys, columnToLeaf, inputs.leftLeaves)};
-        const RelationSet rightSet{
-            keyRelationsOrOperand(rightKeys, columnToLeaf, inputs.rightLeaves)};
-        RelationSet ses{leftSet};
-        ses.unionSet(rightSet);
-        const RelationSet tes = expandTes(
-            ses,
-            join->left(),
-            join->right(),
-            join->joinType(),
-            leafIds,
-            joinInputs);
-        auto [leftTes, rightTes] =
-            splitTes(tes, inputs.leftRelations, inputs.rightRelations);
-
-        graph.addEdge(
-            JoinEdge{
-                leftSet,
-                rightSet,
-                leftTes,
-                rightTes,
-                leftKeys,
-                rightKeys,
-                ExprVector{},
-                join->joinType(),
-                /*nullAware=*/false,
-                /*nullAsValue=*/false});
-      }
-
-      for (ExprCP conjunct : join->filter()) {
-        graph.addFilterConjunct(
-            {conjunct, expressionRelations(conjunct, columnToLeaf)});
-      }
-    } else {
-      // Swap keys when the IR join is a right-form join so the edge's
-      // leftKeys reference the normalized left input.
-      const bool flip = join->joinType() == velox::core::JoinType::kRight ||
-          join->joinType() == velox::core::JoinType::kRightSemiFilter ||
-          join->joinType() == velox::core::JoinType::kRightSemiProject;
-      const ExprVector& edgeLeftKeys =
-          flip ? join->rightKeys() : join->leftKeys();
-      const ExprVector& edgeRightKeys =
-          flip ? join->leftKeys() : join->rightKeys();
-      NodeCP normalizedLeftChild = flip ? join->right() : join->left();
-      NodeCP normalizedRightChild = flip ? join->left() : join->right();
-
-      const RelationSet leftSet{
-          keyRelationsOrOperand(edgeLeftKeys, columnToLeaf, inputs.leftLeaves)};
-      const RelationSet rightSet{keyRelationsOrOperand(
-          edgeRightKeys, columnToLeaf, inputs.rightLeaves)};
-      RelationSet ses{leftSet};
-      ses.unionSet(rightSet);
-      for (ExprCP conjunct : join->filter()) {
-        ses.unionSet(expressionRelations(conjunct, columnToLeaf));
-      }
-      RelationSet tes = expandTes(
-          ses,
-          normalizedLeftChild,
-          normalizedRightChild,
-          inputs.joinType,
-          leafIds,
-          joinInputs);
-
-      addUnnestBarriers(inputs, unnestInputRelations, unnestSubtrees, tes);
-
-      // `populateJoinInputs` already applies the same right-form operand swap
-      // as the normalized child selection above, so these are in normalized
-      // order.
-      auto [leftTes, rightTes] =
-          splitTes(tes, inputs.leftRelations, inputs.rightRelations);
-
-      // kLeftSemiProject preserves the left side and appends a mark; the
-      // Join (and its Apply origin) build outputColumns as
-      // `left.outputColumns ++ mark`, so the mark is the last output
-      // column. Emit reads it back via JoinEdge::markColumn to thread the
-      // mark through reordering. The filtering forms (kLeftSemiFilter /
-      // kAnti) carry no mark.
-      ColumnCP markColumn =
-          inputs.joinType == velox::core::JoinType::kLeftSemiProject
-          ? join->markColumn()
-          : nullptr;
-
-      graph.addEdge(
-          JoinEdge{
-              leftSet,
-              rightSet,
-              leftTes,
-              rightTes,
-              edgeLeftKeys,
-              edgeRightKeys,
-              join->filter(),
-              inputs.joinType,
-              join->nullAware(),
-              join->nullAsValue(),
-              markColumn});
-    }
-  }
-
-  addTransitiveInnerEdges(graph, columnToLeaf);
-
-  // A predicate that reads a side an outer join null-extends takes that edge's
-  // eligibility, so it cannot fire before the padding exists. Edges are
-  // normalized to left form, so no edge carries kRight.
-  for (ExprCP predicate : cluster.filterPredicates) {
+// Adds the cluster's Filter predicates as graph conjuncts. A predicate that
+// reads a side an outer join null-extends takes that edge's eligibility, so it
+// cannot fire before the padding exists. Edges are normalized to left form, so
+// no edge carries kRight.
+void addClusterConjuncts(
+    const ExprVector& predicates,
+    const folly::F14FastMap<ColumnCP, int8_t>& columnToLeaf,
+    JoinHypergraph& graph) {
+  for (ExprCP predicate : predicates) {
     RelationSet relations = expressionRelations(predicate, columnToLeaf);
     for (const auto& edge : graph.edges()) {
       RelationSet extended;
@@ -778,6 +775,59 @@ JoinHypergraph HypergraphBuilder::build(
     }
     graph.addFilterConjunct({predicate, relations});
   }
+}
+
+} // namespace
+
+JoinHypergraph HypergraphBuilder::build(
+    const JoinCluster& cluster,
+    const std::vector<NodeCP>& rewrittenLeaves,
+    EstimateProvider& estimateProvider) {
+  VELOX_CHECK_LE(
+      cluster.leaves.size(),
+      RelationSet::kMaxRelations,
+      "Cluster has more leaves than RelationSet can represent");
+  VELOX_CHECK_EQ(
+      cluster.leaves.size(),
+      rewrittenLeaves.size(),
+      "rewrittenLeaves must align 1:1 with cluster.leaves");
+
+  JoinHypergraph graph;
+  folly::F14FastMap<ColumnCP, int8_t> columnToLeaf;
+  folly::F14FastMap<NodeCP, int8_t> leafIds;
+  addLeafRelations(
+      cluster, rewrittenLeaves, estimateProvider, graph, columnToLeaf, leafIds);
+
+  folly::F14FastMap<UnnestCP, int8_t> unnestIds =
+      addUnnestRelations(cluster, estimateProvider, graph, columnToLeaf);
+
+  folly::F14FastMap<int8_t, RelationSet> unnestInputRelations =
+      addUnnestEdges(cluster, unnestIds, columnToLeaf, graph);
+
+  folly::F14FastMap<JoinCP, JoinInputs> joinInputs;
+  folly::F14FastMap<int8_t, RelationSet> unnestSubtrees;
+  populateJoinInputs(
+      cluster.root, leafIds, unnestIds, joinInputs, unnestSubtrees);
+
+  EdgeBuilder edges{
+      graph,
+      columnToLeaf,
+      leafIds,
+      joinInputs,
+      unnestInputRelations,
+      unnestSubtrees};
+  for (JoinCP join : cluster.joins) {
+    const auto& inputs = joinInputs.at(join);
+    if (join->isInner()) {
+      edges.addInner(join, inputs);
+    } else {
+      edges.addOuter(join, inputs);
+    }
+  }
+
+  addTransitiveInnerEdges(graph, columnToLeaf);
+
+  addClusterConjuncts(cluster.filterPredicates, columnToLeaf, graph);
 
   return graph;
 }

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -79,6 +79,9 @@ bool isClusterable(const Join* join) {
 // together. The emitter applies a conjunct at a join, never at a leaf, so a
 // predicate taken from a Filter over a single leaf would move up to the first
 // join above, away from the scan pushdown placed it on.
+// `dissolveCrossJoins` and `opaqueJoins` say which joins the cluster takes in:
+// a bare keyless inner join is descended through only when the first is set,
+// and a join named by the second always stays a leaf.
 bool separatesJoins(
     NodeCP node,
     bool dissolveCrossJoins,
@@ -104,30 +107,56 @@ bool separatesJoins(
       join->filter().empty();
 }
 
-void collectCluster(
-    NodeCP node,
-    JoinCluster& cluster,
-    bool dissolveCrossJoins,
-    const folly::F14FastSet<const Join*>& opaqueJoins,
-    bool preserved) {
-  if (node->is(NodeType::kJoin)) {
-    const auto* join = node->as<Join>();
-    if (isClusterable(join) && !opaqueJoins.contains(join)) {
-      cluster.joins.push_back(join);
+// Walks a cluster's subtree, taking each node into the cluster or ending the
+// branch with it as a leaf. `preserved` is false once the walk has entered an
+// input a join above does not preserve, where a node that decides which rows
+// that join sees cannot move.
+class ClusterCollector {
+ public:
+  // `dissolveCrossJoins` and `opaqueJoins` carry the same meaning they have in
+  // `separatesJoins`, and vary independently: the first collection dissolves
+  // cross joins with nothing opaque, and the re-collect that stops dissolving
+  // them may still have nothing opaque.
+  ClusterCollector(
+      JoinCluster& cluster,
+      bool dissolveCrossJoins,
+      const folly::F14FastSet<const Join*>& opaqueJoins)
+      : cluster_{cluster},
+        dissolveCrossJoins_{dissolveCrossJoins},
+        opaqueJoins_{opaqueJoins} {}
+
+  void collect(NodeCP node, bool preserved) {
+    switch (node->nodeType()) {
+      case NodeType::kJoin:
+        if (collectJoin(node->as<Join>(), preserved)) {
+          return;
+        }
+        break;
+      case NodeType::kFilter:
+        if (collectFilter(node->as<Filter>(), preserved)) {
+          return;
+        }
+        break;
+      case NodeType::kUnnest:
+        collectUnnest(node->as<Unnest>(), preserved);
+        return;
+      default:
+        break;
+    }
+    cluster_.leaves.push_back(node);
+  }
+
+ private:
+  // These return true when they took the node into the cluster; an Unnest
+  // always joins it.
+
+  bool collectJoin(JoinCP join, bool preserved) {
+    if (isClusterable(join) && !opaqueJoins_.contains(join)) {
+      cluster_.joins.push_back(join);
       const auto sides = Join::preservedSides(join->joinType());
-      collectCluster(
-          join->left(),
-          cluster,
-          dissolveCrossJoins,
-          opaqueJoins,
-          preserved && sides.left);
-      collectCluster(
-          join->right(),
-          cluster,
-          dissolveCrossJoins,
-          opaqueJoins,
-          preserved && sides.right);
-      return;
+      collect(join->left(), preserved && sides.left);
+      collect(join->right(), preserved && sides.right);
+      return true;
     }
     // A bare keyless inner join (no keys, no filter) is a comma-join cross
     // product. Descend through it so its children join the cluster as
@@ -135,18 +164,16 @@ void collectCluster(
     // them (a spurious cross product that the join graph can avoid). A
     // keyless join that carries a filter is a theta or decorrelated-subquery
     // join; leave it an opaque leaf so its semantics are preserved.
-    if (dissolveCrossJoins && join->isInner() && join->leftKeys().empty() &&
+    if (dissolveCrossJoins_ && join->isInner() && join->leftKeys().empty() &&
         join->filter().empty()) {
-      collectCluster(
-          join->left(), cluster, dissolveCrossJoins, opaqueJoins, preserved);
-      collectCluster(
-          join->right(), cluster, dissolveCrossJoins, opaqueJoins, preserved);
-      return;
+      collect(join->left(), preserved);
+      collect(join->right(), preserved);
+      return true;
     }
+    return false;
   }
 
-  if (node->is(NodeType::kFilter)) {
-    const auto* filter = node->as<Filter>();
+  bool collectFilter(FilterCP filter, bool preserved) {
     // A Filter emits its input's columns, so descending through it leaves the
     // relations unchanged. Three things keep it a leaf: a non-deterministic
     // predicate must run where it was written; a Filter inside an input the
@@ -157,31 +184,31 @@ void collectCluster(
         filter->predicates().begin(),
         filter->predicates().end(),
         [](ExprCP predicate) { return predicate->containsNonDeterministic(); });
-    if (deterministic && preserved &&
-        separatesJoins(filter->input(), dissolveCrossJoins, opaqueJoins)) {
-      appendAll(cluster.filterPredicates, filter->predicates());
-      collectCluster(
-          filter->input(), cluster, dissolveCrossJoins, opaqueJoins, preserved);
-      return;
+    if (!deterministic || !preserved ||
+        !separatesJoins(filter->input(), dissolveCrossJoins_, opaqueJoins_)) {
+      return false;
     }
+    appendAll(cluster_.filterPredicates, filter->predicates());
+    collect(filter->input(), preserved);
+    return true;
   }
 
-  if (node->is(NodeType::kUnnest)) {
-    const auto* unnest = node->as<Unnest>();
+  void collectUnnest(UnnestCP unnest, bool preserved) {
     // An Unnest of a constant, as in UNNEST(ARRAY[1, 2]), reads a subtree that
     // produces no columns. No predicate can reference it, so it is not a
     // relation of the cluster; the Unnest emits it as its own input.
     NodeCP input = unnest->input();
     if (!input->outputColumns().empty()) {
-      collectCluster(
-          input, cluster, dissolveCrossJoins, opaqueJoins, preserved);
+      collect(input, preserved);
     }
     // Preserve JoinCluster's post-order invariant.
-    cluster.unnests.push_back(unnest);
-    return;
+    cluster_.unnests.push_back(unnest);
   }
-  cluster.leaves.push_back(node);
-}
+
+  JoinCluster& cluster_;
+  const bool dissolveCrossJoins_;
+  const folly::F14FastSet<const Join*>& opaqueJoins_;
+};
 
 // A kLeftSemiProject join projects a mark, which is a column of no cluster
 // leaf. Another join in the cluster whose predicate reads that mark has no
@@ -481,12 +508,8 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
 
     JoinCluster cluster;
     cluster.root = node;
-    collectCluster(
-        node,
-        cluster,
-        /*dissolveCrossJoins=*/true,
-        /*opaqueJoins=*/{},
-        /*preserved=*/true);
+    ClusterCollector{cluster, /*dissolveCrossJoins=*/true, /*opaqueJoins=*/{}}
+        .collect(node, /*preserved=*/true);
     if (cluster.joins.empty()) {
       return rewriteUnclusteredJoin(node, context);
     }
@@ -496,12 +519,8 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
     if (!opaqueJoins.empty()) {
       cluster = JoinCluster{};
       cluster.root = node;
-      collectCluster(
-          node,
-          cluster,
-          /*dissolveCrossJoins=*/true,
-          opaqueJoins,
-          /*preserved=*/true);
+      ClusterCollector{cluster, /*dissolveCrossJoins=*/true, opaqueJoins}
+          .collect(node, /*preserved=*/true);
     }
 
     // A RelationSet holds `kMaxRelations` relations, so a larger cluster has
@@ -534,12 +553,8 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
     if (hasEndpointStrandedRelation(graph)) {
       cluster = JoinCluster{};
       cluster.root = node;
-      collectCluster(
-          node,
-          cluster,
-          /*dissolveCrossJoins=*/false,
-          opaqueJoins,
-          /*preserved=*/true);
+      ClusterCollector{cluster, /*dissolveCrossJoins=*/false, opaqueJoins}
+          .collect(node, /*preserved=*/true);
       graph = buildGraph();
     }
 


### PR DESCRIPTION
Summary:
`collectCluster` and `HypergraphBuilder::build` had both grown past reading in one pass, and each had become a sequence of independent steps sharing a pile of state through parameters.

`collectCluster` becomes a `ClusterCollector` holding the cluster and the two join-admission rules, with one method per node kind and the type dispatch in one place, so each step takes the node type it handles rather than testing and casting. `build` keeps its sequence and delegates the pieces: leaf relations, the two edge shapes, and the cluster's conjuncts. The helpers are file-local.

No behavior change.

Differential Revision: D119716121
