### PR TITLE
fix(parser): Preserve duplicate names in star expansion

### DIFF
--- a/axiom/logical_plan/NameMappings.cpp
+++ b/axiom/logical_plan/NameMappings.cpp
@@ -175,6 +175,15 @@ void NameMappings::merge(const NameMappings& other) {
     }
   }
 
+  const auto preserveOtherUserName = [&](const std::string& id,
+                                         const std::string& fallback) {
+    if (const auto* userName = other.userName(id)) {
+      userNames_.try_emplace(id, *userName);
+    } else {
+      userNames_.try_emplace(id, fallback);
+    }
+  };
+
   for (const auto& [name, id] : other.mappings_) {
     if (auto existing = mappings_.find(name); existing != mappings_.end()) {
       // The same name exists on both sides, so it is ambiguous across the
@@ -182,6 +191,8 @@ void NameMappings::merge(const NameMappings& other) {
       // both sides reuse a relation alias. Referencing a dropped name later
       // fails as unresolved, matching Presto's report-at-reference-time
       // behavior.
+      userNames_.try_emplace(existing->second, name.name);
+      preserveOtherUserName(id, name.name);
       markAmbiguous(name);
     } else if (
         !name.alias.has_value() && leftQualifiedNames.contains(name.name)) {
@@ -189,6 +200,7 @@ void NameMappings::merge(const NameMappings& other) {
       // already has a qualified name with the same base. The name is ambiguous
       // across joined tables even though the left's unqualified entry was
       // removed by an earlier merge.
+      preserveOtherUserName(id, name.name);
     } else {
       insert(name, id);
     }

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -2156,10 +2156,11 @@ void forEachOutputColumn(
 } // namespace
 
 ExprApi PlanBuilder::OutputColumnName::toCol() const {
-  if (alias.has_value()) {
-    return Col(name, Col(*alias));
+  ExprApi column = alias.has_value() ? Col(name, Col(*alias)) : Col(name);
+  if (userName.has_value()) {
+    return column.as(*userName);
   }
-  return Col(name);
+  return column;
 }
 
 std::vector<PlanBuilder::OutputColumnName> PlanBuilder::findOrAssignOutputNames(
@@ -2185,9 +2186,23 @@ PlanBuilder::OutputColumnName PlanBuilder::findOrAssignOutputNameAt(
   auto names = outputMapping_->reverseLookup(id);
 
   if (names.empty()) {
-    // Anonymous column — assign the internal ID as a resolvable name.
+    if (const auto* userName = outputMapping_->userName(id)) {
+      auto resolutionName = nameAllocator_->newName(id);
+      outputMapping_->add(resolutionName, id);
+      return OutputColumnName{
+          std::nullopt, std::move(resolutionName), *userName};
+    }
+
+    // Use the internal ID when it is available as a name. If the ID is also
+    // an ambiguous user-visible name, allocate a distinct access name.
     outputMapping_->add(id, id);
-    return OutputColumnName{std::nullopt, id};
+    std::string resolutionName{id};
+    if (outputMapping_->lookup(id) != id) {
+      resolutionName = nameAllocator_->newName(id);
+      outputMapping_->add(resolutionName, id);
+    }
+
+    return OutputColumnName{std::nullopt, std::move(resolutionName)};
   }
 
   // Extract the user-visible column name (same for all entries) and the
@@ -2202,14 +2217,21 @@ PlanBuilder::OutputColumnName PlanBuilder::findOrAssignOutputNameAt(
     }
   }
 
+  std::optional<std::string> userName;
+  if (const auto* mappedUserName = outputMapping_->userName(id);
+      mappedUserName != nullptr && *mappedUserName != columnName) {
+    userName = *mappedUserName;
+  }
+
   // If the name resolves unambiguously, no alias is needed.
   if (outputMapping_->lookup(columnName) == id) {
-    return OutputColumnName{std::nullopt, columnName};
+    return OutputColumnName{std::nullopt, columnName, std::move(userName)};
   }
 
   // Name is ambiguous (e.g., same column name from multiple joined tables).
   // Alias is required for disambiguation.
-  return OutputColumnName{columnAlias, columnName};
+  return OutputColumnName{
+      std::move(columnAlias), columnName, std::move(userName)};
 }
 
 namespace {

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -774,8 +774,16 @@ class PlanBuilder {
     /// resolvable by name alone.
     std::optional<std::string> alias;
 
-    /// Column name.
+    /// Name used to resolve the column.
     std::string name;
+
+    /// User-visible output name when it differs from 'name'.
+    std::optional<std::string> userName;
+
+    /// Returns the user-visible output name.
+    const std::string& outputName() const {
+      return userName.has_value() ? *userName : name;
+    }
 
     /// Returns a column reference expression that resolves unambiguously.
     ExprApi toCol() const;
@@ -783,9 +791,9 @@ class PlanBuilder {
     bool operator==(const OutputColumnName&) const = default;
   };
 
-  /// Returns resolvable names for the output columns. Assigns unique names
-  /// for anonymous columns and uses fully qualified names for ambiguous
-  /// columns (e.g., from joins with overlapping column names).
+  /// Returns resolvable names for the output columns. Assigns unique names for
+  /// anonymous columns and for ambiguous columns without relation aliases.
+  /// Uses fully qualified names for ambiguous columns with relation aliases.
   /// @param includeHiddenColumns Whether to include hidden columns.
   /// @param alias Optional alias to filter output columns. If specified,
   /// returns a subset of columns accessible with the specified alias.
@@ -794,8 +802,8 @@ class PlanBuilder {
       const std::optional<std::string>& alias = std::nullopt) const;
 
   /// Returns the resolvable name of the output column at the given index.
-  /// If the column is anonymous, assigns a unique name. If ambiguous, includes
-  /// the table alias for disambiguation.
+  /// Assigns a unique name if the column is anonymous or ambiguous without a
+  /// relation alias. Includes the relation alias when available.
   OutputColumnName findOrAssignOutputNameAt(size_t index) const;
 
   /// Returns the current plan node as-is.

--- a/axiom/logical_plan/tests/PlanBuilderTest.cpp
+++ b/axiom/logical_plan/tests/PlanBuilderTest.cpp
@@ -148,7 +148,7 @@ TEST_F(PlanBuilderTest, duplicateAliasAllowed) {
     return PlanBuilder(context, /*allowAmbiguousOutputNames=*/true);
   };
 
-  // Project: duplicate aliases get unique physical names.
+  // Project: duplicate aliases get unique access names.
   {
     auto builder =
         makeBuilder()
@@ -157,8 +157,23 @@ TEST_F(PlanBuilderTest, duplicateAliasAllowed) {
 
     auto names = builder.findOrAssignOutputNames();
     EXPECT_EQ(4, names.size());
-    EXPECT_EQ("x", names[2].name);
-    EXPECT_TRUE(names[3].name.starts_with("x_"));
+    EXPECT_THAT(
+        (std::vector<std::string>{
+            names[2].outputName(), names[3].outputName()}),
+        testing::ElementsAre("x", "x"));
+    EXPECT_THAT(names[2].name, testing::StartsWith("x_"));
+    EXPECT_THAT(names[3].name, testing::StartsWith("x_"));
+    EXPECT_THAT(names[2].name, testing::Ne(names[3].name));
+
+    EXPECT_THAT(
+        builder.findOrAssignOutputNames(), testing::ElementsAreArray(names));
+
+    builder.project({names[2].toCol(), names[3].toCol()});
+    EXPECT_THAT(
+        builder.outputNames(),
+        testing::ElementsAre(
+            testing::Optional(testing::Eq("x")),
+            testing::Optional(testing::Eq("x"))));
   }
 
   // The duplicate is a column passed through rather than another projection.
@@ -176,13 +191,14 @@ TEST_F(PlanBuilderTest, duplicateAliasAllowed) {
     EXPECT_TRUE(names[2].name.starts_with("a_"));
   }
 
-  // Lookup on duplicate name fails.
+  // Assigning access names does not make a duplicate alias resolvable.
   {
     auto builder =
         makeBuilder()
             .values(ROW({"a", "b"}, BIGINT()), ValuesNode::Variants{})
             .with({"a as x", "b as x"});
 
+    builder.findOrAssignOutputNames();
     VELOX_ASSERT_THROW(builder.project({"x"}), "Cannot resolve");
   }
 

--- a/axiom/sql/presto/ColumnsExpansion.cpp
+++ b/axiom/sql/presto/ColumnsExpansion.cpp
@@ -98,7 +98,7 @@ std::vector<lp::PlanBuilder::OutputColumnName> ColumnsExpansion::matchByRegex(
   auto columns =
       builder.findOrAssignOutputNames(/*includeHiddenColumns=*/false, prefix);
   std::erase_if(columns, [&](const auto& column) {
-    return !re2::RE2::FullMatch(column.name, regex);
+    return !re2::RE2::FullMatch(column.outputName(), regex);
   });
   AXIOM_PRESTO_SEMANTIC_CHECK(
       !columns.empty(),

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1090,7 +1090,7 @@ class RelationPlanner : public AstVisitor {
       // Build set of user-visible names for O(1) lookups.
       std::unordered_set<std::string> columnNameSet;
       for (const auto& column : columns) {
-        columnNameSet.insert(column.name);
+        columnNameSet.insert(column.outputName());
       }
 
       // Apply EXCLUDE: remove excluded columns.
@@ -1108,7 +1108,7 @@ class RelationPlanner : public AstVisitor {
         }
 
         std::erase_if(columns, [&](const auto& column) {
-          return excludeSet.contains(column.name);
+          return excludeSet.contains(column.outputName());
         });
         AXIOM_PRESTO_SEMANTIC_CHECK(
             !columns.empty(),
@@ -1134,7 +1134,7 @@ class RelationPlanner : public AstVisitor {
             name);
         auto numMatches = std::count_if(
             columns.begin(), columns.end(), [&](const auto& column) {
-              return column.name == name;
+              return column.outputName() == name;
             });
         AXIOM_PRESTO_SEMANTIC_CHECK(
             numMatches == 1,
@@ -1151,9 +1151,10 @@ class RelationPlanner : public AstVisitor {
     // Build expressions: use replacement if present, otherwise column
     // reference.
     for (const auto& column : columns) {
-      auto it = replaceMap.find(column.name);
+      const auto& outputName = column.outputName();
+      auto it = replaceMap.find(outputName);
       if (it != replaceMap.end()) {
-        exprs.push_back(lp::ExprApi(it->second, column.name));
+        exprs.push_back(lp::ExprApi(it->second, outputName));
       } else {
         exprs.push_back(column.toCol());
       }
@@ -1216,7 +1217,7 @@ class RelationPlanner : public AstVisitor {
             const std::optional<std::string>& prefix) {
           for (const auto& column : columns) {
             displayNames.push_back(
-                displayNames_.displayName(prefix, column.name));
+                displayNames_.displayName(prefix, column.outputName()));
           }
         };
     for (const auto& item : selectItems) {

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -412,6 +412,31 @@ TEST_F(PrestoParserTest, selectStarDuplicateColumns) {
       "WHERE a.n_nationkey = b.n_nationkey",
       matchJoin().output());
 
+  // Star expansion preserves duplicate names from unaliased relations.
+  testSelect(
+      "SELECT *, 3 AS extra FROM (SELECT 1 AS x) "
+      "JOIN (SELECT 2 AS x) ON TRUE",
+      matchValues()
+          .project()
+          .join(matchValues().project().build())
+          .project()
+          .output({"x", "x", "extra"}));
+
+  VELOX_ASSERT_THROW(
+      parseSql(
+          "SELECT x FROM (SELECT *, 3 AS extra FROM (SELECT 1 AS x) "
+          "JOIN (SELECT 2 AS x) ON TRUE)"),
+      "Cannot resolve column: x");
+
+  testSelect(
+      "SELECT * EXCLUDE (x), 3 AS extra FROM (SELECT 1 AS x, 4 AS y) "
+      "JOIN (SELECT 2 AS x) ON TRUE",
+      matchValues()
+          .project()
+          .join(matchValues().project().build())
+          .project()
+          .output({"y", "extra"}));
+
   // Qualified star with additional columns.
   testSelect(
       "SELECT a.*, b.n_nationkey FROM nation a, nation b "


### PR DESCRIPTION
Summary:
Axiom failed to plan the following query with `Cannot resolve column: x`:

    SELECT *, 3 AS extra FROM (SELECT 1 AS x) JOIN (SELECT 2 AS x) ON TRUE

Keep user-visible output names separate from unique names used to resolve column references. Star expansion can now preserve duplicate names without making a later unqualified reference to either column valid.

Differential Revision: D119768103
